### PR TITLE
fix: avoid UID variable name in make_cert.sh

### DIFF
--- a/examples/certs/make_cert.sh
+++ b/examples/certs/make_cert.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
-UID=$(openssl rand -hex 16)
+# Random Common Name so different deploys don't share a fingerprint.
+# Avoid the name UID — it is a read-only built-in in bash, so anyone running
+# this script via "bash make_cert.sh" would silently get a degraded CN.
+RAND_ID=$(openssl rand -hex 16)
 openssl ecparam -out cakey.pem -name prime256v1 -genkey
-openssl req -new -x509 -days 3650 -key cakey.pem -out cacert.pem -subj /CN="$UID"
+openssl req -new -x509 -days 3650 -key cakey.pem -out cacert.pem -subj /CN="$RAND_ID"
 openssl ecparam -out serverkey.pem -name prime256v1 -genkey
-openssl req -new -key serverkey.pem -out servercert.pem -subj /CN="$UID"
+openssl req -new -key serverkey.pem -out servercert.pem -subj /CN="$RAND_ID"
 openssl x509 -req -days 3650 -in servercert.pem -CA cacert.pem -CAkey cakey.pem -set_serial 01 -out servercert.pem


### PR DESCRIPTION
## Summary

Closes #5.

`UID` is a read-only built-in in bash. When the cert script is invoked as
`bash make_cert.sh` (a normal pattern), the assignment fails silently and
the Common Name of the generated certificate falls back to the user's
numeric UID — typically `1000` — instead of a random 32-hex-char string.
Result: predictable CNs.

Rename the variable to `RAND_ID` and add a one-line comment explaining
why this matters.

## Test plan

Verified on Ubuntu 24.04 with OpenSSL 3.0.13:

```
$ ./make_cert.sh
$ openssl x509 -in cacert.pem -noout -subject
subject=CN = 63ecb2594dd08929c80cbf1192854876        ok

$ bash make_cert.sh
$ openssl x509 -in cacert.pem -noout -subject
subject=CN = 2037e0426d019d7916c4976726900cc3        ok
```

Before this PR, `bash make_cert.sh` emitted `UID: readonly variable` and
produced `CN = 1000`.

## Out of scope (intentionally)

- The `make_cert.bat` Windows counterpart does not have this issue
  (different shell semantics) and is unchanged.
- Migrating the script to OpenSSL 3.0+'s preferred `genpkey` API
  (instead of the deprecated `ecparam -genkey`) is out of scope for
  this Phase 2 quick-win and will be considered alongside the LuaSec /
  OpenSSL hygiene work in Phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)