### PR TITLE
fix: remove deprecated 'register' keyword from tiger.cpp

### DIFF
--- a/adclib/tiger.cpp
+++ b/adclib/tiger.cpp
@@ -76,9 +76,9 @@
 
 #define tiger_compress_macro(str, state) \
      { \
-     register unsigned long long a, b, c, tmpa; \
+     unsigned long long a, b, c, tmpa; \
      unsigned long long aa, bb, cc; \
-     register unsigned long long x0, x1, x2, x3, x4, x5, x6, x7; \
+     unsigned long long x0, x1, x2, x3, x4, x5, x6, x7; \
      int pass_no; \
      \
      a = state[0]; \


### PR DESCRIPTION
## Summary

Closes #2.

The `register` storage-class specifier was removed in C++17. Modern
compilers ignore the hint and pick register allocation themselves, so
removing it is purely cosmetic at the generated-code level — but it
silences 12 `-Wregister` diagnostics emitted from the macro at lines
79–81 on every adclib build with gcc/clang in C++17 mode.

## Diff

```cpp
-     register unsigned long long a, b, c, tmpa; \
+     unsigned long long a, b, c, tmpa; \
      unsigned long long aa, bb, cc; \
-     register unsigned long long x0, x1, x2, x3, x4, x5, x6, x7; \
+     unsigned long long x0, x1, x2, x3, x4, x5, x6, x7; \
```

Two lines, two `register` words removed.

## Test plan

Verified on Ubuntu 24.04 (gcc 13.3.0, OpenSSL 3.0.13):

- [x] Clean build: 17 warnings → 5 warnings
  (the 5 remaining are all OpenSSL-3.0 deprecations from luasec — tracked
  in #3, scoped to Phase 4)
- [x] No `register`-related warnings (`grep 'register.*storage class' /tmp/build.log` returns nothing)
- [x] Hub boots, all 14 core modules and 5 native plugins load cleanly,
      including adclib
- [x] Plain ADC port 5000 binds; previous TLS smoke (port 5001) is
      unaffected by this change

## Note on upstream provenance

`tiger.cpp` is a port of Eli Biham's reference Tiger hash implementation
(public domain, 1995). The original reference code uses `register`. There
is no actively maintained upstream we sync from, so patching in-tree is
appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)