### PR TITLE
fix: replace deprecated lua_open() with luaL_newstate() in hub.c

### DIFF
--- a/hub/hub.c
+++ b/hub/hub.c
@@ -125,7 +125,7 @@ static int restart(lua_State *L)
 
 static void run_lua(void)
 {
-  lua_State *L = lua_open();
+  lua_State *L = luaL_newstate();
   if (!L)
   {
     log_error("cannot create Lua state: not enough memory");


### PR DESCRIPTION
## Summary

Closes #10.

`lua_open()` is the Lua 5.0 spelling, kept as a deprecated `#define` in
Lua 5.1 and **removed** in Lua 5.2:

```c
// lua/src/lua.h:287 (bundled Lua 5.1.5)
#define lua_open() luaL_newstate()
```

Switching call site to `luaL_newstate()` is preprocessor-equivalent on
our current Lua 5.1 runtime — generated machine code is byte-identical —
and removes one source of conditional fixes from the Lua 5.4 migration
in Phase 3.

## Diff

```c
-  lua_State *L = lua_open();
+  lua_State *L = luaL_newstate();
```

One line.

## Test plan

Verified on Ubuntu 24.04 / gcc 13.3.0:

- [x] Clean rebuild: warning count unchanged at 5 (only OpenSSL
      deprecation warnings remain, tracked in #3)
- [x] No new warnings or errors introduced
- [x] Hub boots fully — all 24 `init.lua` steps complete, version
      banner prints, port 5000 (plain ADC) binds
- [x] Clean shutdown on `SIGINT`

## Phase

Phase 2 quick-win, scoped as Lua 5.1 compatible only. Does not commit
us to Phase 3 (Lua 5.4 migration); just removes one of the API edges
that would otherwise need to change in that migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)