### PR TITLE
fix: route +!# server commands from PM-to-hubbot to command pipeline

### DIFF
--- a/core/hub.lua
+++ b/core/hub.lua
@@ -698,11 +698,17 @@ reghubbot = function( name, desc )
         client = function( self, adccmd )
             local user = _nobot_normalstatesids[ adccmd:mysid( ) ]
             if user and adccmd:fourcc( ) == "EMSG" then
-                --// hubbot to mainchat bridge
-                --user.write( adccmd:adcstring( ) )
-                --scripts_firelistener( "onBroadcast", user, adccmd, escapefrom( adccmd[ 8 ] ) )
-                --// new response msg
-                user:reply( _i18n_hubbot_response, _hubbot, _hubbot )
+                -- AirDC++ and other clients route a leading "+", "!" or "#" as a
+                -- "server command" via private message to the hubbot. Forward those
+                -- to the broadcast/command pipeline so cmd_* scripts can pick them
+                -- up. Anything else is a real PM to the bot — keep the polite
+                -- deflection so users don't accidentally trigger handlers by chatting.
+                local text = escapefrom( adccmd[ 8 ] ) or ""
+                if text:match( "^[+!#]" ) then
+                    scripts_firelistener( "onBroadcast", user, adccmd, text )
+                else
+                    user:reply( _i18n_hubbot_response, _hubbot, _hubbot )
+                end
             end
             return true
         end,


### PR DESCRIPTION
## Summary

Closes #4.

When a user types `+help` (or `+myip`, `!ban`, `#topic`, etc.) into the
main-chat input, AirDC++ and most other DC clients **don't** send a
broadcast (BMSG). They send a *private message to the hub bot* (EMSG),
following the historical "server command" convention from the NMDC era.

The handler in `reghubbot()` previously replied to every EMSG with the
i18n `"I am the Hubbot, do you really want to talk to me?"` line. So
server commands silently never reached `cmd_*` scripts.

This PR restores the old PM-to-command bridge that was commented out in
favour of the deflection, **but only for messages that begin with `+`,
`!` or `#`** — the prefixes already used by `etc_hubcommands.lua`. Plain
PMs to the bot still get the polite deflection, so the original
"don't trigger handlers by chatting at the bot" intent is preserved.

## Diff

```lua
 client = function( self, adccmd )
     local user = _nobot_normalstatesids[ adccmd:mysid( ) ]
     if user and adccmd:fourcc( ) == "EMSG" then
-        --// hubbot to mainchat bridge
-        --user.write( adccmd:adcstring( ) )
-        --scripts_firelistener( "onBroadcast", user, adccmd, escapefrom( adccmd[ 8 ] ) )
-        --// new response msg
-        user:reply( _i18n_hubbot_response, _hubbot, _hubbot )
+        local text = escapefrom( adccmd[ 8 ] ) or ""
+        if text:match( "^[+!#]" ) then
+            scripts_firelistener( "onBroadcast", user, adccmd, text )
+        else
+            user:reply( _i18n_hubbot_response, _hubbot, _hubbot )
+        end
     end
     return true
 end,
```

## Edge cases considered

- `escapefrom(adccmd[8])` returning `nil` → `or ""` → empty string → falls
  to deflection branch (no harm).
- Lone `+` / `!` / `#` with no alpha after → matches prefix, fires
  `onBroadcast`, but `etc_hubcommands.lua`'s regex `^[+!#](%a+)` rejects
  it → no command runs, no error.
- `?` and `/` prefixes are intentionally not bridged. They are not
  registered as command prefixes in `etc_hubcommands.lua`, so adding
  them here would only widen the surface without adding routable
  commands.

## Test plan

### Automated (already done on Ubuntu 24.04 / gcc 13.3.0)

- [x] Clean rebuild: 5 warnings (OpenSSL only — same baseline as master)
- [x] No new warnings or errors
- [x] Hub boots fully — all 24 `init.lua` steps complete, banner
      prints, port 5000 binds, clean shutdown on `SIGINT`

### Interactive (needs maintainer with AirDC++ on Windows)

Connect to `adcs://<wsl-ip>:5001` as `dummy` / `test`, then:

- [ ] Type `+help` in main chat → expect a list of available commands
      (instead of the previous "I am the Hubbot..." deflection)
- [ ] Type `+myip` in main chat → expect your IP back (e.g. `172.18.x.y`)
- [ ] Open a PM tab to `[BOT]HubSecurity`, type `Hi bot` → expect the
      "I am the Hubbot, do you really want to talk to me?" deflection
      (regular PMs must still be deflected)
- [ ] Optional: open PM tab to bot, type `+help` → also expect the
      command to run (server commands work in PM tab too — same code
      path as main chat in this client)

## Risk

`core/hub.lua` is the central hot path; this change is in the hubbot's
EMSG handler and runs on every PM addressed to the bot. The added work
is one `string.match` per EMSG. Negligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)