### PR TITLE
build: make Windows build reproducible (env vars, sanity checks, no pauses)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,12 +133,15 @@ The script builds in order: lua → adclib → slnunicode → luasocket → luas
 compile_with_mingw.bat
 ```
 
-**Hardcoded paths in the batch file** (flag for Phase 1 review):
-- `C:\MinGW`
-- `C:\OpenSSL`
+The toolchain locations are read from `LUADCH_MINGW_DIR` and `LUADCH_OPENSSL_DIR`
+(defaults: `C:\MinGW`, `C:\OpenSSL`). If either is missing the script prints a
+clear error before any compilation runs.
 
-The Windows build renames Unix-only socket sources to `*.c.not` to exclude them — this
-is fragile and Phase 1 should consider unifying via CMake.
+The Windows build still uses a `*.c.not` rename trick to exclude Unix-only
+LuaSocket sources. That goes away with the CMake migration (issue #15).
+
+**Full toolchain setup (download links, OpenSSL cross-compile, custom paths):
+see [`docs/BUILDING.md`](docs/BUILDING.md).**
 
 ### First-time login
 

--- a/compile_with_mingw.bat
+++ b/compile_with_mingw.bat
@@ -1,17 +1,73 @@
 rem @echo off
 
-@echo Howto setup MinGW compiler and OpenSSL on x64 Windows:
-@echo 1) Install MinGW-w64 to C:\MinGW, add "C:\MinGW\bin" to your PATH
-@echo 2) Cross compile OpenSSL libraries on Linux:
-@echo `sudo apt-get install mingw-w64`
-@echo `git clone https://github.com/openssl/openssl.git`
-@echo `./Configure --cross-compile-prefix=x86_64-w64-mingw32- mingw64`
-@echo `make`
-@echo 3) Copy OpenSSL to C:\OpenSSL
-@pause
+rem ============================================================================
+rem  luadch Windows build script (MinGW-w64 + OpenSSL 3.x)
+rem
+rem  Toolchain locations are read from environment variables, with the legacy
+rem  hardcoded paths as defaults so existing setups keep working untouched:
+rem
+rem      LUADCH_MINGW_DIR    default: C:\MinGW
+rem                          must contain bin\gcc.exe
+rem
+rem      LUADCH_OPENSSL_DIR  default: C:\OpenSSL
+rem                          must contain include\openssl\ssl.h,
+rem                          libssl-3-x64.dll, libcrypto-3-x64.dll
+rem
+rem  Run from the repo root. Output: build_mingw\luadch\
+rem  Full setup instructions: docs\BUILDING.md
+rem ============================================================================
 
-set openssl_headers=C:\OpenSSL\include
-set openssl_libs=C:\OpenSSL
+if not defined LUADCH_MINGW_DIR    set "LUADCH_MINGW_DIR=C:\MinGW"
+if not defined LUADCH_OPENSSL_DIR  set "LUADCH_OPENSSL_DIR=C:\OpenSSL"
+
+set "openssl_headers=%LUADCH_OPENSSL_DIR%\include"
+set "openssl_libs=%LUADCH_OPENSSL_DIR%"
+set "PATH=%LUADCH_MINGW_DIR%\bin;%PATH%"
+
+rem -- Sanity checks: fail loudly with actionable messages -----------------------
+
+if not exist "%LUADCH_MINGW_DIR%\bin\gcc.exe" (
+    echo.
+    echo ERROR: MinGW gcc.exe not found at "%LUADCH_MINGW_DIR%\bin\gcc.exe"
+    echo.
+    echo Install MinGW-w64 from https://winlibs.com/ and either:
+    echo   - place it at C:\MinGW so that C:\MinGW\bin\gcc.exe exists, OR
+    echo   - set LUADCH_MINGW_DIR to your install root before running this script.
+    echo.
+    echo See docs\BUILDING.md for the full setup walkthrough.
+    echo.
+    exit /b 1
+)
+
+if not exist "%openssl_headers%\openssl\ssl.h" (
+    echo.
+    echo ERROR: OpenSSL headers not found at "%openssl_headers%\openssl\ssl.h"
+    echo.
+    echo Place an OpenSSL 3.x x64 build at "%LUADCH_OPENSSL_DIR%" so that:
+    echo   "%LUADCH_OPENSSL_DIR%\include\openssl\ssl.h"  exists, AND
+    echo   "%LUADCH_OPENSSL_DIR%\libssl-3-x64.dll"        exists, AND
+    echo   "%LUADCH_OPENSSL_DIR%\libcrypto-3-x64.dll"     exists.
+    echo.
+    echo Override the location via LUADCH_OPENSSL_DIR. See docs\BUILDING.md.
+    echo.
+    exit /b 1
+)
+
+if not exist "%openssl_libs%\libssl-3-x64.dll" (
+    echo.
+    echo ERROR: libssl-3-x64.dll not found at "%openssl_libs%\libssl-3-x64.dll"
+    echo See docs\BUILDING.md for OpenSSL setup instructions.
+    echo.
+    exit /b 1
+)
+
+if not exist "%openssl_libs%\libcrypto-3-x64.dll" (
+    echo.
+    echo ERROR: libcrypto-3-x64.dll not found at "%openssl_libs%\libcrypto-3-x64.dll"
+    echo See docs\BUILDING.md for OpenSSL setup instructions.
+    echo.
+    exit /b 1
+)
 
 set root=%cd%
 set build=%root%\build_mingw
@@ -109,8 +165,6 @@ cd %root%\luasec\src\
 del *.dll
 del *.o
 
-@pause
-
 cd %root%\basexx
 @echo Copy core...
 xcopy basexx.lua "%hub%\lib\basexx\*.*" /y /f
@@ -126,5 +180,3 @@ mkdir log
 cd %root%
 
 @echo Building done.
-
-@pause

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -1,0 +1,190 @@
+# Building luadch
+
+This document describes how to build luadch from source on Linux, BSD, and
+Windows. For a quick reminder of the build commands without the toolchain
+setup, see [`CLAUDE.md`](../CLAUDE.md) §4.
+
+---
+
+## Linux / BSD
+
+### Prerequisites
+
+```sh
+# Debian / Ubuntu
+sudo apt-get install build-essential libssl-dev rsync git
+
+# Fedora / RHEL
+sudo dnf install gcc gcc-c++ make openssl-devel rsync git
+
+# FreeBSD / OpenBSD
+pkg install gcc rsync git    # OpenSSL is in base
+```
+
+### Build
+
+```sh
+git clone https://github.com/Aybook/luadch.git
+cd luadch
+./compile
+```
+
+Output lands in `build_$CC/luadch/` (e.g. `build_gcc/luadch/`).
+
+To clean everything:
+
+```sh
+./cleanall
+```
+
+### Run
+
+```sh
+cd build_gcc/luadch
+./luadch
+```
+
+The hub binds plain ADC on port 5000. To enable TLS on port 5001, run
+`certs/make_cert.sh` once (in the build output dir) before starting.
+
+---
+
+## Windows (MinGW-w64 + OpenSSL 3.x)
+
+### Required toolchain
+
+luadch builds on Windows via MinGW-w64 (gcc, g++, windres, strip). It does
+not require Visual Studio.
+
+| Tool        | Used for                                    |
+|-------------|---------------------------------------------|
+| MinGW-w64   | C/C++ compilation, linking, resource compile |
+| OpenSSL 3.x | LuaSec links against `libssl` / `libcrypto` |
+
+### 1. Install MinGW-w64
+
+The simplest distribution is **WinLibs** (https://winlibs.com/) — a single
+zip containing MinGW-w64 with `gcc`, `g++`, `windres`, `strip`, plus
+`mingw32-make`. No installer, just unzip.
+
+Recommended:
+- Download **GCC 13.x or newer**, **x86_64**, **POSIX threads**, **SEH**
+  exception model.
+- Extract the archive so that `gcc.exe` lives at:
+
+  ```
+  C:\MinGW\bin\gcc.exe
+  ```
+
+  (any other location works too — see "Custom paths" below).
+
+Verify:
+
+```cmd
+C:\MinGW\bin\gcc.exe --version
+```
+
+### 2. Provide OpenSSL 3.x DLLs and headers
+
+`compile_with_mingw.bat` expects to find at `C:\OpenSSL\`:
+
+```
+C:\OpenSSL\include\openssl\ssl.h
+C:\OpenSSL\libssl-3-x64.dll
+C:\OpenSSL\libcrypto-3-x64.dll
+```
+
+(plus the rest of the `include\openssl\*.h` headers).
+
+There are several ways to obtain these:
+
+**Option A — cross-compile on Linux/WSL** (matches what the project has
+historically used; produces clean, vendor-neutral DLLs):
+
+```sh
+sudo apt-get install mingw-w64
+git clone https://github.com/openssl/openssl.git
+cd openssl
+git checkout openssl-3.4.0   # or current 3.x LTS
+./Configure --cross-compile-prefix=x86_64-w64-mingw32- mingw64 \
+            --prefix=$PWD/dist
+make -j$(nproc)
+make install
+```
+
+Then copy from `dist/` on the Linux side to `C:\OpenSSL\` on Windows:
+
+```sh
+mkdir -p /mnt/c/OpenSSL
+cp -r dist/include/openssl /mnt/c/OpenSSL/include/
+cp dist/bin/libssl-3-x64.dll /mnt/c/OpenSSL/
+cp dist/bin/libcrypto-3-x64.dll /mnt/c/OpenSSL/
+```
+
+**Option B — pre-built distribution** (faster but third-party):
+
+Sources like Shining Light Productions (slproweb.com) ship Windows
+OpenSSL builds. Download the **MinGW** flavour (not the MSVC one) and
+arrange the files into the layout shown above.
+
+### 3. Build
+
+From the repository root:
+
+```cmd
+compile_with_mingw.bat
+```
+
+Output lands in `build_mingw\luadch\`.
+
+### Custom paths
+
+If your toolchain is **not** at `C:\MinGW` and `C:\OpenSSL`, set
+environment variables before running the script:
+
+```cmd
+set LUADCH_MINGW_DIR=D:\Tools\winlibs-mingw64
+set LUADCH_OPENSSL_DIR=D:\Tools\openssl-3.4-mingw
+compile_with_mingw.bat
+```
+
+These can also be set persistently via `setx LUADCH_MINGW_DIR …` or via
+**System Properties → Environment Variables**.
+
+### Sanity checks
+
+If the script can't find any of `gcc.exe`, the OpenSSL header, or the
+two OpenSSL DLLs, it exits with a clear error message naming the missing
+file and the env-var that overrides its location. There is no need to
+hunt through the build output.
+
+### Run
+
+After a successful build:
+
+```cmd
+cd build_mingw\luadch
+Luadch.exe
+```
+
+Plain ADC on port 5000, optional TLS on port 5001 once
+`certs\make_cert.bat` has been run once.
+
+---
+
+## Cross-platform notes
+
+- The build output layout is identical between Linux and Windows except
+  that Linux produces `luadch` / `liblua.so` / `*.so` and Windows produces
+  `Luadch.exe` / `lua.dll` / `*.dll`. See
+  [`docs/phases/PHASE_1.md`](phases/PHASE_1.md) §3 for the authoritative
+  artifact list.
+
+- The `*.c.not` rename trick in the Windows build (around the LuaSocket
+  step) is a known workaround for excluding Unix-only sources. It will
+  go away with the planned CMake migration (see
+  [issue #15](https://github.com/Aybook/luadch/issues/15)).
+
+- For continuous integration setups, the same env-var approach above
+  works in GitHub Actions / GitLab CI / etc. — pin both vars in your
+  workflow definition and the rest is reproducible.


### PR DESCRIPTION
## Summary

Closes #14.

The previous `compile_with_mingw.bat` hardcoded `C:\MinGW` and
`C:\OpenSSL`, gave cryptic mid-build errors when the toolchain was
elsewhere or missing, and called `@pause` twice — blocking unattended
or CI use. This PR makes the script reproducible without changing the
default behavior for anyone whose tools already live at the legacy paths.

## What changes

### `compile_with_mingw.bat`

- **Env vars**: `LUADCH_MINGW_DIR` and `LUADCH_OPENSSL_DIR` override the
  default paths (`C:\MinGW`, `C:\OpenSSL`). Defaults are preserved, so
  existing setups keep working untouched.
- **Sanity checks**: up-front, the script verifies that `gcc.exe`, the
  OpenSSL header, and the two OpenSSL DLLs all exist. If any is missing
  it exits with a message naming the missing file and the env var that
  overrides its location.
- **Removed two `@pause` calls** (mid-script after `ssl.dll`, and at
  end). The build now runs non-interactively, which is required for any
  CI or scripted workflow. Removed the obsolete instructional header
  block at the very top — the same content lives in `docs/BUILDING.md`
  at much higher fidelity.
- The `*.c.not` rename trick during the LuaSocket build is intentionally
  unchanged; it is fragile but works, and replacing it requires the
  CMake migration tracked in #15.

### `docs/BUILDING.md` (new)

Full toolchain walkthrough for Linux/BSD and Windows:

- Linux: package manager one-liner, `./compile`, run.
- Windows: WinLibs MinGW-w64 install, OpenSSL 3.x cross-compile recipe
  (matches the README pattern from upstream), env var override for
  non-default paths, sanity check semantics.
- Cross-platform notes pointing at the Phase 1 build-output spec
  ([`docs/phases/PHASE_1.md`](docs/phases/PHASE_1.md) §3) as the
  authoritative artifact list.

### `CLAUDE.md` §4

Trimmed Windows section to one paragraph + pointer at `docs/BUILDING.md`
to avoid duplication. Linux section unchanged.

## Test plan

Verified end-to-end on Windows 11 + WSL2 Ubuntu 24.04:

- [x] OpenSSL 3.5.7-dev cross-compiled in WSL via `mingw-w64`
      (`x86_64-w64-mingw32-gcc 13`), installed to `~/openssl/dist/`,
      copied to `/mnt/c/OpenSSL/`.
- [x] WinLibs MinGW-w64 / gcc 16.1.0 UCRT installed at `C:\MinGW`.
- [x] `compile_with_mingw.bat` runs to completion in ~25s, exit 0.
- [x] Sanity checks fire correctly when an env var points at a missing
      path (verified by initial run before MinGW was installed —
      script exited cleanly with the expected error).
- [x] Build emits 7 expected style warnings (gcc 16 stricter than
      gcc 13 on Linux); no compile errors.
- [x] All artifacts produced per Phase 1 build-output spec:
      `Luadch.exe`, `lua.dll`, `lib/adclib/adclib.dll`,
      `lib/unicode/unicode.dll`, `lib/luasocket/socket/socket.dll`,
      `lib/luasocket/mime/mime.dll`, `lib/luasec/ssl/ssl.dll`, plus
      the runtime tree (`core/`, `scripts/`, `cfg/`, `certs/`, `lang/`,
      `docs/`, `log/`).
- [x] `Luadch.exe` launches and binds `0.0.0.0:5000`.
- [ ] (Maintainer) Connect with AirDC++ to `adcs://127.0.0.1:5001`
      (after `certs\make_cert.bat` once).

## Out of scope (filed separately)

- **#15**: CMake migration. Will replace this script entirely and remove
  the `*.c.not` rename trick.
- **#16**: `cmd_hubinfo.lua` calls `wmic`, which was removed in Windows
  11 24H2+. Surfaced during this PR's smoketest as stderr noise on hub
  startup. Non-blocking — hub still binds and runs. Phase 6 candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)