### PR TITLE
docs: refresh README, add INSTALLING and CONFIGURATION guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,89 +1,81 @@
-# Luadch - ADC Hub Server
-[![Latest-Release](https://img.shields.io/github/v/release/luadch/luadch?include_prereleases)](https://github.com/luadch/luadch/releases)
-[![GitHub license](https://img.shields.io/badge/license-GPLv3.0-blueviolet.svg)](https://github.com/luadch/luadch/blob/master/LICENSE)
-[![Website](https://img.shields.io/website?down_message=offline&up_message=online&url=https%3A%2F%2Fluadch.github.io)](https://luadch.github.io/)
-[![Platform](https://img.shields.io/badge/platform-independent-orange.svg)](https://luadch.github.io/)
-![GitHub all releases](https://img.shields.io/github/downloads/luadch/luadch/total)
+# Luadch — DC++ ADC Hub Server
 
-## Features:
+[![License](https://img.shields.io/badge/license-GPLv3.0-blueviolet.svg)](LICENSE)
+[![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20Windows%20%7C%20ARM-orange.svg)](docs/BUILDING.md)
+[![Lua](https://img.shields.io/badge/lua-5.4-blue.svg)](https://www.lua.org/)
 
-    - Encryption, AES128 and AES256 cipher suites with TLSv1.3 support
-    - Fast, stable and small (complete server has ~3 MB)
-    - Supports ARM architecture
-    - Easy to use Lua Scripting API
-    - Many additional scripts available
-    - Comfortable rightclick menu
+A modernised fork of [luadch](https://github.com/luadch/luadch) by
+**blastbeat** and **pulsar**. Maintained by [Aybook](https://github.com/Aybook),
+with help from Claude.
 
-## To run a Luadch Hub:
+## Original Features
 
-* First of all, please read the manual: [Luadch_Manual](https://github.com/luadch/luadch/blob/master/docs/Luadch_Manual.pdf)
+- TLS 1.3 with AES-128 / AES-256 cipher suites
+- Fast, small footprint (≈ 3 MB install size)
+- ARM-compatible (Raspberry Pi, ARM servers, Apple Silicon Linux)
+- Easy-to-use Lua scripting API for plugins
+- Many bundled command and bot scripts
+- Right-click menu support in modern clients (AirDC++)
 
+## New Features
 
-* Without encryption, start the Hub and login with:
+- Soon™
+
+## What's different in this fork
+
+- Lua **5.1** (EOL since 2012) **→ 5.4.7**
+- Unmaintained `slnunicode` C module replaced by a 40-line pure-Lua shim
+  on top of Lua 5.4's builtin `utf8` library — same API, no C maintenance
+- Build system rewritten to **CMake**: one pipeline for Linux / Windows /
+  ARM (`cmake -B build && cmake --build build && cmake --install build`)
+- The `*.c.not` source-rename hack on the Windows build is gone
+- Several pre-existing bugs fixed:
+  - `os.difftime` 1-arg pattern (silently tolerated by 5.1, errors in 5.4)
+  - `cmd_hubinfo.lua` crash on missing certificate file
+  - `wmic` calls replaced with `Get-CimInstance` (Windows 11 24H2+ removed wmic)
+  - `+!#` server commands from PMs now reach the command pipeline again
+  - `make_cert.sh` no longer collides with bash's read-only `UID` builtin
+- Repo hygiene: `.gitattributes` for line endings, reproducible Windows
+  build via env vars, no more `register` C++17 warnings, dropped 1366
+  lines of unmaintained C
+
+Detail per phase in [docs/phases/](docs/phases/).
+
+## Documentation
+
+- **[docs/BUILDING.md](docs/BUILDING.md)** — build from source on
+  Linux, Windows, or ARM
+- **[docs/INSTALLING.md](docs/INSTALLING.md)** — deploy a built hub
+  (file layout, permissions, systemd, backups, updates)
+- **[docs/CONFIGURATION.md](docs/CONFIGURATION.md)** — configure the
+  hub, register users, manage plugins, set up TLS
+- [docs/Luadch_Lua_API.txt](docs/Luadch_Lua_API.txt) — plugin scripting
+  API reference (upstream-style)
+- [docs/Luadch_Manual.pdf](docs/Luadch_Manual.pdf) — original upstream
+  manual (predates this fork)
+
+## Quick start
+
+```sh
+git clone https://github.com/Aybook/luadch.git
+cd luadch
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j$(nproc)
+cmake --install build
+cd build/install/luadch && ./luadch
 ```
-    Nick: dummy
-    Password: test
-    Address: adc://127.0.0.1:5000
-```
-* With encryption:
 
-    - go to: *“certs/”* and start *“make_cert.sh”* on Linux/Unix or *“make_cert.bat”* on Windows to generate the certificates
-    - alternatively you can use the *Luadch Certmanager*
-    - after that you can login with:
-```
-       Nick: dummy
-       Password: test
-       Address: adcs://127.0.0.1:5001
-```
-3. Register an own nickname for you, there are two possibilities to do that:
+Then connect with an ADC client (e.g. AirDC++) to `adc://127.0.0.1:5000`,
+log in as `dummy` / `test`, and read [CONFIGURATION.md](docs/CONFIGURATION.md)
+for first-run steps. Windows users: see the Windows section of
+[BUILDING.md](docs/BUILDING.md).
 
-    - use rightclick menu: *User/Control/Reg*
-    - use command: *+reg nick* ```<Nick>``` ```<Level>```
+## License
 
-    Where ```<Nick>``` is your new nickname and ```<Level>``` should be the highest level *100*
+GPLv3.0 — see [LICENSE](LICENSE).
 
-4. Now delete the dummy account, there are two possibillities to do that:
+## Credits
 
-    - use rightclick menu: *User/Control/Delreg*
-    - use command: *+delreg nick* ```<Nick>```
-
-5. After this first test you should adapt the hub to your needs:
-
-    - open: *“cfg/cfg.tbl”* with a UTF-8 compatible Texteditor best with Lua syntax highlighting
-    - Read the descriptions and set the values to your need, Luadch uses a fair and reasonable default user permissions, but nevertheless you should read all
-
-6. If it's done, start your hub again and login, if he still runs there are two possibillities to enable your changes in the hub:
-
-    - use rightclick menu: *Hub/Core/Hub reload*
-    - use command: *+reload*
-
-7. If you want to set other styles for lines or something:
-
-    - go to: *“scripts/lang/”* here you can find all language files for each script, after that: *+reload*
-
-### Done
-
-
-## How to make a Win32 + Linux/Unix Hybrid version
-
-With Luadch you have the possibility to make a Hybrid version who runs on Win32 systems and one Linux/Unix system of your choice.
-This could be very useful if:
-
-- your "online" Hub runs on a Linux/Unix machine and you want to use a 1:1 copy of that for local tests on a Win32 machine.
-- your "online" Hub runs on a Win32 machine and you want to use a 1:1 copy of that for local tests on a Linux/Unix machine.
-
-Instruction:
-
-1. unzip the Win32 build to a local folder
-
-2. unzip the Linux/Unix build of your choice to a local folder
-
-3. copy the *"lib"* folder from your Linux/Unix build to your Win32 build and skip all existing files during copy process
-
-4. copy the following files from the root folder of your Linux/Unix build to the root folder of your Win32 build:
-
-    - *"liblua.so"* and *"luadch"*
-
-### Done
-
-Important: The Win32 build and the Linux/Unix build must be the same build version!
+All conceptual credit goes to **blastbeat** and **pulsar**, the original
+authors of luadch. This fork only modernises and extends their excellent
+foundation.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,251 @@
+# Configuring luadch
+
+This document covers how to configure a running hub: edit `cfg/cfg.tbl`,
+register your operator account, manage plugins, set up TLS. For getting
+the hub built and deployed in the first place, see
+[BUILDING.md](BUILDING.md) and [INSTALLING.md](INSTALLING.md).
+
+> **Status:** parts of this document are scaffolding with `TODO`
+> markers. The skeleton lays out the topics; detailed semantics for
+> individual `cfg.tbl` keys and plugins will be filled in as the
+> documentation matures.
+
+---
+
+## First-run checklist
+
+After a fresh install, before opening the hub to real users:
+
+1. **Generate TLS certs** (if you want TLS, and you do):
+   - Linux: `cd certs && ./make_cert.sh`
+   - Windows: `cd certs && make_cert.bat`
+2. **Start the hub** and connect with an ADC client:
+   - Address: `adcs://127.0.0.1:5001` (TLS) or `adc://127.0.0.1:5000` (plain)
+   - Nick: `dummy`
+   - Password: `test`
+3. **Register your own operator account**:
+   ```
+   +reg <yournick> 100
+   ```
+   Level 100 = HUBOWNER. Reconnect as that user.
+4. **Delete the dummy account**:
+   ```
+   +delreg dummy
+   ```
+   This is **not optional**. The dummy account is a hubowner with
+   public credentials.
+5. **Edit `cfg/cfg.tbl`** to your deployment (see "cfg.tbl tour" below),
+   then reload:
+   ```
+   +reload
+   ```
+
+---
+
+## File layout (configuration-relevant parts)
+
+| Path                     | What it is                                                   |
+|--------------------------|--------------------------------------------------------------|
+| `cfg/cfg.tbl`            | Main hub configuration (Lua-serialised table)                |
+| `cfg/user.tbl`           | Registered users (nick, password hash, level, …)             |
+| `cfg/user.tbl.bak`       | Rolling backup the hub maintains automatically               |
+| `lang/de.tbl`, `en.tbl`  | Hub-side strings (greeting, error messages, …)               |
+| `scripts/lang/*.lang.de` / `*.lang.en` | Per-script translations                          |
+| `scripts/data/*.tbl`     | Per-script runtime state (bans, chatlog, records, …)         |
+| `certs/`                 | TLS keys + helpers                                           |
+
+Editing rules:
+- All `.tbl` files are Lua tables. Don't open them in a UTF-16 editor.
+- Use a UTF-8 capable editor with Lua syntax highlighting.
+- After edits, run `+reload` in the hub for changes to take effect
+  (no full restart needed for cfg/script changes).
+
+---
+
+## cfg.tbl tour
+
+The shipped `cfg/cfg.tbl` has comments alongside every key. The
+high-impact ones to set on first run:
+
+```lua
+-- TODO(maintainer): expand this with the most common keys
+-- (hub_name, hub_hostaddress, hub_owner, hub_email, hub_topic,
+--  tcp_ports / ssl_ports, max_users, ssl_params.certificate / .key,
+--  scripts list, language)
+```
+
+For now, open `cfg/cfg.tbl` in your editor — every key has an inline
+explanation in the file itself.
+
+### TLS configuration
+
+After running `make_cert.{sh,bat}` once, `cfg.tbl` should already point
+at the right paths under `ssl_params`:
+
+```lua
+ssl_params = {
+    mode      = "server",
+    protocol  = "any",
+    options   = { "all", "no_sslv2", "no_sslv3", "no_tlsv1", "no_tlsv1_1" },
+    cafile    = "certs/cacert.pem",
+    certificate = "certs/servercert.pem",
+    key       = "certs/serverkey.pem",
+    verify    = { "none" },
+},
+```
+
+The verified TLS posture out of the box is **TLS 1.3 + AES-256-GCM**
+(verified during the modernization phases). Nothing else needs to be
+hardened for a default deploy.
+
+### Port configuration
+
+```lua
+tcp_ports = { 5000 },   -- plain ADC
+ssl_ports = { 5001 },   -- TLS ADC
+-- IPv6 listening currently not enabled by default — see issue #105
+```
+
+### Default account warning
+
+The bundled `[BOT]HubSecurity` script warns in main chat as long as the
+`dummy` account is still registered. **Take that warning seriously** —
+do not run a public hub with `dummy / test` active.
+
+---
+
+## User levels
+
+The hub uses an integer-based user level system. Higher levels grant
+more permissions. Bundled defaults:
+
+| Level | Name      | What it can do                              |
+|-------|-----------|---------------------------------------------|
+| 100   | HUBOWNER  | Everything (registers / deletes / shutdown) |
+| 80    | OPERATOR  | (TODO: list typical OP-level capabilities)  |
+| 60    | VIP       | (TODO)                                      |
+| 40    | REG       | Registered user, basic chat / commands      |
+| 20    | UNREG     | Anonymous connection                        |
+| 0     | BANNED    | Refused                                     |
+
+Customise per-script `minlevel` in `cfg.tbl` to grant or restrict
+specific commands.
+
+> TODO(maintainer): full level table is in
+> [docs/Luadch_Default_Levels.txt](Luadch_Default_Levels.txt) — pull the
+> authoritative list from there.
+
+---
+
+## Registering and deleting users
+
+```
++reg <nick> <level>           # register a new user at <level>
++delreg <nick>                # remove a registered user
++regme <nick> <password>      # self-register (if cfg allows it)
++setpass <newpass>            # change your own password
++accinfo <nick>               # show registration info for someone
+```
+
+`user.tbl` is updated atomically; the rolling backup `user.tbl.bak`
+captures the previous state.
+
+---
+
+## Plugins (scripts/)
+
+Plugins live in `scripts/` and are loaded at hub start in the order
+listed under `cfg.scripts` in `cfg.tbl`. Adding or removing a plugin:
+
+1. Add the `.lua` file under `scripts/` (or remove it).
+2. Edit `cfg.scripts` in `cfg/cfg.tbl` to include / exclude the
+   plugin name (without `.lua`).
+3. `+reload` to apply.
+
+### Bundled plugin categories
+
+| Prefix  | What                          | Examples                              |
+|---------|-------------------------------|---------------------------------------|
+| `cmd_`  | User chat commands            | `cmd_help`, `cmd_ban`, `cmd_uptime`   |
+| `bot_`  | Bots that appear in user list | `bot_opchat`, `bot_regchat`           |
+| `etc_`  | Background features           | `etc_chatlog`, `etc_motd`             |
+| `hub_`  | Core hub-level scripts        | `hub_runtime`, `hub_cmd_manager`      |
+| `usr_`  | Per-user constraints          | `usr_share`, `usr_slots`, `usr_uptime`|
+
+> TODO(maintainer): per-script descriptions / common configuration
+> snippets for the plugins that have non-trivial settings (`etc_motd`,
+> `etc_blacklist`, `etc_msgmanager`, …).
+
+### Writing your own plugin
+
+The plugin API is documented in
+[docs/Luadch_Lua_API.txt](Luadch_Lua_API.txt). The core hooks:
+
+- `onStart`, `onExit`
+- `onLogin`, `onFailedAuth`
+- `onBroadcast` (main chat), `onPrivateMessage`
+- `onReg`, `onDelreg`
+- `onTimer`, `onError`
+
+Register a listener with `hub.setlistener(event, id, function)`. See any
+of the bundled `cmd_*.lua` files for working examples.
+
+---
+
+## Languages
+
+Two layers:
+
+- **Hub-side strings** (`lang/de.tbl`, `lang/en.tbl`) — chosen via
+  `cfg.language` in `cfg.tbl`. Affects core hub messages.
+- **Per-script strings** (`scripts/lang/<scriptname>.lang.de` / `.lang.en`)
+  — overrides the script's default texts. Edit the file matching your
+  selected language; missing keys fall back to the script's hardcoded
+  defaults.
+
+After editing language files: `+reload`.
+
+---
+
+## Operational commands at a glance
+
+| Command            | Effect                                              |
+|--------------------|-----------------------------------------------------|
+| `+reload`          | Re-read `cfg.tbl`, reload all scripts (no restart) |
+| `+restart`         | Full hub restart                                    |
+| `+shutdown`        | Stop the hub gracefully                             |
+| `+hubinfo`         | Show OS / CPU / RAM / uptime / connected user counts |
+| `+uptime`          | Just the uptime line                                |
+| `+userlist`        | Online users                                        |
+| `+usercleaner`     | Prune stale registrations                           |
+| `+ban <nick>`      | Ban a user (see cmd_ban for full syntax)            |
+| `+gag <nick>`      | Mute a user temporarily                             |
+
+A full command list is generated in-hub by `+help`. Each registered
+plugin appends its own entries.
+
+---
+
+## Troubleshooting
+
+| Symptom                                                    | Likely cause                                                        |
+|------------------------------------------------------------|---------------------------------------------------------------------|
+| Hub starts but `[BOT]HubSecurity` keeps warning about dummy| `dummy` not yet `+delreg`'d                                         |
+| TLS port 5001 binds but client cannot connect              | Self-signed cert; accept the warning once OR generate a CA-signed cert |
+| `+help` from main chat returns "I am the Hubbot…"          | Older issue, fixed in modernization PR #13 (5.4 build only)         |
+| `wmic` errors on Windows 11 24H2+                          | Older issue, fixed in modernization PR closing #16                  |
+| `+hubinfo` crashes on `attempt to concatenate a nil value` | Older bug, fixed in modernization PR closing it                     |
+| Hub starts but does not bind ports                         | Cert path wrong in `ssl_params`, OR firewall blocking, OR another process on the port |
+
+> TODO(maintainer): expand this with deployment-specific debugging
+> patterns (systemd unit failures, log lines that point to specific
+> misconfigurations).
+
+---
+
+## Where to look for more
+
+- The shipped `cfg/cfg.tbl` itself — every key has an inline comment
+- [Luadch_Lua_API.txt](Luadch_Lua_API.txt) — the plugin API
+- [Luadch_Manual.pdf](Luadch_Manual.pdf) — original upstream manual
+- [docs/phases/](phases/) — modernization journals (what changed and why)

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -1,0 +1,275 @@
+# Installing luadch
+
+This document covers **post-build deployment** — what to do once
+[BUILDING.md](BUILDING.md) has produced a `build/install/luadch/`
+directory. For configuring the hub afterwards, see
+[CONFIGURATION.md](CONFIGURATION.md).
+
+---
+
+## What you have after a build
+
+`cmake --install build` produces a self-contained directory:
+
+```
+build/install/luadch/
+├── luadch          (Linux) or Luadch.exe (Windows) — the hub binary
+├── liblua.so       (Linux) or lua.dll (Windows)
+├── libssl-3-x64.dll, libcrypto-3-x64.dll        (Windows only)
+├── lib/                                          shared plugins (.so/.dll + .lua)
+├── core/           Lua core modules
+├── scripts/        bundled command / bot / utility scripts
+├── cfg/            cfg.tbl + user.tbl (default templates)
+├── certs/          TLS cert generation helpers
+├── lang/           hub-side language files
+├── docs/           embedded docs
+└── log/            empty; the hub writes here at runtime
+```
+
+The directory is portable — copy it anywhere on a target machine and
+run from there. There are no absolute path assumptions in the build.
+
+---
+
+## Linux deployment
+
+### Where to put the install directory
+
+Conventional choices:
+
+| Path                  | When to pick it                                       |
+|-----------------------|-------------------------------------------------------|
+| `/opt/luadch/`        | Single hub on a dedicated server                      |
+| `/srv/luadch/`        | Same as above, FHS-recommended for served data        |
+| `~/luadch/`           | Per-user hub (no root needed)                         |
+| `/var/luadch/<name>/` | Multiple hubs sharing a host                          |
+
+```sh
+# As root, deploy to /opt
+sudo cp -r build/install/luadch /opt/
+sudo chown -R luadch:luadch /opt/luadch    # see "service user" below
+```
+
+### Service user
+
+Run the hub as an unprivileged user, never as root. Create one:
+
+```sh
+sudo useradd --system --home-dir /opt/luadch --shell /usr/sbin/nologin luadch
+```
+
+### File permissions
+
+The two configuration tables hold credentials and registration state.
+Tighten their permissions so other local users on the host cannot read
+them:
+
+```sh
+sudo chmod 600 /opt/luadch/cfg/user.tbl
+sudo chmod 600 /opt/luadch/cfg/cfg.tbl     # contains the dummy default password
+```
+
+The `log/` directory must be writable by the service user:
+
+```sh
+sudo chmod 750 /opt/luadch/log
+```
+
+Everything else (`core/`, `scripts/`, `lib/`, …) can stay read-only for
+the service user — the hub does not modify its own code at runtime.
+
+### systemd unit
+
+Drop this into `/etc/systemd/system/luadch.service`:
+
+```ini
+[Unit]
+Description=Luadch ADC Hub
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=luadch
+Group=luadch
+WorkingDirectory=/opt/luadch
+ExecStart=/opt/luadch/luadch
+Restart=on-failure
+RestartSec=5
+
+# Hardening (optional but recommended)
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/opt/luadch/log /opt/luadch/cfg /opt/luadch/scripts/data
+ProtectHome=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`WorkingDirectory=` is mandatory — the hub uses CWD-relative paths
+internally. If you skip it, the hub will fail to find `core/init.lua`.
+(Issue [#12](https://github.com/Aybook/luadch/issues/12) tracks
+removing this constraint in Phase 6.)
+
+Enable and start:
+
+```sh
+sudo systemctl daemon-reload
+sudo systemctl enable --now luadch
+sudo systemctl status luadch
+```
+
+### Logs
+
+The hub writes to `log/` inside the install directory. systemd captures
+stdout / stderr separately via journald:
+
+```sh
+sudo journalctl -u luadch -f          # live
+sudo journalctl -u luadch --since today
+```
+
+### Network / firewall
+
+- TCP **5000** — plain ADC (`adc://`)
+- TCP **5001** — TLS ADC (`adcs://`)
+
+Open whichever you actually use. For a public hub, you almost certainly
+only want TLS:
+
+```sh
+# UFW
+sudo ufw allow 5001/tcp
+
+# firewalld
+sudo firewall-cmd --add-port=5001/tcp --permanent
+sudo firewall-cmd --reload
+```
+
+If your hub is behind NAT, port-forward the same port to the host.
+
+---
+
+## Windows deployment
+
+### Where to put the install directory
+
+`C:\luadch\` or `D:\luadch\` works. The hub's only requirement is that
+its working directory at launch time is the install root.
+
+### Run as a service
+
+Windows does not natively run console executables as services. Use
+[NSSM](https://nssm.cc/) (the Non-Sucking Service Manager):
+
+```cmd
+:: install
+nssm install luadch C:\luadch\Luadch.exe
+nssm set luadch AppDirectory C:\luadch
+nssm set luadch DisplayName "Luadch ADC Hub"
+nssm set luadch Description "DC++ ADC hub server"
+nssm set luadch Start SERVICE_AUTO_START
+nssm set luadch AppStdout C:\luadch\log\stdout.log
+nssm set luadch AppStderr C:\luadch\log\stderr.log
+
+:: start it
+nssm start luadch
+```
+
+Manage afterwards via `services.msc` or `nssm restart luadch` etc.
+
+### Windows Defender / firewall
+
+Allow the binary on the firewall the first time you run it
+(`netsh advfirewall firewall add rule name="Luadch ADCS" dir=in
+action=allow protocol=TCP localport=5001`). If Defender quarantines
+`Luadch.exe` on a corporate-managed machine, add a path exclusion for
+`C:\luadch\`.
+
+---
+
+## Backups
+
+What is worth backing up:
+
+| Path                       | Why                                    |
+|----------------------------|----------------------------------------|
+| `cfg/cfg.tbl`              | hub configuration, edited by you       |
+| `cfg/user.tbl`             | registered users + hashed credentials  |
+| `cfg/user.tbl.bak`         | rolling backup the hub maintains itself|
+| `scripts/data/*.tbl`       | per-script state (bans, chatlog, etc.) |
+| `certs/cacert.pem`, `serverkey.pem`, `servercert.pem` | TLS keys; users will see a different keyprint after a regen |
+
+Everything else (`core/`, `scripts/*.lua`, `lib/`, `lang/`) reproduces
+from a fresh build.
+
+Rsync-style nightly backup script template:
+
+```sh
+#!/bin/sh
+set -eu
+DST=/var/backups/luadch
+mkdir -p "$DST"
+rsync -a --delete /opt/luadch/cfg/        "$DST"/cfg/
+rsync -a --delete /opt/luadch/certs/      "$DST"/certs/
+rsync -a --delete /opt/luadch/scripts/data/ "$DST"/scripts-data/
+```
+
+---
+
+## Updating the hub
+
+When you pull new code and rebuild:
+
+```sh
+# 1. New build
+git pull
+cmake --build build -j$(nproc)
+cmake --install build              # writes to build/install/luadch/
+
+# 2. Stop the running hub
+sudo systemctl stop luadch
+
+# 3. Replace the read-only parts only — keep cfg/, certs/, scripts/data/, log/
+sudo rsync -a --delete \
+    --exclude='/cfg/' --exclude='/certs/' --exclude='/log/' \
+    --exclude='/scripts/data/' \
+    build/install/luadch/ /opt/luadch/
+
+# 4. Restart
+sudo systemctl start luadch
+```
+
+The exclude list is the contract: those are the directories the
+running hub considers state, and the new build's defaults must not
+clobber them.
+
+If a release notes mentions a `cfg/cfg.tbl` migration, copy any new
+keys from `build/install/luadch/cfg/cfg.tbl` into `/opt/luadch/cfg/cfg.tbl`
+manually before restarting.
+
+---
+
+## Verifying the install
+
+Once running:
+
+```sh
+# port bound?
+ss -tln | grep -E ':500[01]'
+
+# hub responding to ADC handshake?
+printf 'HSUP ADBASE ADTIGR\n' | nc -q1 127.0.0.1 5000 | head
+# Expect: ISUP ... / ISID ... / IINF ...
+
+# active sessions (after first connect)
+grep -c "init.lua" /opt/luadch/log/*.log    # rough heartbeat
+```
+
+Then point an ADC client (e.g. AirDC++) at `adcs://your.host:5001` (TLS)
+or `adc://your.host:5000` (plain) and log in as `dummy` / `test` for the
+first time. Read [CONFIGURATION.md](CONFIGURATION.md) for the
+register-yourself / delete-dummy steps **before** opening the hub to
+real users.


### PR DESCRIPTION
Inter-phase documentation pass requested by the maintainer.

## What's in here

### `README.md`
Rewritten to reflect the fork's status:

- Original-vs-fork feature split
- "What's different in this fork" — concrete list of the modernization
  improvements from Phases 1-5
- Documentation table linking BUILDING / INSTALLING / CONFIGURATION /
  Lua API reference / phase journals
- Five-line quick-start block (`cmake … && cmake --install`)
- Badges repointed at this fork
- "Soon™" placeholder kept per the maintainer's request

### `docs/INSTALLING.md` (new)
Post-build deployment guide. Substantial; covers:

- Linux: install paths convention, service-user creation, file
  permissions (`chmod 600` for `cfg/user.tbl` and `cfg/cfg.tbl`),
  systemd unit template with hardening flags, journalctl usage,
  firewall snippets (ufw / firewalld)
- Windows: NSSM-based service install, Defender / firewall notes
- Backup strategy: identifies which paths are state (`cfg/`,
  `certs/`, `scripts/data/`) vs. which reproduce from a fresh build
- Update procedure with the correct `rsync` exclude set
- Verifying-the-install section (port bound, ADC handshake check)

### `docs/CONFIGURATION.md` (new, partial)
First-run + day-to-day configuration. Skeleton is complete; several
sections are explicitly `TODO`-marked for maintainer-domain knowledge
that the modernization work did not touch:

- First-run checklist (TLS cert gen → register self → delete dummy →
  reload)
- File-layout cheat sheet for `cfg/`, `lang/`, `scripts/`, `certs/`
- `cfg.tbl` tour (TODO: per-key explanations beyond what is in the
  bundled file's inline comments)
- User-level table pulled from `Luadch_Default_Levels.txt`
- Plugin-category map (`cmd_` / `bot_` / `etc_` / `hub_` / `usr_`)
- Language-file mechanics
- Operational commands cheat sheet
- Troubleshooting matrix (existing fixes from the modernization PRs
  + space for deployment-specific issues)
- TODO markers where the maintainer's deployment experience can fill
  in the gaps

## Out of scope

- Wiki migration (decided against during planning — files stay in repo
  for versioning + offline access)
- Translations of the new docs into German (English-first per the
  Working Agreement §1.6)

## No code or build changes

Pure docs PR. Builds, tests, and the runtime are not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)