### PR TITLE
fix: correct cmd_delreg help text fallback

### DIFF
--- a/scripts/cmd_delreg.lua
+++ b/scripts/cmd_delreg.lua
@@ -151,7 +151,7 @@ local msg_notfound = lang.msg_notfound or "[ DELREG ]--> User is not registered.
 
 local help_title = lang.help_title or "delreg"
 local help_usage = lang.help_usage or "[+!#]delreg nick <NICK>  /  or del with blacklist entry:  [+!#]delreg nick <NICK> <DESCRIPTION>"
-local help_desc = lang.help_desc or "delregs a new user by nick or cid"
+local help_desc = lang.help_desc or "delregs an existing user by nick or cid"
 
 local ucmd_menu_ct1 = lang.ucmd_menu_ct1 or { "User", "Control", "Delreg", "by NICK" }
 local ucmd_menu_ct2 = lang.ucmd_menu_ct2 or { "Delreg", "OK" }


### PR DESCRIPTION
## Summary

- Inline English fallback for `help_desc` in `cmd_delreg.lua` said "delregs a new user", which is misleading — `+delreg` only operates on already-registered users.
- Changed to "delregs an existing user by nick or cid" to match the existing `.lang.en` / `.lang.de` strings.

Closes #22. Mirrors upstream luadch/luadch#227.

## Test plan

- [ ] `+help` in hub shows correct description for `delreg` (visible only when no localised string is set)
- [ ] `+delreg <existing-nick>` still works
- [ ] `+delreg <unknown-nick>` still returns `[ DELREG ]--> User is not registered.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)