### PR TITLE
fix: guard reg_date in cmd_usercleaner ghosts branch

### DIFF
--- a/scripts/cmd_usercleaner.lua
+++ b/scripts/cmd_usercleaner.lua
@@ -317,7 +317,7 @@ local checkUsers = function( all, expired, ghosts, level )
                 if ( not user_lastseen ) and user_lastconnect and ( user_lastconnect >= expired_days ) then users[ user_tbl[ i ].nick ] = user_lastconnect end
             end
             if ghosts then --> List of all expired offline accounts who never been used, sorted by reg time in days
-                if ( not user_lastseen ) and ( not user_lastconnect ) and ( reg_date >= expired_days ) then users[ user_tbl[ i ].nick ] = reg_date end
+                if ( not user_lastseen ) and ( not user_lastconnect ) and reg_date and ( reg_date >= expired_days ) then users[ user_tbl[ i ].nick ] = reg_date end
             end
             if level then
                 users[ user_tbl[ i ].nick ] = user_tbl[ i ].level


### PR DESCRIPTION
## Summary

- \`+usercleaner showghosts\` crashed with \`attempt to compare number with boolean\` whenever any registered user lacked a \`date\` attribute.
- Root cause: \`getTime()\` returns \`false\` for missing/invalid input. The ghosts branch was the only one missing the guard that the neighbouring \`expired\` branches already had.
- Added \`reg_date and\` to the condition so dateless users are skipped instead of crashing the comparison.

Closes #24. Mirrors upstream luadch/luadch#234.

## Test plan

- [x] \`+usercleaner showghosts\` runs without error on a hub with at least one dateless registration
- [x] Users with valid \`date\`, no \`lastseen\`, no \`lastconnect\`, and \`reg_date >= expired_days\` are still listed as ghosts
- [x] Other modes (\`showall\`, \`showexpired\`, \`showlevel\`) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)