### PR TITLE
fix: usr_uptime crash on first login after data file loss

### DIFF
--- a/scripts/usr_uptime.lua
+++ b/scripts/usr_uptime.lua
@@ -136,19 +136,18 @@ local new_entry = function( user )
             uptime_tbl = {}
             util.savetable( uptime_tbl, "uptime", uptime_file )
             if opchat then opchat.feed( msg_err ) end
-        else
-            local month, year = tonumber( os.date( "%m" ) ), tonumber( os.date( "%Y" ) )
-            if type( uptime_tbl[ user:firstnick() ] ) == "nil" then
-                uptime_tbl[ user:firstnick() ] = {}
-            end
-            if type( uptime_tbl[ user:firstnick() ][ year ] ) == "nil" then
-                uptime_tbl[ user:firstnick() ][ year ] = {}
-            end
-            if type( uptime_tbl[ user:firstnick() ][ year ][ month ] ) == "nil" then
-                uptime_tbl[ user:firstnick() ][ year ][ month ] = {}
-                uptime_tbl[ user:firstnick() ][ year ][ month ][ "session_start" ] = os.time()
-                uptime_tbl[ user:firstnick() ][ year ][ month ][ "complete" ] = 0
-            end
+        end
+        local month, year = tonumber( os.date( "%m" ) ), tonumber( os.date( "%Y" ) )
+        if type( uptime_tbl[ user:firstnick() ] ) == "nil" then
+            uptime_tbl[ user:firstnick() ] = {}
+        end
+        if type( uptime_tbl[ user:firstnick() ][ year ] ) == "nil" then
+            uptime_tbl[ user:firstnick() ][ year ] = {}
+        end
+        if type( uptime_tbl[ user:firstnick() ][ year ][ month ] ) == "nil" then
+            uptime_tbl[ user:firstnick() ][ year ][ month ] = {}
+            uptime_tbl[ user:firstnick() ][ year ][ month ][ "session_start" ] = os.time()
+            uptime_tbl[ user:firstnick() ][ year ][ month ][ "complete" ] = 0
         end
     end
 end


### PR DESCRIPTION
## Summary

- \`usr_uptime.lua\` crashed on the first user login after the database file was missing or unparseable.
- Cause: \`new_entry()\` had an if/else that returned early on the recovery path, leaving \`uptime_tbl\` empty before \`set_start\` tried to index it.
- Drop the \`else\` so the entry setup runs unconditionally after the optional nil-init.

Closes #26. Mirrors upstream luadch/luadch#199.

## Test plan

- [x] Delete \`scripts/data/usr_uptime.tbl\`, start hub, log in - no crash, file is recreated with valid content
- [x] Log in again on the same day - uptime entries continue to accumulate
- [ ] Log in across a month boundary - new month entry is created cleanly
- [x] \`+useruptime\` shows correct stats afterwards

🤖 Generated with [Claude Code](https://claude.com/claude-code)