### PR TITLE
fix: relay delreg reason to deleted user

### DIFF
--- a/scripts/cmd_delreg.lua
+++ b/scripts/cmd_delreg.lua
@@ -144,6 +144,7 @@ local msg_reason = lang.msg_reason or "No reason."
 local msg_usage = lang.msg_usage or "Usage: [+!#]delreg nick <NICK>  /  or del with blacklist entry:  [+!#]delreg nick <NICK> <DESCRIPTION>"
 local msg_error = lang.msg_error or "[ DELREG ]--> An error occured: "
 local msg_del = lang.msg_del or "[ DELREG ]--> You were delregged."
+local msg_del_reason = lang.msg_del_reason or "[ DELREG ]--> You were delregged. Reason: %s"
 local msg_bot = lang.msg_bot or "[ DELREG ]--> User is a bot."
 local msg_ok = lang.msg_ok or "[ DELREG ]--> User  %s  was delregged by  %s"
 local msg_ok2 = lang.msg_ok2 or "[ DELREG ]--> User  %s  was delregged and blacklisted by  %s  reason: %s"
@@ -279,7 +280,10 @@ local onbmsg = function( user, command, parameters )
         user:reply( message, hub.getbot() )
         report.send( report_activate, report_hubbot, report_opchat, llevel, message )
         --// if target is online: disconnect
-        if target then target:kill( "ISTA 230 " .. hub.escapeto( msg_del ) .. "\n", "TL-1" ) end
+        if target then
+            local del_msg = ( reason ~= "" ) and utf.format( msg_del_reason, reason ) or msg_del
+            target:kill( "ISTA 230 " .. hub.escapeto( del_msg ) .. "\n", "TL-1" )
+        end
         --// refresh "cfg/user.tbl.bak"
         cfg.checkusers()
     end

--- a/scripts/lang/cmd_delreg.lang.de
+++ b/scripts/lang/cmd_delreg.lang.de
@@ -4,6 +4,7 @@
     msg_usage = "Gebrauch: [+!#]delreg nick <NICK>  /  oder löschen mit Blacklist Eintrag:  [+!#]delreg nick <NICK> <DESCRIPTION>",
     msg_error = "[ DELREG ]--> Ein Fehler ist aufgetreten: ",
     msg_del = "[ DELREG ]--> Du wurdest gelöscht.",
+    msg_del_reason = "[ DELREG ]--> Du wurdest gelöscht. Grund: %s",
     msg_bot = "[ DELREG ]--> User ist ein Bot.",
     msg_ok = "[ DELREG ]--> User:  %s  wurde gelöscht von:  %s",
     msg_ok2 = "[ DELREG ]--> User:  %s  wurde gelöscht und zur Blacklist hinzugefügt von:  %s  |  Grund: %s",

--- a/scripts/lang/cmd_delreg.lang.en
+++ b/scripts/lang/cmd_delreg.lang.en
@@ -4,6 +4,7 @@
     msg_usage = "Usage: [+!#]delreg nick <NICK>  /  or del with blacklist entry:  [+!#]delreg nick <NICK> <DESCRIPTION>",
     msg_error = "[ DELREG ]--> An error occured: ",
     msg_del = "[ DELREG ]--> You were delregged.",
+    msg_del_reason = "[ DELREG ]--> You were delregged. Reason: %s",
     msg_bot = "[ DELREG ]--> User is a bot.",
     msg_ok = "[ DELREG ]--> User:  %s  was delregged by:  %s",
     msg_ok2 = "[ DELREG ]--> User:  %s  was delregged and blacklisted by:  %s  |  reason: %s",


### PR DESCRIPTION
## Summary

- \`+delreg <nick> <reason>\` previously only logged the reason locally (OPchat / report / blacklist) — the deleted user saw a generic \"You were delregged.\" with no explanation.
- Added a new \`msg_del_reason\` template (\`scripts/cmd_delreg.lua\` + \`lang.en\` + \`lang.de\`) and pick it when reason is non-empty, otherwise keep the plain \`msg_del\`.

Closes #28. Mirrors upstream luadch/luadch#195.

## Test plan

- [x] \`+delreg nick <user> for spamming\` — target client shows \`[ DELREG ]--> You were delregged. Reason: for spamming\` before disconnect
- [x] \`+delreg nick <user>\` (no reason) — target sees the original \`[ DELREG ]--> You were delregged.\`
- [x] OPchat / report / blacklist behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)