### PR TITLE
fix: make_cert.bat works on OpenSSL 3.5+

### DIFF
--- a/examples/certs/make_cert.bat
+++ b/examples/certs/make_cert.bat
@@ -1,5 +1,8 @@
-set RANDFILE=tmp.rnd
-openssl rand -hex 16 -out uid.txt
+@echo off
+REM Random Common Name so different deploys don't share a fingerprint.
+REM OpenSSL 3.x is strict about argument order: the positional <num>
+REM must follow all options (e.g. -out file, -hex), not precede them.
+openssl rand -hex -out uid.txt 16
 (set /p uid=)<uid.txt
 openssl ecparam -out cakey.pem -name prime256v1 -genkey
 openssl req -new -x509 -days 3650 -key cakey.pem -out cacert.pem -subj /CN=%uid%
@@ -7,5 +10,4 @@ openssl ecparam -out serverkey.pem -name prime256v1 -genkey
 openssl req -new -key serverkey.pem -out servercert.pem -subj /CN=%uid%
 openssl x509 -req -days 3650 -in servercert.pem -CA cacert.pem -CAkey cakey.pem -set_serial 01 -out servercert.pem
 del uid.txt
-del tmp.rnd
 pause


### PR DESCRIPTION
## Summary

- \`certs/make_cert.bat\` silently produced certs with an empty CN on OpenSSL 3.5+ (Git for Windows current, ShiningLight LTS).
- Cause: OpenSSL 3.5+ rejects \`openssl rand -hex 16 -out uid.txt\` because positional \`<num>\` must follow all options.
- Reordered to \`openssl rand -hex -out uid.txt 16\`. While there: \`@echo off\` for cleaner output, dropped \`RANDFILE\` 1.0.x legacy.

Closes #30. Verified locally: random CN like \`CN=f8ed1dea03a3a5f275c61840ff00b7b4\`.

## Test plan

- [x] On Windows with Git-for-Windows OpenSSL 3.5.6: \`cd certs && make_cert.bat\` runs without errors
- [x] \`openssl x509 -in servercert.pem -noout -subject\` shows a non-empty random hex CN
- [x] Two consecutive runs produce different CNs
- [x] Linux \`make_cert.sh\` is unchanged and still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)