### PR TITLE
fix: block main-chat broadcasts during shutdown/restart countdown

### DIFF
--- a/scripts/cmd_restart.lua
+++ b/scripts/cmd_restart.lua
@@ -207,6 +207,17 @@ end
 
 local in_progress = false
 
+-- Block main-chat broadcasts once a restart is queued: the hub will be
+-- down in seconds, and the existing countdown messages are bot output
+-- (not subject to onBroadcast) so the visual countdown remains visible.
+hub.setlistener( "onBroadcast", { },
+    function( )
+        if in_progress then
+            return PROCESSED
+        end
+    end
+)
+
 local onbmsg = function( user, command, parameters )
     if not permission[ user:level() ] then
         user:reply( msg_denied, hub.getbot() )

--- a/scripts/cmd_shutdown.lua
+++ b/scripts/cmd_shutdown.lua
@@ -203,6 +203,17 @@ end
 
 local in_progress = false
 
+-- Block main-chat broadcasts once a shutdown is queued: the hub will be
+-- down in seconds, and the existing countdown messages are bot output
+-- (not subject to onBroadcast) so the visual countdown remains visible.
+hub.setlistener( "onBroadcast", { },
+    function( )
+        if in_progress then
+            return PROCESSED
+        end
+    end
+)
+
 local onbmsg = function( user, command, parameters )
     if not permission[ user:level() ] then
         user:reply( msg_denied, hub.getbot() )


### PR DESCRIPTION
## Summary

- During the \`+shutdown\` / \`+restart\` 10-second countdown, users could still type in main and have their messages broadcast.
- Added an \`onBroadcast\` listener to both scripts that returns \`PROCESSED\` while \`in_progress\` is true, swallowing user messages.
- Bot countdown digits use \`hub.broadcast(..., hub.getbot())\` which doesn't fire \`onBroadcast\`, so the visual countdown remains visible.
- Both \`cmd_shutdown.lua\` and \`cmd_restart.lua\` had the same defect by inspection - fixed together per CLAUDE.md §1.1.

Closes #32. Mirrors upstream luadch/luadch#242.

## Test plan

- [x] Issue \`+shutdown\` as HUBOWNER, watch countdown - user main-chat input is silently swallowed
- [x] Same with \`+restart\`
- [x] Countdown ASCII digits (\`####\` etc.) still show in main during the count
- [x] Issuing \`+shutdown\` again during countdown is ignored (no error, no re-trigger)
- [x] Hub exits/restarts cleanly at end of countdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)