### PR TITLE
release: prepare v3.0.0 (CMake binaries, CHANGELOG, GH Actions)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,6 +28,11 @@ makefile    text eol=lf
 *.md        text eol=lf
 *.txt       text eol=lf
 
+# CI / config: LF (GitHub Actions, YAML parsers, JSON tools all prefer LF).
+*.yml       text eol=lf
+*.yaml      text eol=lf
+*.json      text eol=lf
+
 # Windows-specific build files stay CRLF in the working tree so cmd.exe and
 # the Windows native tools handle them as expected.
 *.bat       text eol=crlf

--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,0 +1,68 @@
+# Luadch v3.0.0
+
+First release of the modernised `Aybook/luadch` fork.
+
+## Highlights
+
+- **Lua 5.1 -> 5.4** (5.1 reached EOL in 2012)
+- **Single CMake build** for Linux, Windows, and ARM aarch64
+- **Pre-built binaries** for Linux x86_64 and Windows x86_64 attached below
+- TLS 1.3 + AES-256-GCM verified end-to-end
+- Three new docs: `BUILDING.md`, `INSTALLING.md`, `CONFIGURATION.md`
+- Six bug fixes from the upstream tracker plus several local discoveries
+
+## Downloads
+
+| File | Platform |
+|---|---|
+| `luadch-v3.0.0-linux-x86_64.tar.gz` | Linux glibc x86_64 |
+| `luadch-v3.0.0-windows-x86_64.zip` | Windows x86_64 (MinGW UCRT64) |
+
+Extract anywhere and run `./luadch` (Linux) or `Luadch.exe` (Windows). The
+trees are self-contained: Lua interpreter, all bundled libs (LuaSec,
+LuaSocket, basexx, adclib), default configs, scripts, certs helpers.
+
+Default plain ADC port `5000`, TLS port `5001` after running
+`certs/make_cert.{sh,bat}` once. First login: nick `dummy`, password `test` -
+**delete that account immediately** after registering yourself, see
+[`docs/CONFIGURATION.md`](https://github.com/Aybook/luadch/blob/v3.0.0/docs/CONFIGURATION.md).
+
+## Breaking changes for existing deployments
+
+- **Plugin authors**: Lua 5.4 idioms required (`load` instead of
+  `loadstring`, explicit `_ENV` instead of `setfenv`, `table.unpack`
+  instead of `unpack`, `math.atan` two-arg form instead of `math.atan2`,
+  etc.).
+- **Build instructions**: now `cmake -B build && cmake --build build && cmake --install build`
+  on every platform. The legacy `compile` shell script and
+  `compile_with_mingw.bat` are gone.
+- **slnunicode**: replaced by a Lua shim. Plugins relying on Unicode-class
+  patterns (e.g. `%l` matching German umlauts) need a dedicated function
+  added to the shim - the bundled scripts use ASCII-only patterns and
+  needed no changes.
+
+## Full changelog
+
+See [`CHANGELOG.md`](https://github.com/Aybook/luadch/blob/v3.0.0/CHANGELOG.md)
+for the complete list, organised by category.
+
+## Build from source
+
+The pipeline is identical on every supported platform:
+
+```sh
+git clone --branch v3.0.0 https://github.com/Aybook/luadch.git
+cd luadch
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j
+cmake --install build
+```
+
+Output lands in `build/install/luadch/` ready to run. Windows needs
+`-G "MinGW Makefiles" -DOPENSSL_ROOT_DIR=...` extra, see
+[`docs/BUILDING.md`](https://github.com/Aybook/luadch/blob/v3.0.0/docs/BUILDING.md).
+
+## Credits
+
+All conceptual credit to **blastbeat** and **pulsar**, original authors of
+luadch. This fork modernises and extends their excellent foundation.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,14 @@ on:
 permissions:
   contents: write
 
+env:
+  # Run JavaScript-based actions on Node.js 24 instead of the default
+  # Node.js 20. GitHub will switch the default in mid-2026; setting this
+  # explicitly avoids the deprecation warning and keeps us off the
+  # to-be-removed runtime. See:
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build-linux:
     name: Build Linux x86_64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,144 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name for filename (used only for manual test runs; no GitHub release is created without a real tag push)'
+        required: false
+        default: 'v0.0.0-test'
+
+permissions:
+  contents: write
+
+jobs:
+  build-linux:
+    name: Build Linux x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake libssl-dev
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build -j"$(nproc)"
+
+      - name: Install into staging tree
+        run: cmake --install build
+
+      - name: Verify install tree
+        run: |
+          test -f build/install/luadch/luadch
+          test -f build/install/luadch/liblua.so
+          test -d build/install/luadch/scripts
+          test -d build/install/luadch/cfg
+          test -d build/install/luadch/certs
+
+      - name: Determine version tag
+        id: tag
+        run: |
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.event.inputs.tag_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Package
+        run: tar czf "luadch-${{ steps.tag.outputs.tag }}-linux-x86_64.tar.gz" -C build/install luadch
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: luadch-linux-x86_64
+          path: luadch-*-linux-x86_64.tar.gz
+          if-no-files-found: error
+
+  build-windows:
+    name: Build Windows x86_64 (MinGW UCRT64)
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-make
+            mingw-w64-ucrt-x86_64-openssl
+            zip
+
+      - name: Configure
+        run: cmake -B build -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR=/ucrt64
+
+      - name: Build
+        run: cmake --build build -j
+
+      - name: Install into staging tree
+        run: cmake --install build
+
+      - name: Verify install tree
+        run: |
+          test -f build/install/luadch/Luadch.exe
+          test -f build/install/luadch/lua.dll
+          test -f build/install/luadch/libssl-3-x64.dll
+          test -f build/install/luadch/libcrypto-3-x64.dll
+          test -d build/install/luadch/scripts
+          test -d build/install/luadch/cfg
+          test -d build/install/luadch/certs
+
+      - name: Determine version tag
+        id: tag
+        run: |
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.event.inputs.tag_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Package
+        run: |
+          cd build/install
+          zip -r "../../luadch-${{ steps.tag.outputs.tag }}-windows-x86_64.zip" luadch
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: luadch-windows-x86_64
+          path: luadch-*-windows-x86_64.zip
+          if-no-files-found: error
+
+  release:
+    name: Create GitHub release
+    needs: [build-linux, build-windows]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: List downloaded artifacts
+        run: ls -la artifacts/
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*
+          body_path: .github/release-body.md
+          draft: false
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      # Build (without creating a release) on every push to a release/*
+      # branch, so we can verify the pipeline before tagging. The release
+      # job is gated on "refs/tags/v*" so it only fires for real tag pushes.
+      - 'release/**'
   workflow_dispatch:
     inputs:
       tag_name:
@@ -47,10 +52,15 @@ jobs:
         id: tag
         run: |
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
-            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            TAG="${GITHUB_REF_NAME}"
+          elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag_name }}"
           else
-            echo "tag=${{ github.event.inputs.tag_name }}" >> "$GITHUB_OUTPUT"
+            # Branch push: derive "vX.Y.Z-dev" from a "release/vX.Y.Z" branch.
+            BRANCH="${GITHUB_REF_NAME}"
+            TAG="${BRANCH#release/}-dev"
           fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Package
         run: tar czf "luadch-${{ steps.tag.outputs.tag }}-linux-x86_64.tar.gz" -C build/install luadch
@@ -104,10 +114,15 @@ jobs:
         id: tag
         run: |
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
-            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            TAG="${GITHUB_REF_NAME}"
+          elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag_name }}"
           else
-            echo "tag=${{ github.event.inputs.tag_name }}" >> "$GITHUB_OUTPUT"
+            # Branch push: derive "vX.Y.Z-dev" from a "release/vX.Y.Z" branch.
+            BRANCH="${GITHUB_REF_NAME}"
+            TAG="${BRANCH#release/}-dev"
           fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Package
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,121 @@
+# Changelog
+
+All notable changes to the `Aybook/luadch` fork are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The upstream project (`luadch/luadch`) is a separate codebase; its release
+history is at https://github.com/luadch/luadch/releases.
+
+## [Unreleased]
+
+## [v3.0.0] - 2026-05-03
+
+First release of the modernised `Aybook/luadch` fork. Forked from upstream
+`luadch/luadch` source `v2.24 [RC4]`; upstream's last public release was
+`v2.23` (2022-04-02).
+
+This release lifts the project off Lua 5.1 (EOL since 2012), replaces the
+ad-hoc Linux/Windows shell+batch build pipeline with a single CMake build,
+and ships several pre-existing-bug fixes on top.
+
+### Breaking changes
+
+- **Lua runtime upgraded from 5.1.5 to 5.4.7.** Plugins relying on
+  `setfenv`, `getfenv`, `loadstring`, `unpack`, `module(...)`, `math.atan2`,
+  `math.pow`, `math.log10`, `LUA_MAXCAPTURES`, etc. will not load - update
+  to 5.4 idioms (`load`, `table.unpack`, explicit `_ENV`, `math.atan` two-arg
+  form).
+- **Build system replaced with CMake.** The old `compile` shell script and
+  `compile_with_mingw.bat` are gone (including the `*.c.not` source-rename
+  hack). The new build is `cmake -B build && cmake --build build && cmake --install build`
+  on every supported platform.
+- **`slnunicode` C module replaced by a 40-line pure-Lua shim** built on
+  Lua 5.4's builtin `utf8` library. Same surface API as the old `unicode`
+  table; pattern-matching call sites confirmed ASCII-only by audit. Plugins
+  using non-trivial Unicode-class patterns (`%l` against German umlauts,
+  etc.) would need a dedicated function added to the shim.
+
+### Added
+
+- CMake build system covering Linux x86_64, Windows x86_64 (MinGW UCRT),
+  and ARM aarch64 (cross-compile from Linux). Same three-step pipeline
+  on every platform.
+- GitHub Actions release workflow that builds Linux + Windows binaries
+  and attaches them to the GitHub release on tag push.
+- `.gitattributes` enforcing platform-correct line endings (CRLF for
+  `.bat` / `.cmd`; LF everywhere else).
+- `docs/BUILDING.md` rewritten with platform-specific Linux / Windows /
+  ARM sections, OpenSSL cross-compile recipe, ARM cross-toolchain setup.
+- `docs/INSTALLING.md`: deployment guide (Linux service-user pattern,
+  systemd unit, Windows NSSM service, backups, update procedure).
+- `docs/CONFIGURATION.md`: post-install configuration reference (first-run
+  checklist, cfg.tbl tour, plugin categories, troubleshooting).
+- `docs/phases/PHASE_{1..5}.md` and `INTERLUDE_UPSTREAM_TRIAGE.md`:
+  per-phase modernisation journals.
+- New `msg_del_reason` template in `cmd_delreg.lua` so deleted users see
+  the reason on disconnect (en + de language files updated).
+
+### Changed
+
+- Hub launcher `hub/hub.c`: `lua_open()` -> `luaL_newstate()` (5.4 API).
+- `adclib/adclib.cpp`: `luaL_reg` -> `luaL_Reg`,
+  `luaL_register` -> `luaL_newlib + return 1`.
+- Windows build: `wmic` calls in `cmd_hubinfo.lua` replaced with
+  PowerShell `Get-CimInstance` (Windows 11 24H2+ removed `wmic`).
+- CMake's Windows OpenSSL DLL bundling now searches both flat
+  (`$ROOT/`) and bin-subdir (`$ROOT/bin/`) layouts so msys2 UCRT64 and
+  WinLibs / ShiningLight Win64 both work without manual flattening.
+
+### Fixed
+
+- `os.difftime` 1-arg call pattern (silently tolerated in 5.1, errors in
+  5.4): 12 scripts updated to `os.time() - x`.
+- `cmd_hubinfo.lua` crash on missing certificate file (`get_certinfos`
+  missing return).
+- `+!#` server commands sent as PMs to the hubbot now route through the
+  command pipeline again
+  ([PR #13](https://github.com/Aybook/luadch/pull/13)).
+- `make_cert.sh`: `UID` variable collision with bash's read-only builtin -
+  renamed to `RAND_ID`.
+- `make_cert.bat`: silently produced certs with an empty CN on
+  OpenSSL 3.5+ because `openssl rand -hex 16 -out X` requires the
+  positional `<num>` last; reordered. Also dropped OpenSSL-1.0.x-era
+  `RANDFILE` legacy.
+- `register` keyword warnings in `adclib/tiger.cpp` (C++17 deprecation).
+- `cmd_delreg.lua` help-text fallback corrected: "delregs an existing
+  user".
+- `cmd_usercleaner.lua`: `+usercleaner showghosts` crashed when any
+  registered user lacked a `date` attribute - guard `reg_date` before
+  comparison.
+- `usr_uptime.lua`: crashed on first user login after the database file
+  was missing or unparseable - removed the `else` branch that returned
+  early with an empty table before the entry-setup ran.
+- `+delreg <nick> <reason>` now relays the reason to the deleted user
+  before kicking, instead of the silent generic "You were delregged."
+- `+shutdown` and `+restart` countdowns now block main-chat broadcasts so
+  users cannot type during the countdown.
+
+### Removed
+
+- Legacy build scripts: `compile`, `compile_with_mingw.bat`, `cleanall`.
+- The `*.c.not` rename trick the Windows build used to skip Unix-only
+  LuaSocket sources.
+- Unmaintained `slnunicode` C module (1366 lines of C, replaced by the
+  40-line Lua shim).
+
+### Security
+
+- TLS 1.3 + AES-256-GCM verified end-to-end after the modernisation.
+- `cfg/cfg.tbl` and `cfg/user.tbl` documented as 0600 by deployment
+  guide (they hold the default-account password and the registered-user
+  hashes respectively).
+
+### Phase journals
+
+For the full per-phase narrative (activities, design decisions, build
+output specs, review-gate checklists), see [`docs/phases/`](docs/phases/).
+
+[Unreleased]: https://github.com/Aybook/luadch/compare/v3.0.0...HEAD
+[v3.0.0]: https://github.com/Aybook/luadch/releases/tag/v3.0.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,9 +93,18 @@ if(WIN32)
             "Pass -DOPENSSL_ROOT_DIR=C:/OpenSSL on the cmake command line."
         )
     endif()
-    install(FILES
-        "${OPENSSL_ROOT_DIR}/libssl-3-x64.dll"
-        "${OPENSSL_ROOT_DIR}/libcrypto-3-x64.dll"
-        DESTINATION .
-    )
+    # Search both flat (WinLibs / ShiningLight: DLLs at OPENSSL_ROOT_DIR root)
+    # and standard (msys2 UCRT64: DLLs under bin/) layouts so the same build
+    # recipe works in both environments.
+    foreach(_dll libssl-3-x64.dll libcrypto-3-x64.dll)
+        string(MAKE_C_IDENTIFIER "${_dll}" _dll_var)
+        find_file(_openssl_${_dll_var}
+            NAMES ${_dll}
+            HINTS "${OPENSSL_ROOT_DIR}" "${OPENSSL_ROOT_DIR}/bin"
+            NO_DEFAULT_PATH
+            REQUIRED
+        )
+        install(FILES "${_openssl_${_dll_var}}" DESTINATION .)
+        unset(_openssl_${_dll_var} CACHE)
+    endforeach()
 endif()

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![License](https://img.shields.io/badge/license-GPLv3.0-blueviolet.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20Windows%20%7C%20ARM-orange.svg)](docs/BUILDING.md)
 [![Lua](https://img.shields.io/badge/lua-5.4-blue.svg)](https://www.lua.org/)
+[![Release](https://img.shields.io/github/v/release/Aybook/luadch.svg)](https://github.com/Aybook/luadch/releases/latest)
 
 A modernised fork of [luadch](https://github.com/luadch/luadch) by
 **blastbeat** and **pulsar**. Maintained by [Aybook](https://github.com/Aybook),
@@ -55,6 +56,12 @@ Detail per phase in [docs/phases/](docs/phases/).
   manual (predates this fork)
 
 ## Quick start
+
+Pre-built binaries for Linux x86_64 and Windows x86_64 are attached to
+each [release](https://github.com/Aybook/luadch/releases/latest) - extract
+and run.
+
+Or build from source:
 
 ```sh
 git clone https://github.com/Aybook/luadch.git

--- a/core/const.lua
+++ b/core/const.lua
@@ -13,7 +13,7 @@ return {
     PROGRAM_NAME = "Luadch",
     VERSION = "v3.0.0",
     COPYRIGHT = "by blastbeat and pulsar",
-    FORK = "modernised fork by Aybook",
+    FORK = "modernised fork by Aybo",
     CONFIG_PATH = "././cfg/",
     -- LOG_PATH = "././log/",
     -- CORE_PATH = "././core/",

--- a/core/const.lua
+++ b/core/const.lua
@@ -11,7 +11,7 @@
 return {
 
     PROGRAM_NAME = "Luadch",
-    VERSION = "v2.24 [RC4]",
+    VERSION = "v3.0.0",
     COPYRIGHT = "by blastbeat and pulsar",
     CONFIG_PATH = "././cfg/",
     -- LOG_PATH = "././log/",

--- a/core/const.lua
+++ b/core/const.lua
@@ -13,6 +13,7 @@ return {
     PROGRAM_NAME = "Luadch",
     VERSION = "v3.0.0",
     COPYRIGHT = "by blastbeat and pulsar",
+    FORK = "modernised fork by Aybook",
     CONFIG_PATH = "././cfg/",
     -- LOG_PATH = "././log/",
     -- CORE_PATH = "././core/",

--- a/core/init.lua
+++ b/core/init.lua
@@ -177,6 +177,7 @@ init = function( )    -- this function is the start point
         .. " "
         --.. const.COPYRIGHT .. " (2007-" .. os.date( "%Y" ) .. ")"
         .. util.decode( 'c75d3b4cc292dbf99f02507e0b3e5f58bb939d19fae422' ) .. " (2007-" .. os.date( "%Y" ) .. ")"
+        .. ", " .. const.FORK
         .. "\n\n"
     )
     signal.set( "start", os.time( ) )

--- a/lua/src/CMakeLists.txt
+++ b/lua/src/CMakeLists.txt
@@ -45,9 +45,12 @@ if(UNIX)
     target_link_libraries(lua PRIVATE m ${CMAKE_DL_LIBS})
 endif()
 
-# Match Phase 1 build-output spec: liblua.so / lua.dll at install root
+# Match Phase 1 build-output spec: liblua.so / lua.dll at install root.
+# We deliberately do NOT install ARCHIVE (the MinGW import lib
+# liblua.dll.a) - it is a build-time linker input, not a runtime
+# artefact, and our in-tree consumers (adclib, luasocket, luasec, hub)
+# link via the `lua` CMake target rather than the installed import lib.
 install(TARGETS lua
     RUNTIME DESTINATION .         # lua.dll on Windows
     LIBRARY DESTINATION .         # liblua.so on Linux
-    ARCHIVE DESTINATION .         # liblua.dll.a (Windows import lib) — staged for downstream
 )

--- a/scripts/cmd_hubinfo.lua
+++ b/scripts/cmd_hubinfo.lua
@@ -173,6 +173,7 @@ local const_tbl = util.loadtable( const_file ) or {}
 local const_PROGRAM = const_tbl[ "PROGRAM_NAME" ]
 local const_VERSION = const_tbl[ "VERSION" ]
 local const_COPYRIGHT = const_tbl[ "COPYRIGHT" ]
+local const_FORK = const_tbl[ "FORK" ]
 
 --// functions
 local get_ssl_value
@@ -590,7 +591,7 @@ output = function()
         "\t\t" .. cache_get_kp,
         "\t\t" .. const_PROGRAM, const_VERSION,
         "\t\t" .. const_COPYRIGHT ..
-        " (2007-" .. os.date( "%Y" ) .. ")",
+        " (2007-" .. os.date( "%Y" ) .. "), " .. const_FORK,
         "\t" .. get_hubruntime(),
         "\t" .. check_uptime(),
         "\t" .. cache_check_script_amount,


### PR DESCRIPTION
## Summary

Prep for the v3.0.0 release tag. After this PR is merged, pushing the tag
\`v3.0.0\` to master triggers the workflow which builds Linux + Windows
binaries and creates a GitHub release with them attached.

- \`core/const.lua\`: VERSION bumped from \`v2.24 [RC4]\` to \`v3.0.0\`.
- \`CHANGELOG.md\`: Keep-a-Changelog format, covers Phases 1-5 + interlude.
- \`.github/workflows/release.yml\`: matrix build (Linux ubuntu-latest +
  Windows windows-latest with msys2 UCRT64), release job runs only on tag
  push, \`workflow_dispatch\` trigger lets us verify the build on a branch
  before tagging.
- \`.github/release-body.md\`: hand-curated body for the v3.0.0 release.
- \`README.md\`: latest-release badge + pre-built binaries hint above the
  build-from-source quick-start.
- \`CMakeLists.txt\`: Windows OpenSSL DLL bundling now searches both flat
  (\`\$ROOT/\`) and bin-subdir (\`\$ROOT/bin/\`) layouts so msys2 UCRT64 and
  WinLibs / ShiningLight Win64 both work without manual flattening.
- \`.gitattributes\`: pin \`*.yml\` / \`*.yaml\` / \`*.json\` to LF.

## Test plan

Before merging, please verify the workflow builds cleanly:

1. Go to **Actions** -> **Release** -> **Run workflow** -> select
   \`release/v3.0.0\` branch -> Run.
2. Both \`build-linux\` and \`build-windows\` jobs should succeed.
3. The \`release\` job should be skipped (\`if: startsWith(github.ref, 'refs/tags/v')\`
   only fires for tag pushes).
4. Download the artefacts from the workflow run summary, sanity-check
   that the trees look complete:
   - Linux: \`luadch\` binary, \`liblua.so\`, \`scripts/\`, \`cfg/\`, \`certs/\`, \`lang/\`
   - Windows: \`Luadch.exe\`, \`lua.dll\`, \`libssl-3-x64.dll\`,
     \`libcrypto-3-x64.dll\`, same dirs

Once green:
1. Merge this PR.
2. Locally: \`git tag v3.0.0 && git push origin v3.0.0\`
3. The workflow runs again on the tag, this time creating the GitHub
   release with both binaries attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)