### PR TITLE
docs: post-release cleanup (Unreleased section, em-dashes, exception.txt gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ CMakeUserPresets.json
 .DS_Store
 Thumbs.db
 desktop.ini
+
+# Hub runtime crash log: hub/hub.c writes to "exception.txt" in CWD when
+# startup fails. Until path-anchoring lands (Phase 6 / issue #12),
+# running the binary from the repo root scatters this file there.
+exception.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The upstream project (`luadch/luadch`) is a separate codebase; its release
 history is at https://github.com/luadch/luadch/releases.
 
-## [Unreleased]
-
 ## [v3.0.0] - 2026-05-03
 
 First release of the modernised `Aybook/luadch` fork. Forked from upstream
@@ -117,5 +115,4 @@ and ships several pre-existing-bug fixes on top.
 For the full per-phase narrative (activities, design decisions, build
 output specs, review-gate checklists), see [`docs/phases/`](docs/phases/).
 
-[Unreleased]: https://github.com/Aybook/luadch/compare/v3.0.0...HEAD
 [v3.0.0]: https://github.com/Aybook/luadch/releases/tag/v3.0.0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Luadch — DC++ ADC Hub Server
+# Luadch - DC++ ADC Hub Server
 
 [![License](https://img.shields.io/badge/license-GPLv3.0-blueviolet.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20Windows%20%7C%20ARM-orange.svg)](docs/BUILDING.md)
@@ -26,7 +26,7 @@ with help from Claude.
 
 - Lua **5.1** (EOL since 2012) **→ 5.4.7**
 - Unmaintained `slnunicode` C module replaced by a 40-line pure-Lua shim
-  on top of Lua 5.4's builtin `utf8` library — same API, no C maintenance
+  on top of Lua 5.4's builtin `utf8` library - same API, no C maintenance
 - Build system rewritten to **CMake**: one pipeline for Linux / Windows /
   ARM (`cmake -B build && cmake --build build && cmake --install build`)
 - The `*.c.not` source-rename hack on the Windows build is gone
@@ -44,15 +44,15 @@ Detail per phase in [docs/phases/](docs/phases/).
 
 ## Documentation
 
-- **[docs/BUILDING.md](docs/BUILDING.md)** — build from source on
+- **[docs/BUILDING.md](docs/BUILDING.md)** - build from source on
   Linux, Windows, or ARM
-- **[docs/INSTALLING.md](docs/INSTALLING.md)** — deploy a built hub
+- **[docs/INSTALLING.md](docs/INSTALLING.md)** - deploy a built hub
   (file layout, permissions, systemd, backups, updates)
-- **[docs/CONFIGURATION.md](docs/CONFIGURATION.md)** — configure the
+- **[docs/CONFIGURATION.md](docs/CONFIGURATION.md)** - configure the
   hub, register users, manage plugins, set up TLS
-- [docs/Luadch_Lua_API.txt](docs/Luadch_Lua_API.txt) — plugin scripting
+- [docs/Luadch_Lua_API.txt](docs/Luadch_Lua_API.txt) - plugin scripting
   API reference (upstream-style)
-- [docs/Luadch_Manual.pdf](docs/Luadch_Manual.pdf) — original upstream
+- [docs/Luadch_Manual.pdf](docs/Luadch_Manual.pdf) - original upstream
   manual (predates this fork)
 
 ## Quick start
@@ -79,7 +79,7 @@ for first-run steps. Windows users: see the Windows section of
 
 ## License
 
-GPLv3.0 — see [LICENSE](LICENSE).
+GPLv3.0 - see [LICENSE](LICENSE).
 
 ## Credits
 


### PR DESCRIPTION
## Summary

Three small post-release cleanups:

- **CHANGELOG**: dropped the empty \`## [Unreleased]\` placeholder and its footnote link. Keep-a-Changelog suggests it but right after v3.0.0 went out it was empty and reading as if v3.0.0 itself hadn't shipped. Easy to add back when there are actual unreleased entries to put under it.
- **README**: replaced 8 em-dashes (\`—\`) with plain hyphens (\`-\`) to match the project's prose style.
- **.gitignore**: added \`exception.txt\` because \`hub/hub.c\` writes to that filename in the CWD on startup failure. Until path-anchoring (Phase 6 / issue #12) moves runtime output into \`log/\`, running the binary from the repo root scatters the file at the project root.

No code changes.

## Test plan

- [x] CHANGELOG.md renders cleanly on GitHub - top entry is now v3.0.0
- [x] README.md renders cleanly - no em-dashes left
- [x] \`git status\` is clean even after a startup-failure run from the repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)