### PR TITLE
fix: anchor runtime paths to binary directory at startup (closes #12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,8 @@ CMakeUserPresets.json
 Thumbs.db
 desktop.ini
 
-# Hub runtime crash log: hub/hub.c writes to "exception.txt" in CWD when
-# startup fails. Until path-anchoring lands (Phase 6 / issue #12),
-# running the binary from the repo root scatters this file there.
+# Hub runtime crash log. Since the Phase 6b path-anchoring change
+# (issue #12), the hub writes log/exception.txt inside its own install
+# tree. This entry is a safety net for older binaries or unusual
+# invocation paths that could still drop the file at the repo root.
 exception.txt

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -108,10 +108,11 @@ PrivateTmp=true
 WantedBy=multi-user.target
 ```
 
-`WorkingDirectory=` is mandatory — the hub uses CWD-relative paths
-internally. If you skip it, the hub will fail to find `core/init.lua`.
-(Issue [#12](https://github.com/Aybook/luadch/issues/12) tracks
-removing this constraint in Phase 6.)
+`WorkingDirectory=` is optional - the hub anchors its own runtime
+paths to the binary's directory at startup (Phase 6b / issue #12),
+so it works regardless of the CWD systemd hands it. We still set it
+explicitly above for clarity and so the unit reads the same on older
+releases that did require it.
 
 Enable and start:
 

--- a/hub/hub.c
+++ b/hub/hub.c
@@ -16,6 +16,8 @@
 #include <unistd.h>
 #include <syslog.h>
 #include <string.h>
+#include <libgen.h>
+#include <limits.h>
 #endif
 #ifdef _WIN32
 #include <windows.h>
@@ -30,8 +32,13 @@ static int do_daemonization = 0;
 
 static void log_error(const char *msg)
 {
+  // Write to log/exception.txt next to the binary. chdir_to_binary_dir
+  // (called from main) anchored the CWD there at startup, so this
+  // resolves to <install>/log/exception.txt regardless of where the
+  // user invoked the hub from. If log/ does not exist, fopen returns
+  // NULL and we just rely on the stderr write below - non-fatal.
   FILE *file = NULL;
-  file = fopen("exception.txt", "a+");
+  file = fopen("log/exception.txt", "a+");
   if (file)
   {
     fprintf(file, "%s\n", msg);
@@ -39,6 +46,56 @@ static void log_error(const char *msg)
   }
   fprintf(stderr, "%s\n", msg);
   fflush(stderr);
+}
+
+// Anchor relative paths inside the hub (./core/init.lua, ./cfg/cfg.tbl,
+// ./scripts/...) to the binary's own directory rather than whatever CWD
+// the user happened to be in when they invoked us. Issue #12.
+//
+// Done via chdir() rather than threading a base-dir variable through
+// every Lua module: the existing "././X" pattern in core/cfg.lua,
+// core/init.lua, core/scripts.lua etc. continues to work unchanged
+// once CWD is correct, and there is no behavioural change for
+// deployments that already chdir into the install tree (systemd
+// WorkingDirectory=/opt/luadch, manual `cd /opt/luadch && ./luadch`).
+//
+// Returns 0 on success, -1 on any failure. We do not bail out on
+// failure: init.lua will then error with a clear "could not load
+// core/init.lua" message which is more diagnostic than a silent abort.
+static int chdir_to_binary_dir(void)
+{
+#ifdef _WIN32
+  char path[MAX_PATH];
+  DWORD len = GetModuleFileNameA(NULL, path, sizeof(path));
+  if (len == 0 || len == sizeof(path))
+  {
+    return -1;
+  }
+  // Strip the trailing filename so `path` becomes the directory.
+  for (DWORD i = len; i > 0; i--)
+  {
+    if (path[i - 1] == '\\' || path[i - 1] == '/')
+    {
+      path[i - 1] = '\0';
+      break;
+    }
+  }
+  return SetCurrentDirectoryA(path) ? 0 : -1;
+#elif defined(__unix__)
+  char buf[PATH_MAX];
+  ssize_t len = readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+  if (len < 0)
+  {
+    return -1;
+  }
+  buf[len] = '\0';
+  // dirname() may modify its argument and may return a pointer into a
+  // static buffer on some libcs; chdir copies the string so the lifetime
+  // is not an issue here.
+  return chdir(dirname(buf));
+#else
+  return -1;
+#endif
 }
 
 #ifdef _WIN32
@@ -203,6 +260,14 @@ int main(int argc, char **argv)
 {
   handle_signals();
   handle_args(argc, argv);
+  if (chdir_to_binary_dir() != 0)
+  {
+    // Non-fatal: continue and let luaL_loadfile report a clear "no such
+    // file" error if the surrounding environment cannot supply
+    // core/init.lua via the inherited CWD either.
+    fprintf(stderr, "warning: could not anchor cwd to binary directory; "
+                    "falling back to inherited cwd\n");
+  }
   daemonize();
   run_lua();
   return EXIT_SUCCESS;

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -136,18 +136,23 @@ def generate_test_cert(staging_dir: Path):
 
 def start_hub(staging_dir: Path):
     """
-    Launch luadch in the staging dir. Returns the Popen handle and a
-    file handle to the captured stdout/stderr stream (combined).
+    Launch luadch from a CWD outside the staging tree. The hub anchors
+    its own runtime paths to the binary's directory at startup
+    (issue #12 / Phase 6b), so it must work regardless of the caller's
+    CWD. Picking a foreign CWD here turns the smoke run into a positive
+    proof of that anchoring; before #12 was fixed the hub would bail
+    out looking for ./core/init.lua relative to the harness's CWD.
     """
     binary = staging_dir / ("Luadch.exe" if sys.platform == "win32" else "luadch")
     if not binary.exists():
         raise RuntimeError(f"hub binary not found at {binary}")
 
+    foreign_cwd = staging_dir.parent  # the temp dir the staging lives inside
     log_file = open(staging_dir / "log" / "smoke-hub.log", "wb")
-    log(f"starting {binary}")
+    log(f"starting {binary} (cwd={foreign_cwd})")
     proc = subprocess.Popen(
         [str(binary)],
-        cwd=str(staging_dir),
+        cwd=str(foreign_cwd),
         stdout=log_file,
         stderr=subprocess.STDOUT,
     )


### PR DESCRIPTION
## Summary

Phase 6b. The hub used CWD-relative paths throughout (\`./core/init.lua\`, \`./cfg/cfg.tbl\`, \`./scripts/data/*.tbl\`) which forced every deployment to chdir into the install tree before launch. That broke \`/opt/luadch/luadch\` from a user's home directory, made \`WorkingDirectory=\` mandatory in the systemd unit, and scattered \`log_error()\`'s \`exception.txt\` wherever the caller's CWD was at the time of crash.

**Fix:** \`chdir()\` to the binary's own directory at startup, before \`luaL_loadfile\` loads \`core/init.lua\`. Existing relative-path patterns in the Lua tree keep working unchanged once CWD is correct. Backward-compatible with deployments that already chdir into the install tree (systemd \`WorkingDirectory=\`, manual \`cd /opt/luadch && ./luadch\`) - those become no-op chdirs.

Per-platform path resolution:
- Linux: \`readlink(\"/proc/self/exe\")\` + \`dirname()\`
- Windows: \`GetModuleFileNameA\` + strip filename component
- Anything else: chdir is skipped (warning to stderr; \`init.lua\`'s \`luaL_loadfile\` then surfaces a clear error)

Also moves \`log_error()\`'s output from \`exception.txt\` to \`log/exception.txt\` so the crash log lives inside the install tree's \`log/\` dir rather than next to the binary.

Closes #12.

## Smoke harness change

\`tests/smoke/run.py\` now starts the hub from the staging dir's *parent* - a foreign CWD - so the test exercises the new anchoring behaviour end-to-end. Before this change that start would have failed at \`luaL_loadfile(\"core/init.lua\")\`.

CI run on this branch confirms it works on both platforms; sample log lines:

\`\`\`
[smoke] starting /tmp/luadch-smoke-XXX/luadch/luadch (cwd=/tmp/luadch-smoke-XXX)
[smoke] PASS  hub binds plain + TLS ports
[smoke] PASS  plain ADC handshake
[smoke] PASS  TLS ADC handshake
[smoke] PASS  no script errors in log
\`\`\`

Note the \`cwd=\` is the staging parent, NOT the install dir - the hub anchors itself.

## Docs / repo

- \`docs/INSTALLING.md\`: \`WorkingDirectory=\` is now noted as optional in the systemd unit example
- \`.gitignore\`: comment for \`exception.txt\` updated to reflect the new \`log/\`-based location

## Test plan

- [x] CI smoke job green on Linux and Windows (already verified on this branch)
- [x] Manual test on Linux: \`cd /tmp && /opt/luadch/luadch\` starts cleanly without \`WorkingDirectory=\` shenanigans
- [x] Manual test on Windows: \`cd C:\ && C:\luadch\Luadch.exe\` starts cleanly
- [x] systemd unit with \`WorkingDirectory=\` removed still works on a Linux box

🤖 Generated with [Claude Code](https://claude.com/claude-code)