### PR TITLE
refactor(cfg): extract user.tbl helpers into core/cfg_users.lua

### DIFF
--- a/core/cfg.lua
+++ b/core/cfg.lua
@@ -544,6 +544,8 @@ _cfgbackup = CONFIG_PATH .. "cfg.tbl.backup"
 local _defaultsettings_module = use "cfg_defaults"
 _defaultsettings = _defaultsettings_module.settings
 
+local _users_module = use "cfg_users"
+
 
 checkcfg = function( )
     for key, value in pairs( _settings ) do
@@ -567,19 +569,7 @@ checklanguage = function( lang )
 end
 
 checkusers = function()
-    local users, err = util_loadtable( get "user_path" .. "user.tbl" )
-    if users then
-        util_maketable( nil, get "user_path" .. "user.tbl.bak" )
-        local _, err = util_savearray( users, get( "user_path" ) .. "user.tbl.bak" )
-        _ = err and out_error( "cfg.lua: function 'checkusers': error while saving user db backup: ", err )
-    else
-        local users, err = util_loadtable( get "user_path" .. "user.tbl.bak" )
-        if users then
-            util_maketable( nil, get "user_path" .. "user.tbl" )
-            local _, err = util_savearray( users, get( "user_path" ) .. "user.tbl" )
-            _ = err and out_error( "cfg.lua: function 'checkusers': error while restoring corrupt user db from backup: ", err )
-        end
-    end
+    return _users_module.checkusers( get "user_path" )
 end
 
 
@@ -609,22 +599,11 @@ get = function( target )
 end
 
 loadusers = function( )
-    local users, err = util_loadtable( get "user_path" .. "user.tbl" )
-    _ = err and out_error( "cfg.lua: function 'loadusers': error while loading users: ", err )
-    return ( users or { } ), err
+    return _users_module.loadusers( get "user_path" )
 end
 
 saveusers = function( regusers )
-    --local _, err = util_savearray( regusers, get( "user_path" ) .. "user.tbl.BACKUP." .. os_date( "[%d.%m.%y.%H.%M.%S]" ) )
-    --local _, err
-    --_ = err and out_error( "cfg.lua: error while backup user db: ", err )
-    local _, err = util_savearray( regusers, get( "user_path" ) .. "user.tbl" )
-    _ = err and out_error( "cfg.lua: function 'saveusers': error while saving user db: ", err )
-    if err then
-        return false, err
-    else
-        return true
-    end
+    return _users_module.saveusers( get "user_path", regusers )
 end
 --[[
 loadlanguage = function( language, name )
@@ -691,6 +670,7 @@ init = function( )
 
     out = use "out"
     out_error = out.error
+    _users_module.bind_late()
     local err
     _settings, err = util_loadtable( _cfgfile )
     _settings = _settings or { }

--- a/core/cfg_users.lua
+++ b/core/cfg_users.lua
@@ -1,0 +1,87 @@
+--[[
+
+    cfg_users.lua - user.tbl I/O helpers extracted from core/cfg.lua
+
+    Phase 6c-2 of the cfg.lua decomposition. Moves the three user-tbl
+    helpers (loadusers, saveusers, checkusers) out of cfg.lua so the
+    orchestrator file stays focused on cfg.tbl + the public cfg.X API.
+
+    The functions take the user_path string explicitly rather than
+    pulling it from `cfg.get` themselves, to avoid a cyclic
+    cfg <-> cfg_users dependency at load time. cfg.lua passes the
+    resolved path on every call from its thin wrappers.
+
+    Public surface returned to cfg.lua:
+
+        {
+            bind_late  = function()  -- see comment below
+            loadusers  = function(user_path)
+            saveusers  = function(user_path, regusers)
+            checkusers = function(user_path)
+        }
+
+    out_error is late-bound: out.lua does `use "cfg"` at file scope,
+    so loading out at our own file-load time would create a cycle
+    (cfg -> cfg_users -> out -> cfg). cfg.init() calls bind_late() at
+    the right time, after which all three functions can log via
+    out.error.
+
+]]--
+
+local use = use
+local util = use "util"
+
+local util_loadtable = util.loadtable
+local util_savearray = util.savearray
+local util_maketable = util.maketable
+
+local _
+
+-- Late-bound: out.lua does `use "cfg"` at file scope, so loading it
+-- here would create a cycle. cfg.init() calls bind_late() once out
+-- is loaded; closures pick up the new value via Lua's by-reference
+-- upvalue capture.
+local out_error
+
+local function bind_late()
+    out_error = use("out").error
+end
+
+local function loadusers( user_path )
+    local users, err = util_loadtable( user_path .. "user.tbl" )
+    _ = err and out_error( "cfg_users.lua: function 'loadusers': error while loading users: ", err )
+    return ( users or { } ), err
+end
+
+local function saveusers( user_path, regusers )
+    local _, err = util_savearray( regusers, user_path .. "user.tbl" )
+    _ = err and out_error( "cfg_users.lua: function 'saveusers': error while saving user db: ", err )
+    if err then
+        return false, err
+    else
+        return true
+    end
+end
+
+local function checkusers( user_path )
+    local users, err = util_loadtable( user_path .. "user.tbl" )
+    if users then
+        util_maketable( nil, user_path .. "user.tbl.bak" )
+        local _, err = util_savearray( users, user_path .. "user.tbl.bak" )
+        _ = err and out_error( "cfg_users.lua: function 'checkusers': error while saving user db backup: ", err )
+    else
+        local users, err = util_loadtable( user_path .. "user.tbl.bak" )
+        if users then
+            util_maketable( nil, user_path .. "user.tbl" )
+            local _, err = util_savearray( users, user_path .. "user.tbl" )
+            _ = err and out_error( "cfg_users.lua: function 'checkusers': error while restoring corrupt user db from backup: ", err )
+        end
+    end
+end
+
+return {
+    bind_late  = bind_late,
+    loadusers  = loadusers,
+    saveusers  = saveusers,
+    checkusers = checkusers,
+}


### PR DESCRIPTION
## Summary

**Phase 6c-2** of the cfg.lua decomposition. Moves \`loadusers\`, \`saveusers\`, and \`checkusers\` (32 lines of user.tbl I/O) out of cfg.lua into a new \`core/cfg_users.lua\`. cfg.lua keeps thin wrappers that resolve \`user_path\` via \`cfg.get\` and forward to the helpers.

## Why pass user_path explicitly

\`out.lua\` does \`use \"cfg\"\` at file scope. If \`cfg_users.lua\` did \`use \"cfg\"\` itself to call \`cfg.get(\"user_path\")\` we'd create a cycle: cfg -> cfg_users -> out -> cfg. cfg.lua's wrappers do the lookup and pass the resolved path.

For the same reason, \`out_error\` is late-bound in cfg_users via the \`bind_late()\` pattern we already use for \`types_adcstr\` in cfg_defaults. \`cfg.init()\` calls both bind functions at the right time.

## Result

| File | Before | After |
|---|---|---|
| \`core/cfg.lua\` | 719 | 699 |
| \`core/cfg_users.lua\` | new | 87 |

cfg.X public API unchanged. Smoke harness validates the round-trip: login depends on user.tbl reads via cfg.loadusers, registration via cfg.saveusers, etc. - both jobs green on this branch.

## Test plan

- [x] CI smoke tests green on Linux + Windows (already verified)
- [x] Manual login as dummy/test still works on plain + TLS

🤖 Generated with [Claude Code](https://claude.com/claude-code)