### PR TITLE
refactor(cfg): extract loadlanguage into core/cfg_lang.lua

### DIFF
--- a/core/cfg.lua
+++ b/core/cfg.lua
@@ -507,7 +507,6 @@ local loadusers
 local saveusers
 local loadlanguage
 local registerevent
-local checklanguage
 local loadcfgprofile
 local checkusers
 
@@ -545,6 +544,7 @@ local _defaultsettings_module = use "cfg_defaults"
 _defaultsettings = _defaultsettings_module.settings
 
 local _users_module = use "cfg_users"
+local _lang_module  = use "cfg_lang"
 
 
 checkcfg = function( )
@@ -556,16 +556,6 @@ checkcfg = function( )
             break
         end
     end
-end
-
-checklanguage = function( lang )
-    --[[for i, k in pairs( lang ) do
-        if not ( types_utf8( k, nil, true ) and types_utf8( i, nil, true ) ) then
-            out_error( "cfg.lua: function 'checklanguage': error while loading hub language: invalid key/value: ", i, "/", k, "; using default" )
-            return { }
-        end
-    end]]
-    return lang
 end
 
 checkusers = function()
@@ -605,36 +595,14 @@ end
 saveusers = function( regusers )
     return _users_module.saveusers( get "user_path", regusers )
 end
---[[
-loadlanguage = function( language, name )
-    language = tostring( language or get "language" )    -- default language
-    local path
-    if not name then
-        path = get "core_lang_path" .. language .. ".tbl"
-    else
-        path = get "scripts_lang_path" .. tostring( name ) .. ".lang." .. language
-    end
-    local ret, err = util_loadtable( path )
-    _ = err and out_error( "cfg.lua: function 'loadlanguage': error while loading language: ", err )
-    return checklanguage( ret or { } ), err
-end
-]]
 
 loadlanguage = function( language, name )
-    language = tostring( language or get "language" )    -- default language
-    local path
-    if not name then
-        path = get "core_lang_path" .. language .. ".tbl"
-    else
-        path = get "scripts_lang_path" .. tostring( name ) .. ".lang." .. language
-    end
-    local ret, err = util_loadtable( path )
-    if name then
-        _ = err and out_error( "cfg.lua: function 'loadlanguage': error while loading language (" .. tostring( name ) .. "): ", err )
-    else
-        _ = err and out_error( "cfg.lua: function 'loadlanguage': error while loading language: ", err )
-    end
-    return checklanguage( ret or { } ), err
+    return _lang_module.loadlanguage(
+        language or get "language",
+        name,
+        get "core_lang_path",
+        get "scripts_lang_path"
+    )
 end
 
 loadcfgprofile = function( profile, name )
@@ -671,6 +639,7 @@ init = function( )
     out = use "out"
     out_error = out.error
     _users_module.bind_late()
+    _lang_module.bind_late()
     local err
     _settings, err = util_loadtable( _cfgfile )
     _settings = _settings or { }

--- a/core/cfg_lang.lua
+++ b/core/cfg_lang.lua
@@ -1,0 +1,68 @@
+--[[
+
+    cfg_lang.lua - language file loader extracted from core/cfg.lua
+
+    Phase 6c-3 of the cfg.lua decomposition. Moves loadlanguage and
+    its private checklanguage helper out of cfg.lua. cfg.lua keeps a
+    thin wrapper that resolves the relevant cfg keys (language /
+    core_lang_path / scripts_lang_path) and forwards them.
+
+    Public surface returned to cfg.lua:
+
+        {
+            bind_late    = function()  -- see comment below
+            loadlanguage = function(language, name, core_lang_path, scripts_lang_path)
+        }
+
+    out_error is late-bound for the same reason as in cfg_users:
+    out.lua does `use "cfg"` at file scope, so loading it at our own
+    file-load time would create a cycle. cfg.init() calls bind_late()
+    after out is up; closures pick up the value via Lua's by-reference
+    upvalue capture.
+
+]]--
+
+local use = use
+local util = use "util"
+
+local util_loadtable = util.loadtable
+
+local tostring = use "tostring"
+
+local _
+
+-- Late-bound: see header comment.
+local out_error
+
+local function bind_late()
+    out_error = use("out").error
+end
+
+-- Currently a no-op pass-through. The original cfg.lua had a commented
+-- out per-key utf-8 validator; preserving the function shape here
+-- means future validation can be re-added without touching callers.
+local function checklanguage( lang )
+    return lang
+end
+
+local function loadlanguage( language, name, core_lang_path, scripts_lang_path )
+    language = tostring( language )
+    local path
+    if not name then
+        path = core_lang_path .. language .. ".tbl"
+    else
+        path = scripts_lang_path .. tostring( name ) .. ".lang." .. language
+    end
+    local ret, err = util_loadtable( path )
+    if name then
+        _ = err and out_error( "cfg_lang.lua: function 'loadlanguage': error while loading language (" .. tostring( name ) .. "): ", err )
+    else
+        _ = err and out_error( "cfg_lang.lua: function 'loadlanguage': error while loading language: ", err )
+    end
+    return checklanguage( ret or { } ), err
+end
+
+return {
+    bind_late    = bind_late,
+    loadlanguage = loadlanguage,
+}


### PR DESCRIPTION
## Summary

**Phase 6c-3** of the cfg.lua decomposition. Moves \`loadlanguage\` and its private \`checklanguage\` helper into a new \`core/cfg_lang.lua\`. cfg.lua keeps a thin wrapper that resolves the cfg keys (\`language\` / \`core_lang_path\` / \`scripts_lang_path\`) and forwards them.

Also drops a stale \`--[[ ... ]]\` commented-out copy of loadlanguage that I'd flagged as a "duplicate definition" in the 6c-1 PR notes - turned out to be a dead multi-line comment block, not an active duplicate. Removing it now while the file is open.

## Why pass paths explicitly

Same reason as 6c-2: \`out.lua\` does \`use \"cfg\"\` at file scope, so \`cfg_lang.lua\` doing \`use \"cfg\"\` to call \`cfg.get\` itself would create a cycle. The wrapper in cfg.lua resolves the values and passes them in.

\`out_error\` is late-bound via the same \`bind_late()\` pattern we already use for \`cfg_defaults\` and \`cfg_users\`. cfg.init() calls \`_lang_module.bind_late()\` once out is up.

## checklanguage stays internal

\`checklanguage\` was not part of cfg.X's public surface (was forward-declared as \`local\` and only called internally by loadlanguage), so the extraction can fully internalise it inside cfg_lang. One less private symbol leaking through cfg.lua.

## Result

| File | Before | After |
|---|---|---|
| \`core/cfg.lua\` | 699 | **668** |
| \`core/cfg_lang.lua\` | new | **68** |

cfg.X public API unchanged. Smoke tests green on both jobs - language loading happens during init for many bundled scripts, so any regression here would have surfaced as missing strings or script errors during plugin load, both caught by the harness.

## Result of Phase 6c overall

After this PR (and 6c-1, 6c-2 already merged):

| File | Lines | Note |
|---|---|---|
| \`core/cfg.lua\` | 668 | orchestrator |
| \`core/cfg_defaults.lua\` | 3039 | data table, ceiling-exempt per CLAUDE.md |
| \`core/cfg_users.lua\` | 87 | user.tbl I/O |
| \`core/cfg_lang.lua\` | 68 | language file loading |

Original cfg.lua: 3688 lines monolith.

Phase 6c done.

## Test plan

- [x] CI smoke green on Linux + Windows (already verified)
- [x] Manual: dummy/test login on plain + TLS, \`+hubinfo\` renders (covers en + de language paths via etc_motd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)