### PR TITLE
refactor(hub): extract ADC dispatcher into core/hub_dispatch.lua

### DIFF
--- a/core/hub.lua
+++ b/core/hub.lua
@@ -230,13 +230,13 @@ local server = use "server"
 local signal = use "signal"
 local scripts = use "scripts"
 
--- The user-instance factory lives in its own module since Phase 6d-1.
--- The bot-instance factory is its sibling, extracted in Phase 6d-2.
--- See hub_user_object.lua / hub_bot_object.lua for why; the bind()
--- calls in init() and updateusers() wire up the helpers / state
--- tables / cfg constants both modules need.
-local _user_module = use "hub_user_object"
-local _bot_module  = use "hub_bot_object"
+-- User / bot factories and the ADC command dispatcher each live in
+-- their own module since Phase 6d. All three use the bind_late()
+-- pattern: hub.lua wires them in init() and re-binds whenever caches
+-- are refreshed (loadsettings, loadlanguage, updateusers).
+local _user_module     = use "hub_user_object"
+local _bot_module      = use "hub_bot_object"
+local _dispatch_module = use "hub_dispatch"
 
 --// core methods //--
 
@@ -267,7 +267,6 @@ local checkuser
 
 local init
 local loop
-local states
 local incoming
 local createhub
 local createbot
@@ -409,6 +408,57 @@ local _cfg_kill_wrong_ips
 
 local NAME = const.PROGRAM_NAME
 local VERSION = const.VERSION
+
+-- Wires hub_dispatch with the current state / cfg cache / i18n /
+-- format strings. Called from init() and from each cache rebuild
+-- (loadsettings, loadlanguage, updateusers). Placed AFTER the forward
+-- `local` declarations above so the closure captures every dep.
+local function _bind_dispatch_module( )
+    _dispatch_module.bind{
+        isuserconnected      = isuserconnected,
+        isuserregged         = isuserregged,
+        insertuser           = insertuser,
+        insertreguser        = insertreguser,
+        login                = login,
+        _regusers            = _regusers,
+        _normalstatesids     = _normalstatesids,
+        _get_user_count      = function() return _user_count end,
+        VERSION              = VERSION,
+        _hubinf_regonly      = _hubinf_regonly,
+        _pingsup             = _pingsup,
+        _normalsup           = _normalsup,
+        _normalsup_regonly   = _normalsup_regonly,
+        _cfg_reg_only        = _cfg_reg_only,
+        _cfg_max_users       = _cfg_max_users,
+        _cfg_kill_wrong_ips  = _cfg_kill_wrong_ips,
+        _cfg_max_bad_password = _cfg_max_bad_password,
+        _cfg_bad_pass_timeout = _cfg_bad_pass_timeout,
+        _cfg_min_share       = _cfg_min_share,
+        _cfg_max_share       = _cfg_max_share,
+        _cfg_min_slots       = _cfg_min_slots,
+        _cfg_max_slots       = _cfg_max_slots,
+        _cfg_max_user_hubs   = _cfg_max_user_hubs,
+        _cfg_max_reg_hubs    = _cfg_max_reg_hubs,
+        _cfg_max_op_hubs     = _cfg_max_op_hubs,
+        _cfg_hub_name        = _cfg_hub_name,
+        _cfg_hub_description = _cfg_hub_description,
+        _cfg_hub_hostaddress = _cfg_hub_hostaddress,
+        _cfg_hub_website     = _cfg_hub_website,
+        _cfg_hub_network     = _cfg_hub_network,
+        _cfg_hub_owner       = _cfg_hub_owner,
+        _i18n_unknown            = _i18n_unknown,
+        _i18n_cid_taken          = _i18n_cid_taken,
+        _i18n_hub_is_full        = _i18n_hub_is_full,
+        _i18n_invalid_ip         = _i18n_invalid_ip,
+        _i18n_invalid_pass       = _i18n_invalid_pass,
+        _i18n_invalid_pid        = _i18n_invalid_pid,
+        _i18n_max_bad_password   = _i18n_max_bad_password,
+        _i18n_nick_taken         = _i18n_nick_taken,
+        _i18n_no_base_support    = _i18n_no_base_support,
+        _i18n_no_cid_nick_found  = _i18n_no_cid_nick_found,
+        _i18n_reg_only           = _i18n_reg_only,
+    }
+end
 
 ----------------------------------// DEFINITION //--
 
@@ -560,6 +610,7 @@ updateusers = function( ) -- new
         _cfg_bot_rank    = _cfg_bot_rank,
         _i18n_unknown    = _i18n_unknown,
     }
+    _bind_dispatch_module()
     mem_free( )
 end
 
@@ -1161,280 +1212,6 @@ createuser = function( _client, _sid )
 end    -- private
 
 
-_protocol = {
-
-    HSUP = function( user, adccmd )
-        if adccmd:hasparam "ADBASE" or adccmd:hasparam "ADBAS0" then
-            local response
-            if (not _cfg_reg_only) and adccmd:hasparam "ADPING" then
-                local min_share = _cfg_min_share[ 0 ] or 100
-                local max_share = _cfg_max_share[ 0 ] or 100
-                min_share = min_share * 1024^3
-                max_share = max_share * 1024^4
-                response = utf_format( _pingsup,
-                    user.sid( ),
-                    _cfg_hub_name,
-                    adclib_escape( VERSION ),
-                    _cfg_hub_description,
-                    _cfg_hub_hostaddress,
-                    _cfg_hub_website,
-                    _cfg_hub_network,
-                    _cfg_hub_owner,
-                    tablesize( _normalstatesids ),
-                    min_share,
-                    max_share,
-                    _cfg_min_slots[ 0 ] or 1,
-                    _cfg_max_slots[ 0 ] or 100,
-                    _cfg_max_user_hubs,
-                    _cfg_max_reg_hubs,
-                    _cfg_max_op_hubs,
-                    _cfg_max_users,
-                    os_difftime( os_time( ), signal_get( "start" ) )
-                )
-            elseif not _cfg_reg_only then
-                response = utf_format( _normalsup,
-                    user.sid( ),
-                    _cfg_hub_name,
-                    adclib_escape( VERSION ),
-                    _cfg_hub_description
-                )
-            elseif _cfg_reg_only then
-                response = utf_format( _normalsup_regonly,
-                    user.sid( ),
-                    adclib_escape( VERSION )
-                )
-            end
-            user.write( response )
-            if _cfg_max_users <= _user_count then
-                user:kill( "ISTA 211 " .. _i18n_hub_is_full .. "\n" )-----!
-                return true
-            end
-            user:sup( adccmd )
-            user:state "identify"
-            user:hash "TIGR"    -- assume TIGR support^^
-        else
-            user:kill( "ISTA 220 " .. _i18n_no_base_support .. "\n", "TL-1" )-----!
-        end
-        return true
-    end
-
-}
-
-_identify = {
-
-    BINF = function( user, adccmd )
-        local pid = adccmd:getnp "PD"
-        local cid = adccmd:getnp "ID"
-        local nick = adccmd:getnp "NI"
-        local ipver = "I4"
-        local infip = adccmd:getnp( ipver )
-        if not infip then
-            ipver = "I6"
-            infip = adccmd:getnp( ipver )
-        end
-        local hash = user.hash( )
-        if not ( cid and pid and nick and infip ) then
-            user:kill( "ISTA 220 " .. _i18n_no_cid_nick_found .. "\n", "TL-1" )
-            scripts_firelistener( "onFailedAuth", ( nick or _i18n_unknown ), ( infip or _i18n_unknown ), ( cid or _i18n_unknown ), escapefrom( _i18n_no_cid_nick_found ) )
-            return true
-        end
-        local userip = user.ip( ) or ""
-        if ( infip == "0.0.0.0" ) or ( infip == "::" ) then
-            adccmd:setnp( ipver, userip )
-        elseif infip ~= userip then
-            if _cfg_kill_wrong_ips then
-                user:kill( "ISTA 246 " .. _i18n_invalid_ip .. userip .. "/" .. infip .. "\n", "TL10" )
-                scripts_firelistener( "onFailedAuth", nick, userip, cid,  escapefrom( _i18n_invalid_ip .. userip .. "/" .. infip ) )
-                return true
-            end
-        end
-        if cid ~= adclib_hash( pid ) then
-            user:kill( "ISTA 227 " .. _i18n_invalid_pid .. "\n", "TL-1" )
-            scripts_firelistener( "onFailedAuth", nick, userip, cid,  escapefrom( _i18n_invalid_pid ) )
-            return true
-        end
-        local onlineuser = isuserconnected( nil, nil, cid, hash ) -- isuserconnected( nick, sid, cid, hash )
-        if onlineuser then
-            onlineuser:kill( "ISTA 224 " .. _i18n_cid_taken .. "\n", "TL-1" )
-            --scripts_firelistener( "onFailedAuth", nick, userip, cid, escapefrom( _i18n_cid_taken ) )
-        end
-        onlineuser = isuserconnected( nick )
-        if onlineuser then
-            local quitmsg = "ISTA 222 " .. _i18n_nick_taken .. "\n"
-            if cfg_get "reg_only" then
-                onlineuser:kill(quitmsg, "TL-1") -- kill zombie client
-            else
-                user:kill(quitmsg, "TL-1") -- kill connecting client
-                --scripts_firelistener( "onFailedAuth", nick, userip, cid, escapefrom( _i18n_nick_taken ) )
-                return true
-            end
-        end
-        local profile = isuserregged( nick )
-        if not profile and cfg_get "reg_only" then -- reg only hub; unregged user will be disconnected
-            user:kill( "ISTA 226 " .. _i18n_reg_only .. "\n", "TL-1" )
-            scripts_firelistener( "onFailedAuth", nick, userip, cid,  escapefrom( _i18n_reg_only ) )
-            return true
-        --else
-        elseif profile then
-            local bol, err = insertreguser( user, profile, cid, hash, nick )
-            if not bol then
-                user:kill( "ISTA 220 " .. escapeto(err) .. "\n", "TL-1" )
-                return true
-            end
-        end
-        adccmd:deletenp "PD"
-        user:inf( adccmd )
-        if user:hasfeature "CCPM" then user:hasccpm( true ) end
-        insertuser( nick, cid, hash, user )
-        if scripts_firelistener( "onConnect", user ) or user.waskilled then
-            return true
-        end
-        if profile then
-            profile.lastconnect = profile.lastconnect or util_date()
-            local lc = tostring( profile.lastconnect )
-            if #lc ~= 14 then profile.lastconnect = util_date() end -- util.date() has allways 14 chars: yyyymmddhhmmss
-            local sec, y, d, h, m, s = util_difftime( util_date(), profile.lastconnect )
-            if ( ( profile.badpassword or 0 ) >= _cfg_max_bad_password ) and ( sec < _cfg_bad_pass_timeout ) then
-                user:kill( "ISTA 223 " .. _i18n_max_bad_password .. sec .. "/" .. _cfg_bad_pass_timeout .. "\n" )
-                scripts_firelistener( "onFailedAuth", nick, userip, cid, escapefrom( _i18n_max_bad_password .. sec .. "/" .. _cfg_bad_pass_timeout ) )
-                return true
-            end
-            --[[profile.lastconnect = profile.lastconnect or os_time( )
-            local diff = os_difftime( os_time( ), profile.lastconnect )
-            if ( ( profile.badpassword or 0 ) >= _cfg_max_bad_password ) and ( diff < _cfg_bad_pass_timeout ) then
-                user:kill( "ISTA 223 " .. _i18n_max_bad_password .. diff .. "/" .. _cfg_bad_pass_timeout .. "\n" )
-                return true
-            end ]]
-            user:salt( adclib_createsalt( ) )
-            user.write( "IGPA " .. user.salt( ) .. "\n" )
-            user:state "verify"
-        else
-            login( user, false )
-        end
-        return true
-    end,
-
-}
-
-_verify = {
-
-    HPAS = function( user, adccmd )
-        local salt = user.salt( )
-        --local pass = _cfg_hub_pass
-        local pass, reason
-        local regged = user.isregged( )
-        local usercid = user.cid( )
-        local userip = user.ip( ) or _i18n_unknown
-        local userhash = adccmd[ 4 ]
-        if regged then
-            pass = user.password( )
-        end
-        local profile = user.profile( )
-        local hubhash = adclib_hashpas( pass, salt )
-        local hubhashold = adclib_hasholdpas( pass, salt, usercid )
-        if ( userhash ~= hubhash ) and ( userhash ~= hubhashold ) then
-            profile.badpassword = ( profile.badpassword or 0 ) + 1
-            user:kill( "ISTA 223 " .. _i18n_invalid_pass .. "\n", "TL-1" )
-            scripts_firelistener( "onFailedAuth", profile.nick, userip, usercid, escapefrom( _i18n_invalid_pass ) )
-        else
-            profile.badpassword = 0
-            if not user:sup( ):hasparam( "ADOSNR" ) then
-                user.write( utf_format( _hubinf_regonly, _cfg_hub_name, _cfg_hub_description ) )
-            end
-            login( user )
-        end
-        --[[
-        if regged and cfg_get "nick_change" then        --// mhh.. the whole thing needs rework
-            user:setregnick( user:nick( ) )
-        end
-        ]]--
-        profile.lastconnect = util_date( )
-        profile.lastseen = util_date( )
-        profile.is_online = 1
-        cfg_saveusers( _regusers )
-        return true
-    end,
-
-}
-
-_normal = {
-    -- ADC: 6.3.4. INF
-    BINF = function( user, adccmd )
-        return scripts_firelistener( "onInf", user, adccmd )
-    end,
-    -- ADC: 6.3.5. MSG
-    BMSG = function( user, adccmd )
-        return scripts_firelistener( "onBroadcast", user, adccmd, escapefrom( adccmd[ 6 ] ) )
-    end,
-    --FMSG = function( user, adccmd )  -- cannot see a good scenario for FMSG; why should a user want to send mainchat messages to clients with specific features only?
-    --    return scripts_firelistener( "onBroadcast", user, adccmd, escapefrom( adccmd[ 8 ] ) )
-    --end,
-    EMSG = function( user, adccmd, targetuser )
-        return scripts_firelistener( "onPrivateMessage", user, targetuser, adccmd, escapefrom( adccmd[ 8 ] ) )
-    end,
-    DMSG = function( user, adccmd, targetuser )
-        return scripts_firelistener( "onPrivateMessage", user, targetuser, adccmd, escapefrom( adccmd[ 8 ] ) )
-    end,
-    -- ADC: 6.3.8. CTM
-    DCTM = function( user, adccmd, targetuser )
-        return scripts_firelistener( "onConnectToMe", user, targetuser, adccmd )
-    end,
-    --ECTM = function( user, adccmd, targetuser ) -- new
-    --    return scripts_firelistener( "onConnectToMe", user, targetuser, adccmd )
-    --end,
-    -- ADC: 6.3.9. RCM
-    DRCM = function( user, adccmd, targetuser )
-        return scripts_firelistener( "onRevConnectToMe", user, targetuser,adccmd )
-    end,
-    --ERCM = function( user, adccmd, targetuser ) -- new
-    --    return scripts_firelistener( "onRevConnectToMe", user, targetuser,adccmd )
-    --end,
-    -- ADC: 6.3.6. SCH
-    BSCH = function( user, adccmd )
-        return scripts_firelistener( "onSearch", user, adccmd )
-    end,
-    FSCH = function( user, adccmd )
-        return scripts_firelistener( "onSearch", user, adccmd )
-     end,
-    DSCH = function( user, adccmd, targetuser )
-        return scripts_firelistener( "onSearch", user, adccmd )
-    end,
-    -- ADC: 6.3.7. RES
-    DRES = function( user, adccmd, targetuser )
-        return scripts_firelistener( "onSearchResult", user, targetuser, adccmd )
-    end,
-    --URES = function( user, adccmd, targetuser ) -- new
-    --    return scripts_firelistener( "onSearchResult", user, targetuser, adccmd )
-    --end,
-    --CRES = function( user, adccmd, targetuser ) -- new
-    --    return scripts_firelistener( "onSearchResult", user, targetuser, adccmd )
-    --end,
-
-}
-
-states = function( user, adccmd, fourcc, state, targetuser )
-    local ret
-    if state == "normal" then
-        ret = _normal[ fourcc ]
-        if ret then
-            return ret( user, adccmd, targetuser )  -- forward it with fireing script listeners
-        end
-        return false    --forward it later without fireing script listeners
-    elseif state == "protocol" then
-        ret = _protocol[ fourcc ]
-    elseif state == "identify" then
-        ret = _identify[ fourcc ]
-    elseif state == "verify" then
-        ret = _verify[ fourcc ]
-    end
-    if not ret then
-        user.write( "ISTA 125 FC" .. fourcc .. "\n" )
-    else
-        ret( user, adccmd, targetuser )
-    end
-    return true
-end
-
 incoming = function( client, data, err )
     local user = _userclients[ client ]
     local usersid = user.sid( )
@@ -1461,7 +1238,7 @@ incoming = function( client, data, err )
         if targetsid and not targetuser then    -- targetuser doesnt exist anymore
             user.write "ISTA 140\n"
         elseif ( not mysid ) or ( mysid == usersid ) then    -- match sids
-            local bol, ret = pcall( states, user, adccmd, fourcc, userstate, targetuser )
+            local bol, ret = pcall( _dispatch_module.states, user, adccmd, fourcc, userstate, targetuser )
             if not bol then     -- error happened
                 out_error( "hub.lua: function 'incoming': lua error: ", ret )
             elseif not ret then     -- need to forward message
@@ -1551,6 +1328,7 @@ loadlanguage = function( )
     _i18n_nick_or_cid_taken = adclib_escape( i18n.hub_nick_or_cid_taken or "Nick/CID taken." )
     _i18n_no_cid_nick_found = adclib_escape( i18n.hub_no_cid_nick_found or "No CID/PID/NICK/IP found in your INF." )
     _i18n_hubbot_response = i18n.hub_hubbot_response or "I am the Hubbot, do you really want to talk to me?"
+    _bind_dispatch_module()
 end
 
 loadsettings = function( )    -- caching table lookups...
@@ -1579,6 +1357,7 @@ loadsettings = function( )    -- caching table lookups...
     _cfg_max_bad_password = cfg_get "max_bad_password"
     _cfg_bad_pass_timeout = cfg_get "bad_pass_timeout"
     _cfg_kill_wrong_ips = cfg_get "kill_wrong_ips" -- not in cfg.tbl
+    _bind_dispatch_module()
 end
 
 add_server_handler = function( p )
@@ -1645,6 +1424,7 @@ init = function( )
         _cfg_bot_rank    = _cfg_bot_rank,
         _i18n_unknown    = _i18n_unknown,
     }
+    _bind_dispatch_module()
     reghubbot( cfg_get "hub_bot", cfg_get "hub_bot_desc" )
     scripts.start( _luadch )
     for i, port in pairs( cfg_get "tcp_ports" ) do

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -1,0 +1,475 @@
+--[[
+
+    hub_dispatch.lua - the ADC command dispatcher extracted from core/hub.lua
+
+    Phase 6d-3 of the hub.lua decomposition. Contains:
+
+      - the four state-machine handler tables _protocol, _identify,
+        _verify, _normal (one per ADC connection state)
+      - states(), which routes an incoming command to the right
+        handler based on the user's current state
+
+    These ~270 lines were the largest remaining chunk of "logic with many
+    upvalues" in hub.lua after the createuser / createbot extractions.
+    Moving them here drops hub.lua under the Phase 6 1500-line ceiling.
+
+    The dispatcher reads HEAVILY from hub.lua's cfg cache (_cfg_*),
+    i18n strings (_i18n_*), format strings (_pingsup, _normalsup,
+    _normalsup_regonly, _hubinf_regonly), and the user-state count
+    (_user_count). Same bind_late() pattern as cfg_defaults / cfg_users /
+    cfg_lang / hub_user_object / hub_bot_object: hub.lua calls
+    _dispatch_module.bind({...}) once after init() and again whenever
+    any of these caches are refreshed (loadsettings, loadlanguage,
+    updateusers).
+
+    _user_count is incremented/decremented in hub.lua's incoming and
+    disconnect; we receive it as a getter closure so the dispatcher
+    sees the live value rather than a stale snapshot.
+
+    Public surface:
+
+        {
+            bind   = function(deps)
+            states = function(user, adccmd, fourcc, state, targetuser)
+        }
+
+]]--
+
+local use = use
+
+local tostring = use "tostring"
+local tablesize = use "tablesize"
+
+local adclib = use "adclib"
+local cfg = use "cfg"
+local scripts = use "scripts"
+local signal = use "signal"
+local unicode = use "unicode"
+local util = use "util"
+local os = use "os"
+
+-- Stable upvalues - resolved once at file load.
+local adclib_createsalt = adclib.createsalt
+local adclib_escape = adclib.escape
+local adclib_hash = adclib.hash
+local adclib_hashpas = adclib.hashpas
+local adclib_hasholdpas = adclib.hasholdpas
+local escapeto = adclib_escape
+local escapefrom = adclib.unescape
+
+local cfg_get = cfg.get
+local cfg_saveusers = cfg.saveusers
+
+local scripts_firelistener = scripts.firelistener
+local signal_get = signal.get
+
+local utf_format = unicode.utf8.format
+
+local util_date = util.date
+local util_difftime = util.difftime
+
+local os_time = os.time
+local os_difftime = os.difftime
+
+-- Late-bound from hub.lua via bind(). Closures inside the four state
+-- tables and states() pick these up via upvalue refs; hub.lua sets
+-- them once init() has run, and re-binds after loadsettings,
+-- loadlanguage, or updateusers refreshes anything.
+--
+-- Helpers and internal state
+local isuserconnected
+local isuserregged
+local insertuser
+local insertreguser
+local login
+
+local _regusers
+local _normalstatesids
+local _get_user_count   -- closure, returns current _user_count
+
+-- The four state-machine tables and states() are file-local; the
+-- bodies below assign to them. Forward-declare here so the sandbox env
+-- recognises the assignments as local-writes rather than undeclared
+-- globals.
+local _protocol
+local _identify
+local _verify
+local _normal
+local states
+
+-- VERSION (set once at hub start, but we late-bind to keep all the
+-- "stamped-from-hub.lua" identifiers in one place).
+local VERSION
+
+-- Format strings (rebuilt on +reload via loadlanguage).
+local _hubinf_regonly
+local _pingsup
+local _normalsup
+local _normalsup_regonly
+
+-- Cached cfg values (rebuilt by hub.lua's loadsettings on +reload).
+local _cfg_reg_only
+local _cfg_max_users
+local _cfg_kill_wrong_ips
+local _cfg_max_bad_password
+local _cfg_bad_pass_timeout
+local _cfg_min_share
+local _cfg_max_share
+local _cfg_min_slots
+local _cfg_max_slots
+local _cfg_max_user_hubs
+local _cfg_max_reg_hubs
+local _cfg_max_op_hubs
+local _cfg_hub_name
+local _cfg_hub_description
+local _cfg_hub_hostaddress
+local _cfg_hub_website
+local _cfg_hub_network
+local _cfg_hub_owner
+
+-- i18n strings (rebuilt on +reload via loadlanguage).
+local _i18n_unknown
+local _i18n_cid_taken
+local _i18n_hub_is_full
+local _i18n_invalid_ip
+local _i18n_invalid_pass
+local _i18n_invalid_pid
+local _i18n_max_bad_password
+local _i18n_nick_taken
+local _i18n_no_base_support
+local _i18n_no_cid_nick_found
+local _i18n_reg_only
+
+local function bind( deps )
+    -- helpers
+    isuserconnected      = deps.isuserconnected
+    isuserregged         = deps.isuserregged
+    insertuser           = deps.insertuser
+    insertreguser        = deps.insertreguser
+    login                = deps.login
+    -- state
+    _regusers            = deps._regusers
+    _normalstatesids     = deps._normalstatesids
+    _get_user_count      = deps._get_user_count
+    -- constants / cache
+    VERSION              = deps.VERSION
+    _hubinf_regonly      = deps._hubinf_regonly
+    _pingsup             = deps._pingsup
+    _normalsup           = deps._normalsup
+    _normalsup_regonly   = deps._normalsup_regonly
+    _cfg_reg_only        = deps._cfg_reg_only
+    _cfg_max_users       = deps._cfg_max_users
+    _cfg_kill_wrong_ips  = deps._cfg_kill_wrong_ips
+    _cfg_max_bad_password = deps._cfg_max_bad_password
+    _cfg_bad_pass_timeout = deps._cfg_bad_pass_timeout
+    _cfg_min_share       = deps._cfg_min_share
+    _cfg_max_share       = deps._cfg_max_share
+    _cfg_min_slots       = deps._cfg_min_slots
+    _cfg_max_slots       = deps._cfg_max_slots
+    _cfg_max_user_hubs   = deps._cfg_max_user_hubs
+    _cfg_max_reg_hubs    = deps._cfg_max_reg_hubs
+    _cfg_max_op_hubs     = deps._cfg_max_op_hubs
+    _cfg_hub_name        = deps._cfg_hub_name
+    _cfg_hub_description = deps._cfg_hub_description
+    _cfg_hub_hostaddress = deps._cfg_hub_hostaddress
+    _cfg_hub_website     = deps._cfg_hub_website
+    _cfg_hub_network     = deps._cfg_hub_network
+    _cfg_hub_owner       = deps._cfg_hub_owner
+    -- i18n
+    _i18n_unknown            = deps._i18n_unknown
+    _i18n_cid_taken          = deps._i18n_cid_taken
+    _i18n_hub_is_full        = deps._i18n_hub_is_full
+    _i18n_invalid_ip         = deps._i18n_invalid_ip
+    _i18n_invalid_pass       = deps._i18n_invalid_pass
+    _i18n_invalid_pid        = deps._i18n_invalid_pid
+    _i18n_max_bad_password   = deps._i18n_max_bad_password
+    _i18n_nick_taken         = deps._i18n_nick_taken
+    _i18n_no_base_support    = deps._i18n_no_base_support
+    _i18n_no_cid_nick_found  = deps._i18n_no_cid_nick_found
+    _i18n_reg_only           = deps._i18n_reg_only
+end
+
+-- The four state-machine handler tables follow verbatim from hub.lua.
+-- The only edits are: replace bare _user_count with _get_user_count(),
+-- since _user_count mutates during normal hub operation and our cached
+-- copy would go stale otherwise.
+
+_protocol = {
+
+    HSUP = function( user, adccmd )
+        if adccmd:hasparam "ADBASE" or adccmd:hasparam "ADBAS0" then
+            local response
+            if (not _cfg_reg_only) and adccmd:hasparam "ADPING" then
+                local min_share = _cfg_min_share[ 0 ] or 100
+                local max_share = _cfg_max_share[ 0 ] or 100
+                min_share = min_share * 1024^3
+                max_share = max_share * 1024^4
+                response = utf_format( _pingsup,
+                    user.sid( ),
+                    _cfg_hub_name,
+                    adclib_escape( VERSION ),
+                    _cfg_hub_description,
+                    _cfg_hub_hostaddress,
+                    _cfg_hub_website,
+                    _cfg_hub_network,
+                    _cfg_hub_owner,
+                    tablesize( _normalstatesids ),
+                    min_share,
+                    max_share,
+                    _cfg_min_slots[ 0 ] or 1,
+                    _cfg_max_slots[ 0 ] or 100,
+                    _cfg_max_user_hubs,
+                    _cfg_max_reg_hubs,
+                    _cfg_max_op_hubs,
+                    _cfg_max_users,
+                    os_difftime( os_time( ), signal_get( "start" ) )
+                )
+            elseif not _cfg_reg_only then
+                response = utf_format( _normalsup,
+                    user.sid( ),
+                    _cfg_hub_name,
+                    adclib_escape( VERSION ),
+                    _cfg_hub_description
+                )
+            elseif _cfg_reg_only then
+                response = utf_format( _normalsup_regonly,
+                    user.sid( ),
+                    adclib_escape( VERSION )
+                )
+            end
+            user.write( response )
+            if _cfg_max_users <= _get_user_count() then
+                user:kill( "ISTA 211 " .. _i18n_hub_is_full .. "\n" )-----!
+                return true
+            end
+            user:sup( adccmd )
+            user:state "identify"
+            user:hash "TIGR"    -- assume TIGR support^^
+        else
+            user:kill( "ISTA 220 " .. _i18n_no_base_support .. "\n", "TL-1" )-----!
+        end
+        return true
+    end
+
+}
+
+_identify = {
+
+    BINF = function( user, adccmd )
+        local pid = adccmd:getnp "PD"
+        local cid = adccmd:getnp "ID"
+        local nick = adccmd:getnp "NI"
+        local ipver = "I4"
+        local infip = adccmd:getnp( ipver )
+        if not infip then
+            ipver = "I6"
+            infip = adccmd:getnp( ipver )
+        end
+        local hash = user.hash( )
+        if not ( cid and pid and nick and infip ) then
+            user:kill( "ISTA 220 " .. _i18n_no_cid_nick_found .. "\n", "TL-1" )
+            scripts_firelistener( "onFailedAuth", ( nick or _i18n_unknown ), ( infip or _i18n_unknown ), ( cid or _i18n_unknown ), escapefrom( _i18n_no_cid_nick_found ) )
+            return true
+        end
+        local userip = user.ip( ) or ""
+        if ( infip == "0.0.0.0" ) or ( infip == "::" ) then
+            adccmd:setnp( ipver, userip )
+        elseif infip ~= userip then
+            if _cfg_kill_wrong_ips then
+                user:kill( "ISTA 246 " .. _i18n_invalid_ip .. userip .. "/" .. infip .. "\n", "TL10" )
+                scripts_firelistener( "onFailedAuth", nick, userip, cid,  escapefrom( _i18n_invalid_ip .. userip .. "/" .. infip ) )
+                return true
+            end
+        end
+        if cid ~= adclib_hash( pid ) then
+            user:kill( "ISTA 227 " .. _i18n_invalid_pid .. "\n", "TL-1" )
+            scripts_firelistener( "onFailedAuth", nick, userip, cid,  escapefrom( _i18n_invalid_pid ) )
+            return true
+        end
+        local onlineuser = isuserconnected( nil, nil, cid, hash ) -- isuserconnected( nick, sid, cid, hash )
+        if onlineuser then
+            onlineuser:kill( "ISTA 224 " .. _i18n_cid_taken .. "\n", "TL-1" )
+            --scripts_firelistener( "onFailedAuth", nick, userip, cid, escapefrom( _i18n_cid_taken ) )
+        end
+        onlineuser = isuserconnected( nick )
+        if onlineuser then
+            local quitmsg = "ISTA 222 " .. _i18n_nick_taken .. "\n"
+            if cfg_get "reg_only" then
+                onlineuser:kill(quitmsg, "TL-1") -- kill zombie client
+            else
+                user:kill(quitmsg, "TL-1") -- kill connecting client
+                --scripts_firelistener( "onFailedAuth", nick, userip, cid, escapefrom( _i18n_nick_taken ) )
+                return true
+            end
+        end
+        local profile = isuserregged( nick )
+        if not profile and cfg_get "reg_only" then -- reg only hub; unregged user will be disconnected
+            user:kill( "ISTA 226 " .. _i18n_reg_only .. "\n", "TL-1" )
+            scripts_firelistener( "onFailedAuth", nick, userip, cid,  escapefrom( _i18n_reg_only ) )
+            return true
+        --else
+        elseif profile then
+            local bol, err = insertreguser( user, profile, cid, hash, nick )
+            if not bol then
+                user:kill( "ISTA 220 " .. escapeto(err) .. "\n", "TL-1" )
+                return true
+            end
+        end
+        adccmd:deletenp "PD"
+        user:inf( adccmd )
+        if user:hasfeature "CCPM" then user:hasccpm( true ) end
+        insertuser( nick, cid, hash, user )
+        if scripts_firelistener( "onConnect", user ) or user.waskilled then
+            return true
+        end
+        if profile then
+            profile.lastconnect = profile.lastconnect or util_date()
+            local lc = tostring( profile.lastconnect )
+            if #lc ~= 14 then profile.lastconnect = util_date() end -- util.date() has allways 14 chars: yyyymmddhhmmss
+            local sec, y, d, h, m, s = util_difftime( util_date(), profile.lastconnect )
+            if ( ( profile.badpassword or 0 ) >= _cfg_max_bad_password ) and ( sec < _cfg_bad_pass_timeout ) then
+                user:kill( "ISTA 223 " .. _i18n_max_bad_password .. sec .. "/" .. _cfg_bad_pass_timeout .. "\n" )
+                scripts_firelistener( "onFailedAuth", nick, userip, cid, escapefrom( _i18n_max_bad_password .. sec .. "/" .. _cfg_bad_pass_timeout ) )
+                return true
+            end
+            --[[profile.lastconnect = profile.lastconnect or os_time( )
+            local diff = os_difftime( os_time( ), profile.lastconnect )
+            if ( ( profile.badpassword or 0 ) >= _cfg_max_bad_password ) and ( diff < _cfg_bad_pass_timeout ) then
+                user:kill( "ISTA 223 " .. _i18n_max_bad_password .. diff .. "/" .. _cfg_bad_pass_timeout .. "\n" )
+                return true
+            end ]]
+            user:salt( adclib_createsalt( ) )
+            user.write( "IGPA " .. user.salt( ) .. "\n" )
+            user:state "verify"
+        else
+            login( user, false )
+        end
+        return true
+    end,
+
+}
+
+_verify = {
+
+    HPAS = function( user, adccmd )
+        local salt = user.salt( )
+        --local pass = _cfg_hub_pass
+        local pass, reason
+        local regged = user.isregged( )
+        local usercid = user.cid( )
+        local userip = user.ip( ) or _i18n_unknown
+        local userhash = adccmd[ 4 ]
+        if regged then
+            pass = user.password( )
+        end
+        local profile = user.profile( )
+        local hubhash = adclib_hashpas( pass, salt )
+        local hubhashold = adclib_hasholdpas( pass, salt, usercid )
+        if ( userhash ~= hubhash ) and ( userhash ~= hubhashold ) then
+            profile.badpassword = ( profile.badpassword or 0 ) + 1
+            user:kill( "ISTA 223 " .. _i18n_invalid_pass .. "\n", "TL-1" )
+            scripts_firelistener( "onFailedAuth", profile.nick, userip, usercid, escapefrom( _i18n_invalid_pass ) )
+        else
+            profile.badpassword = 0
+            if not user:sup( ):hasparam( "ADOSNR" ) then
+                user.write( utf_format( _hubinf_regonly, _cfg_hub_name, _cfg_hub_description ) )
+            end
+            login( user )
+        end
+        --[[
+        if regged and cfg_get "nick_change" then        --// mhh.. the whole thing needs rework
+            user:setregnick( user:nick( ) )
+        end
+        ]]--
+        profile.lastconnect = util_date( )
+        profile.lastseen = util_date( )
+        profile.is_online = 1
+        cfg_saveusers( _regusers )
+        return true
+    end,
+
+}
+
+_normal = {
+    -- ADC: 6.3.4. INF
+    BINF = function( user, adccmd )
+        return scripts_firelistener( "onInf", user, adccmd )
+    end,
+    -- ADC: 6.3.5. MSG
+    BMSG = function( user, adccmd )
+        return scripts_firelistener( "onBroadcast", user, adccmd, escapefrom( adccmd[ 6 ] ) )
+    end,
+    --FMSG = function( user, adccmd )  -- cannot see a good scenario for FMSG; why should a user want to send mainchat messages to clients with specific features only?
+    --    return scripts_firelistener( "onBroadcast", user, adccmd, escapefrom( adccmd[ 8 ] ) )
+    --end,
+    EMSG = function( user, adccmd, targetuser )
+        return scripts_firelistener( "onPrivateMessage", user, targetuser, adccmd, escapefrom( adccmd[ 8 ] ) )
+    end,
+    DMSG = function( user, adccmd, targetuser )
+        return scripts_firelistener( "onPrivateMessage", user, targetuser, adccmd, escapefrom( adccmd[ 8 ] ) )
+    end,
+    -- ADC: 6.3.8. CTM
+    DCTM = function( user, adccmd, targetuser )
+        return scripts_firelistener( "onConnectToMe", user, targetuser, adccmd )
+    end,
+    --ECTM = function( user, adccmd, targetuser ) -- new
+    --    return scripts_firelistener( "onConnectToMe", user, targetuser, adccmd )
+    --end,
+    -- ADC: 6.3.9. RCM
+    DRCM = function( user, adccmd, targetuser )
+        return scripts_firelistener( "onRevConnectToMe", user, targetuser,adccmd )
+    end,
+    --ERCM = function( user, adccmd, targetuser ) -- new
+    --    return scripts_firelistener( "onRevConnectToMe", user, targetuser,adccmd )
+    --end,
+    -- ADC: 6.3.6. SCH
+    BSCH = function( user, adccmd )
+        return scripts_firelistener( "onSearch", user, adccmd )
+    end,
+    FSCH = function( user, adccmd )
+        return scripts_firelistener( "onSearch", user, adccmd )
+     end,
+    DSCH = function( user, adccmd, targetuser )
+        return scripts_firelistener( "onSearch", user, adccmd )
+    end,
+    -- ADC: 6.3.7. RES
+    DRES = function( user, adccmd, targetuser )
+        return scripts_firelistener( "onSearchResult", user, targetuser, adccmd )
+    end,
+    --URES = function( user, adccmd, targetuser ) -- new
+    --    return scripts_firelistener( "onSearchResult", user, targetuser, adccmd )
+    --end,
+    --CRES = function( user, adccmd, targetuser ) -- new
+    --    return scripts_firelistener( "onSearchResult", user, targetuser, adccmd )
+    --end,
+
+}
+
+states = function( user, adccmd, fourcc, state, targetuser )
+    local ret
+    if state == "normal" then
+        ret = _normal[ fourcc ]
+        if ret then
+            return ret( user, adccmd, targetuser )  -- forward it with fireing script listeners
+        end
+        return false    --forward it later without fireing script listeners
+    elseif state == "protocol" then
+        ret = _protocol[ fourcc ]
+    elseif state == "identify" then
+        ret = _identify[ fourcc ]
+    elseif state == "verify" then
+        ret = _verify[ fourcc ]
+    end
+    if not ret then
+        user.write( "ISTA 125 FC" .. fourcc .. "\n" )
+    else
+        ret( user, adccmd, targetuser )
+    end
+    return true
+end
+
+
+return {
+    bind   = bind,
+    states = states,
+}


### PR DESCRIPTION
## Summary

**Phase 6d-3** of the hub.lua decomposition - and the one that finally drops hub.lua under the **Phase 6 1500-line ceiling**.

Moves the four state-machine handler tables (\`_protocol\`, \`_identify\`, \`_verify\`, \`_normal\` - one per ADC connection state) plus \`states()\` (the router) into \`core/hub_dispatch.lua\`.

## Wiring

The dispatcher reads heavily from hub.lua's cfg cache (\`_cfg_*\`), i18n strings (\`_i18n_*\`), format strings (\`_pingsup\`, \`_normalsup\`, \`_normalsup_regonly\`, \`_hubinf_regonly\`), and the live user-state count (\`_user_count\`) - 40+ deps in total.

Same \`bind_late()\` pattern as Phases 6c-1/2/3 and 6d-1/2: hub.lua calls \`_dispatch_module.bind({...})\` once after init() and again whenever any of these caches is refreshed (\`loadsettings\`, \`loadlanguage\`, \`updateusers\`).

A single hub.lua-side helper \`_bind_dispatch_module()\` builds the deps table so the four call sites stay one-liners.

\`_user_count\` mutates during normal hub operation (incoming / disconnect increment / decrement it), so we receive it as a **getter closure** rather than a snapshot - the dispatcher always sees the current value when checking against \`_cfg_max_users\`.

## Result

| File | Before | After |
|---|---|---|
| \`core/hub.lua\` | 1717 | **1497** (under 1500 ceiling) |
| \`core/hub_dispatch.lua\` | new | **475** |

**Phase 6d complete.** core/hub.lua is now within the Phase 6 line ceiling. The full hub.lua decomposition arc:

| Stage | hub.lua LOC |
|---|---|
| Original | 2245 |
| After 6d-1 (createuser) | 1915 |
| After 6d-2 (createbot) | 1717 |
| After 6d-3 (dispatcher) | **1497** |

\`hub.X\` public API unchanged. Smoke tests green - the dispatcher is exercised end-to-end by the existing handshake / login / +cmd-routing tests. The +help test in particular round-trips through all four state tables (HSUP -> identify, BINF -> verify, HPAS -> normal, BMSG dispatch in normal).

## Test plan

- [x] CI smoke green on Linux + Windows (already verified - 7/7 PASS)
- [ ] Manual: \`+reload\` triggers loadsettings/loadlanguage rebind, dispatcher still works afterwards
- [ ] Manual: hub bind shut down via \`+shutdown\` countdown (exercises the broadcast block + dispatcher state during teardown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)