### PR TITLE
fix(auth): use CSPRNG for password salt and SID generation

### DIFF
--- a/adclib/CMakeLists.txt
+++ b/adclib/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(adclib MODULE
     tiger.cpp
 )
 
-target_link_libraries(adclib PRIVATE lua)
+target_link_libraries(adclib PRIVATE lua OpenSSL::Crypto)
 
 # Lua C modules conventionally have no "lib" prefix on Linux either —
 # require("adclib") looks for adclib.so directly, not libadclib.so.

--- a/adclib/adclib.cpp
+++ b/adclib/adclib.cpp
@@ -14,6 +14,8 @@
 #include "base32.h"
 #include "tiger.h"
 
+#include <openssl/rand.h>
+
 extern "C" {
 
 #include "lua.h"
@@ -190,6 +192,24 @@ int hash_pas_oldschool(lua_State* L)
     return 1;
 }
 
+// CSPRNG: returns n cryptographically strong random bytes as a Lua string.
+// Backed by OpenSSL RAND_bytes (libcrypto). Replaces the math.random()-based
+// salt source flagged as F-AUTH-2 in the Phase 7 audit.
+int random_bytes(lua_State* L)
+{
+    lua_Integer n = luaL_checkinteger(L, 1);
+    if (n <= 0 || n > 4096) {
+        return luaL_error(L, "random_bytes: n must be in [1, 4096], got %d",
+                          (int)n);
+    }
+    unsigned char buf[4096];
+    if (RAND_bytes(buf, (int)n) != 1) {
+        return luaL_error(L, "random_bytes: RAND_bytes failed (PRNG not seeded)");
+    }
+    lua_pushlstring(L, (const char *)buf, (size_t)n);
+    return 1;
+}
+
 int escape(lua_State* L)
 {
     std::string s = (std::string) luaL_optstring(L, 1, "");
@@ -247,6 +267,7 @@ static const luaL_Reg adclib[] = {
     {"unescape", unescape},
     {"isutf8", is_valid_utf8},
     {"sanitize_utf8", sanitize_utf8},
+    {"random_bytes", random_bytes},
     {NULL, NULL}
 };
 

--- a/core/adc.lua
+++ b/core/adc.lua
@@ -55,7 +55,6 @@ local os_date = os.date
 local os_time = os.time
 local os_clock = os.clock
 local string_sub = string.sub
-local math_random = math.random
 local string_gsub = string.gsub
 local string_find = string.find
 local string_match = string.match
@@ -76,6 +75,8 @@ local utf_find = unicode.utf8.find
 local adclib_hash = adclib.hash
 local adclib_isutf8 = adclib.isutf8
 local adclib_hashpas = adclib.hashpas
+local adclib_random_bytes = adclib.random_bytes
+local string_byte = string.byte
 
 --// core scripts //--
 
@@ -534,22 +535,25 @@ _protocol_commands = _protocol.commands
 _contextsend = "[BFDE]"
 _contextdirect = "[DE]"
 
+-- CSPRNG-backed: 256 % 32 == 0, so (byte & 31) is a uniform draw from
+-- [0, 31] without modulo bias. Random source is OpenSSL RAND_bytes via
+-- the adclib C module (Phase 7 F-AUTH-2 fix).
 adclib.createsid = function( )
-    return ""..
-        _base32[ math_random( 32 ) ] ..
-        _base32[ math_random( 32 ) ] ..
-        _base32[ math_random( 32 ) ] ..
-        _base32[ math_random( 32 ) ]
+    local b = adclib_random_bytes( 4 )
+    return _base32[ ( string_byte( b, 1 ) % 32 ) + 1 ] ..
+           _base32[ ( string_byte( b, 2 ) % 32 ) + 1 ] ..
+           _base32[ ( string_byte( b, 3 ) % 32 ) + 1 ] ..
+           _base32[ ( string_byte( b, 4 ) % 32 ) + 1 ]
 end
 
 adclib.createsalt = function( num )
     num = num or 10
-    local eol = 0
+    local b = adclib_random_bytes( num )
+    local out = { }
     for i = 1, num do
-        eol = eol + 1
-        _buffer[ eol ] = _base32[ math_random( 32 ) ]
+        out[ i ] = _base32[ ( string_byte( b, i ) % 32 ) + 1 ]
     end
-    return table_concat( _buffer, "", 1, eol )
+    return table_concat( out )
 end
 
 checkadccmd = function( data, traceback, noerror )

--- a/core/util.lua
+++ b/core/util.lua
@@ -100,8 +100,7 @@ local os_time = os.time
 local os_date = os.date
 local os_difftime = os.difftime
 local math_floor = math.floor
-local math_random = math.random
-local math_randomseed = math.randomseed
+local string_byte = string.byte
 local table_sort = table.sort
 local table_insert = table.insert
 local string_format = string.format
@@ -116,6 +115,7 @@ local unicode = use "unicode"
 --// extern lib methods //--
 
 local isutf8 = adclib.isutf8
+local adclib_random_bytes = adclib.random_bytes
 local ascii_sub = unicode.ascii.sub
 local utf_format = unicode.utf8.format
 local ascii_gsub = unicode.ascii.gsub
@@ -444,6 +444,11 @@ formatbytes = function( bytes )
 end
 
 --// returns a random generated alphanumerical password with length = len; if no param is specified then len = 20
+-- Random source is OpenSSL RAND_bytes via adclib (Phase 7 F-AUTH-2 fix).
+-- Two CSPRNG bytes per output character: one drives the bucket choice,
+-- one drives the in-bucket index. The original 40/20/40
+-- digit/upper/lower distribution is preserved for backwards compatibility
+-- with operators' expectations of generated passwords.
 generatepass = function( len )
     local len = tonumber( len )
     if not ( type( len ) == "number" ) or ( len < 0 ) or ( len > 1000 ) then len = 20 end
@@ -451,16 +456,18 @@ generatepass = function( len )
                     "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z" }
     local upper = { "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
                     "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z" }
-    math_randomseed( os_time() )
+    local rng = adclib_random_bytes( len * 2 )
     local pwd = ""
     for i = 1, len do
-        local X = math_random( 0, 9 )
+        local b1 = string_byte( rng, ( i - 1 ) * 2 + 1 )
+        local b2 = string_byte( rng, ( i - 1 ) * 2 + 2 )
+        local X = b1 % 10
         if X < 4 then
-            pwd = pwd .. math_random( 0, 9 )
-        elseif ( X >= 4 ) and ( X < 6 ) then
-            pwd = pwd .. upper[ math_random( 1, 25 ) ]
+            pwd = pwd .. tostring( b2 % 10 )
+        elseif X < 6 then
+            pwd = pwd .. upper[ ( b2 % 25 ) + 1 ]
         else
-            pwd = pwd .. lower[ math_random( 1, 25 ) ]
+            pwd = pwd .. lower[ ( b2 % 25 ) + 1 ]
         end
     end
     return pwd

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -407,6 +407,48 @@ def test_command_routing():
             raise TestFailure(f"+help response unexpectedly short: {response!r}")
 
 
+def test_csprng_salt_uniqueness():
+    """Open N sequential connections to a registered nick, drive each through
+    SUP/BINF until the hub answers IGPA <salt>, capture the salt and disconnect
+    before HPAS (so badpassword stays at 0). Assert all salts are distinct.
+
+    Smoke-coverage for the F-AUTH-2 fix: the math.random() salt source was
+    replaced with OpenSSL RAND_bytes via adclib.random_bytes. A regression to
+    a deterministic / poorly-seeded PRNG would make this test fail on
+    repeated salts."""
+    salts = []
+    N = 10
+    for _ in range(N):
+        with socket.create_connection((HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC) as sock:
+            reader = _ADCReader(sock)
+            sock.sendall(b"HSUP ADBASE ADTIGR\n")
+            reader.recv_until(lambda f: f.startswith("ISUP "))
+            isid = reader.recv_until(lambda f: f.startswith("ISID "))
+            sid = isid.split(" ", 1)[1].strip()
+            reader.recv_until(lambda f: f.startswith("IINF "))
+
+            pid_bytes = secrets.token_bytes(24)
+            cid_b32 = _b32_encode(_tiger.tiger(pid_bytes))
+            pid_b32 = _b32_encode(pid_bytes)
+            binf = (
+                f"BINF {sid}"
+                f" ID{cid_b32}"
+                f" PD{pid_b32}"
+                f" NIdummy"
+                f" I40.0.0.0"
+                f" SUTCP4\n"
+            )
+            sock.sendall(binf.encode("utf-8"))
+
+            gpa = reader.recv_until(lambda f: f.startswith("IGPA "))
+            salts.append(gpa.split(" ", 1)[1].strip())
+            # Drop the connection before HPAS - no badpassword increment.
+
+    if len(set(salts)) != N:
+        dupes = [s for s in salts if salts.count(s) > 1]
+        raise TestFailure(f"salt collision in {N} draws: {dupes!r}")
+
+
 def test_no_script_errors(log_path: Path):
     """
     Plugin-load smoke: scan the captured hub stdout for "script error:"
@@ -433,6 +475,7 @@ TESTS = [
     ("plain ADC full login (dummy/test)", test_full_login_plain),
     ("TLS ADC full login (dummy/test)", test_full_login_tls),
     ("+cmd routing (post-login +help)", test_command_routing),
+    ("CSPRNG salts are unique across connections", test_csprng_salt_uniqueness),
 ]
 
 


### PR DESCRIPTION
Closes #53 (F-AUTH-2).

## Summary

Replaces `math.random()` with OpenSSL `RAND_bytes` for every security-relevant random draw in the hub: HPAS challenge salts (`adclib.createsalt`), session IDs (`adclib.createsid`), and admin-generated user passwords (`util.generatepass`). Drops the `math.randomseed(os.time())` reseed which overrode Lua 5.4's secure default boot seed with second-resolution time.

## What changed

- New C function `adclib.random_bytes(n)` wrapping `RAND_bytes` (libcrypto). Caps n at 4096; errors on PRNG-not-seeded.
- `adclib/CMakeLists.txt` links `OpenSSL::Crypto`. No new bundled dep: OpenSSL is already required by LuaSec, just plumbed into `adclib` too.
- `core/adc.lua` `createsalt` + `createsid` use the new helper. `(byte & 31)` is uniform on `[0, 31]` since `256 % 32 == 0`.
- `core/util.lua` `generatepass` uses the new helper. The `math.randomseed(os.time())` line is gone. The 40/20/40 digit/upper/lower distribution is preserved.
- Smoke harness gains `test_csprng_salt_uniqueness`: opens 10 sequential connections, drives each through SUP/BINF until IGPA, captures salts, asserts all unique. Drops connections before HPAS so `badpassword` stays at 0. A regression to a deterministic PRNG would fail this check.

## Test plan

- [x] `cmake --build build` clean
- [x] `cmake --install build` clean
- [x] Smoke harness 8/8 PASS (was 7/7 before, +1 new CSPRNG check)

```
[smoke] PASS  hub binds plain + TLS ports
[smoke] PASS  plain ADC handshake
[smoke] PASS  TLS ADC handshake
[smoke] PASS  plain ADC full login (dummy/test)
[smoke] PASS  TLS ADC full login (dummy/test)
[smoke] PASS  +cmd routing (post-login +help)
[smoke] PASS  CSPRNG salts are unique across connections
[smoke] PASS  no script errors in log
```

## Out of scope (deliberately)

- The `math_random(1, 25)` off-by-one in `generatepass` (excludes 'z' / 'Z' from a 26-element table). Latent bug, no security impact, kept as-is per "no drive-by refactors".
- F-PRS-4 (parser non-reentrant `_buffer`). `createsalt` no longer touches the shared buffer (uses a local), but the parser-side issue is tracked separately in #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)