### PR TITLE
fix: enforce chmod 600 on user.tbl + cert keys (F-SEC-1)

### DIFF
--- a/core/cfg_users.lua
+++ b/core/cfg_users.lua
@@ -34,6 +34,7 @@ local util = use "util"
 local util_loadtable = util.loadtable
 local util_savearray = util.savearray
 local util_maketable = util.maketable
+local util_chmod_secret = util.chmod_secret
 
 local _
 
@@ -54,11 +55,13 @@ local function loadusers( user_path )
 end
 
 local function saveusers( user_path, regusers )
-    local _, err = util_savearray( regusers, user_path .. "user.tbl" )
+    local file = user_path .. "user.tbl"
+    local _, err = util_savearray( regusers, file )
     _ = err and out_error( "cfg_users.lua: function 'saveusers': error while saving user db: ", err )
     if err then
         return false, err
     else
+        util_chmod_secret( file )
         return true
     end
 end
@@ -66,15 +69,25 @@ end
 local function checkusers( user_path )
     local users, err = util_loadtable( user_path .. "user.tbl" )
     if users then
-        util_maketable( nil, user_path .. "user.tbl.bak" )
-        local _, err = util_savearray( users, user_path .. "user.tbl.bak" )
-        _ = err and out_error( "cfg_users.lua: function 'checkusers': error while saving user db backup: ", err )
+        local backup = user_path .. "user.tbl.bak"
+        util_maketable( nil, backup )
+        local _, err = util_savearray( users, backup )
+        if err then
+            out_error( "cfg_users.lua: function 'checkusers': error while saving user db backup: ", err )
+        else
+            util_chmod_secret( backup )
+        end
     else
         local users, err = util_loadtable( user_path .. "user.tbl.bak" )
         if users then
-            util_maketable( nil, user_path .. "user.tbl" )
-            local _, err = util_savearray( users, user_path .. "user.tbl" )
-            _ = err and out_error( "cfg_users.lua: function 'checkusers': error while restoring corrupt user db from backup: ", err )
+            local file = user_path .. "user.tbl"
+            util_maketable( nil, file )
+            local _, err = util_savearray( users, file )
+            if err then
+                out_error( "cfg_users.lua: function 'checkusers': error while restoring corrupt user db from backup: ", err )
+            else
+                util_chmod_secret( file )
+            end
         end
     end
 end

--- a/core/util.lua
+++ b/core/util.lua
@@ -163,6 +163,8 @@ local spairs
 
 local is_posint
 
+local chmod_secret
+
 local encode
 local decode
 
@@ -606,6 +608,23 @@ spairs = function( tbl )
     return orderedNext, tbl, nil
 end
 
+--// chmod 600 a freshly-written secret file on POSIX. No-op on Windows
+-- (NTFS ACLs are not POSIX mode bits; see docs/BUILDING.md for the
+-- icacls recipe). Invoked from secret-writing call sites such as
+-- saveusers; should NOT be applied to non-secret .tbl files like
+-- bans.tbl or hubstats.tbl. Phase 7 F-SEC-1 mitigation.
+do
+    local is_windows = os.getenv( "COMSPEC" ) and os.getenv( "WINDIR" )
+    chmod_secret = function( path )
+        if is_windows then return end
+        -- Single-quote-escape to neutralise any path metacharacters; the
+        -- only common offender is a literal single quote inside the path,
+        -- which we replace with the standard '\'' escape.
+        local escaped = "'" .. tostring( path ):gsub( "'", "'\\''" ) .. "'"
+        os.execute( "chmod 600 " .. escaped )
+    end
+end
+
 --// low impact encryption - a lightweight pure Lua cipher / based on a code part on stackoverflow.com
 do
     local Key53 = 1529434767825498 -- 67bit
@@ -687,6 +706,7 @@ return {
     spairs = spairs,
     maketable = maketable,
     is_posint = is_posint,
+    chmod_secret = chmod_secret,
     encode = encode,
     decode = decode,
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -186,6 +186,45 @@ default account is hubowner — **delete it as soon as you have your own**.
 
 ---
 
+## File permissions for secrets
+
+`cfg/user.tbl` (registered users with their cleartext passwords - see
+[F-AUTH-1](https://github.com/Aybook/luadch/issues/52) for the
+ADC-protocol-mandated reason) and `certs/serverkey.pem` (TLS private
+key) hold material that must not be world-readable.
+
+### 🐧 Linux / BSD
+
+The hub `chmod 600`s `user.tbl` automatically after every write
+(`+reg`, `+delreg`, `+setpass`, etc.) and the `make_cert.sh` script
+`chmod 600`s the generated private keys. **No manual step needed**
+on a fresh install.
+
+If you have an existing deployment from before this hardening, run
+once:
+
+```sh
+chmod 600 cfg/user.tbl certs/serverkey.pem certs/cakey.pem
+```
+
+### 🪟 Windows
+
+NTFS does not have POSIX permission bits, so the hub does not attempt
+to enforce permissions automatically. Run once after install to
+restrict the secret files to your user account only:
+
+```cmd
+icacls "cfg\user.tbl"           /inheritance:r /grant:r "%USERNAME%:F"
+icacls "certs\serverkey.pem"    /inheritance:r /grant:r "%USERNAME%:F"
+icacls "certs\cakey.pem"        /inheritance:r /grant:r "%USERNAME%:F"
+```
+
+If the hub runs as `LocalService` / a dedicated service user, replace
+`%USERNAME%` with that account name. After you regenerate certificates
+or migrate `user.tbl` to a new install, repeat the `icacls` command.
+
+---
+
 ## Known cosmetic build warnings
 
 The Linux build emits 5 deprecation warnings from the bundled `luasec/` C

--- a/examples/certs/make_cert.sh
+++ b/examples/certs/make_cert.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Random Common Name so different deploys don't share a fingerprint.
-# Avoid the name UID — it is a read-only built-in in bash, so anyone running
+# Avoid the name UID -- it is a read-only built-in in bash, so anyone running
 # this script via "bash make_cert.sh" would silently get a degraded CN.
 RAND_ID=$(openssl rand -hex 16)
 openssl ecparam -out cakey.pem -name prime256v1 -genkey
@@ -8,3 +8,7 @@ openssl req -new -x509 -days 3650 -key cakey.pem -out cacert.pem -subj /CN="$RAN
 openssl ecparam -out serverkey.pem -name prime256v1 -genkey
 openssl req -new -key serverkey.pem -out servercert.pem -subj /CN="$RAND_ID"
 openssl x509 -req -days 3650 -in servercert.pem -CA cacert.pem -CAkey cakey.pem -set_serial 01 -out servercert.pem
+# Tighten permissions on the private key files. Default umask of 022 would
+# leave them world-readable, which is exactly what F-SEC-1 in the Phase 7
+# audit flagged. Public certs (servercert.pem, cacert.pem) stay default.
+chmod 600 cakey.pem serverkey.pem


### PR DESCRIPTION
Closes part of #55 (F-SEC-1).

## Summary

The hub used to leave `cfg/user.tbl` and `certs/serverkey.pem` at the process umask, typically world-readable on Linux. F-SEC-1 in the Phase 7 audit flagged this as a Backup-rsync / share-misconfig leak vector for plaintext passwords (F-AUTH-1) and the TLS private key.

## Changes

1. **New helper `util.chmod_secret(path)`** ([core/util.lua](../blob/master/core/util.lua)): runs `chmod 600 <path>` on POSIX, no-op on Windows. Single-quote-escapes the path so a metacharacter or space cannot break out of `os.execute`.
2. **`cfg_users.lua`** calls `chmod_secret` on `user.tbl` and `user.tbl.bak` after every successful write (`saveusers`, `checkusers`).
3. **`examples/certs/make_cert.sh`** chmods `cakey.pem` and `serverkey.pem` 600 after generation. The `.bat` counterpart is left alone -- Windows users follow the icacls recipe in BUILDING.md.
4. **`docs/BUILDING.md`** gains a *File permissions for secrets* section covering automatic Linux behaviour, a manual one-shot for existing deployments, and the icacls recipe for Windows.

## Out of scope

The startup chmod-or-die check for `master.key` is deliberately NOT in this PR. `master.key` is introduced in Phase 7f (M1, F-AUTH-1, [#52](https://github.com/Aybook/luadch/issues/52)); adding the check pre-emptively for a file that does not exist yet would be dead code.

## Test plan

- [x] `cmake --install build` clean
- [x] Smoke 8/8 PASS unchanged (chmod helper short-circuits on Windows test runner)
- [x] Linux-side chmod will run when CI smoke-linux job exercises a registered-user login (touches `saveusers` via the HPAS lastconnect update path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)