### PR TITLE
feat(security): rate-limit module + DoS hardening (Phase 7c)

### DIFF
--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -3022,6 +3022,98 @@ local defaults = {
         end
     },
 
+    --// RATE-LIMIT / DOS-HARDENING //--
+    --
+    -- Phase 7c. All defaults are conservative; tune to traffic profile.
+    -- Op-level users (level >= ratelimit_bypass_level) bypass every
+    -- per-user check below. Per-IP checks always apply.
+    --
+    -- Each "rate" key is integer per-second tokens (or bursts/window
+    -- where noted). The "burst" key is the bucket capacity, allowing
+    -- short spikes above the steady rate.
+
+    ratelimit_activate = { true,
+        function( value )
+            return types_boolean( value, nil, true )
+        end
+    },
+    ratelimit_bypass_level = { 60,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+    -- Per-IP parallel-socket cap. Connection refused at accept time.
+    -- Default 16 accommodates small-office NAT / CGNAT deployments
+    -- where many users share one public IP. Lower for tighter hubs.
+    ratelimit_perip_max_conns = { 16,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+    -- Per-IP new-connection rate (tokens/second + burst).
+    -- Defaults sized for NAT bursts (e.g. an office reconnecting after
+    -- internet flap). Burst >= max_conns so the parallel-cap is the
+    -- binding limit at steady-state, not the rate-bucket.
+    ratelimit_perip_conn_rate = { 10,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+    ratelimit_perip_conn_burst = { 30,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+    -- TLS handshake wallclock deadline (seconds). 0 disables.
+    ratelimit_handshake_timeout = { 10,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+    -- Per-IP bad-auth attempts. Per-account counter still applies on
+    -- top of this (max_bad_password / bad_pass_timeout).
+    ratelimit_perip_authfail_rate = { 10,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+    ratelimit_perip_authfail_burst = { 5,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+    -- When an IP exceeds the per-IP authfail rate above, block all
+    -- further accepts from it for this many seconds (independent of
+    -- the per-account bad_pass_timeout).
+    ratelimit_authfail_lockout = { 300,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+    -- Per-user chat (BMSG / EMSG / DMSG) rate.
+    ratelimit_user_msg_rate = { 5,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+    ratelimit_user_msg_burst = { 10,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+    -- Per-user search (BSCH / FSCH / DSCH) cooldown. The bucket fills
+    -- at one token every ratelimit_user_search_period seconds.
+    ratelimit_user_search_period = { 2,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+    ratelimit_user_search_burst = { 3,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+
     --// PING //--
 
     use_ping = { true,

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -42,6 +42,7 @@ local tablesize = use "tablesize"
 
 local adclib = use "adclib"
 local cfg = use "cfg"
+local ratelimit = use "ratelimit"
 local scripts = use "scripts"
 local signal = use "signal"
 local unicode = use "unicode"
@@ -59,6 +60,10 @@ local escapefrom = adclib.unescape
 
 local cfg_get = cfg.get
 local cfg_saveusers = cfg.saveusers
+
+local ratelimit_user_msg = ratelimit.user_msg
+local ratelimit_user_search = ratelimit.user_search
+local ratelimit_record_authfail = ratelimit.record_authfail
 
 local scripts_firelistener = scripts.firelistener
 local signal_get = signal.get
@@ -367,6 +372,10 @@ _verify = {
         local hubhashold = adclib_hasholdpas( pass, salt, usercid )
         if ( userhash ~= hubhash ) and ( userhash ~= hubhashold ) then
             profile.badpassword = ( profile.badpassword or 0 ) + 1
+            -- Phase 7c F-AUTH-3: also count this against the offending
+            -- IP so cross-account fishing is throttled, not just the
+            -- per-account counter that an attacker can cycle through.
+            ratelimit_record_authfail( userip )
             user:kill( "ISTA 223 " .. _i18n_invalid_pass .. "\n", "TL-1" )
             scripts_firelistener( "onFailedAuth", profile.nick, userip, usercid, escapefrom( _i18n_invalid_pass ) )
         else
@@ -390,6 +399,19 @@ _verify = {
 
 }
 
+-- Phase 7c F-RL-1 / F-RL-2 helpers. Token-bucket-protected entry points
+-- to the BMSG / EMSG / DMSG / *SCH listeners. Returning `true` from the
+-- handler tells incoming() the message has been handled (so the
+-- broadcast / fan-out is suppressed) without disconnecting the user.
+-- Op-level users (>= ratelimit_bypass_level) bypass the check inside
+-- ratelimit.user_msg / user_search.
+local function rl_msg_drop( user )
+    return not ratelimit_user_msg( user.cid( ), user.level( ) )
+end
+local function rl_search_drop( user )
+    return not ratelimit_user_search( user.cid( ), user.level( ) )
+end
+
 _normal = {
     -- ADC: 6.3.4. INF
     BINF = function( user, adccmd )
@@ -397,15 +419,18 @@ _normal = {
     end,
     -- ADC: 6.3.5. MSG
     BMSG = function( user, adccmd )
+        if rl_msg_drop( user ) then return true end
         return scripts_firelistener( "onBroadcast", user, adccmd, escapefrom( adccmd[ 6 ] ) )
     end,
     --FMSG = function( user, adccmd )  -- cannot see a good scenario for FMSG; why should a user want to send mainchat messages to clients with specific features only?
     --    return scripts_firelistener( "onBroadcast", user, adccmd, escapefrom( adccmd[ 8 ] ) )
     --end,
     EMSG = function( user, adccmd, targetuser )
+        if rl_msg_drop( user ) then return true end
         return scripts_firelistener( "onPrivateMessage", user, targetuser, adccmd, escapefrom( adccmd[ 8 ] ) )
     end,
     DMSG = function( user, adccmd, targetuser )
+        if rl_msg_drop( user ) then return true end
         return scripts_firelistener( "onPrivateMessage", user, targetuser, adccmd, escapefrom( adccmd[ 8 ] ) )
     end,
     -- ADC: 6.3.8. CTM
@@ -424,12 +449,15 @@ _normal = {
     --end,
     -- ADC: 6.3.6. SCH
     BSCH = function( user, adccmd )
+        if rl_search_drop( user ) then return true end
         return scripts_firelistener( "onSearch", user, adccmd )
     end,
     FSCH = function( user, adccmd )
+        if rl_search_drop( user ) then return true end
         return scripts_firelistener( "onSearch", user, adccmd )
      end,
     DSCH = function( user, adccmd, targetuser )
+        if rl_search_drop( user ) then return true end
         return scripts_firelistener( "onSearch", user, adccmd )
     end,
     -- ADC: 6.3.7. RES

--- a/core/init.lua
+++ b/core/init.lua
@@ -78,6 +78,7 @@ _core = {    -- luadch core, order is important
     "cfg",
     "out",
     --"doc",
+    "ratelimit",
     "server",
     "adc",
     "hub",

--- a/core/ratelimit.lua
+++ b/core/ratelimit.lua
@@ -1,0 +1,295 @@
+--[[
+
+    core/ratelimit.lua - DoS hardening rate limiter
+
+    Phase 7c. Token-bucket counters keyed by IP or by user-CID,
+    cfg-tunable, op-level bypass. Hooks:
+
+    - server.lua  : accept_ip / release_ip / handshake_started /
+                    handshake_finished / expired_handshakes
+    - hub_dispatch: user_msg / user_search / record_authfail
+
+    Storage:
+
+        _perip_count[ip]   = active socket count
+        _buckets[id][kind] = { tokens, ts }
+        _hs_started[h]     = handshake start ts
+
+    IDs:
+        "ip:1.2.3.4"   for per-IP buckets
+        "user:CID"     for per-user buckets (CID is stable per session)
+
+    Cleanup:
+        tick() walks _buckets and drops entries idle > 5 min. Per-IP
+        counts drop to zero on release_ip; handshake table is cleaned
+        explicitly on handshake_finished or via the periodic walk
+        triggered by expired_handshakes.
+
+]]--
+
+----------------------------------// DECLARATION //--
+
+--// lua functions //--
+
+local pairs = use "pairs"
+local ipairs = use "ipairs"
+
+--// lua libs //--
+
+local math = use "math"
+
+--// lua lib methods //--
+
+local math_min = math.min
+
+--// extern libs //--
+
+local socket = use "socket"
+
+--// extern lib methods //--
+
+local socket_gettime = socket.gettime
+
+--// core modules //--
+
+local cfg = use "cfg"
+
+--// core methods //--
+
+local cfg_get = cfg.get
+
+--// functions //--
+
+local init
+local accept_ip
+local release_ip
+local handshake_started
+local handshake_finished
+local expired_handshakes
+local user_msg
+local user_search
+local record_authfail
+local tick
+
+--// tables //--
+
+local _perip_count
+local _buckets
+local _hs_started
+local _ip_blocks    -- ip -> expiry-ts; F-AUTH-3 sticky lockout
+
+--// scalars //--
+
+local _activate
+local _bypass_level
+local _perip_max_conns
+local _perip_conn_rate
+local _perip_conn_burst
+local _hs_timeout
+local _authfail_rate_per_sec
+local _authfail_burst
+local _authfail_lockout
+local _msg_rate
+local _msg_burst
+local _search_rate_per_sec
+local _search_burst
+
+local _last_cleanup
+local _cleanup_interval
+local _bucket_idle_max
+
+----------------------------------// DEFINITION //--
+
+_perip_count = { }
+_buckets = { }
+_hs_started = { }
+_ip_blocks = { }
+
+_last_cleanup = 0
+_cleanup_interval = 60
+_bucket_idle_max = 300
+
+local function _bucket( id, kind, capacity )
+    local b = _buckets[ id ]
+    if not b then
+        b = { }
+        _buckets[ id ] = b
+    end
+    local tk = b[ kind ]
+    if not tk then
+        tk = { tokens = capacity, ts = socket_gettime( ) }
+        b[ kind ] = tk
+    end
+    return tk
+end
+
+local function _consume( id, kind, capacity, fill_per_sec )
+    local now = socket_gettime( )
+    local tk = _bucket( id, kind, capacity )
+    local elapsed = now - tk.ts
+    if elapsed > 0 then
+        tk.tokens = math_min( capacity, tk.tokens + elapsed * fill_per_sec )
+        tk.ts = now
+    end
+    if tk.tokens >= 1 then
+        tk.tokens = tk.tokens - 1
+        return true
+    end
+    return false
+end
+
+local function _ip_blocked( ip )
+    local until_ts = _ip_blocks[ ip ]
+    if not until_ts then return false end
+    if socket_gettime( ) >= until_ts then
+        _ip_blocks[ ip ] = nil
+        return false
+    end
+    return true
+end
+
+accept_ip = function( ip )
+    if not _activate then return true end
+    -- Sticky F-AUTH-3 IP block from prior bad-auth abuse.
+    if _ip_blocked( ip ) then
+        return false, "IP locked out due to repeated auth failures: " .. tostring( ip )
+    end
+    -- Parallel-socket cap (F-NET-1, parallel slot count)
+    local count = _perip_count[ ip ] or 0
+    if count >= _perip_max_conns then
+        return false, "too many connections from " .. tostring( ip )
+    end
+    -- Connection-rate (F-NET-1, rate)
+    if not _consume( "ip:" .. ip, "conn", _perip_conn_burst, _perip_conn_rate ) then
+        return false, "connection rate exceeded for " .. tostring( ip )
+    end
+    _perip_count[ ip ] = count + 1
+    return true
+end
+
+release_ip = function( ip )
+    if not ip then return end
+    local count = _perip_count[ ip ]
+    if not count then return end
+    if count <= 1 then
+        _perip_count[ ip ] = nil
+    else
+        _perip_count[ ip ] = count - 1
+    end
+end
+
+handshake_started = function( handler )
+    if not _activate or _hs_timeout <= 0 then return end
+    _hs_started[ handler ] = socket_gettime( )
+end
+
+handshake_finished = function( handler )
+    _hs_started[ handler ] = nil
+end
+
+-- Returns array of handlers whose TLS handshake has been pending
+-- longer than _hs_timeout. Caller (server.lua periodic timer) is
+-- responsible for closing them.
+expired_handshakes = function( )
+    if not _activate or _hs_timeout <= 0 then return nil end
+    local now = socket_gettime( )
+    local result
+    for h, ts in pairs( _hs_started ) do
+        if ( now - ts ) >= _hs_timeout then
+            result = result or { }
+            result[ #result + 1 ] = h
+        end
+    end
+    return result
+end
+
+-- Per-user chat-rate (F-RL-1). level >= bypass_level skips the check.
+user_msg = function( cid, level )
+    if not _activate then return true end
+    if level and level >= _bypass_level then return true end
+    if not cid or cid == "" then return true end
+    return _consume( "user:" .. cid, "msg", _msg_burst, _msg_rate )
+end
+
+-- Per-user search-rate (F-RL-2). level >= bypass_level skips the check.
+user_search = function( cid, level )
+    if not _activate then return true end
+    if level and level >= _bypass_level then return true end
+    if not cid or cid == "" then return true end
+    return _consume( "user:" .. cid, "search", _search_burst, _search_rate_per_sec )
+end
+
+-- Per-IP failed-auth tracking (F-AUTH-3). Consumes a token from the
+-- per-IP authfail bucket; if the rate has been exceeded the IP is
+-- added to the sticky lockout list for `_authfail_lockout` seconds.
+-- accept_ip will refuse new connections from that IP for the duration.
+-- Returns true if still under the rate, false if just locked out.
+record_authfail = function( ip )
+    if not _activate then return true end
+    if not ip or ip == "" then return true end
+    local ok = _consume( "ip:" .. ip, "authfail", _authfail_burst, _authfail_rate_per_sec )
+    if not ok then
+        _ip_blocks[ ip ] = socket_gettime( ) + _authfail_lockout
+    end
+    return ok
+end
+
+tick = function( )
+    local now = socket_gettime( )
+    if ( now - _last_cleanup ) < _cleanup_interval then return end
+    _last_cleanup = now
+    local stale_before = now - _bucket_idle_max
+    for id, kinds in pairs( _buckets ) do
+        local newest = 0
+        for _, tk in pairs( kinds ) do
+            if tk.ts > newest then newest = tk.ts end
+        end
+        if newest < stale_before then
+            _buckets[ id ] = nil
+        end
+    end
+    -- Drop expired IP locks so the table does not grow unboundedly.
+    for ip, until_ts in pairs( _ip_blocks ) do
+        if now >= until_ts then _ip_blocks[ ip ] = nil end
+    end
+end
+
+init = function( )
+    _activate = cfg_get "ratelimit_activate"
+    _bypass_level = cfg_get "ratelimit_bypass_level"
+    _perip_max_conns = cfg_get "ratelimit_perip_max_conns"
+    _perip_conn_rate = cfg_get "ratelimit_perip_conn_rate"
+    _perip_conn_burst = cfg_get "ratelimit_perip_conn_burst"
+    _hs_timeout = cfg_get "ratelimit_handshake_timeout"
+    -- authfail rate is configured per-minute for human-friendly tuning.
+    _authfail_rate_per_sec = cfg_get "ratelimit_perip_authfail_rate" / 60
+    _authfail_burst = cfg_get "ratelimit_perip_authfail_burst"
+    _authfail_lockout = cfg_get "ratelimit_authfail_lockout"
+    _msg_rate = cfg_get "ratelimit_user_msg_rate"
+    _msg_burst = cfg_get "ratelimit_user_msg_burst"
+    -- search is configured as "one per N seconds" for legibility; convert
+    -- to fill-rate per second.
+    local search_period = cfg_get "ratelimit_user_search_period"
+    if not search_period or search_period <= 0 then search_period = 1 end
+    _search_rate_per_sec = 1 / search_period
+    _search_burst = cfg_get "ratelimit_user_search_burst"
+    _last_cleanup = socket_gettime( )
+end
+
+----------------------------------// PUBLIC INTERFACE //--
+
+return {
+
+    init = init,
+
+    accept_ip = accept_ip,
+    release_ip = release_ip,
+    handshake_started = handshake_started,
+    handshake_finished = handshake_finished,
+    expired_handshakes = expired_handshakes,
+    user_msg = user_msg,
+    user_search = user_search,
+    record_authfail = record_authfail,
+    tick = tick,
+
+}

--- a/core/server.lua
+++ b/core/server.lua
@@ -87,6 +87,7 @@ local cfg = use "cfg"
 local out = use "out"
 local mem = use "mem"
 local signal = use "signal"
+local ratelimit = use "ratelimit"
 
 --// core methods //--
 
@@ -96,6 +97,12 @@ local mem_free = mem.free
 local out_error = out.error
 local signal_set = signal.set
 local signal_get = signal.get
+local ratelimit_accept_ip = ratelimit.accept_ip
+local ratelimit_release_ip = ratelimit.release_ip
+local ratelimit_handshake_started = ratelimit.handshake_started
+local ratelimit_handshake_finished = ratelimit.handshake_finished
+local ratelimit_expired_handshakes = ratelimit.expired_handshakes
+local ratelimit_tick = ratelimit.tick
 
 --// functions //--
 
@@ -334,15 +341,26 @@ wrapserver = function( listeners, socket, serverip, serverport, pattern, sslctx,
         local client, err = accept( socket )    -- try to accept
         if client then
             local clientip, clientport = client:getpeername( )
+            -- Phase 7c F-NET-1: per-IP parallel-socket cap and per-IP
+            -- accept-rate cap. Refuse pre-wrap so the offending IP cannot
+            -- consume FDs / slot-list entries.
+            local ok, rl_err = ratelimit_accept_ip( clientip )
+            if not ok then
+                out_put( "server.lua: function 'wrapserver': rate-limit refused ", clientip, ": ", rl_err )
+                client:close( )
+                return false
+            end
             client:settimeout( 0 )
             local _, err = client:setoption( "reuseaddr", true )
             local _, err2 = client:setoption( "keepalive", true )
             if err or err2 then
                 out_put( "server.lua: function 'wrapserver', luasocket socket setoption: ", err or err2 )
+                ratelimit_release_ip( clientip )
                 return false
             end
             local handler, client, err = wrapconnection( handler, listeners, client, serverip, clientip, serverport, clientport, pattern, sslctx, startssl )    -- wrap new client socket
             if err then    -- error while wrapping ssl socket
+                ratelimit_release_ip( clientip )
                 return false
             end
             connections = connections + 1
@@ -433,11 +451,13 @@ wrapconnection = function( server, listeners, socket, serverip, clientip, server
         _writetimes[ handler ] = nil
         _activitytimes[ handler ] = nil
         _closelist[ handler ] = nil
+        ratelimit_handshake_finished( handler )
         socket:close( )
         handler = nil
         socket = nil
         mem_free( )
         _ = server and server.remove( )
+        ratelimit_release_ip( clientip )    -- Phase 7c F-NET-1: free per-IP slot
         out_put "server.lua: function 'wrapconnection': closed client handler and removed socket from lists"
     end
     handler.close = function( forced )
@@ -606,12 +626,14 @@ wrapconnection = function( server, listeners, socket, serverip, clientip, server
     if sslctx then    -- ssl?
         ssl = true
         local wrote
+        ratelimit_handshake_started( handler )    -- Phase 7c F-NET-2: handshake-deadline tracking
         local handshake = coroutine_wrap( function( client )    -- create handshake coroutine
                 local err
                 for i = 1, 20 do    -- 20 handshake attemps
                     _, err = client:dohandshake( )
                     if not err then
                         out_put( "server.lua: function 'wrapconnection': ssl handshake done" )
+                        ratelimit_handshake_finished( handler )    -- Phase 7c F-NET-2
                         _sendlistlen = ( wrote and removesocket( _sendlist, socket, _sendlistlen ) ) or _sendlistlen
                         handler.readbuffer = handle_read_event   -- when handshake is done, replace the handshake function with regular functions
                         handler.sendbuffer = handle_write_event
@@ -969,6 +991,14 @@ addtimer( function( )
                     handler.close( "timeout" )    -- forced disconnect
                 end
             end
+            -- Phase 7c F-NET-2: kill TLS connections stuck in handshake.
+            local expired = ratelimit_expired_handshakes( )
+            if expired then
+                for _, h in ipairs( expired ) do
+                    h.close( "handshake timeout" )
+                end
+            end
+            ratelimit_tick( )    -- prune stale token buckets
         end
     end
 )

--- a/docs/phases/PHASE_7_FINDINGS.md
+++ b/docs/phases/PHASE_7_FINDINGS.md
@@ -348,6 +348,57 @@ shaped by this threat model.
 
 ---
 
+## 2.1. Findings added during 7c scoping
+
+A bestandsaufnahme of existing rate-limit / anti-flood mechanisms before
+Phase 7c implementation surfaced three additional medium-severity gaps
+that 7a had not separately listed. They are filed under the same
+[#56 umbrella](https://github.com/Aybook/luadch/issues/56) as the
+original DoS findings, since the fix shares infrastructure (per-user /
+per-IP token-bucket counters in the new `core/ratelimit.lua`).
+
+### Medium
+
+#### F-RL-1 ([#56](https://github.com/Aybook/luadch/issues/56)) - No per-user message-rate cap on BMSG / EMSG / DMSG (chat / PM spam)
+- **Files:** [`core/hub_dispatch.lua:399-410`](../../core/hub_dispatch.lua).
+- **Evidence:** The dispatcher fires `onBroadcast` / `onPrivateMessage`
+  for every BMSG / EMSG / DMSG with no rate gate. One authenticated
+  client can BMSG-spam main chat or EMSG-spam every other user as fast
+  as the socket accepts.
+- **Why it matters:** Trivial chat / PM flood from any logged-in user.
+  No protection beyond the per-connection 1 MiB send-buffer cap, which
+  protects the *server* from backpressure but happily fans the spam
+  out to every other client at full speed.
+- **Fix direction:** Per-user rate cap (cfg-tunable, default 5 msg/s
+  with small burst), enforced before `scripts_firelistener`. Op-level
+  bypass.
+
+#### F-RL-2 ([#56](https://github.com/Aybook/luadch/issues/56)) - No per-user search-rate cap on BSCH / FSCH / DSCH
+- **Files:** [`core/hub_dispatch.lua:426-433`](../../core/hub_dispatch.lua).
+- **Evidence:** Same shape as F-RL-1; every search command fires
+  `onSearch` with no gate. Combined with broadcast fan-out, a single
+  client triggers N hub-CPU and N×N network operations per search.
+- **Why it matters:** Search-flood DoS scales worse than message-flood
+  because the hub re-broadcasts each query to all matching peers.
+  `cmd_usersearch_max_limit = 20` only caps result *display*, not
+  search rate.
+- **Fix direction:** Per-user search-rate cap (cfg-tunable, default
+  1 search / 2 s with burst). Op-level bypass.
+
+#### F-RL-3 ([#56](https://github.com/Aybook/luadch/issues/56)) - No per-user `+cmd` cooldown
+- **Files:** [`scripts/etc_hubcommands.lua`](../../scripts/etc_hubcommands.lua).
+- **Evidence:** Hub-side `+cmd` dispatch has no rate gate. A client can
+  call `+help`, `+hubinfo`, etc. in tight loop, each round-trip costing
+  hub CPU and emitting bot-reply traffic.
+- **Why it matters:** Lower DoS yield than F-RL-1 / F-RL-2 because the
+  cost is per-command and most plugins reply once, but combined with
+  expensive commands (e.g. `+hubinfo` which renders cert info) it
+  adds up.
+- **Fix direction:** Per-user command-rate cap (cfg-tunable, default
+  2 cmd/s with burst). Op-level bypass.
+
+---
+
 ## 3. What 7a explicitly did NOT find
 
 Recorded as negative findings so a future auditor does not re-derive them:
@@ -396,7 +447,7 @@ By severity and effort:
 | Sub-phase | Findings | Effort | Notes |
 |---|---|---|---|
 | 7b | F-AUTH-2, F-C-1, F-C-3, F-SEC-1, F-DEP-1 | small | High-severity quick wins; 5 small PRs. F-AUTH-2 is the most consequential (CSPRNG for salts). |
-| 7c | F-AUTH-3, F-NET-1, F-NET-2 | medium | DoS hardening - per-IP caps, handshake deadline, throttle. |
+| 7c | F-AUTH-3, F-NET-1, F-NET-2, F-RL-1, F-RL-2, F-RL-3 | medium | DoS hardening - per-IP caps, handshake deadline, message/search/cmd-rate caps. Single comprehensive PR around a new `core/ratelimit.lua` module. |
 | 7d | F-PRS-1, F-PRS-2, F-PRS-3, F-PRS-4, F-PRS-5 | medium | ADC parser hardening - validators + reentrancy. |
 | 7e | F-FIO-1 | large | The big one. `loadtable` migration touches 50+ call sites; needs its own design doc + migration shim. |
 | 7f | F-AUTH-1 | n/a | Document at-rest risk in [`docs/SECURITY.md`](../SECURITY.md); long-term action depends on ADC-protocol movement. |

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -449,6 +449,49 @@ def test_csprng_salt_uniqueness():
         raise TestFailure(f"salt collision in {N} draws: {dupes!r}")
 
 
+def test_perip_connection_cap():
+    """Open more parallel TCP connections from one IP than ratelimit_perip_max_conns
+    (default 16). The N+1th accept must fail or get torn down by the hub before
+    a SUP exchange completes. Smoke coverage for F-NET-1.
+
+    We keep the first batch alive (don't close until end of test), then attempt
+    one extra. If the hub honours the cap, the extra socket either errors at
+    connect or the hub closes it before SUP can complete."""
+    cap = 16
+    keep = []
+    try:
+        for _ in range(cap):
+            sock = socket.create_connection((HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC)
+            keep.append(sock)
+        # The cap+1 attempt: connect may succeed (kernel-level) but the hub must
+        # not produce an ISUP. Give it ~1s; if we get nothing, the hub refused.
+        try:
+            extra = socket.create_connection((HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC)
+        except OSError:
+            return  # connect refused at OS level - that's also acceptable
+        try:
+            extra.settimeout(1.5)
+            extra.sendall(b"HSUP ADBASE ADTIGR\n")
+            data = b""
+            try:
+                data = extra.recv(4096)
+            except (socket.timeout, OSError):
+                pass
+            if data:
+                raise TestFailure(
+                    f"hub accepted connection #{cap + 1} from one IP and answered "
+                    f"with {data[:80]!r}; expected the per-IP cap to refuse"
+                )
+        finally:
+            extra.close()
+    finally:
+        for s in keep:
+            s.close()
+        # Give the hub time to process disconnects and free per-IP slots
+        # before the next test connects.
+        time.sleep(0.6)
+
+
 def test_no_script_errors(log_path: Path):
     """
     Plugin-load smoke: scan the captured hub stdout for "script error:"
@@ -476,6 +519,7 @@ TESTS = [
     ("TLS ADC full login (dummy/test)", test_full_login_tls),
     ("+cmd routing (post-login +help)", test_command_routing),
     ("CSPRNG salts are unique across connections", test_csprng_salt_uniqueness),
+    ("per-IP connection cap refuses overflow", test_perip_connection_cap),
 ]
 
 


### PR DESCRIPTION
Closes #56. Phase 7c.

## Summary

A new `core/ratelimit.lua` module providing token-bucket counters keyed by IP or user-CID, hooked into `core/server.lua` and `core/hub_dispatch.lua` at the DoS-relevant surfaces. Op-level (>= `ratelimit_bypass_level`, default 60) bypasses every per-user check; per-IP checks always apply.

## Findings closed

| ID | Severity | Hook |
|---|---|---|
| F-NET-1 | medium | per-IP parallel-socket cap + accept-rate, refused pre-wrap |
| F-NET-2 | medium | TLS handshake wallclock deadline, killed by existing `_checkinterval` timer |
| F-AUTH-3 | medium | per-IP failed-auth tracking with sticky lockout, independent of per-account bad_pass_timeout |
| F-RL-1 | medium | per-user chat-rate (BMSG/EMSG/DMSG), silent drop in dispatcher |
| F-RL-2 | medium | per-user search-rate (BSCH/FSCH/DSCH), silent drop in dispatcher |

## Defaults (cfg-tunable)

| Key | Default | Rationale |
|---|---|---|
| `ratelimit_activate` | true | global on/off |
| `ratelimit_bypass_level` | 60 | ops/regs above this skip per-user limits |
| `ratelimit_perip_max_conns` | 16 | NAT-friendly (small office / CGNAT) |
| `ratelimit_perip_conn_rate` | 10/s | + burst 30 |
| `ratelimit_handshake_timeout` | 10s | slowloris cutoff |
| `ratelimit_perip_authfail_rate` | 10/min | + burst 5 |
| `ratelimit_authfail_lockout` | 300s | sticky IP block after rate exceeded |
| `ratelimit_user_msg_rate` | 5/s | + burst 10 |
| `ratelimit_user_search_period` | 2s | + burst 3 |

## Storage

```
_perip_count[ip]   = active socket count
_buckets[id][kind] = { tokens, ts }      token-bucket per (id, kind)
_hs_started[h]     = handshake start ts
_ip_blocks[ip]     = expiry ts           sticky lockout
```

`ratelimit.tick()` is called from server.lua's existing `_checkinterval` timer and prunes idle buckets / expired locks.

## Test plan

- [x] `cmake --install build` clean
- [x] Smoke 9/9 PASS

```
[smoke] PASS  hub binds plain + TLS ports
[smoke] PASS  plain ADC handshake
[smoke] PASS  TLS ADC handshake
[smoke] PASS  plain ADC full login (dummy/test)
[smoke] PASS  TLS ADC full login (dummy/test)
[smoke] PASS  +cmd routing (post-login +help)
[smoke] PASS  CSPRNG salts are unique across connections
[smoke] PASS  per-IP connection cap refuses overflow      <-- new
[smoke] PASS  no script errors in log
```

The new `test_perip_connection_cap` opens 16 parallel sockets from 127.0.0.1 and asserts the hub refuses the 17th. End-to-end verification of the F-NET-1 path.

## What is NOT in this PR

- Two-client chat/search smoke tests. The drops are silent (dispatcher returns `true` to suppress broadcast without disconnect), so verifying them needs either a second low-level account or a test-only bypass override -- both add fixture complexity. The hooks themselves are reviewable by inspection in `core/hub_dispatch.lua` `BMSG`/`EMSG`/`DMSG`/`BSCH`/`FSCH`/`DSCH` handlers. Filed for a follow-up if needed.
- F-RL-3 (per-user `+cmd` cooldown). Currently subsumed by F-RL-1 since `+cmd` invocations travel as BMSG; tighter command-specific throttling can be added in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)