### PR TITLE
fix(util): sandbox loadtable() with empty _ENV (Phase 7e, F-FIO-1 critical)

### DIFF
--- a/core/util.lua
+++ b/core/util.lua
@@ -80,6 +80,7 @@
 local type = use "type"
 local table = use "table"
 local pairs = use "pairs"
+local pcall = use "pcall"
 local ipairs = use "ipairs"
 local tostring = use "tostring"
 local tonumber = use "tonumber"
@@ -275,14 +276,41 @@ sortserialize = function( tbl, name, file, tab, r )
 end
 
 --// loads a local table from file
+-- Phase 7e F-FIO-1: was `loadfile(path)` which loads with the caller's
+-- full _ENV - any attacker who tampers a .tbl file gains RCE on the
+-- hub host (cfg.tbl / user.tbl / lang/*.lng / dozens of plugin state
+-- files all flow through here).
+--
+-- Hardening:
+--   1. mode = "t" rejects compiled bytecode files (text source only).
+--   2. env = {} gives the chunk an empty _ENV: no os, io, debug,
+--      package, load*, require, dofile, loadfile, ... - effectively
+--      a sandbox where the chunk can compute pure data but cannot
+--      reach the host. Legitimate .tbl files are
+--      "local foo; foo = { ... }; return foo" which uses zero
+--      globals and works unchanged.
+--   3. pcall wraps the chunk call so a tampered file that errors at
+--      runtime (e.g. arithmetic on nil, infinite recursion past the
+--      Lua stack guard) cannot crash the hub - we just log and
+--      return nil.
+--
+-- Residual risk: a chunk can still loop indefinitely or allocate
+-- large tables. That is a DoS, not RCE, and only reachable by an
+-- attacker who already has file-write access (i.e. existing
+-- corruption / chmod / disk-fill primitives). Acceptable trade-off
+-- vs. a full hand-rolled non-executable parser (~300 LoC).
 loadtable = function( path )
     local _, err = checkfile( path )
     if err then
         return nil, err
     end
-    local chunk, err = loadfile( path )
+    local chunk, err = loadfile( path, "t", { } )
     if chunk then
-        local ret = chunk( )
+        local ok, ret = pcall( chunk )
+        if not ok then
+            out_error( "util.lua: function 'loadtable': chunk error in ", path, ": ", ret )
+            return nil, ret
+        end
         if ret and type( ret ) == "table" then
             return ret, err
         else


### PR DESCRIPTION
Closes #51 (F-FIO-1, **critical**). Phase 7e.

## Summary

`util.loadtable()` previously executed any tampered `.tbl` file with the hub's full `_ENV` (full `os`, `io`, `debug`, `package`, ...). Now loads with mode="t" + empty env so the chunk has no access to system primitives. RCE eliminated; legitimate data files load unchanged.

## Fix

```lua
- local chunk, err = loadfile( path )
+ local chunk, err = loadfile( path, "t", { } )
  if chunk then
-     local ret = chunk( )
+     local ok, ret = pcall( chunk )
+     if not ok then
+         out_error( ... )
+         return nil, ret
+     end
      ...
```

- `mode = "t"` rejects compiled bytecode files.
- `env = {}` gives the chunk an empty `_ENV`. No globals reachable.
- `pcall` wraps the call so a chunk that errors at runtime cannot crash the hub.

## Why empty-env sandbox vs the original "JSON / hand-rolled parser" plan

The original [#51 issue body](https://github.com/Aybook/luadch/issues/51) floated two heavier alternatives. Both would also eliminate the residual DoS surface (infinite loops, deep recursion, large in-chunk allocations) on top of RCE. The empty-env sandbox is a 1-line change with the following trade-offs:

| Approach | LoC delta | RCE eliminated? | DoS-via-loop eliminated? | Migration |
|---|---|---|---|---|
| **Empty-env sandbox** (this PR) | 1 | yes | no | none |
| Hand-rolled parser | ~300 | yes | yes | none |
| JSON via dkjson | ~30 + new dep | yes | yes | all .tbl files |

The residual DoS surface is only reachable by an attacker who already has file-write access (i.e. they can already corrupt files or fill the disk regardless). That's a far less impactful primitive than RCE, so the trade-off favours the small, low-risk change.

## What works in an empty env

`savetable` and `savearray` emit:

```lua
local foo

foo = {
    [ "key" ] = "value",
    [ 1 ] = { ... },
    ...
}

return foo
```

Pure data: local declarations, table literals, return. Zero globals consumed.

## What fails in an empty env

```lua
os.execute("rm -rf /")              -- nil indexing -> error
debug.getinfo(1).func()             -- nil indexing -> error
require("malicious")                -- nil call -> error
```

`pcall` catches the runtime error; loadtable returns `nil, err`. Hub uses defaults / logs error.

## Test plan

- [x] `cmake --install build` clean
- [x] Smoke 9/9 PASS unchanged

```
[smoke] PASS  hub binds plain + TLS ports
[smoke] PASS  plain ADC handshake
[smoke] PASS  TLS ADC handshake
[smoke] PASS  plain ADC full login (dummy/test)
[smoke] PASS  TLS ADC full login (dummy/test)
[smoke] PASS  +cmd routing (post-login +help)
[smoke] PASS  CSPRNG salts are unique across connections
[smoke] PASS  per-IP connection cap refuses overflow
[smoke] PASS  no script errors in log
```

Confirms cfg.tbl, user.tbl, language files, and the 20+ plugin state files all still load via the sandboxed loader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)