### PR TITLE
feat(security): AES-256-GCM at-rest encryption for user.tbl (Phase 7f, F-AUTH-1)

### DIFF
--- a/adclib/adclib.cpp
+++ b/adclib/adclib.cpp
@@ -15,6 +15,7 @@
 #include "tiger.h"
 
 #include <openssl/rand.h>
+#include <openssl/evp.h>
 
 extern "C" {
 
@@ -23,6 +24,14 @@ extern "C" {
 #include "lauxlib.h"
 
 }
+
+// AES-GCM constants. The Lua wrapper in core/cfg_secret.lua enforces
+// the same constants for framing on disk.
+enum {
+    AES_KEY_SIZE = 32,    // AES-256
+    AES_NONCE_SIZE = 12,  // GCM standard 96-bit nonce
+    AES_TAG_SIZE = 16,    // GCM standard 128-bit tag
+};
 
 enum {SIZE = 192/8};
 
@@ -237,6 +246,130 @@ int random_bytes(lua_State* L)
     return 1;
 }
 
+// AES-256-GCM seal: takes (key, nonce, plaintext), returns
+// ciphertext || tag concatenated as one Lua string. The plaintext can
+// be any binary; key must be exactly 32 bytes, nonce exactly 12 bytes.
+// Phase 7f F-AUTH-1 mitigation: at-rest encryption of user.tbl.
+int aes_gcm_seal(lua_State* L)
+{
+    size_t key_len, nonce_len, pt_len;
+    const unsigned char* key = (const unsigned char*)luaL_checklstring(L, 1, &key_len);
+    const unsigned char* nonce = (const unsigned char*)luaL_checklstring(L, 2, &nonce_len);
+    const unsigned char* pt = (const unsigned char*)luaL_checklstring(L, 3, &pt_len);
+
+    if (key_len != AES_KEY_SIZE) {
+        return luaL_error(L, "aes_gcm_seal: key must be %d bytes, got %d",
+                          AES_KEY_SIZE, (int)key_len);
+    }
+    if (nonce_len != AES_NONCE_SIZE) {
+        return luaL_error(L, "aes_gcm_seal: nonce must be %d bytes, got %d",
+                          AES_NONCE_SIZE, (int)nonce_len);
+    }
+
+    EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
+    if (!ctx) return luaL_error(L, "aes_gcm_seal: EVP_CIPHER_CTX_new failed");
+
+    if (EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, key, nonce) != 1) {
+        EVP_CIPHER_CTX_free(ctx);
+        return luaL_error(L, "aes_gcm_seal: EVP_EncryptInit_ex failed");
+    }
+
+    luaL_Buffer b;
+    luaL_buffinit(L, &b);
+    // Allocate space for ciphertext (same size as plaintext for GCM) + tag.
+    unsigned char* out = (unsigned char*)luaL_prepbuffsize(&b, pt_len + AES_TAG_SIZE);
+
+    int outlen = 0;
+    if (EVP_EncryptUpdate(ctx, out, &outlen, pt, (int)pt_len) != 1) {
+        EVP_CIPHER_CTX_free(ctx);
+        return luaL_error(L, "aes_gcm_seal: EVP_EncryptUpdate failed");
+    }
+    int finlen = 0;
+    if (EVP_EncryptFinal_ex(ctx, out + outlen, &finlen) != 1) {
+        EVP_CIPHER_CTX_free(ctx);
+        return luaL_error(L, "aes_gcm_seal: EVP_EncryptFinal_ex failed");
+    }
+    if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, AES_TAG_SIZE,
+                            out + outlen + finlen) != 1) {
+        EVP_CIPHER_CTX_free(ctx);
+        return luaL_error(L, "aes_gcm_seal: EVP_CTRL_GCM_GET_TAG failed");
+    }
+    EVP_CIPHER_CTX_free(ctx);
+
+    luaL_addsize(&b, outlen + finlen + AES_TAG_SIZE);
+    luaL_pushresult(&b);
+    return 1;
+}
+
+// AES-256-GCM open: takes (key, nonce, ciphertext_with_tag), returns
+// plaintext on success or (nil, error_message) on tag-mismatch or
+// malformed input. Tag-mismatch is the security-critical signal: a
+// tampered file fails here.
+int aes_gcm_open(lua_State* L)
+{
+    size_t key_len, nonce_len, blob_len;
+    const unsigned char* key = (const unsigned char*)luaL_checklstring(L, 1, &key_len);
+    const unsigned char* nonce = (const unsigned char*)luaL_checklstring(L, 2, &nonce_len);
+    const unsigned char* blob = (const unsigned char*)luaL_checklstring(L, 3, &blob_len);
+
+    if (key_len != AES_KEY_SIZE) {
+        return luaL_error(L, "aes_gcm_open: key must be %d bytes, got %d",
+                          AES_KEY_SIZE, (int)key_len);
+    }
+    if (nonce_len != AES_NONCE_SIZE) {
+        return luaL_error(L, "aes_gcm_open: nonce must be %d bytes, got %d",
+                          AES_NONCE_SIZE, (int)nonce_len);
+    }
+    if (blob_len < AES_TAG_SIZE) {
+        lua_pushnil(L);
+        lua_pushstring(L, "ciphertext shorter than tag");
+        return 2;
+    }
+    size_t ct_len = blob_len - AES_TAG_SIZE;
+    const unsigned char* ct = blob;
+    const unsigned char* tag = blob + ct_len;
+
+    EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
+    if (!ctx) return luaL_error(L, "aes_gcm_open: EVP_CIPHER_CTX_new failed");
+
+    if (EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, key, nonce) != 1) {
+        EVP_CIPHER_CTX_free(ctx);
+        return luaL_error(L, "aes_gcm_open: EVP_DecryptInit_ex failed");
+    }
+
+    luaL_Buffer b;
+    luaL_buffinit(L, &b);
+    unsigned char* out = (unsigned char*)luaL_prepbuffsize(&b, ct_len);
+
+    int outlen = 0;
+    if (EVP_DecryptUpdate(ctx, out, &outlen, ct, (int)ct_len) != 1) {
+        EVP_CIPHER_CTX_free(ctx);
+        lua_pushnil(L);
+        lua_pushstring(L, "EVP_DecryptUpdate failed");
+        return 2;
+    }
+    if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, AES_TAG_SIZE,
+                            (void*)tag) != 1) {
+        EVP_CIPHER_CTX_free(ctx);
+        lua_pushnil(L);
+        lua_pushstring(L, "EVP_CTRL_GCM_SET_TAG failed");
+        return 2;
+    }
+    int finlen = 0;
+    if (EVP_DecryptFinal_ex(ctx, out + outlen, &finlen) != 1) {
+        // Tag mismatch - tampering or wrong key.
+        EVP_CIPHER_CTX_free(ctx);
+        lua_pushnil(L);
+        lua_pushstring(L, "tag mismatch (file tampered or wrong key)");
+        return 2;
+    }
+    EVP_CIPHER_CTX_free(ctx);
+
+    luaL_addsize(&b, outlen + finlen);
+    luaL_pushresult(&b);
+    return 1;
+}
+
 int escape(lua_State* L)
 {
     std::string s = (std::string) luaL_optstring(L, 1, "");
@@ -295,6 +428,8 @@ static const luaL_Reg adclib[] = {
     {"isutf8", is_valid_utf8},
     {"sanitize_utf8", sanitize_utf8},
     {"random_bytes", random_bytes},
+    {"aes_gcm_seal", aes_gcm_seal},
+    {"aes_gcm_open", aes_gcm_open},
     {NULL, NULL}
 };
 

--- a/core/cfg_secret.lua
+++ b/core/cfg_secret.lua
@@ -1,0 +1,238 @@
+--[[
+
+    core/cfg_secret.lua - at-rest encryption for user.tbl
+
+    Phase 7f F-AUTH-1 mitigation. Standard ADC requires the hub to
+    hold a password-equivalent secret at rest (the BASE HPAS challenge
+    flow needs to recompute Tiger(stored, fresh_salt) on every login),
+    so plaintext-equivalent in RAM is non-negotiable. This module
+    eliminates plaintext on DISK with AES-256-GCM under a host-bound
+    master key.
+
+    Threat model covered:
+      - Backup / snapshot exfiltration of cfg/ without the host
+      - World-readable cfg/user.tbl from a default-umask
+      - File-system-only read primitive (read-only mount, share)
+
+    Threat model NOT covered:
+      - On-host RCE / Lua-sandbox escape (key + plaintext in process RAM)
+      - Plugin compromise (plugins are admin-trusted by design)
+      - Master-key file theft (use OS-bound key wrapping in Phase 8 if
+        needed: TPM, DPAPI, libsecret, ...)
+
+    Wire format on disk:
+      offset  bytes
+        0     4    magic "LDC1"
+        4    12    nonce (96-bit, fresh per write via OpenSSL RAND_bytes)
+       16    N     ciphertext
+     16+N   16    GCM authentication tag
+
+    Master key:
+      cfg/master.key, 32 raw bytes, mode 0600 on POSIX.
+      Generated on first boot if missing. Hub refuses to start if the
+      key file exists with overly-permissive POSIX permissions.
+
+    Public surface:
+
+        {
+            init       = function()         -- called by init.lua
+            seal       = function(plaintext) -- returns blob with magic
+            open       = function(blob)      -- returns plaintext or nil
+            is_active  = function()          -- has key been loaded?
+            is_blob    = function(s)         -- detect magic prefix
+        }
+
+]]--
+
+----------------------------------// DECLARATION //--
+
+local use = use
+
+local type = use "type"
+local error = use "error"
+local pcall = use "pcall"
+local string = use "string"
+local tonumber = use "tonumber"
+local tostring = use "tostring"
+
+local string_byte = string.byte
+local string_char = string.char
+local string_sub = string.sub
+
+local io = use "io"
+local io_open = io.open
+local io_popen = io.popen
+
+local os = use "os"
+local os_getenv = os.getenv
+local os_remove = os.remove
+
+--// extern libs //--
+
+local adclib = use "adclib"
+local adclib_random_bytes = adclib.random_bytes
+local adclib_aes_gcm_seal = adclib.aes_gcm_seal
+local adclib_aes_gcm_open = adclib.aes_gcm_open
+
+--// core scripts //--
+
+local const = use "const"
+local CONFIG_PATH = const.CONFIG_PATH
+
+-- out is late-bound to avoid the cfg <-> out load cycle.
+local out_error
+local out_put
+
+----------------------------------// CONSTANTS //--
+
+local MAGIC = "LDC1"
+local MAGIC_LEN = 4
+local KEY_SIZE = 32       -- AES-256
+local NONCE_SIZE = 12     -- GCM standard 96-bit nonce
+local TAG_SIZE = 16       -- GCM standard 128-bit tag
+local MIN_BLOB_LEN = MAGIC_LEN + NONCE_SIZE + TAG_SIZE
+
+----------------------------------// STATE //--
+
+local _key
+local _key_path
+
+local function _is_windows( )
+    return os_getenv "COMSPEC" and os_getenv "WINDIR"
+end
+
+----------------------------------// IMPLEMENTATION //--
+
+local function _read_file( path )
+    local f = io_open( path, "rb" )
+    if not f then return nil end
+    local content = f:read "*a"
+    f:close( )
+    return content
+end
+
+local function _write_file( path, content )
+    local f, err = io_open( path, "wb" )
+    if not f then return false, err end
+    f:write( content )
+    f:close( )
+    return true
+end
+
+-- POSIX permissions check on the master key file. Returns:
+--   true            -- OK (Linux 0600, or any Windows path)
+--   false, message  -- mode wrong on POSIX; caller must abort
+-- We shell out to stat(1) because the standalone Lua interpreter has
+-- no native syscall surface; lua-posix would be a new dep.
+local function _check_master_key_perms( path )
+    if _is_windows( ) then
+        return true
+    end
+    local cmd = "stat -c '%a' " .. path .. " 2>/dev/null"
+    local p = io_popen( cmd )
+    if not p then return true end    -- best-effort; can't check
+    local mode = p:read "*l"
+    p:close( )
+    if mode and mode ~= "" and mode ~= "600" then
+        return false, "master.key has insecure mode " .. mode .. " (expected 600); refuse to start. fix with: chmod 600 " .. path
+    end
+    return true
+end
+
+-- POSIX-only chmod 600 helper. Mirrors util.chmod_secret but used
+-- before util is bound; duplicated to avoid an init-order dependency.
+local function _chmod_600( path )
+    if _is_windows( ) then return end
+    local escaped = "'" .. tostring( path ):gsub( "'", "'\\''" ) .. "'"
+    os.execute( "chmod 600 " .. escaped )
+end
+
+local function init( )
+    -- out late-bind: out.lua does `use "cfg"` at file scope, so we
+    -- can't import out at our own load time; init.lua calls our init
+    -- after out is up.
+    local out = use "out"
+    out_error = out.error
+    out_put = out.put
+
+    _key_path = CONFIG_PATH .. "master.key"
+
+    -- Try to load existing key.
+    local content = _read_file( _key_path )
+    if content then
+        if #content ~= KEY_SIZE then
+            error( "cfg_secret: master.key has wrong size " .. #content .. " (expected " .. KEY_SIZE .. ")", 0 )
+        end
+        local ok, err = _check_master_key_perms( _key_path )
+        if not ok then
+            error( "cfg_secret: " .. err, 0 )
+        end
+        _key = content
+        out_put( "cfg_secret: loaded master.key (", KEY_SIZE, " bytes) from ", _key_path )
+        return
+    end
+
+    -- No key on disk - generate one. F-AUTH-1 first-boot migration.
+    out_put( "cfg_secret: master.key not found, generating new 256-bit key at ", _key_path )
+    local key, err = adclib_random_bytes( KEY_SIZE )
+    if not key then
+        error( "cfg_secret: failed to generate master.key: " .. tostring( err ), 0 )
+    end
+    local ok, werr = _write_file( _key_path, key )
+    if not ok then
+        error( "cfg_secret: cannot write master.key to " .. _key_path .. ": " .. tostring( werr ), 0 )
+    end
+    _chmod_600( _key_path )
+    _key = key
+end
+
+local function is_active( )
+    return _key ~= nil
+end
+
+local function is_blob( s )
+    return type( s ) == "string"
+        and #s >= MIN_BLOB_LEN
+        and string_sub( s, 1, MAGIC_LEN ) == MAGIC
+end
+
+local function seal( plaintext )
+    if not _key then
+        return nil, "cfg_secret: not initialized"
+    end
+    local nonce = adclib_random_bytes( NONCE_SIZE )
+    local ok, ct_with_tag = pcall( adclib_aes_gcm_seal, _key, nonce, plaintext )
+    if not ok then
+        return nil, "cfg_secret: seal failed: " .. tostring( ct_with_tag )
+    end
+    return MAGIC .. nonce .. ct_with_tag
+end
+
+local function open( blob )
+    if not _key then
+        return nil, "cfg_secret: not initialized"
+    end
+    if not is_blob( blob ) then
+        return nil, "cfg_secret: not an encrypted blob"
+    end
+    local nonce = string_sub( blob, MAGIC_LEN + 1, MAGIC_LEN + NONCE_SIZE )
+    local ct = string_sub( blob, MAGIC_LEN + NONCE_SIZE + 1 )
+    local ok, plaintext, err = pcall( adclib_aes_gcm_open, _key, nonce, ct )
+    if not ok then
+        return nil, "cfg_secret: open call failed: " .. tostring( plaintext )
+    end
+    if not plaintext then
+        return nil, "cfg_secret: decrypt failed: " .. tostring( err )
+    end
+    return plaintext
+end
+
+----------------------------------// PUBLIC INTERFACE //--
+
+return {
+    init = init,
+    seal = seal,
+    open = open,
+    is_active = is_active,
+    is_blob = is_blob,
+}

--- a/core/cfg_users.lua
+++ b/core/cfg_users.lua
@@ -6,35 +6,38 @@
     helpers (loadusers, saveusers, checkusers) out of cfg.lua so the
     orchestrator file stays focused on cfg.tbl + the public cfg.X API.
 
-    The functions take the user_path string explicitly rather than
-    pulling it from `cfg.get` themselves, to avoid a cyclic
-    cfg <-> cfg_users dependency at load time. cfg.lua passes the
-    resolved path on every call from its thin wrappers.
+    Phase 7f F-AUTH-1: user.tbl is now AES-256-GCM encrypted at rest
+    via core/cfg_secret. Reads detect the LDC1 magic and decrypt; old
+    plaintext files load via the existing util.loadtable path and get
+    re-written as encrypted on the next save (transparent migration).
 
     Public surface returned to cfg.lua:
 
         {
-            bind_late  = function()  -- see comment below
+            bind_late  = function()
             loadusers  = function(user_path)
             saveusers  = function(user_path, regusers)
             checkusers = function(user_path)
         }
 
-    out_error is late-bound: out.lua does `use "cfg"` at file scope,
-    so loading out at our own file-load time would create a cycle
-    (cfg -> cfg_users -> out -> cfg). cfg.init() calls bind_late() at
-    the right time, after which all three functions can log via
-    out.error.
-
 ]]--
 
 local use = use
+local io = use "io"
 local util = use "util"
+local secret = use "cfg_secret"
 
+local io_open = io.open
 local util_loadtable = util.loadtable
+local util_loadtable_string = util.loadtable_string
 local util_savearray = util.savearray
+local util_arraytostring = util.arraytostring
 local util_maketable = util.maketable
 local util_chmod_secret = util.chmod_secret
+local secret_seal = secret.seal
+local secret_open = secret.open
+local secret_is_blob = secret.is_blob
+local secret_is_active = secret.is_active
 
 local _
 
@@ -43,49 +46,142 @@ local _
 -- is loaded; closures pick up the new value via Lua's by-reference
 -- upvalue capture.
 local out_error
+local out_put
 
 local function bind_late()
-    out_error = use("out").error
+    local out = use "out"
+    out_error = out.error
+    out_put = out.put
+end
+
+-- Read the raw file bytes; nil if missing.
+local function _read_raw( path )
+    local f = io_open( path, "rb" )
+    if not f then return nil end
+    local content = f:read "*a"
+    f:close( )
+    return content
+end
+
+-- Write `content` to `path` as binary. chmod 600 on POSIX since
+-- this file holds the encrypted user db with embedded plaintext
+-- passwords.
+local function _write_raw( path, content )
+    local f, err = io_open( path, "wb" )
+    if not f then return false, err end
+    f:write( content )
+    f:close( )
+    util_chmod_secret( path )
+    return true
+end
+
+-- Internal load: returns (table, err). Detects encrypted vs plaintext
+-- format via the LDC1 magic prefix and routes accordingly. Plaintext
+-- files load via the legacy util.loadtable path so existing
+-- deployments keep working without a migration step; the next save
+-- will rewrite the file as encrypted.
+local function _load( path )
+    local raw = _read_raw( path )
+    if not raw then
+        return nil, "file not found"
+    end
+    if secret_is_blob( raw ) then
+        local plaintext, err = secret_open( raw )
+        if not plaintext then
+            return nil, err
+        end
+        return util_loadtable_string( plaintext, path )
+    end
+    -- Legacy plaintext format. Use the sandboxed loadtable so a
+    -- tampered file cannot reach os/io/etc.
+    return util_loadtable( path )
 end
 
 local function loadusers( user_path )
-    local users, err = util_loadtable( user_path .. "user.tbl" )
-    _ = err and out_error( "cfg_users.lua: function 'loadusers': error while loading users: ", err )
+    local file = user_path .. "user.tbl"
+    local users, err = _load( file )
+    if err and out_error then
+        out_error( "cfg_users.lua: function 'loadusers': ", err )
+    end
     return ( users or { } ), err
 end
 
 local function saveusers( user_path, regusers )
     local file = user_path .. "user.tbl"
-    local _, err = util_savearray( regusers, file )
-    _ = err and out_error( "cfg_users.lua: function 'saveusers': error while saving user db: ", err )
-    if err then
-        return false, err
-    else
-        util_chmod_secret( file )
+    if secret_is_active( ) then
+        local plaintext = util_arraytostring( regusers )
+        local blob, err = secret_seal( plaintext )
+        if not blob then
+            if out_error then out_error( "cfg_users.lua: function 'saveusers': seal: ", err ) end
+            return false, err
+        end
+        local ok, werr = _write_raw( file, blob )
+        if not ok then
+            if out_error then out_error( "cfg_users.lua: function 'saveusers': write: ", werr ) end
+            return false, werr
+        end
         return true
     end
+    -- cfg_secret never came up (init failed?). Fall back to plaintext
+    -- so the hub at least keeps running. This branch is a defence
+    -- against double-fault more than an expected path.
+    local _, err = util_savearray( regusers, file )
+    if err then
+        if out_error then out_error( "cfg_users.lua: function 'saveusers': ", err ) end
+        return false, err
+    end
+    util_chmod_secret( file )
+    return true
 end
 
 local function checkusers( user_path )
-    local users, err = util_loadtable( user_path .. "user.tbl" )
+    local file = user_path .. "user.tbl"
+    local backup = user_path .. "user.tbl.bak"
+
+    local users, err = _load( file )
     if users then
-        local backup = user_path .. "user.tbl.bak"
+        -- Healthy primary; refresh the backup. Backup is also
+        -- encrypted so the same threat-model applies.
         util_maketable( nil, backup )
-        local _, err = util_savearray( users, backup )
-        if err then
-            out_error( "cfg_users.lua: function 'checkusers': error while saving user db backup: ", err )
+        if secret_is_active( ) then
+            local plaintext = util_arraytostring( users )
+            local blob, sealerr = secret_seal( plaintext )
+            if blob then
+                local ok, werr = _write_raw( backup, blob )
+                if not ok and out_error then
+                    out_error( "cfg_users.lua: function 'checkusers': backup write: ", werr )
+                end
+            elseif out_error then
+                out_error( "cfg_users.lua: function 'checkusers': backup seal: ", sealerr )
+            end
         else
+            local _, werr = util_savearray( users, backup )
+            if werr and out_error then
+                out_error( "cfg_users.lua: function 'checkusers': backup save: ", werr )
+            end
             util_chmod_secret( backup )
         end
     else
-        local users, err = util_loadtable( user_path .. "user.tbl.bak" )
-        if users then
-            local file = user_path .. "user.tbl"
+        -- Primary broken; try the backup. Fail closed if both fail.
+        local restored, berr = _load( backup )
+        if restored then
             util_maketable( nil, file )
-            local _, err = util_savearray( users, file )
-            if err then
-                out_error( "cfg_users.lua: function 'checkusers': error while restoring corrupt user db from backup: ", err )
+            if secret_is_active( ) then
+                local plaintext = util_arraytostring( restored )
+                local blob, sealerr = secret_seal( plaintext )
+                if blob then
+                    local ok, werr = _write_raw( file, blob )
+                    if not ok and out_error then
+                        out_error( "cfg_users.lua: function 'checkusers': restore write: ", werr )
+                    end
+                elseif out_error then
+                    out_error( "cfg_users.lua: function 'checkusers': restore seal: ", sealerr )
+                end
             else
+                local _, werr = util_savearray( restored, file )
+                if werr and out_error then
+                    out_error( "cfg_users.lua: function 'checkusers': restore save: ", werr )
+                end
                 util_chmod_secret( file )
             end
         end

--- a/core/init.lua
+++ b/core/init.lua
@@ -75,6 +75,7 @@ _core = {    -- luadch core, order is important
     "mem",
     "signal",
     "util",
+    "cfg_secret",
     "cfg",
     "out",
     --"doc",

--- a/core/ratelimit.lua
+++ b/core/ratelimit.lua
@@ -33,6 +33,7 @@
 
 local pairs = use "pairs"
 local ipairs = use "ipairs"
+local tostring = use "tostring"
 
 --// lua libs //--
 

--- a/core/util.lua
+++ b/core/util.lua
@@ -78,9 +78,11 @@
 --// lua functions //--
 
 local type = use "type"
+local load = use "load"
 local table = use "table"
 local pairs = use "pairs"
 local pcall = use "pcall"
+local select = use "select"
 local ipairs = use "ipairs"
 local tostring = use "tostring"
 local tonumber = use "tonumber"
@@ -104,6 +106,7 @@ local math_floor = math.floor
 local string_byte = string.byte
 local table_sort = table.sort
 local table_insert = table.insert
+local table_concat = table.concat
 local string_format = string.format
 local string_find = string.find
 local string_match = string.match
@@ -146,8 +149,10 @@ local serialize
 local sortserialize
 
 local loadtable
+local loadtable_string
 local savetable
 local savearray
+local arraytostring
 local maketable
 
 local formatseconds
@@ -335,14 +340,11 @@ savetable = function( tbl, name, path )
     end
 end
 
---// saves an array to a local file
-savearray = function( array, path )
+-- Internal: emit a savearray-shaped serialisation to any writer that
+-- accepts :write(...). Used by both savearray (file-backed) and
+-- arraytostring (in-memory builder, for cfg_secret).
+local _writearray = function( array, writer )
     array = array or { }
-    local file, err = io_open( path, "w+" )
-    if not file then
-        out_error( "util.lua: function 'savearray': error in ", path, ": ", err, " (savearray)" )
-        return false, err
-    end
     local iterate, savetbl
     iterate = function( tbl )
         local tmp = { }
@@ -353,10 +355,10 @@ savearray = function( array, path )
         for i, key in ipairs( tmp ) do
             key = tonumber( key ) or key
             if type( tbl[ key ] ) == "table" then
-                file:write( ( ( type( key ) ~= "number" ) and tostring( key ) .. " = " ) or " " )
+                writer:write( ( ( type( key ) ~= "number" ) and tostring( key ) .. " = " ) or " " )
                 savetbl( tbl[ key ] )
             else
-                file:write( ( ( type( key ) ~= "number" and tostring( key ) .. " = " ) or "" ) .. ( ( type( tbl[ key ] ) == "string" ) and utf_format( "%q", tbl[ key ] ) or tostring( tbl[ key ] ) ) .. ", " )
+                writer:write( ( ( type( key ) ~= "number" and tostring( key ) .. " = " ) or "" ) .. ( ( type( tbl[ key ] ) == "string" ) and utf_format( "%q", tbl[ key ] ) or tostring( tbl[ key ] ) ) .. ", " )
             end
         end
     end
@@ -366,21 +368,65 @@ savearray = function( array, path )
             tmp[ #tmp + 1 ] = tostring( key )
         end
         table_sort( tmp )
-        file:write( "{ " )
+        writer:write( "{ " )
         iterate( tbl )
-        file:write( "}, " )
+        writer:write( "}, " )
     end
-    file:write( "return {\n\n" )
+    writer:write( "return {\n\n" )
     for i, tbl in ipairs( array ) do
         if type( tbl ) == "table" then
-            file:write( "    { " )
+            writer:write( "    { " )
             iterate( tbl )
-            file:write( "},\n" )
+            writer:write( "},\n" )
         else
-            file:write( "    ", utf_format( "%q,\n", tostring( tbl ) ) )
+            writer:write( "    ", utf_format( "%q,\n", tostring( tbl ) ) )
         end
     end
-    file:write( "\n}" )
+    writer:write( "\n}" )
+end
+
+-- Same shape as savearray but returns the serialised content as a
+-- string. Used by core/cfg_secret.lua so we can encrypt the
+-- serialised bytes before they ever touch disk (Phase 7f F-AUTH-1).
+arraytostring = function( array )
+    local sb = { buf = { }, n = 0 }
+    function sb:write( ... )
+        local n = select( "#", ... )
+        for i = 1, n do
+            self.n = self.n + 1
+            self.buf[ self.n ] = tostring( ( select( i, ... ) ) or "" )
+        end
+    end
+    _writearray( array, sb )
+    return table_concat( sb.buf, "", 1, sb.n )
+end
+
+-- Sandboxed string-loader for plaintext .tbl content already in
+-- memory (Phase 7f F-AUTH-1: cfg_secret.open returns plaintext bytes
+-- of an encrypted user.tbl, and we want the same empty-_ENV protection
+-- as loadtable). Same return-shape as loadtable.
+loadtable_string = function( content, name )
+    local fn, err = load( content, name or "tbl_string", "t", { } )
+    if not fn then return nil, err end
+    local ok, ret = pcall( fn )
+    if not ok then
+        out_error( "util.lua: function 'loadtable_string': chunk error: ", ret )
+        return nil, ret
+    end
+    if ret and type( ret ) == "table" then
+        return ret
+    end
+    return nil, "invalid table"
+end
+
+--// saves an array to a local file
+savearray = function( array, path )
+    local file, err = io_open( path, "w+" )
+    if not file then
+        out_error( "util.lua: function 'savearray': error in ", path, ": ", err, " (savearray)" )
+        return false, err
+    end
+    _writearray( array, file )
     file:close( )
     return true
 end
@@ -721,8 +767,10 @@ return {
     checkfile = checkfile,
     savetable = savetable,
     loadtable = loadtable,
+    loadtable_string = loadtable_string,
     serialize = serialize,
     savearray = savearray,
+    arraytostring = arraytostring,
     formatseconds = formatseconds,
     formatbytes = formatbytes,
     generatepass = generatepass,

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -492,6 +492,32 @@ def test_perip_connection_cap():
         time.sleep(0.6)
 
 
+def test_usertbl_encrypted_at_rest(staging_dir: Path):
+    """Phase 7f F-AUTH-1: user.tbl on disk must start with the LDC1 magic
+    after the hub has had any reason to save it (HPAS lastconnect update
+    runs every login). master.key must exist with the AES-256 key size.
+
+    We rely on the prior tests having logged in dummy/test (forces a
+    saveusers via the HPAS handler), so by the time this runs user.tbl
+    is in the encrypted format."""
+    cfg_dir = staging_dir / "cfg"
+    user_tbl = cfg_dir / "user.tbl"
+    master_key = cfg_dir / "master.key"
+    if not master_key.exists():
+        raise TestFailure(f"master.key missing at {master_key}")
+    key_bytes = master_key.read_bytes()
+    if len(key_bytes) != 32:
+        raise TestFailure(f"master.key size {len(key_bytes)}; expected 32")
+    if not user_tbl.exists():
+        raise TestFailure(f"user.tbl missing at {user_tbl}")
+    head = user_tbl.read_bytes()[:4]
+    if head != b"LDC1":
+        raise TestFailure(
+            f"user.tbl is not encrypted at rest (head={head!r}); "
+            f"expected LDC1 magic prefix"
+        )
+
+
 def test_no_script_errors(log_path: Path):
     """
     Plugin-load smoke: scan the captured hub stdout for "script error:"
@@ -523,7 +549,8 @@ TESTS = [
 ]
 
 
-def run_tests(log_path: Path):
+def run_tests(staging_dir: Path):
+    log_path = staging_dir / "log" / "smoke-hub.log"
     failed = []
     for name, fn in TESTS:
         try:
@@ -533,6 +560,16 @@ def run_tests(log_path: Path):
             failed.append(name)
         else:
             log(f"PASS  {name}")
+
+    # State-of-disk tests run after the protocol tests so any post-login
+    # save (HPAS lastconnect update) has had a chance to land.
+    try:
+        test_usertbl_encrypted_at_rest(staging_dir)
+    except Exception as e:
+        log(f"FAIL  user.tbl encrypted at rest: {e}")
+        failed.append("user.tbl encrypted at rest")
+    else:
+        log("PASS  user.tbl encrypted at rest")
 
     # The plugin-load test reads the hub log, so it runs after all
     # protocol tests have had a chance to exercise the listeners.
@@ -572,7 +609,7 @@ def main():
         override_test_ports(staging_dir)
         generate_test_cert(staging_dir)
         proc, log_file = start_hub(staging_dir)
-        failed = run_tests(staging_dir / "log" / "smoke-hub.log")
+        failed = run_tests(staging_dir)
     finally:
         if proc is not None:
             stop_hub(proc, log_file)


### PR DESCRIPTION
Closes #52. Phase 7f.

## Summary

ADC requires the hub to hold a password-equivalent secret at rest (BASE HPAS challenge needs to recompute \`Tiger(stored, fresh_salt)\` on every login - see [#52 research](https://github.com/Aybook/luadch/issues/52)), so plaintext-equivalent in RAM is non-negotiable. This PR eliminates plaintext on **disk** with AES-256-GCM under a host-bound master key.

## Components

| New | What |
|---|---|
| \`core/cfg_secret.lua\` | master.key load/generate, AES-256-GCM seal/open, magic-byte detection, POSIX-permission gate at startup |
| \`adclib.aes_gcm_seal\` / \`aes_gcm_open\` | C functions over OpenSSL EVP_CIPHER. Tag mismatch surfaces to Lua as \`(nil, "tag mismatch (file tampered or wrong key)")\` |
| \`util.arraytostring\` / \`util.loadtable_string\` | In-memory siblings of \`savearray\` / \`loadtable\` so cfg_users can serialise / deserialise without plaintext ever touching disk |

| Modified | What |
|---|---|
| \`core/cfg_users.lua\` | \`loadusers\` / \`saveusers\` / \`checkusers\` route through \`cfg_secret\` |
| \`core/init.lua\` | \`cfg_secret\` joins \`_core\` between \`util\` and \`cfg\` so \`cfg.init\` sees an initialised secret |
| \`core/ratelimit.lua\` | side-fix: missing \`tostring\` import on the error paths surfaced from this PR's error.log inspection |
| \`tests/smoke/run.py\` | new \`test_usertbl_encrypted_at_rest\` |

## Wire format

```
offset  bytes
  0     4    magic "LDC1"
  4    12    nonce (96-bit, fresh per write via OpenSSL RAND_bytes)
 16    N     ciphertext
16+N   16    GCM authentication tag
```

## Master key

\`cfg/master.key\`, 32 raw bytes, mode 0600 on POSIX (chmod 600 on creation; **refuse-to-start** if mode != 600 at next boot, per the M3 chmod-or-die from the F-AUTH-1 research). Generated via \`adclib.random_bytes\` (OpenSSL RAND_bytes) on first boot if missing.

## Migration

On first boot a plaintext \`user.tbl\` loads via the legacy sandboxed loader (Phase 7e); the hub's normal post-login save path (HPAS lastconnect update) re-writes it as an encrypted blob. No operator action required.

## Threat model

| Threat | Covered? |
|---|---|
| Backup / snapshot exfiltration of \`cfg/\` without the host | yes |
| World-readable \`cfg/user.tbl\` from a default-umask | yes |
| File-system-only read primitive (read-only mount, share) | yes |
| On-host RCE / Lua-sandbox escape | **no** (key + plaintext live in process RAM by ADC-protocol mandate; same as Firefox primary password, Telegram local DB, Apple Keychain unlocked state) |
| Plugin compromise | **no** (plugins are admin-trusted by design - F-SAND-1) |
| Master-key file theft | **no** (Phase 8 candidate: TPM / DPAPI / libsecret OS-bound key wrapping) |

## Test plan

- [x] \`cmake --build build\` clean
- [x] \`cmake --install build\` clean
- [x] Smoke 10/10 PASS

```
[smoke] PASS  hub binds plain + TLS ports
[smoke] PASS  plain ADC handshake
[smoke] PASS  TLS ADC handshake
[smoke] PASS  plain ADC full login (dummy/test)
[smoke] PASS  TLS ADC full login (dummy/test)
[smoke] PASS  +cmd routing (post-login +help)
[smoke] PASS  CSPRNG salts are unique across connections
[smoke] PASS  per-IP connection cap refuses overflow
[smoke] PASS  user.tbl encrypted at rest          <-- new
[smoke] PASS  no script errors in log
```

The new test confirms \`user.tbl\` starts with the \`LDC1\` magic after the dummy/test login triggers a saveusers, and \`master.key\` is exactly 32 bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)