### PR TITLE
chore(security): phase 7g hygiene + SECURITY.md (closes #58)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,10 +46,17 @@ endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # -----------------------------------------------------------------------------
-# OpenSSL: used by luasec. find_package finds the system install on Linux;
-# on Windows pass -DOPENSSL_ROOT_DIR=C:/OpenSSL.
+# OpenSSL: used by luasec, adclib (AES-GCM via EVP_CIPHER, RAND_bytes).
+# find_package finds the system install on Linux; on Windows pass
+# -DOPENSSL_ROOT_DIR=C:/OpenSSL.
+#
+# Phase 7g F-DEP-4: pin OpenSSL >= 3.0 so the build fails loudly if a
+# maintainer somehow links against the EOL'd 1.1.1 series (EOL
+# 2023-09-11). The Windows install path already ships libssl-3-x64.dll
+# / libcrypto-3-x64.dll, so 3.x has been the documented runtime; this
+# just makes the Linux build match.
 # -----------------------------------------------------------------------------
-find_package(OpenSSL REQUIRED)
+find_package(OpenSSL 3.0 REQUIRED)
 message(STATUS "luadch: OpenSSL ${OPENSSL_VERSION} at ${OPENSSL_INCLUDE_DIR}")
 
 # -----------------------------------------------------------------------------

--- a/adclib/tiger.cpp
+++ b/adclib/tiger.cpp
@@ -102,8 +102,19 @@ void ADCLIB::TigerHash::tigerCompress( const unsigned long long * str, unsigned 
 
 void ADCLIB::TigerHash::update( const void * data, unsigned long length )
 {
-  unsigned long tmppos = ( unsigned long ) ( pos & BLOCK_SIZE - 1 );
+  // Phase 7g F-C-2: explicit parens. `pos & BLOCK_SIZE - 1` evaluated
+  // correctly only by precedence accident; a maintainer "fixing" the
+  // missing parens would invert the mask and silently corrupt every
+  // hash. Make the intent unambiguous.
+  unsigned long tmppos = ( unsigned long ) ( pos & ( BLOCK_SIZE - 1 ) );
   const unsigned char * str = ( const unsigned char * ) data;
+  // Phase 7g F-C-5: memcpy into an aligned local before passing to
+  // tigerCompress, which expects unsigned-long-long-aligned access.
+  // tmp itself is unsigned char[BLOCK_SIZE]; alignment was implicit
+  // but not guaranteed, and `str` is attacker-controlled and may be
+  // arbitrarily aligned. Strict-aliasing is also satisfied since the
+  // local is the actual ull[] type tigerCompress operates on.
+  unsigned long long aligned[ BLOCK_SIZE / sizeof( unsigned long long ) ];
   if( tmppos > 0 )
   {
     unsigned long n = length <= BLOCK_SIZE - tmppos ? length : BLOCK_SIZE - tmppos;
@@ -114,13 +125,15 @@ void ADCLIB::TigerHash::update( const void * data, unsigned long length )
 
     if( ( tmppos + n ) == BLOCK_SIZE )
     {
-      tigerCompress( ( unsigned long long * ) tmp, res );
+      memcpy( aligned, tmp, BLOCK_SIZE );
+      tigerCompress( aligned, res );
       tmppos = 0;
     }
   }
   while( length >= BLOCK_SIZE )
   {
-    tigerCompress( ( unsigned long long * ) str, res );
+    memcpy( aligned, str, BLOCK_SIZE );
+    tigerCompress( aligned, res );
     str += BLOCK_SIZE;
     pos += BLOCK_SIZE;
     length -= BLOCK_SIZE;
@@ -131,16 +144,21 @@ void ADCLIB::TigerHash::update( const void * data, unsigned long length )
 
 unsigned char * ADCLIB::TigerHash::finalize()
 {
-  unsigned long tmppos = ( unsigned long ) ( pos & BLOCK_SIZE - 1 );
+  // Phase 7g F-C-2: see update() for the explicit-parens rationale.
+  unsigned long tmppos = ( unsigned long ) ( pos & ( BLOCK_SIZE - 1 ) );
   // Tmp buffer always has at least one pos, otherwise it would have
   // been processed in update()
 
   tmp[tmppos++] = 0x01;
 
+  // Phase 7g F-C-5: aligned local for tigerCompress (see update()).
+  unsigned long long aligned[ BLOCK_SIZE / sizeof( unsigned long long ) ];
+
   if( tmppos > ( BLOCK_SIZE - sizeof( unsigned long long ) ) )
   {
     memset( tmp + tmppos, 0, BLOCK_SIZE - tmppos );
-    tigerCompress( ( ( unsigned long long * ) tmp ), res );
+    memcpy( aligned, tmp, BLOCK_SIZE );
+    tigerCompress( aligned, res );
     memset( tmp, 0, BLOCK_SIZE );
   }
   else
@@ -148,8 +166,16 @@ unsigned char * ADCLIB::TigerHash::finalize()
     memset( tmp + tmppos, 0, BLOCK_SIZE - tmppos - sizeof( unsigned long long ) );
   }
 
-  ( ( unsigned long long * ) ( & ( tmp[56] ) ) ) [0] = pos << 3;
-  tigerCompress( ( unsigned long long * ) tmp, res );
+  // Phase 7g F-C-5: write the bit-length via memcpy instead of an
+  // aliased pointer cast. Still LE-on-LE: Tiger's spec is little-endian
+  // and Phase 5 only verified LE platforms (x86, aarch64-LE). On
+  // big-endian or strict-alignment ARMv7 the hash would silently differ;
+  // those targets are out of scope and would need an explicit
+  // byte-wise serialise.
+  unsigned long long bit_length = pos << 3;
+  memcpy( &tmp[56], &bit_length, sizeof( bit_length ) );
+  memcpy( aligned, tmp, BLOCK_SIZE );
+  tigerCompress( aligned, res );
   return getResult();
 }
 

--- a/basexx/basexx.lua
+++ b/basexx/basexx.lua
@@ -1,4 +1,19 @@
 --------------------------------------------------------------------------------
+-- basexx - pure-Lua base16/32/64 codec
+--
+-- Vendored from https://github.com/aiq/basexx
+--   upstream tag:    v0.4.1 (2019-04-23)
+--   commit:          aiq/basexx is essentially abandoned; no SHA-pinned
+--                    version was recorded at original import. Future
+--                    upstream-syncs should diff against the v0.4.1 tag.
+--   license:         MIT (see LICENSE file in the upstream repo)
+--   verified:        2026-05-04 by Phase 7g audit (F-DEP-3)
+--
+-- Used by luadch for base32 encoding of CIDs / PIDs / TLS keyprints.
+-- Pure-Lua, no native deps. Encoding-only - no security surface.
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
 -- util functions
 --------------------------------------------------------------------------------
 

--- a/core/adc.lua
+++ b/core/adc.lua
@@ -858,34 +858,39 @@ parse = function( data )
 
     local np = cmd.np
 
+    -- Phase 7g F-PRS-6: unknown two-letter named parameters used to be
+    -- forwarded verbatim - the corridor a future protocol-confusion
+    -- bug would use. Apply the safe-charset default validator (rejects
+    -- raw control bytes) to anything not in cmd.np so an attacker
+    -- cannot smuggle CR / NL / NUL via "XX" the parser does not
+    -- recognise. Forwards-compat with future ADC extensions still
+    -- works for clean ASCII / UTF-8 payloads.
+    local default_validator = _regex.default
+
     for i = len + 1, eol do
         local param = buffer[ i ]
         local name = string_sub( param, 1, 2 ) or ""
-        local npregex = np[ name ]
-        --if npregex then
-            local body = string_sub( param, 3, -1 ) or ""
-            if clone[ name ] ~= true and clone[ name ] ~= body then
-                if ( not npregex ) or npregex( body ) then
-                    length = length + 3
-                    command[ length - 2 ] = " "
-                    command[ length - 1 ] = name
-                    command[ length ] = body
-                    if noclones then
-                        clone[ name ] = true
-                    else
-                        clone[ name ] = body
-                    end
-                    namedstart = namedstart or length - 1
+        local npregex = np[ name ] or default_validator
+        local body = string_sub( param, 3, -1 ) or ""
+        if clone[ name ] ~= true and clone[ name ] ~= body then
+            if npregex( body ) then
+                length = length + 3
+                command[ length - 2 ] = " "
+                command[ length - 1 ] = name
+                command[ length ] = body
+                if noclones then
+                    clone[ name ] = true
                 else
-                    out_put( "adc.lua: function 'parse': invalid named parameter in '", fourcc, "': ", body )
-                    return nil
+                    clone[ name ] = body
                 end
+                namedstart = namedstart or length - 1
             else
-                out_put( "adc.lua: function 'parse': removed clone named parameter in '", fourcc, "': ", body )
+                out_put( "adc.lua: function 'parse': invalid named parameter in '", fourcc, "': ", body )
+                return nil
             end
-        --else
-        --    out_put( "adc.lua: function 'parse': ignored unknown named parameter in '", fourcc, "': ", name )
-        --end
+        else
+            out_put( "adc.lua: function 'parse': removed clone named parameter in '", fourcc, "': ", body )
+        end
     end
     -- `clone` is now parse-local; the explicit clean() call from the
     -- module-global era is no longer needed (closure goes out of

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,268 @@
+# Security model
+
+This document describes the security boundaries luadch enforces, the
+trust assumptions it makes about its operating environment, and the
+design rationale behind the at-rest data protections introduced in
+the Phase 7 security audit.
+
+It is the authoritative reference for operators deciding how to deploy
+luadch and for contributors reviewing security-relevant changes. The
+detailed audit findings live in
+[`docs/phases/PHASE_7_FINDINGS.md`](phases/PHASE_7_FINDINGS.md).
+
+---
+
+## 1. Threat model
+
+The hub serves untrusted ADC clients on the public internet. The
+classes of attacker we defend against:
+
+| Attacker | Capability | Defended against? |
+|---|---|---|
+| Network attacker | Can send arbitrary bytes to the listening ports | yes |
+| Authenticated user | Has valid credentials, opens a normal session | yes |
+| Backup thief | Reads `cfg/`, `certs/` from a snapshot or unprotected backup, no host access | yes |
+| World-readable share | Hub data ends up on a misconfigured Samba / NFS / Dropbox mount | yes |
+| Local file-write | Has filesystem write to `cfg/` but no shell on the host | partially (RCE eliminated; file-tamper still causes load-fail) |
+| Host-level RCE / shell | Can read process memory, exec arbitrary code | **no** |
+| Plugin author | Writes a malicious script and the operator installs it | **no** (see §2) |
+
+The "host-level RCE" row is the one that matters most: ADC's password
+challenge protocol forces the hub to keep a password-equivalent secret
+in process memory while the hub runs (see §3). Anyone who breaks out
+of the host's OS-level isolation can read it. The same trade-off
+applies to Firefox's primary password, Telegram's local DB, and Apple
+Keychain in its unlocked state. We accept it as a protocol constraint.
+
+---
+
+## 2. Plugin trust contract
+
+Plugins under [`scripts/`](../scripts/) are **trusted by design**.
+
+[`core/scripts.lua`](../core/scripts.lua) builds each plugin's `_ENV`
+by copying every entry of the global table. Plugins have direct
+access to `os`, `io`, `debug`, `package`, `load*`, `require`, the
+file system, and the ability to spawn subprocesses. The
+`cfg.no_global_scripting` setting only adds an
+error-on-undeclared-globals metatable; it does **not** restrict the
+library surface.
+
+This is intentional. Plugins are part of the hub's privileged code
+base; the boundary is between "operator-installed plugin" and
+"untrusted ADC client", not between "plugin" and "core".
+
+**Operator responsibilities:**
+
+1. Audit every plugin you install. Read the source. Do not pull
+   plugins from random forums.
+2. Treat the `scripts/` directory like the rest of the hub binary:
+   write-protect it from non-admin users on the host.
+3. A compromised plugin trivially exfiltrates `cfg/master.key`,
+   `certs/serverkey.pem`, and the in-RAM cleartext of `user.tbl`. No
+   in-hub mechanism prevents that.
+
+The corresponding audit finding is
+[F-SAND-1](phases/PHASE_7_FINDINGS.md) (info-level; documented, not
+"fixed" because tightening the sandbox would break the existing
+plugin ecosystem).
+
+---
+
+## 3. Password storage and the ADC `BASE` constraint
+
+luadch implements the ADC `BASE` extension's HPAS challenge-response:
+
+```
+Server: IGPA <fresh_per_login_salt>
+Client: HPAS base32(Tiger(password || salt))
+Server: must compute Tiger(stored, salt) and match
+```
+
+For the server's hash to match the client's, **the stored value must
+equal the client's password input**. Any one-way KDF (Argon2id,
+bcrypt, scrypt, PBKDF2) makes the server unable to produce the same
+Tiger output, so login breaks. This constraint is shared by the
+entire ADC ecosystem (ADCH++ stores cleartext in XML, uHub in
+`users.conf`, …) and there is no published ADC extension that lifts
+it. The audit research is recorded in issue
+[#52](https://github.com/Aybook/luadch/issues/52).
+
+### What luadch actually does
+
+1. **In RAM, while the hub runs:** plaintext passwords are present as
+   field values on each registered user's profile object. There is
+   no way around this within standard ADC.
+2. **On disk:** `cfg/user.tbl` is AES-256-GCM encrypted under a
+   host-bound master key (Phase 7f, [F-AUTH-1](phases/PHASE_7_FINDINGS.md)).
+
+### Wire format on disk
+
+```
+offset  bytes
+  0     4    magic "LDC1"
+  4    12    nonce (96-bit, fresh per write via OpenSSL RAND_bytes)
+ 16    N     ciphertext
+16+N   16    GCM authentication tag
+```
+
+GCM authentication is the security-critical signal: a tampered file
+fails the tag check and `loadusers` returns an error. The hub does
+not silently accept tampered input.
+
+### Master key
+
+- **Path:** `cfg/master.key`
+- **Size:** 32 raw bytes (AES-256)
+- **Generation:** automatic on first boot via OpenSSL `RAND_bytes`
+- **POSIX permissions:** `chmod 600`. The hub **refuses to start** if
+  the existing key file has any other mode (modeled on OpenSSH's
+  `~/.ssh/id_rsa` strict-mode check).
+- **Windows permissions:** see §4 below.
+
+### What the on-disk encryption protects against
+
+- Backup / snapshot exfiltration of `cfg/` without the host
+- World-readable `cfg/user.tbl` from a default umask
+- File-system-only read primitive (read-only mount, share, lost
+  laptop, …)
+
+### What it does NOT protect against
+
+- On-host RCE / Lua-sandbox escape (see §1, §2)
+- Plugin compromise (see §2)
+- Master-key file theft. If the attacker exfiltrates both
+  `cfg/master.key` and `cfg/user.tbl`, they have all the credentials.
+
+OS-bound key wrapping (TPM, DPAPI machine-scope, libsecret, macOS
+Keychain) would harden the master-key-theft case and is tracked as a
+Phase 8+ candidate in
+[#48](https://github.com/Aybook/luadch/issues/48).
+
+---
+
+## 4. File-permission baseline
+
+The hub automatically `chmod 600`s every secret file it writes on
+POSIX (Phase 7b,
+[F-SEC-1](phases/PHASE_7_FINDINGS.md)). That covers:
+
+- `cfg/user.tbl` (registered-user database, encrypted blob)
+- `cfg/user.tbl.bak`
+- `cfg/master.key`
+- `certs/serverkey.pem` and `certs/cakey.pem` are 0600'd by
+  `examples/certs/make_cert.sh` at generation time.
+
+### Linux / BSD - one-time migration
+
+Existing deployments that pre-date Phase 7b should run once:
+
+```sh
+chmod 600 cfg/user.tbl cfg/user.tbl.bak certs/serverkey.pem certs/cakey.pem
+# master.key is created by Phase 7f and ships pre-chmod'd
+```
+
+### Windows - manual ACL setup
+
+NTFS does not have POSIX permission bits, so the hub does not
+attempt to enforce permissions automatically. After install, run:
+
+```cmd
+icacls "cfg\user.tbl"           /inheritance:r /grant:r "%USERNAME%:F"
+icacls "cfg\user.tbl.bak"       /inheritance:r /grant:r "%USERNAME%:F"
+icacls "cfg\master.key"         /inheritance:r /grant:r "%USERNAME%:F"
+icacls "certs\serverkey.pem"    /inheritance:r /grant:r "%USERNAME%:F"
+icacls "certs\cakey.pem"        /inheritance:r /grant:r "%USERNAME%:F"
+```
+
+Replace `%USERNAME%` with the dedicated service account if the hub
+runs as `LocalService` or similar. The same recipe lives in
+[`docs/BUILDING.md`](BUILDING.md).
+
+---
+
+## 5. Network-level defenses
+
+| Defense | Where | Tunable via cfg |
+|---|---|---|
+| Per-IP parallel-socket cap | [`core/server.lua` accept](../core/server.lua) | `ratelimit_perip_max_conns` (default 16) |
+| Per-IP accept-rate cap | same | `ratelimit_perip_conn_rate` / `_burst` |
+| TLS handshake wallclock deadline | same | `ratelimit_handshake_timeout` (default 10s) |
+| Per-IP failed-auth tracking + sticky lockout | [`core/hub_dispatch.lua` HPAS](../core/hub_dispatch.lua) | `ratelimit_perip_authfail_*`, `ratelimit_authfail_lockout` |
+| Per-account bad-password lockout (independent of per-IP) | same | `max_bad_password`, `bad_pass_timeout` |
+| Per-user chat / search rate-limit | [`core/hub_dispatch.lua` BMSG/BSCH](../core/hub_dispatch.lua) | `ratelimit_user_msg_*`, `ratelimit_user_search_*` |
+| Op-level bypass of per-user limits | same | `ratelimit_bypass_level` (default 60) |
+| Parser-side message-size cap | [`core/adc.lua` parse](../core/adc.lua) | hardcoded 64 KiB |
+| Connection read-buffer cap | [`core/server.lua`](../core/server.lua) | hardcoded 1 MiB |
+
+The full DoS-hardening rationale is in Phase 7c
+([#56](https://github.com/Aybook/luadch/issues/56)).
+
+---
+
+## 6. TLS configuration
+
+luadch supports plain ADC and TLS-wrapped ADCS in parallel. Default
+TLS configuration in [`core/cfg_defaults.lua`](../core/cfg_defaults.lua):
+
+- Protocol: TLS 1.3 (`tlsv1_3`)
+- Cipher list: `"HIGH"`
+- Disabled: SSLv2, SSLv3
+- Peer-cert verify: off (correct for the server-side ADC role -
+  clients are unauthenticated at the TLS layer; auth happens at the
+  ADC HPAS layer)
+
+The ADC `KEYP` extension lets clients pin the hub's TLS certificate
+fingerprint; operators can publish their fingerprint via the
+`+hubinfo` command and clients that support `KEYP` will reject
+mismatching certs.
+
+---
+
+## 7. CVE / dependency tracking
+
+luadch bundles all native dependencies as source. Operators should
+subscribe to upstream releases:
+
+- [Lua](https://www.lua.org/versions.html) - currently 5.4.8
+- [LuaSec](https://github.com/lunarmodules/luasec) - currently 1.3.2
+- [LuaSocket](https://github.com/lunarmodules/luasocket) - currently 3.1.0
+- [aiq/basexx](https://github.com/aiq/basexx) - vendored from
+  v0.4.1, upstream essentially abandoned
+- [OpenSSL](https://github.com/openssl/openssl) - linked dynamically;
+  `find_package(OpenSSL 3.0 REQUIRED)` enforces the floor
+
+Quarterly checklist: query
+[osv.dev](https://osv.dev) and the GitHub Advisory Database for each
+of the above. Record the bundled SHA / version of every dep in
+[`docs/BUILDING.md`](BUILDING.md) so audits compare to a written
+truth, not to greps.
+
+---
+
+## 8. Reporting a security issue
+
+Open a private security advisory at
+<https://github.com/Aybook/luadch/security/advisories/new> rather
+than a public issue, especially for issues that:
+
+- enable RCE without prior authentication
+- bypass auth or login throttling
+- leak `master.key`, plaintext credentials, or TLS keys
+
+Public issues are fine for findings that are already documented in
+[`docs/phases/PHASE_7_FINDINGS.md`](phases/PHASE_7_FINDINGS.md) or
+that require operator misconfiguration to exploit (e.g. a
+world-readable `master.key` because the operator skipped §4).
+
+---
+
+## 9. Audit history
+
+| Phase | Scope | Doc |
+|---|---|---|
+| Phase 7a | Read-only audit of every surface listed in [`CLAUDE.md`](../CLAUDE.md) §5 Phase 7 | [`docs/phases/PHASE_7_FINDINGS.md`](phases/PHASE_7_FINDINGS.md) |
+| Phase 7b - 7g | Each finding either fixed or filed with a documented disposition | [`docs/phases/PHASE_7_FINDINGS.md`](phases/PHASE_7_FINDINGS.md) §5 |
+
+A future phase may re-audit. Until then, this file plus
+`PHASE_7_FINDINGS.md` is the security baseline for v3.0.x.

--- a/hub/hub.c
+++ b/hub/hub.c
@@ -175,7 +175,25 @@ static void run_lua(void);
 static int restart(lua_State *L)
 {
   lua_close(L);
-  atexit(run_lua);
+  /*
+   * Phase 7g F-C-4: every restart pushes another run_lua onto the
+   * atexit stack. POSIX guarantees only 32 registrations; further
+   * atexit calls return non-zero and were silently ignored. After
+   * ~32 +reload cycles the next restart would just exit cleanly
+   * without re-entering run_lua, leaving the operator with a dead
+   * hub. Check the return value and log loudly so the failure mode
+   * is visible. Treating as fatal is the conservative choice -
+   * better to refuse the +reload than pretend it worked.
+   */
+  if (atexit(run_lua) != 0)
+  {
+    log_error(
+      "cannot register atexit handler for restart "
+      "(atexit limit reached after many +reloads); "
+      "exiting without re-entering Lua. Restart the hub process manually."
+    );
+    exit(EXIT_FAILURE);
+  }
   exit(EXIT_SUCCESS);
   return 0;
 }


### PR DESCRIPTION
Closes #58. Final hygiene PR for Phase 7.

## Code fixes

| Finding | File | Severity | Change |
|---|---|---|---|
| F-C-2 | [adclib/tiger.cpp](../blob/master/adclib/tiger.cpp) | medium (latent) | Explicit parens on \`pos & ( BLOCK_SIZE - 1 )\` |
| F-C-5 | [adclib/tiger.cpp](../blob/master/adclib/tiger.cpp) | low | memcpy into aligned ull[] for tigerCompress; memcpy bit-length at offset 56 |
| F-C-4 | [hub/hub.c](../blob/master/hub/hub.c) | low | Check \`atexit()\` return value, fail loudly after limit |
| F-DEP-4 | [CMakeLists.txt](../blob/master/CMakeLists.txt) | low | \`find_package(OpenSSL 3.0 REQUIRED)\` floor |
| F-DEP-3 | [basexx/basexx.lua](../blob/master/basexx/basexx.lua) | low | Provenance header (upstream tag, retrieval date, license) |
| F-PRS-6 | [core/adc.lua](../blob/master/core/adc.lua) | info | Unknown named-params now go through the same control-byte-rejecting default validator as known fields |

## Documentation

New [`docs/SECURITY.md`](../blob/master/docs/SECURITY.md) covering:

1. Threat model (what we defend against, what we explicitly don't)
2. Plugin trust contract (F-SAND-1: admin-trusted, not capability-sandboxed)
3. Password storage and the ADC \`BASE\` constraint (F-AUTH-1: protocol-mandated cleartext-equivalent in RAM, AES-256-GCM at rest, master-key chmod 600 enforcement)
4. File-permission baseline for Linux + Windows (icacls recipe)
5. Network-level defenses (rate-limit table from Phase 7c)
6. TLS configuration defaults
7. CVE / dependency tracking process
8. How to report a security issue (private advisory link)
9. Audit history pointing back to PHASE_7_FINDINGS.md

## What stays open

F-DEP-2 (LuaSec OpenSSL-3 deprecated APIs) remains classified as \`upstream-blocked\` / \`wontfix\` per #3. Phase 7g re-checked the upstream LuaSec source and confirmed nothing has shifted; LuaSec 1.3.2 is still the latest tag. Re-evaluate when upstream cuts 1.4.x.

## Test plan

- [x] \`cmake --build build\` clean
- [x] \`cmake --install build\` clean
- [x] Smoke 10/10 PASS unchanged

```
[smoke] PASS  hub binds plain + TLS ports
[smoke] PASS  plain ADC handshake
[smoke] PASS  TLS ADC handshake
[smoke] PASS  plain ADC full login (dummy/test)
[smoke] PASS  TLS ADC full login (dummy/test)
[smoke] PASS  +cmd routing (post-login +help)
[smoke] PASS  CSPRNG salts are unique across connections
[smoke] PASS  per-IP connection cap refuses overflow
[smoke] PASS  user.tbl encrypted at rest
[smoke] PASS  no script errors in log
```

The Tiger refactor (F-C-5) is exercised by every full ADC login (Tiger(password || salt) round-trip); a regression would fail the dummy/test login tests.

After merge, Phase 7 is **content-complete**. A small follow-up will write \`docs/phases/PHASE_7.md\` with the merged-PR list and close out the modernisation phase, mirroring how Phase 6 was closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)