### PR TITLE
feat(security): configurable master_key_path for backup separation

### DIFF
--- a/core/cfg.lua
+++ b/core/cfg.lua
@@ -475,6 +475,7 @@ local out
 
 local util = use "util"
 local const = use "const"
+local secret = use "cfg_secret"
 
 local types = use "types"
 
@@ -645,6 +646,11 @@ init = function( )
     _settings = _settings or { }
     _ = err and out_error( "cfg.lua: function 'init': error while loading hub settings: ", err, "; using default cfg" )
     checkcfg( )
+    -- cfg_secret reads master_key_path from cfg, so it must be
+    -- initialised AFTER _settings is loaded. Done here rather than
+    -- in init.lua's _core init phase (where cfg_secret's init would
+    -- fire before cfg.init had a chance to populate _settings).
+    secret.init( )
 end
 
 ----------------------------------// BEGIN //--

--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -226,6 +226,39 @@ local defaults = {
             return types_utf8( value, nil, true )
         end
     },
+
+    --[[
+        Path to the master key that decrypts cfg/user.tbl
+        (Phase 7f F-AUTH-1, AES-256-GCM at rest).
+
+        IMPORTANT:
+            Empty string falls back to "<install>/cfg/master.key", which
+            sits next to the encrypted user.tbl. That default exists for
+            backwards compatibility and zero-config first-boot, but it
+            is NOT the recommended production setup: anyone who exfiltrates
+            a routine `tar czf backup.tar.gz cfg/` gets BOTH the encrypted
+            blob AND its decryption key, and can decrypt offline. The
+            at-rest encryption then provides zero protection.
+
+        SET THIS to an absolute path OUTSIDE the install directory before
+        you put real users in user.tbl, e.g.:
+
+            master_key_path = "/etc/luadch/master.key"     -- POSIX
+            master_key_path = "C:/ProgramData/luadch/master.key"  -- Windows
+
+        Then exclude that path from your routine backup, or back it up to
+        a separate destination (different host / encrypted-with-passphrase
+        archive). Same handling as your TLS private key. See
+        docs/SECURITY.md §3 for the backup-separation rationale.
+
+        On POSIX the hub refuses to start if the file mode is not 0600.
+        On Windows use icacls (see docs/BUILDING.md).
+    ]]--
+    master_key_path = { "",
+        function( value )
+            return types_utf8( value, nil, true )
+        end
+    },
     reg_level = { 20,
         function( value )
             return types_number( value, nil, true )

--- a/core/cfg_secret.lua
+++ b/core/cfg_secret.lua
@@ -79,6 +79,11 @@ local adclib_aes_gcm_open = adclib.aes_gcm_open
 local const = use "const"
 local CONFIG_PATH = const.CONFIG_PATH
 
+-- cfg is late-bound: cfg.lua does `use "cfg_secret"` at file scope,
+-- so importing cfg here would cycle. cfg.init() calls our init() and
+-- by then cfg.get is fully wired.
+local cfg_get
+
 -- out is late-bound to avoid the cfg <-> out load cycle.
 local out_error
 local out_put
@@ -149,13 +154,27 @@ end
 
 local function init( )
     -- out late-bind: out.lua does `use "cfg"` at file scope, so we
-    -- can't import out at our own load time; init.lua calls our init
-    -- after out is up.
+    -- can't import out at our own load time; cfg.init() calls our
+    -- init after out is up.
     local out = use "out"
     out_error = out.error
     out_put = out.put
 
-    _key_path = CONFIG_PATH .. "master.key"
+    -- cfg late-bind: cfg.init() guarantees _settings is loaded by
+    -- the time we run, so cfg.get works for master_key_path.
+    cfg_get = use( "cfg" ).get
+
+    -- Resolve master.key path. The cfg key master_key_path can move
+    -- the key outside the install dir entirely - see the strong
+    -- recommendation in cfg_defaults.lua. Empty string falls back to
+    -- the in-tree default.
+    local configured = cfg_get "master_key_path"
+    if type( configured ) == "string" and configured ~= "" then
+        _key_path = configured
+        out_put( "cfg_secret: master.key path overridden by cfg: ", _key_path )
+    else
+        _key_path = CONFIG_PATH .. "master.key"
+    end
 
     -- Try to load existing key.
     local content = _read_file( _key_path )

--- a/core/init.lua
+++ b/core/init.lua
@@ -75,7 +75,10 @@ _core = {    -- luadch core, order is important
     "mem",
     "signal",
     "util",
-    "cfg_secret",
+    -- cfg_secret is not in _core because its init() needs cfg_get
+    -- (master_key_path). cfg.lua does `use "cfg_secret"` and calls
+    -- secret.init() from cfg.init() after _settings is loaded so
+    -- the cfg-side path override works on first boot.
     "cfg",
     "out",
     --"doc",

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -112,7 +112,8 @@ not silently accept tampered input.
 
 ### Master key
 
-- **Path:** `cfg/master.key`
+- **Default path:** `cfg/master.key` (set the `master_key_path` cfg
+  key to override; see "Backup separation" below)
 - **Size:** 32 raw bytes (AES-256)
 - **Generation:** automatic on first boot via OpenSSL `RAND_bytes`
 - **POSIX permissions:** `chmod 600`. The hub **refuses to start** if
@@ -120,9 +121,38 @@ not silently accept tampered input.
   `~/.ssh/id_rsa` strict-mode check).
 - **Windows permissions:** see §4 below.
 
+### Backup separation - **required for the encryption to be meaningful**
+
+The default `cfg/master.key` location was chosen for first-boot
+convenience and backwards compatibility, **not** for production
+security. With the default, a routine
+`tar czf backup.tar.gz cfg/` bundles **both** the encrypted
+`user.tbl` AND its decryption key into one archive. An attacker who
+exfiltrates that backup decrypts everything offline; the at-rest
+encryption provides zero protection in that scenario.
+
+For production deployments, set the `master_key_path` cfg key in
+`cfg/cfg.tbl` to an absolute path **outside** the install directory:
+
+```lua
+master_key_path = "/etc/luadch/master.key"            -- POSIX
+master_key_path = "C:/ProgramData/luadch/master.key"  -- Windows
+```
+
+Then handle that path the same way you handle
+`certs/serverkey.pem`:
+
+- exclude it from the routine `cfg/` backup, or
+- back it up to a separate destination (different host, different
+  storage tier, or pass-phrase-encrypted archive).
+
+The hub still enforces 0600 on the configured path on POSIX. On
+Windows, apply `icacls` to the new path - see §4.
+
 ### What the on-disk encryption protects against
 
-- Backup / snapshot exfiltration of `cfg/` without the host
+- Backup / snapshot exfiltration of `cfg/` without the host - **only
+  if `master_key_path` points outside `cfg/` per the section above**
 - World-readable `cfg/user.tbl` from a default umask
 - File-system-only read primitive (read-only mount, share, lost
   laptop, …)
@@ -159,7 +189,8 @@ Existing deployments that pre-date Phase 7b should run once:
 
 ```sh
 chmod 600 cfg/user.tbl cfg/user.tbl.bak certs/serverkey.pem certs/cakey.pem
-# master.key is created by Phase 7f and ships pre-chmod'd
+# master.key is created by Phase 7f and ships pre-chmod'd. If you
+# moved it via master_key_path, chmod that path too.
 ```
 
 ### Windows - manual ACL setup
@@ -176,7 +207,9 @@ icacls "certs\cakey.pem"        /inheritance:r /grant:r "%USERNAME%:F"
 ```
 
 Replace `%USERNAME%` with the dedicated service account if the hub
-runs as `LocalService` or similar. The same recipe lives in
+runs as `LocalService` or similar. If `master_key_path` points to a
+different location (e.g. `C:\ProgramData\luadch\master.key`), apply
+the same `icacls` line there. The same recipe lives in
 [`docs/BUILDING.md`](BUILDING.md).
 
 ---

--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -47,6 +47,29 @@ return { -- the settings are a lua table, do not tough this!
     min_password_length = 10,  -- minimum length of the password (integer)
     max_password_length = 30,  -- maximum length of the password (integer)
 
+    -- ====================================================================
+    -- !!! IMPORTANT - SET BEFORE PUTTING REAL USERS INTO USER.TBL !!!
+    --
+    -- Path to the master.key that decrypts cfg/user.tbl (Phase 7f, AES-256-GCM).
+    --
+    -- Empty default (= cfg/master.key) is for first-boot convenience and
+    -- backwards compatibility ONLY. With the default, anyone who steals a
+    -- routine `tar czf backup.tar.gz cfg/` gets BOTH the encrypted user db
+    -- AND its decryption key, and can decrypt offline. The encryption then
+    -- provides zero protection.
+    --
+    -- For production, set an absolute path OUTSIDE the install directory,
+    -- treat the file like your TLS private key (chmod 600, separate
+    -- backup destination), then exclude that path from the cfg/ backup.
+    --
+    -- Examples:
+    --     master_key_path = "/etc/luadch/master.key"            -- POSIX
+    --     master_key_path = "C:/ProgramData/luadch/master.key"  -- Windows
+    --
+    -- See docs/SECURITY.md §3 for the threat model.
+    -- ====================================================================
+    master_key_path = "",
+
     min_nickname_length = 3,  -- minimum length of the nickname (integer)
     max_nickname_length = 30,  -- maximum length of the nickname (integer)
 


### PR DESCRIPTION
Phase 7f follow-up. Refs #52.

## Why

The default \`cfg/master.key\` location chosen in #67 was a first-boot-convenience compromise: a routine \`tar czf backup.tar.gz cfg/\` bundles BOTH the encrypted \`user.tbl\` AND its decryption key, so an attacker who exfiltrates that backup decrypts everything offline. The at-rest encryption then provides zero protection.

This PR adds a cfg key so operators can put the master key outside the install directory and treat it like the TLS private key (separate backup destination or excluded from backup entirely).

## Change

New cfg key \`master_key_path\`:

- Empty string (default) → existing \`cfg/master.key\` behaviour, fully backwards-compatible
- Absolute path → the key lives there instead. POSIX 0600 enforcement and chmod-or-die check still apply, just on the new path.

```lua
master_key_path = "/etc/luadch/master.key"            -- POSIX
master_key_path = "C:/ProgramData/luadch/master.key"  -- Windows
```

## Wiring change

\`cfg_secret.init()\` now reads \`cfg_get("master_key_path")\`, which means it must run AFTER \`cfg.init()\` has loaded \`_settings\`. Removed from init.lua's \`_core\` init phase; called from the bottom of \`cfg.init()\` instead. \`cfg_secret\` stays loadable as a regular module via \`use()\` (cfg.lua and cfg_users.lua both import it the standard way).

## Documentation

- New "!!! IMPORTANT !!!" block in [\`examples/cfg/cfg.tbl\`](../blob/master/examples/cfg/cfg.tbl) next to the password / bad-pass-timeout settings, so anyone walking through the example config sees the recommendation.
- New "Backup separation" subsection in [\`docs/SECURITY.md\`](../blob/master/docs/SECURITY.md) §3 making the trade-off explicit and giving the recipe.
- Long comment in \`cfg_defaults.lua\` for anyone reading that file.

## Test plan

- [x] \`cmake --install build\` clean
- [x] Smoke 10/10 PASS with default (empty) \`master_key_path\`
- [x] Manual: \`master_key_path = "d:/tmp/master_key_test_dir/master.key"\` → hub creates the key at the configured path, leaves \`cfg/\` key-free, encrypts \`user.tbl\` as expected, login works on next boot

```
$ ls cfg/                           # after run, key NOT in cfg/
cfg.tbl
user.tbl
$ ls /d/tmp/master_key_test_dir/    # key at configured path
master.key   (32 bytes)
```

## Migration

| Operator type | What to do |
|---|---|
| New install | First boot generates `cfg/master.key`. Decide if production: edit cfg.tbl, set absolute path, move file, restart. |
| Existing install (post-#67), default location | Same recipe: stop hub, `mv cfg/master.key /etc/luadch/master.key`, set `master_key_path` in cfg.tbl, ensure chmod 600 + ownership, restart. |
| Existing install (pre-#67), plaintext user.tbl | First boot post-update generates the key (default location); see above to move it. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)