### PR TITLE
release: prepare v3.1.0 (Phase 6 + Phase 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,164 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The upstream project (`luadch/luadch`) is a separate codebase; its release
 history is at https://github.com/luadch/luadch/releases.
 
+## [v3.1.0] - 2026-05-04
+
+Phase 6 (refactor + smoke harness) and Phase 7 (security audit + hardening)
+of the modernisation programme. No breaking changes for operators on
+default cfg; existing `cfg/user.tbl` is transparently migrated to the
+new encrypted-at-rest format on first save after upgrade. Phase journals
+in [`docs/phases/PHASE_6.md`](docs/phases/PHASE_6.md) and
+[`docs/phases/PHASE_7.md`](docs/phases/PHASE_7.md).
+
+### Added
+
+#### Phase 7 - security features
+
+- **AES-256-GCM at-rest encryption of `cfg/user.tbl`** (Phase 7f, F-AUTH-1).
+  New module `core/cfg_secret.lua`; auto-managed master key at
+  `cfg/master.key` with chmod 600 enforcement (refuse-to-start on POSIX
+  if mode != 0600). New cfg key `master_key_path` (Phase 7h) lets
+  operators move the key outside the install directory for backup
+  separation - strongly recommended for production. See
+  [`docs/SECURITY.md`](docs/SECURITY.md) §3.
+- **DoS hardening** (Phase 7c, F-NET-1 / F-NET-2 / F-AUTH-3 / F-RL-1 /
+  F-RL-2). New module `core/ratelimit.lua` with token-bucket counters:
+  per-IP parallel-socket cap (default 16, NAT-friendly), per-IP accept
+  rate, TLS handshake wallclock deadline (default 10 s, slowloris cut),
+  per-IP failed-auth lockout (independent of per-account
+  bad_pass_timeout), per-user chat / search rate limits with op-level
+  bypass. All cfg-tunable.
+- **Sandboxed config / state loaders** (Phase 7e, F-FIO-1, **critical**).
+  `util.loadtable()` runs chunks with empty `_ENV` so a tampered `.tbl`
+  file cannot reach `os` / `io` / `debug` / `package` / `require`.
+  Eliminates the universal RCE-on-tampered-file class for `cfg.tbl`,
+  `user.tbl`, language files, and the 20+ plugin state files. Format
+  on disk unchanged - zero migration.
+- **POSIX file-permission enforcement on secret files** (Phase 7b, F-SEC-1).
+  Hub `chmod 600`s `user.tbl` and `user.tbl.bak` after every write;
+  `make_cert.sh` 0600s the generated TLS private keys. Windows: `icacls`
+  recipe in [`docs/BUILDING.md`](docs/BUILDING.md) and
+  [`docs/SECURITY.md`](docs/SECURITY.md) §4.
+- **Secure salt generation** (Phase 7b, F-AUTH-2). HPAS challenge salts and
+  SIDs now drawn from OpenSSL `RAND_bytes` via the new
+  `adclib.random_bytes` C function instead of `math.random` reseeded
+  with `os.time()`. New `adclib.aes_gcm_seal` / `aes_gcm_open` C
+  functions wrap OpenSSL EVP_CIPHER for the at-rest encryption.
+- **ADC parser hardening** (Phase 7d, F-PRS-1..5).
+  - `_regex.default` and `_regex.nowhitespace` now reject raw control
+    bytes (`%c`); the previous validators were a no-op and a literal
+    `\\n`/`\\s` substring search respectively.
+  - `parse()` is reentrant: `_buffer` / `_clone` / `_eol` are
+    parse-locals instead of module-globals.
+  - `MAX_COMMAND_SIZE = 64 KiB` cap at parser entry; UTF-8 check
+    re-enabled at parse entry.
+  - Unknown two-letter named parameters now go through the same
+    control-byte-rejecting default validator as known fields.
+- **adclib hardening** (Phase 7b, F-C-1 + F-C-3).
+  - `hash_pas` / `hash_pas_oldschool` no longer use VLAs sized by
+    Lua-side input; salt length is bounded against
+    `MAX_SALT_BYTES = 64`.
+  - `luaL_checklstring` everywhere binary-safe Lua strings are
+    expected, so an embedded NUL in a password no longer silently
+    truncates the input.
+- **Tiger hash hygiene** (Phase 7g, F-C-2 + F-C-5). Explicit parens on
+  `pos & ( BLOCK_SIZE - 1 )`; `tigerCompress` receives memcpy'd
+  aligned `unsigned long long[]` instead of an aliased `tmp` cast;
+  bit-length finalize uses memcpy at offset 56.
+
+#### Phase 7 - documentation
+
+- **`docs/SECURITY.md`** (new top-level doc): threat model, plugin trust
+  contract, F-AUTH-1 protocol-mandated cleartext disclosure, file-
+  permission baseline (Linux + Windows `icacls`), network-defense map,
+  TLS configuration, CVE-tracking process, security-issue reporting
+  channel, audit history.
+- **`docs/phases/PHASE_7_FINDINGS.md`**: full security-audit findings
+  document (24 findings with severity + evidence + fix direction); each
+  finding linked to its closing PR.
+- **`docs/phases/PHASE_7.md`**: phase journal with the 12-PR list,
+  recurring techniques, module-state shapes, review-gate findings.
+
+#### Phase 6 - refactor + tests
+
+- **CI smoke harness**: 10 protocol-level tests (plain + TLS handshake,
+  full ADC login, +cmd routing, CSPRNG-salt-uniqueness, per-IP
+  connection cap, encrypted-at-rest user.tbl, no-script-errors-in-log)
+  on every push and PR via `.github/workflows/smoke.yml`. Both Linux
+  (ubuntu-latest) and Windows (windows-latest with msys2 UCRT64).
+- Vendored Tiger-192 implementation as `tests/smoke/tiger.py` so the
+  smoke client and the hub agree on the hash by construction.
+- **`docs/phases/PHASE_6.md`** journal.
+
+### Changed
+
+#### Phase 7
+
+- Bundled Lua **5.4.7 → 5.4.8** (Phase 7b, F-DEP-1). Drop-in upstream
+  patch-version sync; ABI-stable.
+- `find_package(OpenSSL 3.0 REQUIRED)` in CMakeLists.txt - refuse to
+  link against EOL'd OpenSSL 1.1.1 (Phase 7g, F-DEP-4).
+- `basexx/basexx.lua` carries a provenance header (upstream tag,
+  retrieval date, license, MIT) for future auditability (Phase 7g,
+  F-DEP-3).
+- `hub/hub.c` `restart()` checks the `atexit()` return value and exits
+  loudly when the registration limit is hit, instead of silently
+  exiting cleanly without re-entering Lua (Phase 7g, F-C-4).
+- `core/util.lua` gains `chmod_secret`, `arraytostring`, and
+  `loadtable_string` helpers used by the encryption path.
+
+#### Phase 6
+
+- **`core/cfg.lua` 3688 → 668 lines** (Phase 6c). Decomposed into:
+  - `core/cfg_defaults.lua` (~3000-line data table, ceiling-exempt)
+  - `core/cfg_users.lua` (user.tbl I/O)
+  - `core/cfg_lang.lua` (language file loader)
+- **`core/hub.lua` 2245 → 1497 lines** (Phase 6d). Decomposed into:
+  - `core/hub_user_object.lua` (`createuser` factory)
+  - `core/hub_bot_object.lua` (`createbot` factory)
+  - `core/hub_dispatch.lua` (ADC state-machine handler tables)
+- All code modules now under the 1500-line ceiling, with
+  `cfg_defaults.lua` exempt as a flat data table.
+
+### Fixed
+
+- **Path anchoring** (Phase 6b, closes #12): hub `chdir`s to its binary
+  directory at startup so `log/exception.txt` and other relative paths
+  resolve correctly regardless of how the hub is launched.
+- TODO/FIXME audit (Phase 6e) and dead-file removal (`core/test.lua`,
+  `slnunicode/.travis.yml`).
+
+### Security
+
+Full audit findings in
+[`docs/phases/PHASE_7_FINDINGS.md`](docs/phases/PHASE_7_FINDINGS.md).
+Severity rollup: 24 findings filed; 22 fixed; 1 deferred-by-design
+(F-AUTH-1 transparent KDF migration is ADC-protocol-immanent and
+mitigated via at-rest encryption + chmod 600 + configurable
+`master_key_path`); 1 stays `upstream-blocked` (F-DEP-2 LuaSec
+OpenSSL-3 deprecated APIs, tracked as #3).
+
+### Migration
+
+- **Operators on v3.0.0**: upgrade is in-place. First boot generates
+  `cfg/master.key`; first post-login save migrates `user.tbl` from
+  plaintext to AES-256-GCM-encrypted. **Strongly recommended**: set
+  `master_key_path = "/etc/luadch/master.key"` (or your preferred
+  external path) in `cfg/cfg.tbl` and move the key file before
+  putting real users into `user.tbl`. See
+  [`docs/SECURITY.md`](docs/SECURITY.md) §3 "Backup separation".
+- **Existing world-readable secrets**: run once on POSIX after upgrade:
+
+  ```sh
+  chmod 600 cfg/user.tbl cfg/user.tbl.bak certs/serverkey.pem certs/cakey.pem
+  ```
+
+  On Windows, see the `icacls` recipe in
+  [`docs/SECURITY.md`](docs/SECURITY.md) §4.
+
+[v3.1.0]: https://github.com/Aybook/luadch/releases/tag/v3.1.0
+
+
 ## [v3.0.0] - 2026-05-03
 
 First release of the modernised `Aybook/luadch` fork. Forked from upstream

--- a/core/const.lua
+++ b/core/const.lua
@@ -11,7 +11,7 @@
 return {
 
     PROGRAM_NAME = "Luadch",
-    VERSION = "v3.0.0",
+    VERSION = "v3.1.0",
     COPYRIGHT = "by blastbeat and pulsar",
     FORK = "modernised fork by Aybo",
     CONFIG_PATH = "././cfg/",


### PR DESCRIPTION
Release-prep PR for **v3.1.0**, mirroring the v3.0.0 prep pattern (PR #35).

## Summary

- Bump `VERSION` in [`core/const.lua`](../blob/master/core/const.lua) from \`v3.0.0\` to \`v3.1.0\`.
- New [`CHANGELOG.md`](../blob/master/CHANGELOG.md) entry covering the merged Phase 6 + Phase 7 work since v3.0.0 (2026-05-03).

## Why v3.1.0 (and not v3.0.1 or v4.0.0)

Per [SemVer](https://semver.org/spec/v2.0.0.html):

- **Not v4.0.0** - no breaking changes for operators on default cfg. Existing \`user.tbl\` is transparently migrated to the encrypted-at-rest format on first save after upgrade. New cfg keys (\`master_key_path\`, \`ratelimit_*\`) all have backwards-compatible defaults.
- **Not v3.0.1** - significant new functionality (AES-GCM at-rest encryption, rate-limiting module, sandboxed loaders), not just bug-fixes.
- **v3.1.0** is the right minor bump.

## What's in the release

Phase 6 (refactor + smoke harness) and Phase 7 (security audit + hardening). 11 + 1 PRs (#38-#50 for Phase 6 + close-out, #59-#70 for Phase 7 + close-out). Full CHANGELOG block in this PR.

Headlines:

- AES-256-GCM at-rest encryption of \`cfg/user.tbl\` with auto-managed master.key + configurable \`master_key_path\` for backup separation
- DoS hardening (per-IP / per-user rate limits, TLS handshake deadline, per-IP failed-auth lockout) in new \`core/ratelimit.lua\`
- Sandboxed config / state loaders eliminate the RCE-on-tampered-.tbl-file class
- ADC parser hardening (control-byte rejection, reentrant \`parse()\`, 64 KiB cap)
- POSIX file-permission enforcement on secret files; chmod-or-die boot check on master.key
- CSPRNG salts via OpenSSL \`RAND_bytes\`; Lua 5.4.7 → 5.4.8
- New top-level [\`docs/SECURITY.md\`](../blob/master/docs/SECURITY.md)
- 10 protocol-level smoke tests in CI (up from 7)

## Migration notes for operators

- Drop-in upgrade. First boot generates \`cfg/master.key\`; first post-login save migrates \`user.tbl\` to encrypted format.
- **Strongly recommended** before putting real users in \`user.tbl\`: set \`master_key_path = "/etc/luadch/master.key"\` (or your preferred external path) in \`cfg/cfg.tbl\` and move the key file. See [\`docs/SECURITY.md\`](../blob/master/docs/SECURITY.md) §3 "Backup separation".
- Existing world-readable secrets: one-time \`chmod 600 cfg/user.tbl cfg/user.tbl.bak certs/serverkey.pem certs/cakey.pem\` on POSIX. Windows \`icacls\` recipe in [\`docs/BUILDING.md\`](../blob/master/docs/BUILDING.md).

## Test plan

- [x] \`cmake --build build\` clean
- [x] \`cmake --install build\` clean
- [x] Smoke 10/10 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)