### PR TITLE
docs(release): update .github/release-body.md to v3.1.0

### DIFF
--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,57 +1,94 @@
-# Luadch v3.0.0
+# Luadch v3.1.0
 
-First release of the modernised `Aybook/luadch` fork.
+Phase 6 (refactor + smoke harness) and Phase 7 (security audit + hardening)
+of the modernisation programme. Drop-in upgrade from v3.0.0.
 
 ## Highlights
 
-- **Lua 5.1 -> 5.4** (5.1 reached EOL in 2012)
-- **Single CMake build** for Linux, Windows, and ARM aarch64
-- **Pre-built binaries** for Linux x86_64 and Windows x86_64 attached below
-- TLS 1.3 + AES-256-GCM verified end-to-end
-- Three new docs: `BUILDING.md`, `INSTALLING.md`, `CONFIGURATION.md`
-- Six bug fixes from the upstream tracker plus several local discoveries
+- **AES-256-GCM at-rest encryption** of `cfg/user.tbl` with auto-managed
+  master key + configurable `master_key_path` for backup separation
+- **DoS hardening**: per-IP / per-user rate limits, TLS handshake deadline,
+  per-IP failed-auth lockout (new `core/ratelimit.lua`)
+- **Sandboxed config / state loaders**: tampered `.tbl` files cannot
+  achieve RCE
+- **ADC parser hardening**: control-byte rejection, reentrant `parse()`,
+  64 KiB command-size cap
+- **POSIX file-permission enforcement** on every secret file;
+  chmod-or-die boot check on `master.key`
+- **CSPRNG salts** via OpenSSL `RAND_bytes`; bundled Lua **5.4.7 → 5.4.8**
+- **`core/cfg.lua` and `core/hub.lua` decomposed** into focused modules
+  under a 1500-line ceiling (Phase 6c-d)
+- **Comprehensive security audit** (Phase 7): 24 findings filed, 22 fixed;
+  see [`docs/SECURITY.md`](https://github.com/Aybook/luadch/blob/v3.1.0/docs/SECURITY.md)
+  and [`docs/phases/PHASE_7_FINDINGS.md`](https://github.com/Aybook/luadch/blob/v3.1.0/docs/phases/PHASE_7_FINDINGS.md)
+- **CI smoke harness** extended from 7 to 10 protocol-level tests
+  (handshake, login, +cmd routing, CSPRNG-salt-uniqueness, per-IP cap,
+  encryption-at-rest, no-script-errors), green on Linux + Windows
 
 ## Downloads
 
 | File | Platform |
 |---|---|
-| `luadch-v3.0.0-linux-x86_64.tar.gz` | Linux glibc x86_64 |
-| `luadch-v3.0.0-windows-x86_64.zip` | Windows x86_64 (MinGW UCRT64) |
+| `luadch-v3.1.0-linux-x86_64.tar.gz` | Linux glibc x86_64 |
+| `luadch-v3.1.0-windows-x86_64.zip`  | Windows x86_64 (MinGW UCRT64) |
 
 Extract anywhere and run `./luadch` (Linux) or `Luadch.exe` (Windows). The
 trees are self-contained: Lua interpreter, all bundled libs (LuaSec,
 LuaSocket, basexx, adclib), default configs, scripts, certs helpers.
 
 Default plain ADC port `5000`, TLS port `5001` after running
-`certs/make_cert.{sh,bat}` once. First login: nick `dummy`, password `test` -
-**delete that account immediately** after registering yourself, see
-[`docs/CONFIGURATION.md`](https://github.com/Aybook/luadch/blob/v3.0.0/docs/CONFIGURATION.md).
+`certs/make_cert.{sh,bat}` once. First login: nick `dummy`, password
+`test` - **delete that account immediately** after registering yourself,
+see [`docs/CONFIGURATION.md`](https://github.com/Aybook/luadch/blob/v3.1.0/docs/CONFIGURATION.md).
 
-## Breaking changes for existing deployments
+## Migration from v3.0.0
 
-- **Plugin authors**: Lua 5.4 idioms required (`load` instead of
-  `loadstring`, explicit `_ENV` instead of `setfenv`, `table.unpack`
-  instead of `unpack`, `math.atan` two-arg form instead of `math.atan2`,
-  etc.).
-- **Build instructions**: now `cmake -B build && cmake --build build && cmake --install build`
-  on every platform. The legacy `compile` shell script and
-  `compile_with_mingw.bat` are gone.
-- **slnunicode**: replaced by a Lua shim. Plugins relying on Unicode-class
-  patterns (e.g. `%l` matching German umlauts) need a dedicated function
-  added to the shim - the bundled scripts use ASCII-only patterns and
-  needed no changes.
+No breaking changes for operators on default cfg. Existing `cfg/user.tbl`
+is transparently migrated to the encrypted-at-rest format on the first
+post-login save after upgrade.
+
+**Strongly recommended** before putting real users into `user.tbl`:
+
+1. Read [`docs/SECURITY.md`](https://github.com/Aybook/luadch/blob/v3.1.0/docs/SECURITY.md)
+   §3 "Backup separation".
+2. Set `master_key_path` in `cfg/cfg.tbl` to an absolute path **outside**
+   the install directory:
+
+   ```lua
+   master_key_path = "/etc/luadch/master.key"            -- POSIX
+   master_key_path = "C:/ProgramData/luadch/master.key"  -- Windows
+   ```
+
+   Otherwise a routine `tar czf backup.tar.gz cfg/` bundles the
+   encrypted user database AND its decryption key into the same
+   archive, and the at-rest encryption provides zero protection
+   against backup theft.
+3. Move the existing `cfg/master.key` (if first-boot already generated
+   one) to the new path, ensure mode 0600 on POSIX (or `icacls` on
+   Windows), and restart.
+
+Existing world-readable secrets - one-time fix on POSIX:
+
+```sh
+chmod 600 cfg/user.tbl cfg/user.tbl.bak certs/serverkey.pem certs/cakey.pem
+```
+
+Windows `icacls` recipe in [`docs/BUILDING.md`](https://github.com/Aybook/luadch/blob/v3.1.0/docs/BUILDING.md)
+and [`docs/SECURITY.md`](https://github.com/Aybook/luadch/blob/v3.1.0/docs/SECURITY.md) §4.
 
 ## Full changelog
 
-See [`CHANGELOG.md`](https://github.com/Aybook/luadch/blob/v3.0.0/CHANGELOG.md)
-for the complete list, organised by category.
+See [`CHANGELOG.md`](https://github.com/Aybook/luadch/blob/v3.1.0/CHANGELOG.md)
+for the complete categorised list. Phase journals in
+[`docs/phases/PHASE_6.md`](https://github.com/Aybook/luadch/blob/v3.1.0/docs/phases/PHASE_6.md)
+and [`docs/phases/PHASE_7.md`](https://github.com/Aybook/luadch/blob/v3.1.0/docs/phases/PHASE_7.md).
 
 ## Build from source
 
 The pipeline is identical on every supported platform:
 
 ```sh
-git clone --branch v3.0.0 https://github.com/Aybook/luadch.git
+git clone --branch v3.1.0 https://github.com/Aybook/luadch.git
 cd luadch
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
@@ -60,7 +97,7 @@ cmake --install build
 
 Output lands in `build/install/luadch/` ready to run. Windows needs
 `-G "MinGW Makefiles" -DOPENSSL_ROOT_DIR=...` extra, see
-[`docs/BUILDING.md`](https://github.com/Aybook/luadch/blob/v3.0.0/docs/BUILDING.md).
+[`docs/BUILDING.md`](https://github.com/Aybook/luadch/blob/v3.1.0/docs/BUILDING.md).
 
 ## Credits
 


### PR DESCRIPTION
Follow-up fix for v3.1.0.

## Issue

PR #71 (release: prepare v3.1.0) bumped \`core/const.lua\` and wrote the CHANGELOG entry but missed updating \`.github/release-body.md\`. The release workflow takes that file verbatim as the GitHub-release body, so [v3.1.0 went out](https://github.com/Aybook/luadch/releases/tag/v3.1.0) with the static v3.0.0 body.

The **live** release body has been manually corrected via \`gh release edit v3.1.0 --notes-file .github/release-body.md\` (the new content; same as in this PR). This PR syncs the in-repo file so future readers and the next release-prep don't see stale text.

## For posterity

Release-prep PRs should also update \`.github/release-body.md\`. The v3.0.0 prep (PR #35) did include it - that convention slipped here. Recording it in the commit message so next time around the checklist is right.

## Test plan

No code changes; doc only. \`gh release view v3.1.0\` already shows the new body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)