### PR TITLE
chore: update primary doc refs after Aybook/luadch -> luadch-ng/luadch transfer

### DIFF
--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -19,8 +19,8 @@ of the modernisation programme. Drop-in upgrade from v3.0.0.
 - **`core/cfg.lua` and `core/hub.lua` decomposed** into focused modules
   under a 1500-line ceiling (Phase 6c-d)
 - **Comprehensive security audit** (Phase 7): 24 findings filed, 22 fixed;
-  see [`docs/SECURITY.md`](https://github.com/Aybook/luadch/blob/v3.1.0/docs/SECURITY.md)
-  and [`docs/phases/PHASE_7_FINDINGS.md`](https://github.com/Aybook/luadch/blob/v3.1.0/docs/phases/PHASE_7_FINDINGS.md)
+  see [`docs/SECURITY.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/docs/SECURITY.md)
+  and [`docs/phases/PHASE_7_FINDINGS.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/docs/phases/PHASE_7_FINDINGS.md)
 - **CI smoke harness** extended from 7 to 10 protocol-level tests
   (handshake, login, +cmd routing, CSPRNG-salt-uniqueness, per-IP cap,
   encryption-at-rest, no-script-errors), green on Linux + Windows
@@ -39,7 +39,7 @@ LuaSocket, basexx, adclib), default configs, scripts, certs helpers.
 Default plain ADC port `5000`, TLS port `5001` after running
 `certs/make_cert.{sh,bat}` once. First login: nick `dummy`, password
 `test` - **delete that account immediately** after registering yourself,
-see [`docs/CONFIGURATION.md`](https://github.com/Aybook/luadch/blob/v3.1.0/docs/CONFIGURATION.md).
+see [`docs/CONFIGURATION.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/docs/CONFIGURATION.md).
 
 ## Migration from v3.0.0
 
@@ -49,7 +49,7 @@ post-login save after upgrade.
 
 **Strongly recommended** before putting real users into `user.tbl`:
 
-1. Read [`docs/SECURITY.md`](https://github.com/Aybook/luadch/blob/v3.1.0/docs/SECURITY.md)
+1. Read [`docs/SECURITY.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/docs/SECURITY.md)
    §3 "Backup separation".
 2. Set `master_key_path` in `cfg/cfg.tbl` to an absolute path **outside**
    the install directory:
@@ -73,22 +73,22 @@ Existing world-readable secrets - one-time fix on POSIX:
 chmod 600 cfg/user.tbl cfg/user.tbl.bak certs/serverkey.pem certs/cakey.pem
 ```
 
-Windows `icacls` recipe in [`docs/BUILDING.md`](https://github.com/Aybook/luadch/blob/v3.1.0/docs/BUILDING.md)
-and [`docs/SECURITY.md`](https://github.com/Aybook/luadch/blob/v3.1.0/docs/SECURITY.md) §4.
+Windows `icacls` recipe in [`docs/BUILDING.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/docs/BUILDING.md)
+and [`docs/SECURITY.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/docs/SECURITY.md) §4.
 
 ## Full changelog
 
-See [`CHANGELOG.md`](https://github.com/Aybook/luadch/blob/v3.1.0/CHANGELOG.md)
+See [`CHANGELOG.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/CHANGELOG.md)
 for the complete categorised list. Phase journals in
-[`docs/phases/PHASE_6.md`](https://github.com/Aybook/luadch/blob/v3.1.0/docs/phases/PHASE_6.md)
-and [`docs/phases/PHASE_7.md`](https://github.com/Aybook/luadch/blob/v3.1.0/docs/phases/PHASE_7.md).
+[`docs/phases/PHASE_6.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/docs/phases/PHASE_6.md)
+and [`docs/phases/PHASE_7.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/docs/phases/PHASE_7.md).
 
 ## Build from source
 
 The pipeline is identical on every supported platform:
 
 ```sh
-git clone --branch v3.1.0 https://github.com/Aybook/luadch.git
+git clone --branch v3.1.0 https://github.com/luadch-ng/luadch.git
 cd luadch
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
@@ -97,7 +97,7 @@ cmake --install build
 
 Output lands in `build/install/luadch/` ready to run. Windows needs
 `-G "MinGW Makefiles" -DOPENSSL_ROOT_DIR=...` extra, see
-[`docs/BUILDING.md`](https://github.com/Aybook/luadch/blob/v3.1.0/docs/BUILDING.md).
+[`docs/BUILDING.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/docs/BUILDING.md).
 
 ## Credits
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-All notable changes to the `Aybook/luadch` fork are documented here.
+All notable changes to the `luadch-ng/luadch` fork are documented here.
+The repo lived at `Aybook/luadch` before the v3.1.x line; auto-redirects
+handle historic links.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -163,7 +165,7 @@ OpenSSL-3 deprecated APIs, tracked as #3).
   On Windows, see the `icacls` recipe in
   [`docs/SECURITY.md`](docs/SECURITY.md) §4.
 
-[v3.1.0]: https://github.com/Aybook/luadch/releases/tag/v3.1.0
+[v3.1.0]: https://github.com/luadch-ng/luadch/releases/tag/v3.1.0
 
 
 ## [v3.0.0] - 2026-05-03
@@ -273,4 +275,4 @@ and ships several pre-existing-bug fixes on top.
 For the full per-phase narrative (activities, design decisions, build
 output specs, review-gate checklists), see [`docs/phases/`](docs/phases/).
 
-[v3.0.0]: https://github.com/Aybook/luadch/releases/tag/v3.0.0
+[v3.0.0]: https://github.com/luadch-ng/luadch/releases/tag/v3.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,7 +317,7 @@ and review gate. The strict "one phase at a time" discipline still applies.
   modernization phase: activities, findings, build-output specs, and the review-gate
   checklist. Entry point for "what happened in phase N" is `docs/phases/PHASE_N.md`.
   These are the narrative — issues and code are the actionable state.
-- **GitHub issues** — https://github.com/Aybook/luadch/issues — the actionable backlog.
+- **GitHub issues** — https://github.com/luadch-ng/luadch/issues — the actionable backlog.
   Each finding from a phase journal that needs work is an issue here, labeled with the
   target phase (`phase-2`, `phase-3`, …). Use `gh issue list --label phase-2` to scope
   upcoming work. Upstream `luadch/luadch` issues are referenced selectively when we
@@ -329,7 +329,7 @@ and review gate. The strict "one phase at a time" discipline still applies.
 
 ### Upstream policy
 
-The repo at `Aybook/luadch` is currently a fork of `luadch/luadch`. The upstream is
+The repo at `luadch-ng/luadch` is a fork of `luadch/luadch`. The upstream is
 not actively released (last release 2022-04-02) but still receives occasional commits.
 We do **not** plan to push modernization work back upstream and do **not** bulk-import
 upstream's open issues. When a phase touches an area covered by an upstream issue, we

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![License](https://img.shields.io/badge/license-GPLv3.0-blueviolet.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20Windows%20%7C%20ARM-orange.svg)](docs/BUILDING.md)
 [![Lua](https://img.shields.io/badge/lua-5.4-blue.svg)](https://www.lua.org/)
-[![Smoke](https://github.com/Aybook/luadch/actions/workflows/smoke.yml/badge.svg)](https://github.com/Aybook/luadch/actions/workflows/smoke.yml)
-[![Release](https://img.shields.io/github/v/release/Aybook/luadch.svg)](https://github.com/Aybook/luadch/releases/latest)
+[![Smoke](https://github.com/luadch-ng/luadch/actions/workflows/smoke.yml/badge.svg)](https://github.com/luadch-ng/luadch/actions/workflows/smoke.yml)
+[![Release](https://img.shields.io/github/v/release/luadch-ng/luadch.svg)](https://github.com/luadch-ng/luadch/releases/latest)
 
 A modernised fork of [luadch](https://github.com/luadch/luadch) by
-**blastbeat** and **pulsar**. Maintained by [Aybook](https://github.com/Aybook),
-with help from Claude.
+**blastbeat** and **pulsar**, hosted at [`luadch-ng`](https://github.com/luadch-ng).
+Maintained by [Aybo](https://github.com/Aybook), with help from Claude.
 
 ## Original Features
 
@@ -21,9 +21,9 @@ with help from Claude.
 
 ## New Features
 
-- **DoS hardening** ([#56](https://github.com/Aybook/luadch/issues/56)) - per-IP / per-user rate limits, TLS handshake deadline, failed-auth lockout
-- **Encrypted user database** ([#52](https://github.com/Aybook/luadch/issues/52)) - AES-256-GCM at-rest encryption of `cfg/user.tbl`
-- **Sandboxed config / state loaders** ([#51](https://github.com/Aybook/luadch/issues/51)) - tampered `.tbl` files cannot achieve RCE
+- **DoS hardening** ([#56](https://github.com/luadch-ng/luadch/issues/56)) - per-IP / per-user rate limits, TLS handshake deadline, failed-auth lockout
+- **Encrypted user database** ([#52](https://github.com/luadch-ng/luadch/issues/52)) - AES-256-GCM at-rest encryption of `cfg/user.tbl`
+- **Sandboxed config / state loaders** ([#51](https://github.com/luadch-ng/luadch/issues/51)) - tampered `.tbl` files cannot achieve RCE
 - **POSIX file-permission enforcement** on secret files
 
 See [`docs/SECURITY.md`](docs/SECURITY.md) for the full threat model
@@ -78,13 +78,13 @@ Detail per phase in [docs/phases/](docs/phases/).
 ## Quick start
 
 Pre-built binaries for Linux x86_64 and Windows x86_64 are attached to
-each [release](https://github.com/Aybook/luadch/releases/latest) - extract
+each [release](https://github.com/luadch-ng/luadch/releases/latest) - extract
 and run.
 
 Or build from source:
 
 ```sh
-git clone https://github.com/Aybook/luadch.git
+git clone https://github.com/luadch-ng/luadch.git
 cd luadch
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j$(nproc)

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -35,7 +35,7 @@ OpenSSL 3.x development headers.
 ### Build & install
 
 ```sh
-git clone https://github.com/Aybook/luadch.git
+git clone https://github.com/luadch-ng/luadch.git
 cd luadch
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j$(nproc)
@@ -189,7 +189,7 @@ default account is hubowner — **delete it as soon as you have your own**.
 ## File permissions for secrets
 
 `cfg/user.tbl` (registered users with their cleartext passwords - see
-[F-AUTH-1](https://github.com/Aybook/luadch/issues/52) for the
+[F-AUTH-1](https://github.com/luadch-ng/luadch/issues/52) for the
 ADC-protocol-mandated reason) and `certs/serverkey.pem` (TLS private
 key) hold material that must not be world-readable.
 
@@ -232,7 +232,7 @@ sources against system OpenSSL 3.x (`EC_KEY_*`, `PEM_read_bio_DHparams`,
 `SSL_CTX_set_tmp_dh_callback`, `EC_KEY_free`, `DH_free`). These are
 cosmetic — the functions still work in current OpenSSL. The negotiated
 TLS session is modern (TLS 1.3 + AES-256-GCM verified). Tracked in
-[issue #3](https://github.com/Aybook/luadch/issues/3) as
+[issue #3](https://github.com/luadch-ng/luadch/issues/3) as
 `upstream-blocked` / `wontfix`.
 
 The Windows build (gcc 16+) emits 2 stylistic `-Wparentheses` warnings

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -86,7 +86,7 @@ Tiger output, so login breaks. This constraint is shared by the
 entire ADC ecosystem (ADCH++ stores cleartext in XML, uHub in
 `users.conf`, …) and there is no published ADC extension that lifts
 it. The audit research is recorded in issue
-[#52](https://github.com/Aybook/luadch/issues/52).
+[#52](https://github.com/luadch-ng/luadch/issues/52).
 
 ### What luadch actually does
 
@@ -167,7 +167,7 @@ Windows, apply `icacls` to the new path - see §4.
 OS-bound key wrapping (TPM, DPAPI machine-scope, libsecret, macOS
 Keychain) would harden the master-key-theft case and is tracked as a
 Phase 8+ candidate in
-[#48](https://github.com/Aybook/luadch/issues/48).
+[#48](https://github.com/luadch-ng/luadch/issues/48).
 
 ---
 
@@ -229,7 +229,7 @@ the same `icacls` line there. The same recipe lives in
 | Connection read-buffer cap | [`core/server.lua`](../core/server.lua) | hardcoded 1 MiB |
 
 The full DoS-hardening rationale is in Phase 7c
-([#56](https://github.com/Aybook/luadch/issues/56)).
+([#56](https://github.com/luadch-ng/luadch/issues/56)).
 
 ---
 
@@ -276,7 +276,7 @@ truth, not to greps.
 ## 8. Reporting a security issue
 
 Open a private security advisory at
-<https://github.com/Aybook/luadch/security/advisories/new> rather
+<https://github.com/luadch-ng/luadch/security/advisories/new> rather
 than a public issue, especially for issues that:
 
 - enable RCE without prior authentication


### PR DESCRIPTION
First PR on the new \`luadch-ng/luadch\` repo. After the org transfer earlier today, refresh the customer-facing primary docs so they read with the new path. GitHub auto-redirects every URL from \`Aybook/luadch\` to \`luadch-ng/luadch\` (issues, PRs, releases, git operations, API), so this is purely cosmetic / discoverability - nothing was broken to begin with.

## Touched

| File | What |
|---|---|
| \`README.md\` | Smoke + Release badge URLs, clone command, issue links (#56 / #52 / #51 / etc.), maintainer line uses \`[Aybo](https://github.com/Aybook)\` per CLAUDE.md privacy rule |
| \`.github/release-body.md\` | All repo paths used by the next release-body template (v3.1.x onward) |
| \`CHANGELOG.md\` | v3.0.0 + v3.1.0 footer link refs, header note explaining the historic Aybook/luadch path |
| \`CLAUDE.md\` §6 | GitHub-issues URL + upstream-policy paragraph wording |
| \`docs/SECURITY.md\` | Issue tracker links, security-advisory reporting URL |
| \`docs/BUILDING.md\` | Clone command + visible issue refs |

## Untouched on purpose

Phase journals (\`docs/phases/PHASE_*.md\`, \`INTERLUDE_UPSTREAM_TRIAGE{,_2}.md\`). These document state at a specific point in time when the repo was at Aybook/luadch; auto-redirect handles the URLs and rewriting historic narrative would be churn without value. Same for the body text of historic CHANGELOG entries.

## Test plan

- [x] No code changes
- [x] Smoke 10/10 PASS (sanity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)