### PR TITLE
fix: small cleanups from #48

### DIFF
--- a/scripts/cmd_ban.lua
+++ b/scripts/cmd_ban.lua
@@ -706,7 +706,7 @@ hub.setlistener( "onConnect", {},
                 message = utf.format( msg_ban, ban.by_nick, ban.reason ) .. get_bantime( remaining )
                 -- remember: never fire listenter X inside listener X; will cause infinite loop
                 -- also: never fire listener X in listener Y, where listener Y fires listener X; will as well cause a infinite loop.
-                --scripts.firelistener( "onFailedAuth", user:nick( ), user:ip( ), user:cid( ), "Banned for "  .. get_bantime( remaining ) .. " (" .. ban.reason .. ")" ) -- todo: i18n
+                --scripts.firelistener( "onFailedAuth", user:nick( ), user:ip( ), user:cid( ), "Banned for "  .. get_bantime( remaining ) .. " (" .. ban.reason .. ")" )
                 user:kill( "ISTA 231 " .. hub.escapeto( message ) .. "\n", "TL" .. remaining )
                 return PROCESSED
             end

--- a/scripts/hub_inf_manager.lua
+++ b/scripts/hub_inf_manager.lua
@@ -23,6 +23,7 @@ local scriptlang = cfg.get "language"
 local lang, err = cfg.loadlanguage( scriptlang, scriptname ); lang = lang or { }; err = err and hub.debug( err )
 
 local msg_invalid = hub.escapeto( lang.msg_invalid or "invalid named parameter in inf: " )
+local msg_failedauth_reason = lang.msg_failedauth_reason or "User sent offending flag in INF: "
 
 --// forbidden named parameters in inf //--
 
@@ -60,8 +61,7 @@ end
 local fire_onfailedauth = function( user, offending_flag )
     -- remember: never fire listenter X inside listener X; will cause infinite loop
     -- also: never fire listener X in listener Y, where listener Y fires listener X; will as well cause a infinite loop.
-    -- failure-reason string is hardcoded English; i18n tracked in #48.
-    scripts.firelistener( "onFailedAuth", user:nick( ), user:ip( ), user:cid( ), "User send offending flag in INF: "  .. offending_flag )
+    scripts.firelistener( "onFailedAuth", user:nick( ), user:ip( ), user:cid( ), msg_failedauth_reason .. offending_flag )
 end
 
 hub.setlistener( "onConnect", { },

--- a/scripts/lang/hub_inf_manager.lang.de
+++ b/scripts/lang/hub_inf_manager.lang.de
@@ -1,5 +1,6 @@
 ﻿return {
 
     msg_invalid = "Ungültiger Parameter in Inf: ",
+    msg_failedauth_reason = "User sendet unzulässige Flag in INF: ",
 
 }

--- a/scripts/lang/hub_inf_manager.lang.en
+++ b/scripts/lang/hub_inf_manager.lang.en
@@ -1,5 +1,6 @@
 ﻿return {
 
     msg_invalid = "Invalid named parameter in inf: ",
+    msg_failedauth_reason = "User sent offending flag in INF: ",
 
 }

--- a/scripts/usr_nick_length.lua
+++ b/scripts/usr_nick_length.lua
@@ -11,9 +11,10 @@ local scriptname = "usr_nick_length.lua"
 local scriptversion = "0.01"
 
 local check = function( user, nick )
-    -- byte length: rejects multi-byte (Cyrillic etc.) nicks earlier than
-    -- their codepoint length suggests; codepoint-aware fix tracked in #48.
-    local len = #nick
+    -- min/max_nickname_length is documented in codepoints; use utf.len so
+    -- multi-byte (e.g. Cyrillic) nicks aren't rejected at lower codepoint
+    -- counts than ASCII nicks.
+    local len = utf.len( nick )
     if ( cfg.get "min_nickname_length" <= len ) and ( len <= cfg.get "max_nickname_length" ) then
         return nil
     end

--- a/scripts/usr_nick_prefix.lua
+++ b/scripts/usr_nick_prefix.lua
@@ -4,7 +4,6 @@
 
         - this script adds a prefix to the nick of an user
         - you can use the prefix table to define different prefixes for different user levels
-        - onInf nick-change handling tracked in issue #48
 
         v0.12: by pulsar
             - removed table lookups
@@ -114,7 +113,7 @@ hub.setlistener( "onConnect", { },
             local bol, err = user:updatenick( prefix .. user:nick(), true )
             if not bol then
                 -- disable to prevent spam; remember: never fire listenter X inside listener X; will cause infinite loop
-                --scripts.firelistener( "onFailedAuth", user:nick( ), user:ip( ), user:cid( ), "Nick prefix failed: " .. err ) -- todo: i18n
+                --scripts.firelistener( "onFailedAuth", user:nick( ), user:ip( ), user:cid( ), "Nick prefix failed: " .. err )
                 user:kill( "ISTA 220 " .. hub.escapeto( err ) .. "\n", "TL300" )
                 return PROCESSED
             end

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -131,7 +131,15 @@ def generate_test_cert(staging_dir: Path):
     # depending on locale, and openssl's stderr can include non-ASCII
     # chars in error paths. Decoding with errors="replace" sidesteps
     # any locale fight just to surface a useful error message.
-    result = subprocess.run(cmd, cwd=certs_dir, capture_output=True)
+    #
+    # stdin=DEVNULL: bundled make_cert.bat ends with `pause`, intended
+    # for interactive admins reading openssl's output. When invoked
+    # without an explicit stdin override we'd inherit the parent
+    # console and `pause` would block forever. DEVNULL gives `pause`
+    # an immediate EOF; cert generation is unaffected.
+    result = subprocess.run(
+        cmd, cwd=certs_dir, capture_output=True, stdin=subprocess.DEVNULL
+    )
     if result.returncode != 0:
         stdout = result.stdout.decode("utf-8", errors="replace")
         stderr = result.stderr.decode("utf-8", errors="replace")


### PR DESCRIPTION
Pulls a small subset of [#48](https://github.com/luadch-ng/luadch/issues/48) (Phase 8+ TODO/FIXME audit) - the trivially safe items that fit a single review without protocol or sandbox surface.

## Script changes

- **usr_nick_length.lua** (concrete bug): \`#nick\` (byte length) -> \`utf.len(nick)\` (codepoint length). Cyrillic and other multi-byte nicks were being rejected at lower codepoint counts than ASCII because cfg.tbl documents \`min/max_nickname_length\` in codepoints.
- **hub_inf_manager.lua + lang/hub_inf_manager.lang.{en,de}**: route the \`onFailedAuth\` failure reason through the existing per-script lang file as \`msg_failedauth_reason\` instead of a hardcoded English string.
- **cmd_ban.lua, usr_nick_prefix.lua** (doc cleanup): drop misleading \`-- todo: i18n\` trailers from firelistener calls that are *intentionally* commented out (\"disable to prevent spam\" / recursion). The i18n marker on a dead line was rotz from the Phase 6e audit.
- **usr_nick_prefix.lua** (doc cleanup): remove docstring claim about onInf nick-change handling. The script does have an onInf listener (lines 82-93); behaviour under nick-change is order-dependent with hub_inf_manager and #48 had no clean repro - touching it without one was the wrong call.

## Smoke harness fix

While running the smoke harness locally to verify the script changes, hit a long-standing Windows-only hang: \`make_cert.bat\` ends with \`pause\` (for interactive admins reading openssl's output), \`subprocess.run(..., capture_output=True)\` leaves stdin inheriting the parent console, so \`pause\` blocks forever waiting for a keypress. CI never tripped this because Linux uses \`make_cert.sh\` (no pause). Fixed by passing \`stdin=subprocess.DEVNULL\` so \`pause\` sees EOF and exits cleanly.

## Out of scope (still in #48)

The architectural items (\`getbot(\"all\")\` semantics, \`reguser\` regex single-hash assumption, \`removeListener\` API, two further i18n gaps in dead code blocks) stay parked in #48. Those are bigger surface than \"small cleanup\" - they want their own scoped phase or PR.

## Test plan

- [x] Lua-syntax review of all touched scripts
- [x] Local smoke run on Windows: 10 / 10 PASS
- [x] CI smoke (Linux + Windows) on this branch

Refs #48