### PR TITLE
release: prepare v3.1.1

### DIFF
--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,36 +1,39 @@
-# Luadch v3.1.0
+# Luadch v3.1.1
 
-Phase 6 (refactor + smoke harness) and Phase 7 (security audit + hardening)
-of the modernisation programme. Drop-in upgrade from v3.0.0.
+Patch release on top of v3.1.0. Drop-in upgrade: no cfg / on-disk-format
+changes, no Lua API changes, no new dependencies. Smoke harness still
+10 / 10 PASS on Linux + Windows.
 
 ## Highlights
 
-- **AES-256-GCM at-rest encryption** of `cfg/user.tbl` with auto-managed
-  master key + configurable `master_key_path` for backup separation
-- **DoS hardening**: per-IP / per-user rate limits, TLS handshake deadline,
-  per-IP failed-auth lockout (new `core/ratelimit.lua`)
-- **Sandboxed config / state loaders**: tampered `.tbl` files cannot
-  achieve RCE
-- **ADC parser hardening**: control-byte rejection, reentrant `parse()`,
-  64 KiB command-size cap
-- **POSIX file-permission enforcement** on every secret file;
-  chmod-or-die boot check on `master.key`
-- **CSPRNG salts** via OpenSSL `RAND_bytes`; bundled Lua **5.4.7 → 5.4.8**
-- **`core/cfg.lua` and `core/hub.lua` decomposed** into focused modules
-  under a 1500-line ceiling (Phase 6c-d)
-- **Comprehensive security audit** (Phase 7): 24 findings filed, 22 fixed;
-  see [`docs/SECURITY.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/docs/SECURITY.md)
-  and [`docs/phases/PHASE_7_FINDINGS.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/docs/phases/PHASE_7_FINDINGS.md)
-- **CI smoke harness** extended from 7 to 10 protocol-level tests
-  (handshake, login, +cmd routing, CSPRNG-salt-uniqueness, per-IP cap,
-  encryption-at-rest, no-script-errors), green on Linux + Windows
+- **Security: DSCH search fanout fixed** ([luadch#200](https://github.com/luadch/luadch/issues/200)).
+  `etc_trafficmanager.lua` no longer fans out direct (D / E type) searches
+  to every user; the hub's default direct-routing path delivers correctly
+  to the single intended SID. Same root cause also clears the AirDC++ 4.21
+  "search spam detected" disconnect ([luadch#226](https://github.com/luadch/luadch/issues/226)).
+- **Six more upstream-bug fixes** (Interlude 2, rounds 2 + 3): negative DS
+  in INF blocked login ([#241](https://github.com/luadch/luadch/issues/241)),
+  `+delreg` against blacklisted nicks ([#228](https://github.com/luadch/luadch/issues/228)),
+  trafficmanager prefix-script regression ([#240](https://github.com/luadch/luadch/issues/240)),
+  forgot-prefix commands in main chat ([#223](https://github.com/luadch/luadch/issues/223)),
+  misleading `+help cmd_mass` levels ([#217](https://github.com/luadch/luadch/issues/217)),
+  cryptic SSL-context error on first Windows run ([#177](https://github.com/luadch/luadch/issues/177)).
+- **Codepoint-aware nick-length check**: `usr_nick_length.lua` now uses
+  `utf.len()` so Cyrillic / multi-byte nicks aren't rejected at lower
+  codepoint counts than ASCII ones.
+- **`hub_inf_manager.lua` failure reason** routed through the per-script
+  lang file instead of a hardcoded English string.
+- **Smoke harness Windows hang fixed**: `make_cert.bat`'s trailing `pause`
+  no longer blocks the harness when run from an interactive shell.
+- **Org transfer**: repo now lives at `luadch-ng/luadch` (auto-redirects
+  keep historic links working). Project page: <https://luadch-ng.github.io/>.
 
 ## Downloads
 
 | File | Platform |
 |---|---|
-| `luadch-v3.1.0-linux-x86_64.tar.gz` | Linux glibc x86_64 |
-| `luadch-v3.1.0-windows-x86_64.zip`  | Windows x86_64 (MinGW UCRT64) |
+| `luadch-v3.1.1-linux-x86_64.tar.gz` | Linux glibc x86_64 |
+| `luadch-v3.1.1-windows-x86_64.zip`  | Windows x86_64 (MinGW UCRT64) |
 
 Extract anywhere and run `./luadch` (Linux) or `Luadch.exe` (Windows). The
 trees are self-contained: Lua interpreter, all bundled libs (LuaSec,
@@ -39,56 +42,28 @@ LuaSocket, basexx, adclib), default configs, scripts, certs helpers.
 Default plain ADC port `5000`, TLS port `5001` after running
 `certs/make_cert.{sh,bat}` once. First login: nick `dummy`, password
 `test` - **delete that account immediately** after registering yourself,
-see [`docs/CONFIGURATION.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/docs/CONFIGURATION.md).
+see [`docs/CONFIGURATION.md`](https://github.com/luadch-ng/luadch/blob/v3.1.1/docs/CONFIGURATION.md).
 
-## Migration from v3.0.0
+## Migration from v3.1.0
 
-No breaking changes for operators on default cfg. Existing `cfg/user.tbl`
-is transparently migrated to the encrypted-at-rest format on the first
-post-login save after upgrade.
+None required. Drop the new install tree in place of the old one (or
+`git pull && cmake --build build && cmake --install build` from source).
+`cfg/`, `certs/`, `master.key`, encrypted `user.tbl` carry over without
+change.
 
-**Strongly recommended** before putting real users into `user.tbl`:
-
-1. Read [`docs/SECURITY.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/docs/SECURITY.md)
-   §3 "Backup separation".
-2. Set `master_key_path` in `cfg/cfg.tbl` to an absolute path **outside**
-   the install directory:
-
-   ```lua
-   master_key_path = "/etc/luadch/master.key"            -- POSIX
-   master_key_path = "C:/ProgramData/luadch/master.key"  -- Windows
-   ```
-
-   Otherwise a routine `tar czf backup.tar.gz cfg/` bundles the
-   encrypted user database AND its decryption key into the same
-   archive, and the at-rest encryption provides zero protection
-   against backup theft.
-3. Move the existing `cfg/master.key` (if first-boot already generated
-   one) to the new path, ensure mode 0600 on POSIX (or `icacls` on
-   Windows), and restart.
-
-Existing world-readable secrets - one-time fix on POSIX:
-
-```sh
-chmod 600 cfg/user.tbl cfg/user.tbl.bak certs/serverkey.pem certs/cakey.pem
-```
-
-Windows `icacls` recipe in [`docs/BUILDING.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/docs/BUILDING.md)
-and [`docs/SECURITY.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/docs/SECURITY.md) §4.
+If you're still on v3.0.0, follow the v3.1.0 migration notes:
+<https://github.com/luadch-ng/luadch/releases/tag/v3.1.0>.
 
 ## Full changelog
 
-See [`CHANGELOG.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/CHANGELOG.md)
-for the complete categorised list. Phase journals in
-[`docs/phases/PHASE_6.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/docs/phases/PHASE_6.md)
-and [`docs/phases/PHASE_7.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/docs/phases/PHASE_7.md).
+See [`CHANGELOG.md`](https://github.com/luadch-ng/luadch/blob/v3.1.1/CHANGELOG.md)
+for the categorised list. Triage notes for the upstream-issue fixes are in
+[`docs/phases/INTERLUDE_UPSTREAM_TRIAGE_2.md`](https://github.com/luadch-ng/luadch/blob/v3.1.1/docs/phases/INTERLUDE_UPSTREAM_TRIAGE_2.md).
 
 ## Build from source
 
-The pipeline is identical on every supported platform:
-
 ```sh
-git clone --branch v3.1.0 https://github.com/luadch-ng/luadch.git
+git clone --branch v3.1.1 https://github.com/luadch-ng/luadch.git
 cd luadch
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
@@ -97,7 +72,7 @@ cmake --install build
 
 Output lands in `build/install/luadch/` ready to run. Windows needs
 `-G "MinGW Makefiles" -DOPENSSL_ROOT_DIR=...` extra, see
-[`docs/BUILDING.md`](https://github.com/luadch-ng/luadch/blob/v3.1.0/docs/BUILDING.md).
+[`docs/BUILDING.md`](https://github.com/luadch-ng/luadch/blob/v3.1.1/docs/BUILDING.md).
 
 ## Credits
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,110 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The upstream project (`luadch/luadch`) is a separate codebase; its release
 history is at https://github.com/luadch/luadch/releases.
 
+## [v3.1.1] - 2026-05-05
+
+Patch release. Drop-in upgrade from v3.1.0; no cfg / on-disk-format changes,
+no Lua API changes, smoke harness still 10 / 10. Two upstream-issue triage
+rounds plus a small post-modernisation cleanup landed since v3.1.0.
+
+### Fixed
+
+- **DSCH search fanout** (closes upstream
+  [luadch#200](https://github.com/luadch/luadch/issues/200), security).
+  `etc_trafficmanager.lua` `onSearch` was fanning out direct (D / E type)
+  searches to every user; receivers logged a `SECURITY WARNING: received
+  a DSCH message that should have been sent to a different user.` for
+  every cross-addressed message. The hub's default direct-routing path
+  already delivers correctly to the single intended SID; the fan-out was
+  redundant and protocol-violating. Same root cause as upstream
+  [luadch#226](https://github.com/luadch/luadch/issues/226) (AirDC++ 4.21
+  "search spam detected (severe)" disconnects).
+- **Negative DS in INF blocked login** (closes upstream
+  [luadch#241](https://github.com/luadch/luadch/issues/241)).
+  `_regex.integer` now accepts signed decimals (`^%-?%d+$`) so a single
+  buggy field doesn't cause the parser to drop the entire BINF and
+  reject the login.
+- **`etc_trafficmanager.lua` no message / no `[BLOCKED]` flag with
+  custom prefix scripts** (closes upstream
+  [luadch#240](https://github.com/luadch/luadch/issues/240)). Resolve
+  blocked target via firstnick iteration instead of computing
+  `prefix + firstnick` and looking up `hub.isnickonline()`. Robust
+  against any nick-prefix scheme.
+- **`+delreg <blacklisted-nick>` failed** (closes upstream
+  [luadch#228](https://github.com/luadch/luadch/issues/228)). Extend
+  the command to remove a blacklist entry when the target is not (or
+  no longer) registered. New `blacklist_del()` helper +
+  `msg_deblacklist` lang string.
+- **Forgot-prefix commands leaked into main chat** (closes upstream
+  [luadch#223](https://github.com/luadch/luadch/issues/223)). New
+  `onBroadcast` fallback in `etc_hubcommands.lua`: if a message starts
+  with a known command name as a whole word and is shaped like a
+  forgotten command, swallow the broadcast and reply with a prefix
+  hint.
+- **`+help cmd_mass` showed misleading min-level** (closes upstream
+  [luadch#217](https://github.com/luadch/luadch/issues/217)).
+  `util.getlowestlevel()` returns just the lowest TRUE-keyed level,
+  hiding gaps in the permission table. Append the actual permitted-level
+  list to `help_desc` at script-load time, formatted with level names
+  where available.
+- **Cryptic "wrong sslctx parameters" on first Windows run** (closes
+  upstream [luadch#177](https://github.com/luadch/luadch/issues/177)).
+  `core/server.lua` `wrapserver` now `io.open`-pre-checks
+  `sslctx.{key,certificate,cafile}` and surfaces a human-readable hint
+  pointing at `certs/make_cert.{sh,bat}` or `use_ssl = false`.
+- **Multi-byte nicks rejected at lower codepoint counts than ASCII**
+  (refs [#48](https://github.com/luadch-ng/luadch/issues/48)).
+  `usr_nick_length.lua` switched from `#nick` (byte length) to
+  `utf.len(nick)` (codepoint length). `min/max_nickname_length` is
+  documented in codepoints; Cyrillic / multi-byte nicks were tripping
+  the threshold sooner than intended.
+- **`hub_inf_manager.lua` failure reason hardcoded English**
+  (refs [#48](https://github.com/luadch-ng/luadch/issues/48)). Routed
+  through the existing per-script lang file as `msg_failedauth_reason`.
+- **Smoke harness Windows-only hang** (refs
+  [#48](https://github.com/luadch-ng/luadch/issues/48)).
+  `subprocess.run(..., capture_output=True)` lets `cmd.exe` inherit
+  the parent console; `make_cert.bat` ends with `pause` and blocked
+  forever waiting for a keypress when the harness was invoked from an
+  interactive shell. Pass `stdin=subprocess.DEVNULL` so `pause` sees
+  EOF and exits cleanly. CI was unaffected (Linux uses
+  `make_cert.sh`, no pause).
+
+### Audited as already addressed by an earlier fix
+
+Documented in [`docs/phases/INTERLUDE_UPSTREAM_TRIAGE_2.md`](docs/phases/INTERLUDE_UPSTREAM_TRIAGE_2.md)
+so the next triage round doesn't re-discover them.
+
+- Upstream [luadch#214](https://github.com/luadch/luadch/issues/214)
+  (failed-auth hammering): handled by Phase 7c F-AUTH-3 (per-IP
+  failed-auth lockout).
+- Upstream [luadch#221](https://github.com/luadch/luadch/issues/221)
+  (search protection): handled by Phase 7c F-RL-2 (per-user search
+  rate cap).
+- Upstream [luadch#226](https://github.com/luadch/luadch/issues/226)
+  (AirDC++ 4.21 search-spam disconnect): same root cause as #200,
+  fixed there.
+- Upstream [luadch#230](https://github.com/luadch/luadch/issues/230)
+  (sporadic invalid-password): symptom matches the unresolved
+  data-loss [luadch#189](https://github.com/luadch/luadch/issues/189);
+  same workaround (`+reload`).
+- Upstream [luadch#236](https://github.com/luadch/luadch/issues/236),
+  [luadch#237](https://github.com/luadch/luadch/issues/237),
+  [luadch#238](https://github.com/luadch/luadch/issues/238),
+  [luadch#242](https://github.com/luadch/luadch/issues/242):
+  resolved or made unreachable by Phase 6 / Phase 7 work.
+
+### Other
+
+- Repo transferred from `Aybook/luadch` to `luadch-ng/luadch`
+  (auto-redirects keep historic links working). Project page:
+  <https://luadch-ng.github.io/>. Doc references and release notes
+  updated to point at the new path; existing operator install trees
+  need no action.
+
+[v3.1.1]: https://github.com/luadch-ng/luadch/releases/tag/v3.1.1
+
+
 ## [v3.1.0] - 2026-05-04
 
 Phase 6 (refactor + smoke harness) and Phase 7 (security audit + hardening)

--- a/core/const.lua
+++ b/core/const.lua
@@ -11,7 +11,7 @@
 return {
 
     PROGRAM_NAME = "Luadch",
-    VERSION = "v3.1.0",
+    VERSION = "v3.1.1",
     COPYRIGHT = "by blastbeat and pulsar",
     FORK = "modernised fork by Aybo",
     CONFIG_PATH = "././cfg/",


### PR DESCRIPTION
Patch release on top of v3.1.0. Bundles every shippable change merged since the v3.1.0 tag:

- **Interlude 2** (PR #73): seven upstream-issue fixes (#200, #241, #240, #228, #223, #217, #177).
- **Small cleanups** (PR #75): codepoint nick length, hub_inf_manager i18n routing, smoke harness Windows hang.
- **Org transfer** (PR #74): doc references updated; auto-redirects keep historic links working.

## What's in this PR

- \`core/const.lua\`: \`VERSION = \"v3.1.0\"\` -> \`v3.1.1\`
- \`CHANGELOG.md\`: new v3.1.1 section above v3.1.0 with the categorised list (Fixed, Audited as already addressed, Other) and links to upstream issue numbers.
- \`.github/release-body.md\`: rewritten for v3.1.1; highlights the security-class fix (#200), the six other upstream fixes, the codepoint check, and the org-transfer note. v3.1.1-versioned doc links throughout.

## Why a patch release now

Two reasons:

1. **#200 is security-class** (DSCH cross-routing leaks search messages to wrong recipients, also tripping AirDC++ 4.21 \"search spam detected\" disconnects per upstream #226). Operators on v3.1.0 are exposed; a same-week patch is the right cadence.
2. The other six fixes are quality bug fixes that change observable hub behaviour (login error path, command help, blacklist UX, prefix-script compatibility). Worth shipping as a coherent unit rather than letting them sit for a Phase-8+ feature release weeks or months out.

## Test plan

- [x] \`cmake --build build && cmake --install build\` clean, no new warnings
- [x] Local smoke harness (Windows): 10 / 10 PASS
- [x] CI smoke (Linux + Windows) on this branch
- [x] On merge: tag v3.1.1, GitHub Release builds + uploads Linux + Windows artefacts

## Post-merge sequence

After merge, tagging \`v3.1.1\` triggers \`.github/workflows/release.yml\`, which builds the Linux and Windows artefacts and creates the GitHub Release using \`.github/release-body.md\` as the body. Same flow as v3.1.0.