### PR TITLE
fix(build): canonical LuaSocket / LuaSec install layout (closes #88)

### DIFF
--- a/luasec/CMakeLists.txt
+++ b/luasec/CMakeLists.txt
@@ -1,7 +1,11 @@
 # Build the LuaSec TLS plugin: TLS handshake on top of LuaSocket TCP sockets.
 #
-# Output: lib/luasec/ssl/ssl.so / .dll
-#         plus https.lua / options.lua / ssl.lua copied to lib/luasec/lua/
+# Outputs:
+#   lib/luasec/ssl/ssl.so / .dll                (C module)
+#   plus the Lua-side helpers under lib/luasec/lua/, in the canonical
+#   LuaSec layout (closes luadch-ng/luadch#88):
+#     lib/luasec/lua/ssl.lua                    (entrypoint)
+#     lib/luasec/lua/ssl/https.lua   , options.lua  (`require "ssl.https"` etc.)
 
 set(LSEC_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
@@ -45,5 +49,8 @@ endif()
 install(TARGETS ssl LIBRARY DESTINATION lib/luasec/ssl
                     RUNTIME DESTINATION lib/luasec/ssl)
 
-file(GLOB LSEC_LUA_HELPERS "${LSEC_SRC}/*.lua")
-install(FILES ${LSEC_LUA_HELPERS} DESTINATION lib/luasec/lua)
+# Canonical LuaSec layout (closes #88): top-level entrypoint + `ssl/` subdir
+# for `ssl.X` submodules.
+install(FILES ${LSEC_SRC}/ssl.lua      DESTINATION lib/luasec/lua)
+install(FILES ${LSEC_SRC}/https.lua
+              ${LSEC_SRC}/options.lua  DESTINATION lib/luasec/lua/ssl)

--- a/luasocket/CMakeLists.txt
+++ b/luasocket/CMakeLists.txt
@@ -5,9 +5,17 @@
 # using per-platform source lists directly.
 #
 # Outputs:
-#   lib/luasocket/socket/socket.so / .dll
-#   lib/luasocket/mime/mime.so   / .dll
-#   plus the .lua bridge files copied flat into lib/luasocket/lua/
+#   lib/luasocket/socket/socket.so / .dll       (C module)
+#   lib/luasocket/mime/mime.so   / .dll         (C module)
+#   plus the Lua-side helpers under lib/luasocket/lua/, in the canonical
+#   LuaSocket layout (closes luadch-ng/luadch#88):
+#     lib/luasocket/lua/socket.lua              (entrypoint)
+#     lib/luasocket/lua/mime.lua    , ltn12.lua , mbox.lua  (top-level helpers)
+#     lib/luasocket/lua/socket/http.lua   , url.lua  , headers.lua
+#     lib/luasocket/lua/socket/ftp.lua    , smtp.lua , tp.lua
+#   so plugins can `require "socket.http"` / `require "ssl.https"` per the
+#   standard Lua convention; http.lua's own internal `require "socket.url"`
+#   etc. resolve in the same layout.
 
 set(LSOCKET_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
@@ -98,6 +106,22 @@ install(TARGETS socket LIBRARY DESTINATION lib/luasocket/socket
 install(TARGETS mime   LIBRARY DESTINATION lib/luasocket/mime
                        RUNTIME DESTINATION lib/luasocket/mime)
 
-# Copy the Lua-side helpers (http, ftp, smtp, ltn12, …) into the runtime tree
-file(GLOB LSOCKET_LUA_HELPERS "${LSOCKET_SRC}/*.lua")
-install(FILES ${LSOCKET_LUA_HELPERS} DESTINATION lib/luasocket/lua)
+# Copy the Lua-side helpers into the runtime tree, split into the canonical
+# LuaSocket layout: top-level entrypoints + a nested `socket/` subdir for
+# the `socket.X` submodules. See the header comment for why - closes #88.
+set(LSOCKET_LUA_TOPLEVEL
+    ${LSOCKET_SRC}/socket.lua    # entrypoint loaded by `require "socket"`
+    ${LSOCKET_SRC}/mime.lua      # top-level per LuaSocket convention
+    ${LSOCKET_SRC}/ltn12.lua     # top-level per LuaSocket convention
+    ${LSOCKET_SRC}/mbox.lua      # top-level per LuaSocket convention
+)
+set(LSOCKET_LUA_SUBMODULES
+    ${LSOCKET_SRC}/http.lua      # `require "socket.http"`
+    ${LSOCKET_SRC}/url.lua       # `require "socket.url"`
+    ${LSOCKET_SRC}/headers.lua   # `require "socket.headers"`
+    ${LSOCKET_SRC}/ftp.lua       # `require "socket.ftp"`
+    ${LSOCKET_SRC}/smtp.lua      # `require "socket.smtp"`
+    ${LSOCKET_SRC}/tp.lua        # `require "socket.tp"`
+)
+install(FILES ${LSOCKET_LUA_TOPLEVEL}    DESTINATION lib/luasocket/lua)
+install(FILES ${LSOCKET_LUA_SUBMODULES}  DESTINATION lib/luasocket/lua/socket)

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -526,6 +526,37 @@ def test_usertbl_encrypted_at_rest(staging_dir: Path):
         )
 
 
+def test_canonical_socket_layout(staging_dir: Path):
+    """Closes #88: LuaSocket and LuaSec install in the canonical layout
+    so plugins can `require "socket.http"` / `require "ssl.https"` per
+    the standard Lua convention.
+
+    Static path-existence check - if the CMake install rules drift back
+    to the flat luadch-2.x bundling, http.lua's own internal
+    `require "socket.url"` would fail and any HTTP-using plugin breaks.
+    """
+    expected = [
+        # LuaSocket entrypoint + top-level helpers
+        "lib/luasocket/lua/socket.lua",
+        "lib/luasocket/lua/mime.lua",
+        "lib/luasocket/lua/ltn12.lua",
+        # LuaSocket submodules (require "socket.X")
+        "lib/luasocket/lua/socket/http.lua",
+        "lib/luasocket/lua/socket/url.lua",
+        "lib/luasocket/lua/socket/headers.lua",
+        # LuaSec entrypoint + submodules
+        "lib/luasec/lua/ssl.lua",
+        "lib/luasec/lua/ssl/https.lua",
+        "lib/luasec/lua/ssl/options.lua",
+    ]
+    missing = [p for p in expected if not (staging_dir / p).exists()]
+    if missing:
+        raise TestFailure(
+            "canonical LuaSocket / LuaSec layout incomplete; missing:\n  "
+            + "\n  ".join(missing)
+        )
+
+
 def test_no_script_errors(log_path: Path):
     """
     Plugin-load smoke: scan the captured hub stdout for "script error:"
@@ -571,6 +602,14 @@ def run_tests(staging_dir: Path):
 
     # State-of-disk tests run after the protocol tests so any post-login
     # save (HPAS lastconnect update) has had a chance to land.
+    try:
+        test_canonical_socket_layout(staging_dir)
+    except Exception as e:
+        log(f"FAIL  canonical LuaSocket / LuaSec layout: {e}")
+        failed.append("canonical LuaSocket / LuaSec layout")
+    else:
+        log("PASS  canonical LuaSocket / LuaSec layout")
+
     try:
         test_usertbl_encrypted_at_rest(staging_dir)
     except Exception as e:


### PR DESCRIPTION
Closes #88. Unblocks [\`luadch-ng/scripts#10\`](https://github.com/luadch-ng/scripts/issues/10) (ptx_RSSFeedWatch).

## What was broken

Plugins doing \`require \"socket.http\"\` or \`require \"ssl.https\"\` failed to load on stock luadch-ng v3.1.x because the bundle was installed flat (\`lib/luasocket/lua/http.lua\`) instead of the canonical nested tree (\`lib/luasocket/lua/socket/http.lua\`). Even calling \`require \"http\"\` directly didn't help - \`http.lua\`'s own internal \`require \"socket.url\"\` and \`require \"socket.headers\"\` hit the same wall.

This was a luadch-2.x-era bundling quirk that the modernization had not yet ironed out. Phase 4 (dependency update) didn't catch it because hub-internal usage is limited to \`use \"socket\"\` and \`use \"ssl\"\`, both of which are entrypoints unaffected by the submodule layout.

## Fix

Split the \`install(FILES ...)\` rules in \`luasocket/CMakeLists.txt\` and \`luasec/CMakeLists.txt\`:

| Group | Files | Destination |
|---|---|---|
| LuaSocket entrypoints + top-level helpers | \`socket.lua\`, \`mime.lua\`, \`ltn12.lua\`, \`mbox.lua\` | \`lib/luasocket/lua/\` |
| LuaSocket \`socket.X\` submodules | \`http.lua\`, \`url.lua\`, \`headers.lua\`, \`ftp.lua\`, \`smtp.lua\`, \`tp.lua\` | \`lib/luasocket/lua/socket/\` |
| LuaSec entrypoint | \`ssl.lua\` | \`lib/luasec/lua/\` |
| LuaSec \`ssl.X\` submodules | \`https.lua\`, \`options.lua\` | \`lib/luasec/lua/ssl/\` |

Source files in \`luasocket/src/\` and \`luasec/src/\` are unchanged; only the install-tree layout flips. Hub-internal usage is unaffected (only the entrypoints are required). C modules at \`lib/luasocket/socket/socket.so\` and \`lib/luasec/ssl/ssl.so\` are unchanged - those live on the cpath, not the lua-path.

## Smoke regression

Added \`test_canonical_socket_layout(staging_dir)\` to \`tests/smoke/run.py\`. Static path-exists check on the canonical paths; if a future CMake change drifts back to the flat layout, the smoke gate fires.

Smoke harness: **11 / 11 PASS** (10 prior + the new layout check).

## Manual end-to-end validation

Dropped ptx_RSSFeedWatch (from \`luadch-ng/scripts\`) into the install tree with cfg.tbl whitelist injection (per the cfg.tbl-validation methodology):

- Plugin's \`require \"socket\"\` resolves at \`lib/luasocket/lua/socket.lua\`
- \`require \"socket.http\"\` resolves at \`lib/luasocket/lua/socket/http.lua\`
- \`http.lua\`'s internal \`require \"socket.url\"\` / \`require \"socket.headers\"\` resolve at the nested paths
- \`require \"ssl.https\"\` resolves at \`lib/luasec/lua/ssl/https.lua\`
- Plugin loads cleanly; smoke 10/10 PASS with no script errors in log

## What this unblocks

- [\`luadch-ng/scripts ptx_RSSFeedWatch\`](https://github.com/luadch-ng/scripts/issues/10) goes from blocked-on-hub to drop-in T2; the operator-side workaround (\"manually rearrange your install/lib\") is no longer needed.
- Future plugins using canonical Lua HTTP/HTTPS idiom load drop-in.
- Phase-8+ feature work that needs HTTP ([REST API #82](https://github.com/luadch-ng/luadch/issues/82), [Prometheus exporter #83](https://github.com/luadch-ng/luadch/issues/83), AbuseIPDB plugin in \`luadch-ng/scripts\`) starts from canonical assumptions.
- Future LuaSocket / LuaSec dependency bumps stay patch-free; only the source files swap, the install-rule split is independent.

## Test plan

- [x] Wipe + reinstall: layout matches canonical (verified by \`find\`).
- [x] Smoke 11/11 PASS with new regression test.
- [x] Manual end-to-end with ptx_RSSFeedWatch + slaxml + cfg.tbl entry: 10/10 PASS, all four \`require\` calls resolve.
- [x] On merge: prepare a v3.1.2 patch release; close \`luadch-ng/scripts#10\` after re-validating ptx_RSSFeedWatch against the new hub.