### PR TITLE
release: prepare v3.1.2

### DIFF
--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,69 +1,70 @@
-# Luadch v3.1.1
+# Luadch v3.1.2
 
-Patch release on top of v3.1.0. Drop-in upgrade: no cfg / on-disk-format
-changes, no Lua API changes, no new dependencies. Smoke harness still
-10 / 10 PASS on Linux + Windows.
+Patch release on top of v3.1.1. Drop-in upgrade: no cfg / on-disk-format
+changes, no Lua API changes. Single fix; smoke harness now 11 / 11
+PASS on Linux + Windows.
 
 ## Highlights
 
-- **Security: DSCH search fanout fixed** ([luadch#200](https://github.com/luadch/luadch/issues/200)).
-  `etc_trafficmanager.lua` no longer fans out direct (D / E type) searches
-  to every user; the hub's default direct-routing path delivers correctly
-  to the single intended SID. Same root cause also clears the AirDC++ 4.21
-  "search spam detected" disconnect ([luadch#226](https://github.com/luadch/luadch/issues/226)).
-- **Six more upstream-bug fixes** (Interlude 2, rounds 2 + 3): negative DS
-  in INF blocked login ([#241](https://github.com/luadch/luadch/issues/241)),
-  `+delreg` against blacklisted nicks ([#228](https://github.com/luadch/luadch/issues/228)),
-  trafficmanager prefix-script regression ([#240](https://github.com/luadch/luadch/issues/240)),
-  forgot-prefix commands in main chat ([#223](https://github.com/luadch/luadch/issues/223)),
-  misleading `+help cmd_mass` levels ([#217](https://github.com/luadch/luadch/issues/217)),
-  cryptic SSL-context error on first Windows run ([#177](https://github.com/luadch/luadch/issues/177)).
-- **Codepoint-aware nick-length check**: `usr_nick_length.lua` now uses
-  `utf.len()` so Cyrillic / multi-byte nicks aren't rejected at lower
-  codepoint counts than ASCII ones.
-- **`hub_inf_manager.lua` failure reason** routed through the per-script
-  lang file instead of a hardcoded English string.
-- **Smoke harness Windows hang fixed**: `make_cert.bat`'s trailing `pause`
-  no longer blocks the harness when run from an interactive shell.
-- **Org transfer**: repo now lives at `luadch-ng/luadch` (auto-redirects
-  keep historic links working). Project page: <https://luadch-ng.github.io/>.
+- **Canonical LuaSocket / LuaSec install layout** (closes
+  [#88](https://github.com/luadch-ng/luadch/issues/88)). Plugins doing
+  `require "socket.http"` or `require "ssl.https"` now load drop-in
+  instead of failing because the bundle was installed flat. Source
+  files unchanged; only the install-tree layout flips. Hub-internal
+  usage unaffected (only the entrypoints `socket.lua` / `ssl.lua` are
+  required, both stay top-level).
+- **Smoke regression test** added so future CMake changes can't drift
+  back to the flat bundling without the smoke gate firing.
+
+## What this unblocks
+
+- [`luadch-ng/scripts ptx_RSSFeedWatch`](https://github.com/luadch-ng/scripts)
+  loads drop-in now (previously needed an operator-side manual
+  rearrangement of `lib/`).
+- Future plugins using canonical Lua HTTP/HTTPS idiom load without
+  any luadch-specific workarounds.
+- Phase-8+ feature work that needs HTTP (REST API, Prometheus
+  exporter, AbuseIPDB integration) starts from canonical assumptions.
 
 ## Downloads
 
 | File | Platform |
 |---|---|
-| `luadch-v3.1.1-linux-x86_64.tar.gz` | Linux glibc x86_64 |
-| `luadch-v3.1.1-windows-x86_64.zip`  | Windows x86_64 (MinGW UCRT64) |
+| `luadch-v3.1.2-linux-x86_64.tar.gz` | Linux glibc x86_64 |
+| `luadch-v3.1.2-windows-x86_64.zip`  | Windows x86_64 (MinGW UCRT64) |
 
-Extract anywhere and run `./luadch` (Linux) or `Luadch.exe` (Windows). The
-trees are self-contained: Lua interpreter, all bundled libs (LuaSec,
+Extract anywhere and run `./luadch` (Linux) or `Luadch.exe` (Windows).
+The trees are self-contained: Lua interpreter, all bundled libs (LuaSec,
 LuaSocket, basexx, adclib), default configs, scripts, certs helpers.
 
 Default plain ADC port `5000`, TLS port `5001` after running
 `certs/make_cert.{sh,bat}` once. First login: nick `dummy`, password
 `test` - **delete that account immediately** after registering yourself,
-see [`docs/CONFIGURATION.md`](https://github.com/luadch-ng/luadch/blob/v3.1.1/docs/CONFIGURATION.md).
+see [`docs/CONFIGURATION.md`](https://github.com/luadch-ng/luadch/blob/v3.1.2/docs/CONFIGURATION.md).
 
-## Migration from v3.1.0
+## Migration from v3.1.1
 
 None required. Drop the new install tree in place of the old one (or
-`git pull && cmake --build build && cmake --install build` from source).
-`cfg/`, `certs/`, `master.key`, encrypted `user.tbl` carry over without
-change.
+`git pull && cmake --build build && cmake --install build` from
+source). `cfg/`, `certs/`, `master.key`, encrypted `user.tbl` carry
+over without change.
 
-If you're still on v3.0.0, follow the v3.1.0 migration notes:
-<https://github.com/luadch-ng/luadch/releases/tag/v3.1.0>.
+If you had previously hand-rearranged `lib/luasocket/lua/socket/` to
+get an HTTP plugin to work, the new install tree already provides
+that layout - your manual rearrangement is now redundant but harmless.
+
+If you're still on v3.1.0 or earlier, follow the v3.1.0 migration
+notes: <https://github.com/luadch-ng/luadch/releases/tag/v3.1.0>.
 
 ## Full changelog
 
-See [`CHANGELOG.md`](https://github.com/luadch-ng/luadch/blob/v3.1.1/CHANGELOG.md)
-for the categorised list. Triage notes for the upstream-issue fixes are in
-[`docs/phases/INTERLUDE_UPSTREAM_TRIAGE_2.md`](https://github.com/luadch-ng/luadch/blob/v3.1.1/docs/phases/INTERLUDE_UPSTREAM_TRIAGE_2.md).
+See [`CHANGELOG.md`](https://github.com/luadch-ng/luadch/blob/v3.1.2/CHANGELOG.md)
+for the categorised list.
 
 ## Build from source
 
 ```sh
-git clone --branch v3.1.1 https://github.com/luadch-ng/luadch.git
+git clone --branch v3.1.2 https://github.com/luadch-ng/luadch.git
 cd luadch
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
@@ -72,7 +73,7 @@ cmake --install build
 
 Output lands in `build/install/luadch/` ready to run. Windows needs
 `-G "MinGW Makefiles" -DOPENSSL_ROOT_DIR=...` extra, see
-[`docs/BUILDING.md`](https://github.com/luadch-ng/luadch/blob/v3.1.1/docs/BUILDING.md).
+[`docs/BUILDING.md`](https://github.com/luadch-ng/luadch/blob/v3.1.2/docs/BUILDING.md).
 
 ## Credits
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The upstream project (`luadch/luadch`) is a separate codebase; its release
 history is at https://github.com/luadch/luadch/releases.
 
+## [v3.1.2] - 2026-05-06
+
+Patch release. Drop-in upgrade from v3.1.1; no cfg / on-disk-format
+changes, no Lua API changes. Single fix: bundled LuaSocket / LuaSec
+now install in the canonical layout so plugins doing
+`require "socket.http"` / `require "ssl.https"` load drop-in.
+
+### Fixed
+
+- **Canonical LuaSocket / LuaSec install layout** (closes
+  [#88](https://github.com/luadch-ng/luadch/issues/88)). The Lua-side
+  helpers were installed flat under `lib/luasocket/lua/` and
+  `lib/luasec/lua/`, which broke `require "socket.http"` and
+  `require "ssl.https"` for plugins. Even calling `require "http"`
+  directly didn't help because `http.lua`'s own internal
+  `require "socket.url"` and `require "socket.headers"` hit the same
+  wall. Split the CMake `install(FILES ...)` rules so entrypoints
+  (`socket.lua`, `mime.lua`, `ltn12.lua`, `mbox.lua`, `ssl.lua`) stay
+  top-level and `socket.X` / `ssl.X` submodules go into nested
+  subdirectories. Source files unchanged; hub-internal usage
+  (`use "socket"`, `use "ssl"` only) unaffected. Unblocks the
+  [`luadch-ng/scripts ptx_RSSFeedWatch`](https://github.com/luadch-ng/scripts)
+  plugin and any future HTTP-using plugin.
+
+### Added
+
+- **Smoke regression test** for the canonical layout
+  (`tests/smoke/run.py:test_canonical_socket_layout`). Static
+  path-exists check on the LuaSocket / LuaSec submodule paths; if a
+  future CMake change drifts back to the flat bundling, the smoke
+  gate fires. Smoke harness now runs 11 protocol-level + state-of-disk
+  tests (was 10).
+
+[v3.1.2]: https://github.com/luadch-ng/luadch/releases/tag/v3.1.2
+
+
 ## [v3.1.1] - 2026-05-05
 
 Patch release. Drop-in upgrade from v3.1.0; no cfg / on-disk-format changes,

--- a/core/const.lua
+++ b/core/const.lua
@@ -11,7 +11,7 @@
 return {
 
     PROGRAM_NAME = "Luadch",
-    VERSION = "v3.1.1",
+    VERSION = "v3.1.2",
     COPYRIGHT = "by blastbeat and pulsar",
     FORK = "modernised fork by Aybo",
     CONFIG_PATH = "././cfg/",


### PR DESCRIPTION
Patch release on top of v3.1.1 with the single fix from PR #89.

## What's in this PR

- \`core/const.lua\`: \`VERSION = \"v3.1.1\"\` -> \`v3.1.2\`
- \`CHANGELOG.md\`: new v3.1.2 section above v3.1.1 documenting the canonical install-layout fix (closes #88) and the new \`test_canonical_socket_layout\` regression check.
- \`.github/release-body.md\`: rewritten for v3.1.2; highlights the layout fix, what it unblocks (ptx_RSSFeedWatch + future HTTP plugins), v3.1.2-versioned doc links throughout.

## Why a patch release

The fix in #89 changes the install-tree layout for any future \`cmake --install\`. Operators currently building from source on master would already have the new layout; tagging v3.1.2 makes it available as a binary release for operators who pull the GitHub release artefacts.

Drop-in upgrade for everyone: no cfg / on-disk-format changes, no Lua API changes, no new dependencies. The only operator-visible side effect is benign: anyone who had previously hand-rearranged \`lib/luasocket/lua/socket/\` to make an HTTP plugin work now has redundant-but-harmless duplicates.

## Test plan

- [x] \`cmake --build && cmake --install\` clean, no new warnings.
- [x] Local smoke harness: **11 / 11 PASS** (10 prior + the new \`test_canonical_socket_layout\` from PR #89).
- [x] CI smoke (Linux + Windows) on this branch.
- [x] On merge: tag \`v3.1.2\`, GitHub Release builds + uploads Linux + Windows artefacts.

## Post-merge sequence

After merge, tagging \`v3.1.2\` triggers \`.github/workflows/release.yml\`, which builds the Linux and Windows artefacts and creates the GitHub Release using \`.github/release-body.md\` as the body. Same flow as v3.1.1.

Plus a small follow-up in \`luadch-ng/scripts\`: drop the "BLOCKED ON HUB FIX" banner from \`ptx_RSSFeedWatch.lua\`'s provenance header, reclass tier in \`docs/IMPORT_NOTES.md\` from "Blocked-on-hub" back to T2, close \`luadch-ng/scripts#10\`.