### PR TITLE
fix(security): post-Phase-7 audit batch (#91 #92 #93 #94 #96)

### DIFF
--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -1550,6 +1550,29 @@ local defaults = {
         end
     },
 
+    -- #96: command names whose post-command-name argument string is
+    -- replaced with `<redacted>` in log/cmd.log. Prevents passwords
+    -- supplied via +setpass / +newpw from landing on disk in plaintext
+    -- through etc_cmdlog's audit trail.
+    etc_cmdlog_redact_args = { {
+
+        [ "setpass" ] = true,
+        [ "newpw" ] = true,
+    },
+        function( value )
+            if not types_table( value ) then
+                return false
+            else
+                for i, k in pairs( value ) do
+                    if not ( types_boolean( k, nil, true ) and types_utf8( i, nil, true ) ) then
+                        return false
+                    end
+                end
+            end
+            return true
+        end
+    },
+
     ---------------------------------------------------------------------------------------------------------------------------------
     --// etc_log_cleaner.lua settings
 

--- a/core/cfg_secret.lua
+++ b/core/cfg_secret.lua
@@ -129,11 +129,17 @@ end
 --   false, message  -- mode wrong on POSIX; caller must abort
 -- We shell out to stat(1) because the standalone Lua interpreter has
 -- no native syscall surface; lua-posix would be a new dep.
+--
+-- #93: master_key_path is operator-controlled (cfg.tbl), not remote,
+-- but POSIX-quote it anyway so paths with spaces / metacharacters
+-- ("/var/lib/my hub/master.key") parse correctly instead of silently
+-- bypassing the strict-mode check.
 local function _check_master_key_perms( path )
     if _is_windows( ) then
         return true
     end
-    local cmd = "stat -c '%a' " .. path .. " 2>/dev/null"
+    local quoted = "'" .. tostring( path ):gsub( "'", "'\\''" ) .. "'"
+    local cmd = "stat -c '%a' " .. quoted .. " 2>/dev/null"
     local p = io_popen( cmd )
     if not p then return true end    -- best-effort; can't check
     local mode = p:read "*l"

--- a/core/hub.lua
+++ b/core/hub.lua
@@ -1280,7 +1280,16 @@ disconnect = function( client, err, user, quitstring )
         local ip, port = user.peer( )
 
         _usersids[ usersid ] = nil
-        _usernicks[ usernick ] = nil
+        -- #91: a pending-takeover connection (reg_only nick collision,
+        -- BINF stored ._takeover_target and skipped insertuser) does
+        -- NOT own the _usernicks[nick] slot; that still belongs to the
+        -- existing online user. If this user disconnects pre-HPAS
+        -- (failed auth, network drop, race), we must not wipe the
+        -- legitimate user's mapping. Only clear the slot if it is
+        -- actually ours.
+        if _usernicks[ usernick ] == user then
+            _usernicks[ usernick ] = nil
+        end
         _usercids[ userhash ][ usercid ] = nil
         _userclients[ user ] = nil
         _normalstatesids[ usersid ] = nil

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -298,12 +298,17 @@ _identify = {
         end
         onlineuser = isuserconnected( nick )
         if onlineuser then
-            local quitmsg = "ISTA 222 " .. _i18n_nick_taken .. "\n"
+            -- F-AUTH-NICK (#91): the legacy "kill zombie client" branch in
+            -- reg_only mode killed the existing online user before HPAS
+            -- proved the new connection holds the password. Pre-auth DoS:
+            -- attacker only needed the target nick. Defer the takeover
+            -- until HPAS validates: stash the existing user, skip
+            -- insertuser/onConnect, and let _verify.HPAS perform the swap
+            -- on success or kill the new connection on failure.
             if cfg_get "reg_only" then
-                onlineuser:kill(quitmsg, "TL-1") -- kill zombie client
+                user._takeover_target = onlineuser
             else
-                user:kill(quitmsg, "TL-1") -- kill connecting client
-                --scripts_firelistener( "onFailedAuth", nick, userip, cid, escapefrom( _i18n_nick_taken ) )
+                user:kill( "ISTA 222 " .. _i18n_nick_taken .. "\n", "TL-1" ) -- kill connecting client
                 return true
             end
         end
@@ -323,9 +328,16 @@ _identify = {
         adccmd:deletenp "PD"
         user:inf( adccmd )
         if user:hasfeature "CCPM" then user:hasccpm( true ) end
-        insertuser( nick, cid, hash, user )
-        if scripts_firelistener( "onConnect", user ) or user.waskilled then
-            return true
+        -- F-AUTH-NICK (#91): defer insertuser + onConnect when this BINF
+        -- is a pending takeover. _usernicks[nick] still belongs to the
+        -- existing user; clobbering it before HPAS would re-introduce
+        -- the DoS we are fixing. The HPAS success handler completes the
+        -- swap: kill the existing user, then insertuser + fire onConnect.
+        if not user._takeover_target then
+            insertuser( nick, cid, hash, user )
+            if scripts_firelistener( "onConnect", user ) or user.waskilled then
+                return true
+            end
         end
         if profile then
             profile.lastconnect = profile.lastconnect or util_date()
@@ -358,8 +370,7 @@ _verify = {
 
     HPAS = function( user, adccmd )
         local salt = user.salt( )
-        --local pass = _cfg_hub_pass
-        local pass, reason
+        local pass
         local regged = user.isregged( )
         local usercid = user.cid( )
         local userip = user.ip( ) or _i18n_unknown
@@ -370,26 +381,52 @@ _verify = {
         local profile = user.profile( )
         local hubhash = adclib_hashpas( pass, salt )
         local hubhashold = adclib_hasholdpas( pass, salt, usercid )
+
         if ( userhash ~= hubhash ) and ( userhash ~= hubhashold ) then
+            -- F-AUTH-FAIL (#94): on failed auth we MUST NOT update
+            -- lastconnect / lastseen / is_online afterwards; the user
+            -- never connected. The badpassword counter still has to
+            -- persist, both for #91 takeover-defence book-keeping and
+            -- for Phase 7c F-AUTH-3 per-account bad_pass_timeout.
             profile.badpassword = ( profile.badpassword or 0 ) + 1
-            -- Phase 7c F-AUTH-3: also count this against the offending
-            -- IP so cross-account fishing is throttled, not just the
-            -- per-account counter that an attacker can cycle through.
             ratelimit_record_authfail( userip )
+            cfg_saveusers( _regusers )
             user:kill( "ISTA 223 " .. _i18n_invalid_pass .. "\n", "TL-1" )
             scripts_firelistener( "onFailedAuth", profile.nick, userip, usercid, escapefrom( _i18n_invalid_pass ) )
-        else
-            profile.badpassword = 0
-            if not user:sup( ):hasparam( "ADOSNR" ) then
-                user.write( utf_format( _hubinf_regonly, _cfg_hub_name, _cfg_hub_description ) )
+            return true
+        end
+
+        -- F-AUTH-NICK (#91): if this BINF was deferred as a takeover
+        -- pending HPAS, the new connection has now proven password
+        -- ownership. Swap the slot: kill the existing user, claim
+        -- _usernicks[nick] via insertuser, fire the deferred onConnect.
+        if user._takeover_target then
+            local target = user._takeover_target
+            user._takeover_target = nil
+            local nick = user:nick( )
+            -- Race guard: another concurrent takeover may already have
+            -- swapped the slot to a third connection. If so, our target
+            -- is no longer the canonical owner; refuse this takeover.
+            local current_owner = isuserconnected( nick )
+            if current_owner and current_owner ~= target then
+                user:kill( "ISTA 222 " .. _i18n_nick_taken .. "\n", "TL-1" )
+                scripts_firelistener( "onFailedAuth", profile.nick, userip, usercid, escapefrom( _i18n_nick_taken ) )
+                return true
             end
-            login( user )
+            if not target.waskilled then
+                target:kill( "ISTA 222 " .. _i18n_nick_taken .. "\n", "TL-1" )
+            end
+            insertuser( nick, usercid, user.hash( ), user )
+            if scripts_firelistener( "onConnect", user ) or user.waskilled then
+                return true
+            end
         end
-        --[[
-        if regged and cfg_get "nick_change" then        --// mhh.. the whole thing needs rework
-            user:setregnick( user:nick( ) )
+
+        profile.badpassword = 0
+        if not user:sup( ):hasparam( "ADOSNR" ) then
+            user.write( utf_format( _hubinf_regonly, _cfg_hub_name, _cfg_hub_description ) )
         end
-        ]]--
+        login( user )
         profile.lastconnect = util_date( )
         profile.lastseen = util_date( )
         profile.is_online = 1

--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -863,6 +863,12 @@ return { -- the settings are a lua table, do not tough this!
         [ "setpass" ] = true,
     },
 
+    etc_cmdlog_redact_args = {  -- commands whose arguments are replaced with <redacted> in cmd.log (table of booleans, keyed by command name)
+
+        [ "setpass" ] = true,
+        [ "newpw" ] = true,
+    },
+
     ---------------------------------------------------------------------------------------------------------------------------------
     --// etc_log_cleaner.lua settings | this script adds a command to clean log files
 

--- a/scripts/cmd_nickchange.lua
+++ b/scripts/cmd_nickchange.lua
@@ -106,7 +106,6 @@ local report_hubbot = cfg.get( "cmd_nickchange_report_hubbot" )
 local report_opchat = cfg.get( "cmd_nickchange_report_opchat" )
 
 --// database
-local user_db = "cfg/user.tbl"
 local user_tbl = hub.getregusers()
 local description_file = "scripts/data/cmd_reg_descriptions.tbl"
 
@@ -229,7 +228,7 @@ onbmsg = function( user, command, parameters )
                     user_tbl[ k ].nick = newnick
                     user:reply( msg_ok .. newnick, hub.getbot() )
                     user:kill( "ISTA 230 " .. hub.escapeto( msg_disconnect ) .. "\n", "TL-1" )
-                    util.savearray( user_tbl, user_db )
+                    cfg.saveusers( user_tbl )
                     hub.updateusers()
                     description_check( newnick, user_firstnick )
                     local msg = utf.format( msg_op, user_firstnick, newnick )
@@ -286,7 +285,7 @@ onbmsg = function( user, command, parameters )
                         target_user:reply( msg_ok .. newnickfrom, hub.getbot(), hub.getbot() )
                         target_user:kill( "ISTA 230 " .. hub.escapeto( msg_disconnect ) .. "\n", "TL-1" )
                     end
-                    util.savearray( user_tbl, user_db )
+                    cfg.saveusers( user_tbl )
                     hub.updateusers()
                     description_check( newnickfrom, oldnickfrom )
                     local msg = utf.format( msg_op2, user_firstnick, oldnickfrom, newnickfrom )
@@ -342,7 +341,7 @@ onbmsg = function( user, command, parameters )
                     user:reply( msg_ok .. newnickfrom, hub.getbot() )
                     target:reply( msg_ok .. newnickfrom, hub.getbot(), hub.getbot() )
                     target:kill( "ISTA 230 " .. hub.escapeto( msg_disconnect ) .. "\n", "TL-1" )
-                    util.savearray( user_tbl, user_db )
+                    cfg.saveusers( user_tbl )
                     hub.updateusers()
                     description_check( newnickfrom, target_firstnick )
                     local msg = utf.format( msg_op2, user_firstnick, target_firstnick, newnickfrom )

--- a/scripts/cmd_setpass.lua
+++ b/scripts/cmd_setpass.lua
@@ -136,8 +136,6 @@ local ucmd_menu_ct2_1 = lang.ucmd_menu_ct2_1 or { "Change", "password" }
 local ucmd_pass = lang.ucmd_pass or "Password:"
 local ucmd_nick = lang.ucmd_nick or "Nickname:"
 
-local user_db = "cfg/user.tbl"
-
 
 ----------
 --[CODE]--
@@ -206,7 +204,7 @@ onbmsg = function( user, command, parameters )
                         else
                             user_tbl[ k ].password = pass
                             user:reply( msg_ok .. pass, hub.getbot() )
-                            util.savearray( user_tbl, user_db )
+                            cfg.saveusers( user_tbl )
                             return PROCESSED
                         end
                     end
@@ -229,7 +227,7 @@ onbmsg = function( user, command, parameters )
                             if target then
                                 target:reply( msg_ok2 .. pass, hub.getbot(), hub.getbot() )
                             end
-                            util.savearray( user_tbl, user_db )
+                            cfg.saveusers( user_tbl )
                             return PROCESSED
                         end
                     end
@@ -253,7 +251,7 @@ onbmsg = function( user, command, parameters )
                                 else
                                     user_tbl[ k ].password = pass
                                     user:reply( msg_ok .. pass, hub.getbot() )
-                                    util.savearray( user_tbl, user_db )
+                                    cfg.saveusers( user_tbl )
                                     return PROCESSED
                                 end
                             end
@@ -268,7 +266,7 @@ onbmsg = function( user, command, parameters )
                                     user_tbl[ k ].password = pass
                                     user:reply( msg_ok .. pass, hub.getbot() )
                                     target:reply( msg_ok2 .. pass, hub.getbot(), hub.getbot() )
-                                    util.savearray( user_tbl, user_db )
+                                    cfg.saveusers( user_tbl )
                                     return PROCESSED
                                 end
                             end

--- a/scripts/cmd_upgrade.lua
+++ b/scripts/cmd_upgrade.lua
@@ -112,8 +112,8 @@ local hub_debug = hub.debug
 local hub_issidonline = hub.issidonline
 local hub_isnickonline = hub.isnickonline
 local util_loadtable = util.loadtable
-local util_savearray = util.savearray
 local util_getlowestlevel = util.getlowestlevel
+local cfg_saveusers = cfg.saveusers
 local table_insert = table.insert
 local table_sort = table.sort
 
@@ -130,9 +130,6 @@ local report_activate = cfg_get( "cmd_upgrade_report" )
 local llevel = cfg_get( "cmd_upgrade_llevel" )
 local report_hubbot = cfg_get( "cmd_upgrade_report_hubbot" )
 local report_opchat = cfg_get( "cmd_upgrade_report_opchat" )
-
---// database
-local user_db = "cfg/user.tbl"
 
 --// msgs
 local msg_denied = lang.msg_denied or "You are not allowed to use this command or the target user has a higher level than you!"
@@ -207,7 +204,7 @@ local onbmsg = function( user, command, parameters )
                 user_tbl[ k ].level = tonumber( level )
                 local msg = utf_format( msg_out, user_nick, target:nick(), target_oldlevel, targetoldlevelname, level, targetlevelname )
                 target:kill( "ISTA 230 " .. hub_escapeto( msg ) .. "\n", "TL300" )
-                util_savearray( user_tbl, user_db )
+                cfg_saveusers( user_tbl )
                 user:reply( msg, hub_getbot )
                 report.send( report_activate, report_hubbot, report_opchat, llevel, msg )
                 return PROCESSED
@@ -254,7 +251,7 @@ local onbmsg = function( user, command, parameters )
                         end
                     end
                     user_tbl[ k ].level = tonumber( level )
-                    util_savearray( user_tbl, user_db )
+                    cfg_saveusers( user_tbl )
                     user:reply( msg, hub_getbot )
                     report.send( report_activate, report_hubbot, report_opchat, llevel, msg )
                     return PROCESSED

--- a/scripts/etc_cmdlog.lua
+++ b/scripts/etc_cmdlog.lua
@@ -81,6 +81,10 @@ local io_open = io.open
 local logfile = "log/cmd.log"
 local minlevel = cfg_get( "etc_cmdlog_minlevel" )
 local command_tbl = cfg_get( "etc_cmdlog_command_tbl" ) or {}
+-- #96: commands listed here have their post-command-name argument string
+-- replaced with <redacted> in cmd.log, so passwords supplied via
+-- +setpass / +newpw never land on disk.
+local redact_args = cfg_get( "etc_cmdlog_redact_args" ) or {}
 local scriptlang = cfg_get( "language" )
 
 --// msgs
@@ -119,7 +123,11 @@ hub.setlistener( "onBroadcast", {},
         local s1 = utf_match( txt, "^[+!#](%S+)" )
         local s2 = utf_match( txt, "^[+!#]%S+ (.+)" )
         if command_tbl[ s1 ] then
-            s2 = s2 or ""
+            if redact_args[ s1 ] then
+                s2 = "<redacted>"
+            else
+                s2 = s2 or ""
+            end
             local f = io_open( logfile, "a" )
             f:write( os_date( " [ %Y-%m-%d / %H:%M:%S ]" ) .. msg1 .. s1 .. " " .. s2 .. msg2 .. user:nick() .. "\n" )
             f:close()

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -500,6 +500,67 @@ def test_perip_connection_cap():
         time.sleep(0.6)
 
 
+def test_setpass_preserves_encryption(staging_dir: Path):
+    """#92 regression: cmd_setpass must persist user.tbl through the
+    encrypted cfg.saveusers() path, not bypass it via util.savearray().
+    Pre-fix, every +setpass invocation rewrote user.tbl as plaintext
+    Lua source, silently undoing the Phase 7f F-AUTH-1 mitigation.
+
+    Drive a real +setpass from the dummy login, verify the on-disk
+    user.tbl still carries the LDC1 magic, and confirm by re-login
+    that the new password actually took effect (catches silent no-ops
+    that would leave LDC1 magic unchanged from the prior HPAS save).
+
+    The new password must satisfy the default min_password_length=10
+    so cmd_setpass does not bail out at the length check before saving.
+    No subsequent test logs in as dummy, so we do not reset; staging
+    is rebuilt per harness run anyway."""
+    new_pass = "smoketestnew"  # 12 chars; passes min_password_length=10
+    user_tbl = staging_dir / "cfg" / "user.tbl"
+
+    # ADC BMSG body: spaces inside the message are escaped as `\s` so
+    # the parser treats the whole thing as one positional parameter.
+    # Without escaping, "+setpass nick myself smoketestnew" arrives at
+    # the script as `parameters=""` (only the leading "+setpass" lands
+    # in adccmd[6]) and the command silently no-ops.
+    body = _adc_escape(f"+setpass nick myself {new_pass}")
+
+    with socket.create_connection((HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC) as sock:
+        sid, reader = _adc_login(sock, "dummy", "test")
+        sock.sendall(f"BMSG {sid} {body}\n".encode("utf-8"))
+        # cmd_setpass replies via user:reply(...), which goes out as
+        # private chat (E or D type) from the hubbot. Wait for it so
+        # we know the script's save path has executed.
+        reader.recv_until(
+            lambda f: f.startswith("EMSG ") or f.startswith("DMSG "),
+            timeout=PROTOCOL_TIMEOUT_SEC,
+        )
+
+    head = user_tbl.read_bytes()[:4]
+    if head != b"LDC1":
+        raise TestFailure(
+            f"user.tbl bypassed encryption after +setpass (head={head!r}); "
+            f"#92 regression: cmd_setpass writes plaintext via util.savearray"
+        )
+
+    # Confirm cmd_setpass actually persisted the new password (the LDC1
+    # magic alone is also produced by the prior HPAS save, so without
+    # this the test could pass even with a silent no-op).
+    with socket.create_connection((HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC) as sock:
+        try:
+            _adc_login(sock, "dummy", new_pass)
+        except TestFailure as e:
+            raise TestFailure(
+                f"+setpass did not actually change the password (re-login "
+                f"with new value rejected): {e}"
+            )
+
+    # Give the hub a moment to flush the disconnect-driven cfg.saveusers
+    # so the next disk-state test does not race the io_open("wb") +
+    # f:write cycle and observe a transiently empty user.tbl.
+    time.sleep(0.5)
+
+
 def test_usertbl_encrypted_at_rest(staging_dir: Path):
     """Phase 7f F-AUTH-1: user.tbl on disk must start with the LDC1 magic
     after the hub has had any reason to save it (HPAS lastconnect update
@@ -609,6 +670,14 @@ def run_tests(staging_dir: Path):
         failed.append("canonical LuaSocket / LuaSec layout")
     else:
         log("PASS  canonical LuaSocket / LuaSec layout")
+
+    try:
+        test_setpass_preserves_encryption(staging_dir)
+    except Exception as e:
+        log(f"FAIL  +setpass preserves encryption: {e}")
+        failed.append("+setpass preserves encryption")
+    else:
+        log("PASS  +setpass preserves encryption")
 
     try:
         test_usertbl_encrypted_at_rest(staging_dir)


### PR DESCRIPTION
## Summary

Five fixes from the 2026-05-07 static security audit (meta tracker: #98). Coherent v3.1.3 patch scope - all fixes touch the auth path or related persistence.

| # | Sev | Subject |
|---|---|---|
| #92 | HIGH | cmd_setpass / cmd_nickchange / cmd_upgrade bypassed Phase 7f AES-GCM via `util.savearray` (9 sites) |
| #91 | HIGH | Pre-auth DoS: registered users kicked on nick collision before HPAS in reg_only mode |
| #94 | LOW | Failed-auth HPAS still updated lastconnect / lastseen / is_online |
| #93 | LOW | `master_key_path` stat shell-call lacked POSIX quoting |
| #96 | MED | `etc_cmdlog` logged `+setpass` arguments verbatim to `cmd.log` |

Out of scope for v3.1.3: #95 (password-disclosure reply paths; broader UX call) and #97 (`kill_wrong_ips` default; will bundle with #78 unified-blocklist) - both deferred to Phase-8 hardening.

## #91 design choice

The issue acceptance criteria asked for HPAS-gated takeover semantics (legitimate password-holder still wins, attacker without password gets rejected). Implemented:

- `_identify.BINF` for reg_only + nick collision: stash `user._takeover_target = onlineuser`, skip `insertuser`/`onConnect`.
- `_verify.HPAS` success: race-guard, kill the existing user, claim the slot via `insertuser`, fire deferred `onConnect`, then `login`.
- `_verify.HPAS` failure: standard kill of the new connection; existing user untouched.
- `disconnect()`: only clear `_usernicks[nick]` if the entry is actually ours, so a takeover-pending drop pre-HPAS does not wipe the legitimate user's mapping.
- Race guard: if a concurrent takeover already swapped the slot, the late HPAS-success bails with `nick taken` instead of clobbering the third connection.

## Test plan

- [x] Smoke harness 12/12 PASS (3 stable runs)
- [x] New regression test `test_setpass_preserves_encryption` exercises +setpass and asserts (a) user.tbl on disk still has LDC1 magic, (b) the new password actually took effect (catches silent no-ops)
- [x] Existing 11 tests still pass: full login flow, +cmd routing, CSPRNG salt uniqueness, per-IP cap, encrypted-at-rest baseline
- [ ] Manual #91 takeover scenarios (reg_only mode) - deferred to operator validation

## Closes

#91 #92 #93 #94 #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)