### PR TITLE
release: prepare v3.1.3 (security audit batch)

### DIFF
--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,81 +1,61 @@
-# Luadch v3.1.2
+# Luadch v3.1.3
 
-Patch release on top of v3.1.1. Drop-in upgrade: no cfg / on-disk-format
-changes, no Lua API changes. Single fix; smoke harness now 11 / 11
-PASS on Linux + Windows.
+Security patch on top of v3.1.2. Drop-in upgrade: no cfg / on-disk-format changes, no Lua API changes. Smoke harness now 12 / 12 PASS on Linux + Windows.
 
 ## Highlights
 
-- **Canonical LuaSocket / LuaSec install layout** (closes
-  [#88](https://github.com/luadch-ng/luadch/issues/88)). Plugins doing
-  `require "socket.http"` or `require "ssl.https"` now load drop-in
-  instead of failing because the bundle was installed flat. Source
-  files unchanged; only the install-tree layout flips. Hub-internal
-  usage unaffected (only the entrypoints `socket.lua` / `ssl.lua` are
-  required, both stay top-level).
-- **Smoke regression test** added so future CMake changes can't drift
-  back to the flat bundling without the smoke gate firing.
+- **Pre-auth DoS gone** (closes [#91](https://github.com/luadch-ng/luadch/issues/91)). In `reg_only` mode, an unauthenticated BINF claiming a registered user's nick used to kill that user before HPAS proved the new connection held the password. Attacker only needed the target nick. Now: defer the takeover, run HPAS, and only swap if the new connection's password verifies. Race-guarded and safe against pre-HPAS disconnects.
+- **`user.tbl` encryption-bypass closed** (closes [#92](https://github.com/luadch-ng/luadch/issues/92)). `+setpass`, `+nickchange` and `+upgrade` were writing the user database directly via `util.savearray`, silently undoing the Phase 7f AES-256-GCM at-rest encryption. All nine call sites now route through `cfg.saveusers()` so the encryption layer holds.
+- **Audit-trail leak fixed** (closes [#96](https://github.com/luadch-ng/luadch/issues/96)). `etc_cmdlog` no longer writes `+setpass` / `+newpw` arguments verbatim to `log/cmd.log`. New `etc_cmdlog_redact_args` cfg key (default `{ setpass, newpw }`) replaces them with `<redacted>`.
+- Two more low-impact tightenings: HPAS state-pollution on failed auth ([#94](https://github.com/luadch-ng/luadch/issues/94)) and POSIX shell-quoting for the `master_key_path` perms check ([#93](https://github.com/luadch-ng/luadch/issues/93)).
 
 ## What this unblocks
 
-- [`luadch-ng/scripts ptx_RSSFeedWatch`](https://github.com/luadch-ng/scripts)
-  loads drop-in now (previously needed an operator-side manual
-  rearrangement of `lib/`).
-- Future plugins using canonical Lua HTTP/HTTPS idiom load without
-  any luadch-specific workarounds.
-- Phase-8+ feature work that needs HTTP (REST API, Prometheus
-  exporter, AbuseIPDB integration) starts from canonical assumptions.
+- Operators running `reg_only` hubs are no longer one-packet away from a pre-auth DoS against any registered user.
+- Phase 7f at-rest encryption is now end-to-end correct: every code path that mutates `user.tbl` goes through the encryption layer.
 
 ## Downloads
 
 | File | Platform |
 |---|---|
-| `luadch-v3.1.2-linux-x86_64.tar.gz` | Linux glibc x86_64 |
-| `luadch-v3.1.2-windows-x86_64.zip`  | Windows x86_64 (MinGW UCRT64) |
+| `luadch-v3.1.3-linux-x86_64.tar.gz` | Linux glibc x86_64 |
+| `luadch-v3.1.3-windows-x86_64.zip`  | Windows x86_64 (MinGW UCRT64) |
 
-Extract anywhere and run `./luadch` (Linux) or `Luadch.exe` (Windows).
-The trees are self-contained: Lua interpreter, all bundled libs (LuaSec,
-LuaSocket, basexx, adclib), default configs, scripts, certs helpers.
+Extract anywhere and run `./luadch` (Linux) or `Luadch.exe` (Windows). The trees are self-contained: Lua interpreter, all bundled libs (LuaSec, LuaSocket, basexx, adclib), default configs, scripts, certs helpers.
 
-Default plain ADC port `5000`, TLS port `5001` after running
-`certs/make_cert.{sh,bat}` once. First login: nick `dummy`, password
-`test` - **delete that account immediately** after registering yourself,
-see [`docs/CONFIGURATION.md`](https://github.com/luadch-ng/luadch/blob/v3.1.2/docs/CONFIGURATION.md).
+Default plain ADC port `5000`, TLS port `5001` after running `certs/make_cert.{sh,bat}` once. First login: nick `dummy`, password `test` - **delete that account immediately** after registering yourself, see [`docs/CONFIGURATION.md`](https://github.com/luadch-ng/luadch/blob/v3.1.3/docs/CONFIGURATION.md).
 
-## Migration from v3.1.1
+## Migration from v3.1.2
 
-None required. Drop the new install tree in place of the old one (or
-`git pull && cmake --build build && cmake --install build` from
-source). `cfg/`, `certs/`, `master.key`, encrypted `user.tbl` carry
-over without change.
+None required. Drop the new install tree in place of the old one (or `git pull && cmake --build build && cmake --install build` from source). `cfg/`, `certs/`, `master.key`, encrypted `user.tbl` carry over without change.
 
-If you had previously hand-rearranged `lib/luasocket/lua/socket/` to
-get an HTTP plugin to work, the new install tree already provides
-that layout - your manual rearrangement is now redundant but harmless.
+The new `etc_cmdlog_redact_args` cfg key gets a sensible default (`{ setpass, newpw }`) on fresh installs; existing `cfg/cfg.tbl` files without the key fall back to the same default automatically (cfg defaults are merged, not required).
 
-If you're still on v3.1.0 or earlier, follow the v3.1.0 migration
-notes: <https://github.com/luadch-ng/luadch/releases/tag/v3.1.0>.
+If you're still on v3.1.1 or earlier, follow the v3.1.1 / v3.1.2 migration notes:
+<https://github.com/luadch-ng/luadch/releases>
+
+## Deferred to Phase-8
+
+Two findings from the same audit are intentionally not in this patch:
+- [#95](https://github.com/luadch-ng/luadch/issues/95) - password disclosure in admin reply paths (broader UX call)
+- [#97](https://github.com/luadch-ng/luadch/issues/97) - `kill_wrong_ips` default flip (will bundle with the unified blocklist track in [#78](https://github.com/luadch-ng/luadch/issues/78))
 
 ## Full changelog
 
-See [`CHANGELOG.md`](https://github.com/luadch-ng/luadch/blob/v3.1.2/CHANGELOG.md)
-for the categorised list.
+See [`CHANGELOG.md`](https://github.com/luadch-ng/luadch/blob/v3.1.3/CHANGELOG.md) for the categorised list.
 
 ## Build from source
 
 ```sh
-git clone --branch v3.1.2 https://github.com/luadch-ng/luadch.git
+git clone --branch v3.1.3 https://github.com/luadch-ng/luadch.git
 cd luadch
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
 cmake --install build
 ```
 
-Output lands in `build/install/luadch/` ready to run. Windows needs
-`-G "MinGW Makefiles" -DOPENSSL_ROOT_DIR=...` extra, see
-[`docs/BUILDING.md`](https://github.com/luadch-ng/luadch/blob/v3.1.2/docs/BUILDING.md).
+Output lands in `build/install/luadch/` ready to run. Windows needs `-G "MinGW Makefiles" -DOPENSSL_ROOT_DIR=...` extra, see [`docs/BUILDING.md`](https://github.com/luadch-ng/luadch/blob/v3.1.3/docs/BUILDING.md).
 
 ## Credits
 
-All conceptual credit to **blastbeat** and **pulsar**, original authors of
-luadch. This fork modernises and extends their excellent foundation.
+All conceptual credit to **blastbeat** and **pulsar**, original authors of luadch. This fork modernises and extends their excellent foundation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The upstream project (`luadch/luadch`) is a separate codebase; its release
 history is at https://github.com/luadch/luadch/releases.
 
+## [v3.1.3] - 2026-05-07
+
+Security patch on top of v3.1.2. Drop-in upgrade; no cfg / on-disk-format changes. Smoke 12/12 PASS on Linux + Windows.
+
+### Bugfixes
+
+- [#91](https://github.com/luadch-ng/luadch/issues/91) - Pre-auth DoS via reg_only nick collision (HPAS-gated takeover)
+- [#92](https://github.com/luadch-ng/luadch/issues/92) - Encrypted `user.tbl` bypass in `cmd_setpass` / `cmd_nickchange` / `cmd_upgrade`
+- [#93](https://github.com/luadch-ng/luadch/issues/93) - `master_key_path` POSIX shell-quoting in `cfg_secret`
+- [#94](https://github.com/luadch-ng/luadch/issues/94) - Failed-auth state pollution in HPAS handler
+- [#96](https://github.com/luadch-ng/luadch/issues/96) - `etc_cmdlog` redacts password-bearing arguments via new `etc_cmdlog_redact_args` cfg key
+
+### Notes
+
+- Smoke regression test added for #92 (`test_setpass_preserves_encryption`)
+- Deferred to Phase-8 hardening: [#95](https://github.com/luadch-ng/luadch/issues/95), [#97](https://github.com/luadch-ng/luadch/issues/97)
+- Audit meta tracker: [#98](https://github.com/luadch-ng/luadch/issues/98)
+
+[v3.1.3]: https://github.com/luadch-ng/luadch/releases/tag/v3.1.3
+
+
 ## [v3.1.2] - 2026-05-06
 
 Patch release. Drop-in upgrade from v3.1.1; no cfg / on-disk-format

--- a/core/const.lua
+++ b/core/const.lua
@@ -11,7 +11,7 @@
 return {
 
     PROGRAM_NAME = "Luadch",
-    VERSION = "v3.1.2",
+    VERSION = "v3.1.3",
     COPYRIGHT = "by blastbeat and pulsar",
     FORK = "modernised fork by Aybo",
     CONFIG_PATH = "././cfg/",


### PR DESCRIPTION
## Summary

Release-prep for v3.1.3. Security patch on top of v3.1.2.

- Bumps `VERSION` in `core/const.lua` to `v3.1.3`.
- Adds v3.1.3 section to `CHANGELOG.md` (new minimal Bugfixes/Notes layout).
- Rewrites `.github/release-body.md` for the v3.1.3 release notes.

## Scope

Pure release-prep. No code changes; the actual fixes already landed in #99.

## Test plan

- [x] Smoke 12/12 PASS locally (Windows MinGW UCRT64) on v3.1.3
- [x] Smoke green on Linux + Windows CI (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)