### PR TITLE
fix(etc_motd): gsub-based placeholders, {nick} preferred + %s legacy

### DIFF
--- a/scripts/etc_motd.lua
+++ b/scripts/etc_motd.lua
@@ -4,6 +4,13 @@
 
         - this script sends a message to users after login
 
+        v0.09: by Aybo
+            - placeholder substitution is gsub-based instead of
+              string.format; both `{nick}` (preferred) and `%s` (legacy)
+              are now supported. Any number of placeholders is fine, no
+              more "bad argument #N to format" errors when an MOTD uses
+              the placeholder twice (e.g. multilingual greetings).
+
         v0.08: by pulsar
             - removed table lookups
 
@@ -39,7 +46,7 @@
 --------------
 
 local scriptname = "etc_motd"
-local scriptversion = "0.08"
+local scriptversion = "0.09"
 
 --// imports
 local scriptlang = cfg.get( "language" )
@@ -65,7 +72,14 @@ end
 hub.setlistener( "onLogin", {},
     function( user )
         if permission[ user:level() ] then
-            local msg = utf.format( msg_motd, user:firstnick() )
+            -- v0.09: gsub-based template replacement. Both {nick} and
+            -- %s expand to the user's firstnick, any number of times,
+            -- with no string.format-style "wrong argument count" errors
+            -- when an MOTD uses the placeholder more than once (e.g.
+            -- bilingual greetings). %s is kept for backwards-compat
+            -- with upstream MOTDs; {nick} is the recommended form.
+            local nick = user:firstnick()
+            local msg = ( msg_motd:gsub( "{nick}", nick ):gsub( "%%s", nick ) )
             if destination_main then user:reply( msg, hub.getbot() ) end
             if destination_pm then user:reply( msg, hub.getbot(), hub.getbot() ) end
         end

--- a/scripts/lang/etc_motd.lang.de
+++ b/scripts/lang/etc_motd.lang.de
@@ -5,10 +5,10 @@
 
 === MOTD ========================================================================================
 
-                                                                     Welcome %s
+                                                                     Welcome {nick}
                                                                      This is the Message of the day
 
 ======================================================================================== MOTD ===
-      ]], -- optional you can use %s to get the nickname of the user
+      ]], -- {nick} wird durch den firstnick des Users ersetzt. Beliebig oft verwendbar. %s wird zur Abwärtskompatibilität mit Upstream-MOTDs ebenfalls akzeptiert.
 
 }

--- a/scripts/lang/etc_motd.lang.en
+++ b/scripts/lang/etc_motd.lang.en
@@ -5,10 +5,10 @@
 
 === MOTD ========================================================================================
 
-                                                                     Welcome %s
+                                                                     Welcome {nick}
                                                                      This is the Message of the day
 
 ======================================================================================== MOTD ===
-      ]], -- optional you can use %s to get the nickname of the user
+      ]], -- {nick} expands to the user's firstnick. May be used multiple times. %s is also accepted for backwards compatibility with upstream MOTDs.
 
 }


### PR DESCRIPTION
## Summary

Operator-side bug: an MOTD that uses the nick placeholder more than once - e.g. a bilingual greeting

\`\`\`
Welcome %s to ...
Willkommen %s beim ...
\`\`\`

crashes the \`onLogin\` listener with \`bad argument #3 to 'format' (no value)\`. \`string.format\` expects one argument per \`%s\`, but [scripts/etc_motd.lua:68](scripts/etc_motd.lua#L68) only passes \`user:firstnick()\` once.

## Fix

Switch to gsub-based template substitution. Two placeholder forms supported:

- **\`{nick}\`** (recommended, self-explanatory)
- **\`%s\`** (kept for backwards-compat with upstream MOTDs and existing deployments)

Both expand to the user's firstnick. Any number of placeholders is fine, no format-arity errors. \`scriptversion: 0.08 -> 0.09\`.

\`scripts/lang/etc_motd.lang.{en,de}\` ship with \`{nick}\` in the default MOTD as the documented form, with a comment line noting the \`%s\` alias.

## Test plan

- [x] Smoke 12/12 PASS locally (default MOTD with single \`{nick}\` rendered cleanly via dummy login)
- [x] CI smoke green on Linux + Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)