### PR TITLE
fix(security): kill_wrong_ips default to true; forbid I4/I6 in INF (closes #97)

### DIFF
--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -3072,7 +3072,17 @@ local defaults = {
             return types_boolean( value, nil, true )
         end
     },
-    kill_wrong_ips = { false,
+    -- #97: default kept off historically because some NAT setups
+    -- legitimately advertise a different IP than the TCP source
+    -- (clients behind symmetric NAT, IPv6 fallback weirdness). The
+    -- legitimate "I40.0.0.0" passive-mode case is handled separately
+    -- in core/hub_dispatch.lua (the hub fills in the real IP); the
+    -- only branch this gate fires on is "client claims a real but
+    -- different IP". Per-IP rate limits, GeoIP rules, abuse logs, and
+    -- the unified blocklist all rely on the IP being trustworthy, so
+    -- the default is now true. NAT-weird deployments opt out by
+    -- setting kill_wrong_ips = false in their cfg/cfg.tbl.
+    kill_wrong_ips = { true,
         function( value )
             return types_boolean( value, nil, true )
         end

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -227,9 +227,43 @@ the same `icacls` line there. The same recipe lives in
 | Op-level bypass of per-user limits | same | `ratelimit_bypass_level` (default 60) |
 | Parser-side message-size cap | [`core/adc.lua` parse](../core/adc.lua) | hardcoded 64 KiB |
 | Connection read-buffer cap | [`core/server.lua`](../core/server.lua) | hardcoded 1 MiB |
+| INF-IP consistency check (kick on TCP-source vs INF-claim mismatch) | [`core/hub_dispatch.lua` BINF](../core/hub_dispatch.lua) + [`scripts/hub_inf_manager.lua`](../scripts/hub_inf_manager.lua) | `kill_wrong_ips` (default **true** since v3.1.4) |
 
 The full DoS-hardening rationale is in Phase 7c
 ([#56](https://github.com/luadch-ng/luadch/issues/56)).
+
+### `kill_wrong_ips` operator note ([#97](https://github.com/luadch-ng/luadch/issues/97))
+
+The `kill_wrong_ips` default flipped from `false` to `true` in v3.1.4:
+a connecting client whose INF advertises an `I4` / `I6` value
+different from the TCP source IP is now disconnected. Same check
+fires on `onInf` updates in normal state via
+[`scripts/hub_inf_manager.lua`](../scripts/hub_inf_manager.lua) -
+post-login a user cannot re-stamp their advertised IP either.
+
+The legitimate **passive-mode `I40.0.0.0`** case is handled before
+the kill check (the hub fills in the real IP at
+[`core/hub_dispatch.lua`](../core/hub_dispatch.lua)), so passive
+clients are unaffected.
+
+**When to opt out (`kill_wrong_ips = false`):** deployments where
+clients legitimately advertise an IP different from the TCP source.
+Mostly:
+
+- users behind symmetric NAT or carrier-grade NAT (CGNAT) where the
+  client cannot determine its public IP and falls back to a stale
+  cached value
+- bridged / dual-stack setups where the user's own selection of
+  `I4` vs `I6` does not match what the kernel chose for the
+  outbound TCP connection
+- corporate proxies / TLS-terminating reverse proxies in front of
+  the hub that rewrite the source IP
+
+The cost of opting out: per-IP rate limits, GeoIP / unified
+blocklist matches, abuse logs, and any plugin reading
+`user:ip()` operate on the **TCP source IP** anyway, so the check
+is purely defence-in-depth against IP-spoofing INFs - the rest of
+the stack stays sound.
 
 ---
 

--- a/scripts/hub_inf_manager.lua
+++ b/scripts/hub_inf_manager.lua
@@ -5,6 +5,13 @@
         - this script kills users with forbidden inf flags
         - do not change anything here when you dont know what you are doing
 
+        v0.06: by Aybo
+            - re-enabled "I4" + added "I6" to flags_on_inf
+                - paired with the kill_wrong_ips default flip in #97;
+                  closes the "user changes their advertised IP after
+                  login via a fresh BINF in normal state" path that
+                  the on-connect check alone cannot cover
+
         v0.05: by pulsar
             - improved user:kill()
 
@@ -17,7 +24,7 @@
 ]]--
 
 local scriptname = "hub_inf_manager"
-local scriptversion = "0.05"
+local scriptversion = "0.06"
 local scriptlang = cfg.get "language"
 
 local lang, err = cfg.loadlanguage( scriptlang, scriptname ); lang = lang or { }; err = err and hub.debug( err )
@@ -43,7 +50,13 @@ local forbidden = {
 
         "PD",
         "ID",
-        --"I4",
+        -- #97: I4 / I6 are valid in the initial BINF (the hub validates
+        -- and fills them in core/hub_dispatch.lua) but MUST NOT be
+        -- changed after login - allowing it would let a normal-state
+        -- user re-stamp their advertised IP and bypass per-IP rate
+        -- limits / GeoIP rules / abuse logs.
+        "I4",
+        "I6",
 
     },
 


### PR DESCRIPTION
## Summary

Security default flip from the 2026-05-07 audit batch, deferred from v3.1.3 to keep that patch scope tight. Closes #97. Tracks back to meta tracker #98.

The \`kill_wrong_ips\` gate already existed in [\`core/hub_dispatch.lua\` BINF](core/hub_dispatch.lua) - a TCP-source IP that doesn't match the client's advertised \`I4\` / \`I6\` was already kickable - but the cfg default was \`false\`. Out-of-the-box deployments silently ignored IP-spoofing INFs, blinding per-IP rate limits, GeoIP rules, the unified blocklist (#78), abuse logs, and any plugin reading \`user:ip()\` (those see the real TCP source, while a malicious client can claim something else and survive the auth flow).

## Changes

1. **[\`core/cfg_defaults.lua\`](core/cfg_defaults.lua)**: \`kill_wrong_ips\` default \`false\` -> \`true\`. Comment block explains the legitimate \`I40.0.0.0\` passive-mode case is handled separately in \`hub_dispatch\` (the hub fills in the real IP before this gate fires).
2. **[\`scripts/hub_inf_manager.lua\`](scripts/hub_inf_manager.lua)**: re-enable \`\"I4\"\` in \`forbidden.flags_on_inf\` and add \`\"I6\"\`. Closes the "user changes their advertised IP after login via fresh BINF in normal state" path, which the on-connect check alone cannot cover. \`scriptversion\` 0.05 -> 0.06.
3. **[\`docs/SECURITY.md\`](docs/SECURITY.md)**: new row in the network-defenses table + dedicated operator note documenting the opt-out for NAT-weird deployments (symmetric NAT / CGNAT, dual-stack mismatches, TLS-terminating reverse proxies). Sets expectations: the rest of the rate-limit / GeoIP stack uses TCP source IP, so the gate is purely defence-in-depth against IP-spoofing INFs.

## Risk + opt-out

NAT-weird deployments where clients legitimately advertise an IP different from the TCP source can opt out by setting \`kill_wrong_ips = false\` in their \`cfg/cfg.tbl\`. The full operator note lives in [\`docs/SECURITY.md\` § 5](docs/SECURITY.md).

## Test plan

- [x] Smoke 12/12 PASS x3 stable runs locally
- [x] Smoke client uses \`I40.0.0.0\` (passive-mode shortcut) - kill check not exercised, existing flows unaffected
- [x] CI: smoke green on Linux + Windows

## Closes

#97

🤖 Generated with [Claude Code](https://claude.com/claude-code)