### PR TITLE
fix(security): regusers staleness + atomic user.tbl write (closes upstream luadch#189)

### DIFF
--- a/core/cfg_users.lua
+++ b/core/cfg_users.lua
@@ -11,6 +11,16 @@
     plaintext files load via the existing util.loadtable path and get
     re-written as encrypted on the next save (transparent migration).
 
+    Atomic-write + always-fresh .bak (closes upstream luadch#189):
+    the previous saveusers() did open(W) + write + close on the live
+    user.tbl, which truncates the file at open. A crash or filesystem
+    error mid-write left user.tbl partial; checkusers() then fell back
+    to user.tbl.bak (potentially weeks old, refreshed only at hub
+    startup / +reload) and silently lost recent registrations. We now
+    write to a .tmp sidecar and atomically rename, and we refresh
+    user.tbl.bak with the same content on every successful save - the
+    backup is therefore always current rather than a stale snapshot.
+
     Public surface returned to cfg.lua:
 
         {
@@ -24,15 +34,16 @@
 
 local use = use
 local io = use "io"
+local os = use "os"
 local util = use "util"
 local secret = use "cfg_secret"
 
 local io_open = io.open
+local os_rename = os.rename
+local os_remove = os.remove
 local util_loadtable = util.loadtable
 local util_loadtable_string = util.loadtable_string
-local util_savearray = util.savearray
 local util_arraytostring = util.arraytostring
-local util_maketable = util.maketable
 local util_chmod_secret = util.chmod_secret
 local secret_seal = secret.seal
 local secret_open = secret.open
@@ -75,6 +86,31 @@ local function _write_raw( path, content )
     return true
 end
 
+-- Atomically replace `path` with new `content`. Writes to
+-- `path .. ".tmp"` first, then rename(2) the sidecar over the
+-- target. POSIX guarantees atomicity (same filesystem); Windows
+-- rename errors when the target exists, so we fall back to a
+-- remove-then-rename on that platform - that loses the strict
+-- atomicity guarantee but still avoids the open(W)+truncate
+-- corruption window of the naive write path.
+local function _atomic_write( path, content )
+    local tmp = path .. ".tmp"
+    local ok, err = _write_raw( tmp, content )
+    if not ok then
+        os_remove( tmp )    -- best-effort cleanup
+        return false, err
+    end
+    -- POSIX: succeeds and atomically replaces.
+    local rok = os_rename( tmp, path )
+    if rok then return true end
+    -- Windows fallback: remove target first, then rename.
+    os_remove( path )
+    rok, err = os_rename( tmp, path )
+    if rok then return true end
+    os_remove( tmp )    -- best-effort cleanup on full failure
+    return false, err or "rename failed"
+end
+
 -- Internal load: returns (table, err). Detects encrypted vs plaintext
 -- format via the LDC1 magic prefix and routes accordingly. Plaintext
 -- files load via the legacy util.loadtable path so existing
@@ -108,6 +144,14 @@ end
 
 local function saveusers( user_path, regusers )
     local file = user_path .. "user.tbl"
+    local backup = user_path .. "user.tbl.bak"
+
+    -- Build the on-disk bytes once (encrypted blob if cfg_secret is
+    -- active, plaintext Lua-source as a defensive fallback). Both
+    -- user.tbl and user.tbl.bak get written from the same buffer so
+    -- they end up byte-identical; that lets `cmp user.tbl
+    -- user.tbl.bak` validate the .bak refresh externally.
+    local content
     if secret_is_active( ) then
         local plaintext = util_arraytostring( regusers )
         local blob, err = secret_seal( plaintext )
@@ -115,22 +159,33 @@ local function saveusers( user_path, regusers )
             if out_error then out_error( "cfg_users.lua: function 'saveusers': seal: ", err ) end
             return false, err
         end
-        local ok, werr = _write_raw( file, blob )
-        if not ok then
-            if out_error then out_error( "cfg_users.lua: function 'saveusers': write: ", werr ) end
-            return false, werr
-        end
-        return true
+        content = blob
+    else
+        -- cfg_secret never came up (init failed?). Fall back to
+        -- plaintext Lua-source so the hub at least keeps running.
+        -- This branch is a defence against double-fault more than an
+        -- expected path.
+        content = util_arraytostring( regusers )
     end
-    -- cfg_secret never came up (init failed?). Fall back to plaintext
-    -- so the hub at least keeps running. This branch is a defence
-    -- against double-fault more than an expected path.
-    local _, err = util_savearray( regusers, file )
-    if err then
-        if out_error then out_error( "cfg_users.lua: function 'saveusers': ", err ) end
+
+    -- Atomic primary write. Anything fancier (fsync, filesystem
+    -- barriers) is out of scope; the rename(2) call is the strongest
+    -- crash-safety primitive standard Lua exposes.
+    local ok, err = _atomic_write( file, content )
+    if not ok then
+        if out_error then out_error( "cfg_users.lua: function 'saveusers': write: ", err ) end
         return false, err
     end
-    util_chmod_secret( file )
+
+    -- Refresh the backup with the same bytes. Best-effort: a failure
+    -- here does NOT fail the save (the primary write already
+    -- succeeded, callers should not have to handle "saved but no
+    -- backup" as a separate state). The next save will retry.
+    local bok, berr = _atomic_write( backup, content )
+    if not bok and out_error then
+        out_error( "cfg_users.lua: function 'saveusers': backup refresh: ", berr )
+    end
+
     return true
 end
 
@@ -138,53 +193,48 @@ local function checkusers( user_path )
     local file = user_path .. "user.tbl"
     local backup = user_path .. "user.tbl.bak"
 
+    -- Primary OK? saveusers() refreshes .bak on every successful
+    -- write, so when the primary is readable .bak is already current
+    -- (or will be on the next save). No prophylactic refresh here.
     local users, err = _load( file )
     if users then
-        -- Healthy primary; refresh the backup. Backup is also
-        -- encrypted so the same threat-model applies.
-        util_maketable( nil, backup )
-        if secret_is_active( ) then
-            local plaintext = util_arraytostring( users )
-            local blob, sealerr = secret_seal( plaintext )
-            if blob then
-                local ok, werr = _write_raw( backup, blob )
-                if not ok and out_error then
-                    out_error( "cfg_users.lua: function 'checkusers': backup write: ", werr )
-                end
-            elseif out_error then
-                out_error( "cfg_users.lua: function 'checkusers': backup seal: ", sealerr )
-            end
-        else
-            local _, werr = util_savearray( users, backup )
-            if werr and out_error then
-                out_error( "cfg_users.lua: function 'checkusers': backup save: ", werr )
-            end
-            util_chmod_secret( backup )
+        return
+    end
+
+    -- Primary broken; try to restore from .bak. This path triggers
+    -- when user.tbl was manually deleted or the filesystem corrupted
+    -- it (since v3.1.5 the atomic-write path makes the
+    -- crash-during-save case impossible).
+    local restored, berr = _load( backup )
+    if not restored then
+        if out_error then
+            out_error( "cfg_users.lua: function 'checkusers': both primary and backup unreadable: ",
+                       tostring( err ), " / ", tostring( berr ) )
         end
+        return
+    end
+
+    -- Re-encrypt on restore: a legacy plaintext .bak from a pre-7f
+    -- deployment loads fine via _load's auto-detection but should be
+    -- written back encrypted now that cfg_secret is active.
+    local content
+    if secret_is_active( ) then
+        local plaintext = util_arraytostring( restored )
+        local blob, sealerr = secret_seal( plaintext )
+        if not blob then
+            if out_error then
+                out_error( "cfg_users.lua: function 'checkusers': restore seal: ", sealerr )
+            end
+            return
+        end
+        content = blob
     else
-        -- Primary broken; try the backup. Fail closed if both fail.
-        local restored, berr = _load( backup )
-        if restored then
-            util_maketable( nil, file )
-            if secret_is_active( ) then
-                local plaintext = util_arraytostring( restored )
-                local blob, sealerr = secret_seal( plaintext )
-                if blob then
-                    local ok, werr = _write_raw( file, blob )
-                    if not ok and out_error then
-                        out_error( "cfg_users.lua: function 'checkusers': restore write: ", werr )
-                    end
-                elseif out_error then
-                    out_error( "cfg_users.lua: function 'checkusers': restore seal: ", sealerr )
-                end
-            else
-                local _, werr = util_savearray( restored, file )
-                if werr and out_error then
-                    out_error( "cfg_users.lua: function 'checkusers': restore save: ", werr )
-                end
-                util_chmod_secret( file )
-            end
-        end
+        content = util_arraytostring( restored )
+    end
+
+    local ok, werr = _atomic_write( file, content )
+    if not ok and out_error then
+        out_error( "cfg_users.lua: function 'checkusers': restore write: ", werr )
     end
 end
 

--- a/scripts/cmd_nickchange.lua
+++ b/scripts/cmd_nickchange.lua
@@ -8,6 +8,16 @@
 
         note: this script needs "nick_change = true" in "cfg/cfg.tbl"
 
+        v1.9: by Aybo
+            - drop file-scope cache of hub.getregusers() in favour of
+              per-function fresh fetches. The cached reference went
+              stale after hub.updateusers() reassigned _regusers, so
+              subsequent +nickchange operations saved a stale snapshot
+              to disk and silently lost any +reg entries added in
+              between. Most plausible root cause for upstream
+              luadch#189 ("Registered users suddenly loses their
+              accounts").
+
         v1.8:
             - using "TL-1" for disconnects  / thx Sopor
                 - fix #182 -> https://github.com/luadch/luadch/issues/182
@@ -81,7 +91,7 @@
 --------------
 
 local scriptname = "cmd_nickchange"
-local scriptversion = "1.8"
+local scriptversion = "1.9"
 
 local cmd = "nickchange"
 local cmd_param_1 = "mynick"
@@ -106,7 +116,13 @@ local report_hubbot = cfg.get( "cmd_nickchange_report_hubbot" )
 local report_opchat = cfg.get( "cmd_nickchange_report_opchat" )
 
 --// database
-local user_tbl = hub.getregusers()
+-- NOTE: user_tbl (= hub.getregusers()) is fetched fresh in every
+-- function that needs it. The previous file-scope cache went stale
+-- whenever hub.updateusers() reassigned _regusers, and any
+-- subsequent +nickchange would then save the stale snapshot back to
+-- disk - silently dropping registrations added in between (upstream
+-- luadch#189). Always grabbing the live reference at the call site
+-- closes that hole.
 local description_file = "scripts/data/cmd_reg_descriptions.tbl"
 
 --// msgs
@@ -163,6 +179,7 @@ end
 
 --// check if new nick is taken
 isTaken = function( oldnick, newnick )
+    local user_tbl = hub.getregusers()
     for i, user in ipairs( user_tbl ) do
         if user.nick ~= oldnick then
             if user.nick == newnick then
@@ -175,6 +192,7 @@ end
 
 --// check if nick is regged
 isRegged = function( nick )
+    local user_tbl = hub.getregusers()
     for i, user in ipairs( user_tbl ) do
         if user.nick == nick then
             return true
@@ -184,6 +202,7 @@ isRegged = function( nick )
 end
 
 onbmsg = function( user, command, parameters )
+    local user_tbl = hub.getregusers()
     local user_level = user:level()
     local user_nick = user:nick()
     local user_firstnick = user:firstnick()

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -561,6 +561,37 @@ def test_setpass_preserves_encryption(staging_dir: Path):
     time.sleep(0.5)
 
 
+def test_usertbl_bak_atomic_refresh(staging_dir: Path):
+    """Closes upstream luadch#189: previously user.tbl.bak only got
+    refreshed at hub start / +reload, so a corrupted user.tbl would
+    fall back to a weeks-old snapshot and silently lose recent regs.
+
+    saveusers() now writes user.tbl atomically (.tmp + rename) and
+    immediately mirrors the same on-disk bytes to user.tbl.bak. After
+    every successful save the two files should be byte-identical and
+    both carry the LDC1 encrypted-at-rest magic. The prior tests in
+    this run have driven multiple saveusers calls (HPAS lastconnect
+    updates + the +setpass test), so by the time this test runs both
+    files exist and reflect the latest save."""
+    cfg_dir = staging_dir / "cfg"
+    user_tbl = cfg_dir / "user.tbl"
+    user_tbl_bak = cfg_dir / "user.tbl.bak"
+
+    if not user_tbl_bak.exists():
+        raise TestFailure(f"user.tbl.bak missing at {user_tbl_bak}")
+    if user_tbl_bak.read_bytes()[:4] != b"LDC1":
+        raise TestFailure(f"user.tbl.bak is not encrypted at rest")
+
+    # Same bytes -> same nonce -> same blob -> byte-equal files.
+    # saveusers() builds the encrypted blob once and writes it to both
+    # paths, so this is the strict equality check we want.
+    if user_tbl.read_bytes() != user_tbl_bak.read_bytes():
+        raise TestFailure(
+            "user.tbl and user.tbl.bak diverged - .bak refresh after "
+            "saveusers is not running atomically"
+        )
+
+
 def test_usertbl_encrypted_at_rest(staging_dir: Path):
     """Phase 7f F-AUTH-1: user.tbl on disk must start with the LDC1 magic
     after the hub has had any reason to save it (HPAS lastconnect update
@@ -686,6 +717,14 @@ def run_tests(staging_dir: Path):
         failed.append("user.tbl encrypted at rest")
     else:
         log("PASS  user.tbl encrypted at rest")
+
+    try:
+        test_usertbl_bak_atomic_refresh(staging_dir)
+    except Exception as e:
+        log(f"FAIL  user.tbl.bak atomic refresh: {e}")
+        failed.append("user.tbl.bak atomic refresh")
+    else:
+        log("PASS  user.tbl.bak atomic refresh")
 
     # The plugin-load test reads the hub log, so it runs after all
     # protocol tests have had a chance to exercise the listeners.


### PR DESCRIPTION
## Summary

Fixes the long-standing "registered users suddenly disappear" bug from upstream [luadch/luadch#189](https://github.com/luadch/luadch/issues/189), reported via #108 by @Sopor. Two independent root causes, both in our v3.x fork until now.

### 1. Staleness in cmd_nickchange.lua

The script cached \`local user_tbl = hub.getregusers()\` at **file scope**. After \`hub.updateusers()\` reassigned \`_regusers\` (any \`+reg\` / \`+delreg\` / \`+ban\`), the cached reference pointed at the old, smaller table. The next \`+nickchange\` mutated that stale table, then \`cfg.saveusers()\` wrote it to disk - silently overwriting any registrations added in between.

Sopor's documented workaround in upstream #189 ("+reload after every +reg / +delreg / +ban") matches exactly: \`+reload\` re-runs every script, re-binding the file-scope cache.

**Fix:** drop the file-scope cache; \`isTaken\` / \`isRegged\` / \`onbmsg\` each grab a fresh \`hub.getregusers()\` at call time. cmd_nickchange bumped 1.8 → 1.9. grep verified that cmd_nickchange was the only script in our tree with this pattern.

### 2. Non-atomic write in cfg_users.saveusers + stale .bak

The previous \`saveusers()\` did \`io_open(path, "wb") + write\` on the live \`user.tbl\`, which **truncates** at open. A crash or filesystem error mid-write left \`user.tbl\` partial; \`checkusers()\` then fell back to \`user.tbl.bak\`, which was only refreshed at hub startup / +reload. So the .bak was potentially weeks old, and overwriting \`user.tbl\` with that stale snapshot dropped recent regs.

**Fix:**
- \`saveusers()\` writes to \`user.tbl.tmp\` and atomically \`rename(2)\` it onto \`user.tbl\`. Windows fallback does \`remove\`+\`rename\` (loses strict atomicity but still avoids the truncate-in-place hole).
- Same encrypted blob is atomically written to \`user.tbl.bak\` in the same call. Two files end up byte-identical (same blob → same nonce), \`.bak\` always reflects the latest save.
- \`checkusers()\` simplified to just the recovery path. The prophylactic-refresh half is now redundant.

## Test plan

- [x] Smoke 13/13 PASS x3 stable. New test: \`test_usertbl_bak_atomic_refresh\` verifies \`user.tbl.bak\` exists, has LDC1 magic, and matches \`user.tbl\` byte-for-byte after the prior tests have driven multiple \`saveusers()\` calls.
- [x] Existing 12 tests still PASS, including \`test_setpass_preserves_encryption\`.
- [x] CI smoke green on Linux + Windows.

## Closes

#108 (and upstream luadch#189 by virtue of fixing the root causes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)