### PR TITLE
feat(docker): auto-sync bundled scripts/*.lua on container start

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,19 @@
 
 PUID=1000
 PGID=1000
+
+# Auto-sync bundled top-level scripts/*.lua from the image to your
+# mounted scripts/ directory on every container start. Default ON (1).
+#
+# When ON: image upgrades automatically deliver bug-fixes to plugin
+# code. Operator-customizable state (scripts/lang/*, scripts/data/*,
+# scripts/cfg/*, custom *.lua files with their own filename) is never
+# touched.
+#
+# Set to 0 if you have hand-patched bundled .lua files and want to
+# preserve those edits across image upgrades. The recommended pattern
+# for plugin customization is a NEW filename (e.g. cmd_help_custom.lua)
+# rather than editing the bundled scripts; with that pattern you can
+# keep the auto-sync ON.
+#
+# LUADCH_AUTOSYNC_SCRIPTS=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,11 @@ services:
     image: ghcr.io/luadch-ng/luadch:latest
     container_name: luadch
     user: "${PUID:-1000}:${PGID:-1000}"
+    environment:
+      # Auto-sync bundled top-level scripts/*.lua from the image to
+      # the mounted scripts/ on every container start. See .env.example
+      # for the full explanation. Default ON (1).
+      LUADCH_AUTOSYNC_SCRIPTS: "${LUADCH_AUTOSYNC_SCRIPTS:-1}"
     ports:
       # Plain ADC (legacy clients / debug). Comment out for TLS-only
       # deployments once your users are on adcs:// URLs.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -38,6 +38,46 @@ done
 mkdir -p "${LUADCH_HOME}/log"
 
 # ---------------------------------------------------------------------------
+# 1b. Auto-sync bundled top-level scripts/*.lua from /defaults
+# ---------------------------------------------------------------------------
+# After the initial seed, the operator's mounted scripts/ directory is
+# stable - the seed path above only fires when it's empty. That means
+# bug-fixes we ship in subsequent images never reach existing
+# deployments unless the operator manually copies them.
+#
+# This block fixes that for the narrow case of TOP-LEVEL .lua files
+# (the bundled plugin code). It does NOT touch:
+#
+#   scripts/lang/*.lang.*  - operator-customized translations / MOTD
+#   scripts/data/*.tbl     - runtime state (bans, regs, plugin caches)
+#   scripts/cfg/*.tbl      - per-plugin operator settings
+#   scripts/<dir>/         - any other subdirectory
+#
+# Operators who hand-patched a bundled .lua (rare, discouraged) can
+# disable this with LUADCH_AUTOSYNC_SCRIPTS=0 in their .env. The
+# recommended pattern for custom plugins is a NEW filename - those
+# never collide with the bundle so the auto-sync leaves them alone.
+#
+# Idempotent: cmp -s skips files that are already byte-identical, so
+# steady-state restarts are no-ops.
+if [ "${LUADCH_AUTOSYNC_SCRIPTS:-1}" = "1" ]; then
+    updated=0
+    for f in "${DEFAULTS}"/scripts/*.lua; do
+        [ -f "$f" ] || continue
+        n=$(basename "$f")
+        target="${LUADCH_HOME}/scripts/${n}"
+        if [ ! -e "$target" ] || ! cmp -s "$f" "$target"; then
+            cp "$f" "$target"
+            log "auto-synced bundled script: ${n}"
+            updated=$((updated + 1))
+        fi
+    done
+    if [ "$updated" -gt 0 ]; then
+        log "auto-synced ${updated} bundled scripts from /defaults"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
 # 2. Generate TLS cert if missing
 # ---------------------------------------------------------------------------
 # Cert generation is a one-off on first start; the cert lives in the

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -277,6 +277,15 @@ rules don't get involved).
 
 ## Updating
 
+> **⚠️ Always back up first.** Operator-owned state lives in `cfg/`,
+> `scripts/lang/`, `scripts/data/`, `scripts/cfg/`, `certs/`, and
+> `secrets/`. None of these are touched by an image upgrade, but a
+> clean snapshot is the safety net for any production hub.
+>
+> ```sh
+> tar -czf "luadch-backup-$(date +%F).tar.gz" cfg scripts certs secrets
+> ```
+
 Pull the new image and recreate the container; mounts persist:
 
 ```sh
@@ -290,6 +299,95 @@ get unexpected jumps:
 ```yaml
 image: ghcr.io/luadch-ng/luadch:v3.1.3
 ```
+
+### What gets updated automatically
+
+The container's entrypoint **auto-syncs the bundled top-level
+`scripts/*.lua` files** from the image to your mounted `scripts/`
+directory on every start. Bug-fixes we ship in plugin code reach
+your hub on the next image pull without manual action.
+
+What is **not** touched:
+
+| Path | Reason |
+|---|---|
+| `cfg/cfg.tbl` | Your settings; new defaults are merged at runtime via the `cfg.get()` fallback path |
+| `cfg/user.tbl`, `cfg/user.tbl.bak` | User database |
+| `scripts/lang/*.lang.*` | Your translations / MOTD customizations |
+| `scripts/data/*.tbl` | Plugin runtime state (bans, regs, caches) |
+| `scripts/cfg/*.tbl` | Per-plugin operator settings |
+| `scripts/<your-custom>.lua` | Custom plugins keep their distinct filenames - the auto-sync only touches files that exist in the image's `/defaults/scripts/` |
+| `certs/*` | TLS keys |
+| `secrets/master.key` | AES master key |
+
+The entrypoint logs each updated file:
+
+```
+[entrypoint] auto-synced bundled script: cmd_nickchange.lua
+[entrypoint] auto-synced 1 bundled scripts from /defaults
+```
+
+If a bundled script's content matches what's already on disk, it is
+skipped (idempotent on restart).
+
+### Opting out of auto-sync
+
+If you have hand-patched a bundled script and want to preserve those
+edits across image upgrades, set in your `.env`:
+
+```
+LUADCH_AUTOSYNC_SCRIPTS=0
+```
+
+In that mode, image bug-fixes stop reaching your hub automatically.
+You will need to copy them manually:
+
+```sh
+# Diff: which bundled scripts in your mount differ from the new image
+docker compose exec luadch sh -c '
+    for f in /defaults/scripts/*.lua; do
+        n=$(basename "$f")
+        cmp -s "$f" "/opt/luadch/scripts/$n" 2>/dev/null \
+            || echo "differs: $n"
+    done
+'
+
+# Apply a single file
+docker compose exec luadch \
+    cp /defaults/scripts/cmd_nickchange.lua /opt/luadch/scripts/
+docker compose restart luadch
+```
+
+The recommended pattern for plugin customization is to **add a custom
+filename** rather than editing a bundled file. With that pattern the
+auto-sync is harmless and you can leave it ON.
+
+### Updating `lang/*.lang.*` after a release that changed translations
+
+Translation files (and other `scripts/<subdir>/` content) are never
+auto-synced because they typically contain operator-customized strings
+(e.g. your MOTD). When a release changes a bundled translation key
+that you have not customized, the in-script `lang.foo or "<fallback>"`
+pattern keeps the hub running on the hardcoded fallback - you just
+miss the new translation until you sync.
+
+To sync a specific lang file, diff against the image and merge what
+matters:
+
+```sh
+# Show your file vs the image's
+docker compose exec luadch \
+    diff /opt/luadch/scripts/lang/etc_motd.lang.en \
+         /defaults/scripts/lang/etc_motd.lang.en
+
+# Apply the image version (will overwrite your customizations!)
+docker compose exec luadch \
+    cp /defaults/scripts/lang/etc_motd.lang.en /opt/luadch/scripts/lang/
+docker compose restart luadch
+```
+
+Release notes call out lang/data file changes explicitly when they
+happen so you know to sync.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Image upgrades did not previously deliver bundled-plugin bug fixes to existing operators. The entrypoint only seeded the \`scripts/\` mount when it was empty - after first start the mount is non-empty (operator's host directory has the seeded files), so subsequent image pulls left stale \`.lua\` files in place.

Real example: an operator who runs v3.1.4 and pulls v3.1.5 would still execute the broken \`cmd_nickchange.lua\` that drops registrations on \`+nickchange\` (PR #109 fix), because their bind-mounted \`scripts/cmd_nickchange.lua\` is the v1.8 file from their first start.

## What this PR does

The entrypoint now does a per-file diff between \`/defaults/scripts/\` and \`/opt/luadch/scripts/\` on every start and copies any **top-level \`*.lua\`** file whose contents differ. Operator-customizable state is deliberately untouched:

| Path | Auto-synced? |
|---|---|
| \`scripts/*.lua\` (top-level, bundled plugin code) | ✅ yes |
| \`scripts/lang/*.lang.*\` (translations / MOTD) | ❌ no |
| \`scripts/data/*.tbl\` (plugin runtime state) | ❌ no |
| \`scripts/cfg/*.tbl\` (per-plugin operator settings) | ❌ no |
| \`scripts/<custom>.lua\` (custom plugins with distinct filenames) | ❌ no (auto-sync only touches files that exist in \`/defaults/scripts/\`) |

The auto-sync is **idempotent** (\`cmp -s\` short-circuits identical files) and logs each updated file plus a summary line. Operators who have hand-patched a bundled \`.lua\` can opt out via \`LUADCH_AUTOSYNC_SCRIPTS=0\` in their \`.env\`.

## docs/DOCKER.md

New "Updating" section covers:

- ⚠ backup warning before any upgrade (matches the convention I'll start putting in every \`.github/release-body.md\` going forward)
- explanation of what is / is not auto-synced
- the opt-out env var and when to use it
- manual recipes for syncing \`scripts/lang/*\` files when a release changes them (those are not auto-synced because operators customize them)

## Test plan

Verified locally on Docker Desktop via 5 scenarios:

- [x] **Empty volumes**: silent (image-baked content is already current, no diff to sync)
- [x] **Modify a script + restart**: auto-sync detects diff, restores file. \`auto-synced bundled script: cmd_nickchange.lua\` + \`auto-synced 1 bundled scripts from /defaults\` in the entrypoint log
- [x] **Restart with no changes**: idempotent, no output
- [x] **Restart with \`LUADCH_AUTOSYNC_SCRIPTS=0\`**: stale file persists
- [x] **File content after sync**: matches the image's bundled version (UTF-8 BOM + script header intact)
- [x] CI: smoke green on Linux + Windows (smoke harness doesn't exercise Docker but the underlying entrypoint shell logic is platform-portable)

## Closes

(no specific issue - this is a UX improvement raised in conversation, follow-up to #102 / #109)

🤖 Generated with [Claude Code](https://claude.com/claude-code)