### PR TITLE
release: prepare v3.1.5 (upstream luadch#189 fix + Docker autosync)

### DIFF
--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,65 +1,46 @@
-# Luadch v3.1.4
+# Luadch v3.1.5
 
-Patch release on top of v3.1.3. Drop-in upgrade: no cfg / on-disk-format changes, no Lua API changes. Smoke harness 12 / 12 PASS on Linux + Windows. **First release with an official container image.**
+Patch release. Closes upstream `luadch/luadch#189` (registered users disappearing) and adds image-side auto-sync of bundled plugin code on `docker compose pull`.
 
-## Highlights
+## ⚠️ Before upgrading
 
-- **Pure-rootless container image** (closes [#87](https://github.com/luadch-ng/luadch/issues/87)). Multi-stage Alpine 3.20, runs as UID/GID 1000 by default - no `s6-overlay`, no `gosu`, no PUID/PGID entrypoint magic. Operators override at run time via Docker's built-in `--user` flag. Multi-arch images on `ghcr.io/luadch-ng/luadch` (linux/amd64 + linux/arm64). Self-signed cert + keyprint generated and logged on first start, master.key on a separate `/secrets` mount per the F-AUTH-1 backup-separation recommendation. Compose file at the repo root, full operator guide at [`docs/DOCKER.md`](https://github.com/luadch-ng/luadch/blob/v3.1.4/docs/DOCKER.md).
-- **`kill_wrong_ips` defaults to `true`** (closes [#97](https://github.com/luadch-ng/luadch/issues/97)). A connecting client whose INF advertises an IP different from the TCP source is now disconnected; same check fires on post-login INF updates via `hub_inf_manager` (`I4`/`I6` added to `forbidden.flags_on_inf`). Per-IP rate limits, GeoIP rules, the unified blocklist, and abuse logs are no longer blinded by IP-spoofing INFs. Operator opt-out for NAT-weird deployments documented in [`docs/SECURITY.md` § 5](https://github.com/luadch-ng/luadch/blob/v3.1.4/docs/SECURITY.md).
-- **`etc_motd` multi-placeholder fix** (closes [#103](https://github.com/luadch-ng/luadch/issues/103)). MOTDs that use the nick placeholder more than once (e.g. bilingual greetings) no longer crash the `onLogin` listener with `bad argument #3 to 'format' (no value)`. New `{nick}` template form is the recommended placeholder; legacy `%s` is still accepted.
+Back up your `cfg/`, `scripts/lang/`, `scripts/data/`, `scripts/cfg/`, `certs/`, and `secrets/` directories. Bundled `scripts/*.lua` are auto-synced from the image; everything else is operator-owned and never touched by an upgrade, but a clean snapshot is the safety net for any production hub.
 
-## What this unblocks
+```sh
+tar -czf "luadch-backup-$(date +%F).tar.gz" cfg scripts certs secrets
+```
 
-- One-line container deployment for first-time operators: `docker compose up -d`.
-- The audit deferral for IP-spoofing INFs is closed; combined with v3.1.3's encryption-bypass + DoS fixes, the post-Phase-7 audit batch ([#98](https://github.com/luadch-ng/luadch/issues/98)) is fully resolved except for the password-reply-paths UX call ([#95](https://github.com/luadch-ng/luadch/issues/95), Phase-8).
+## Bugfixes
+
+- [#108](https://github.com/luadch-ng/luadch/issues/108) / [upstream luadch#189](https://github.com/luadch/luadch/issues/189) - registered users no longer disappear from `user.tbl`. Stale file-scope cache in `cmd_nickchange.lua` + non-atomic `saveusers` were the two root causes; both fixed in [#109](https://github.com/luadch-ng/luadch/pull/109).
+
+## Features
+
+- Docker entrypoint auto-syncs bundled `scripts/*.lua` from the image to the mounted `scripts/` directory on every container start ([#110](https://github.com/luadch-ng/luadch/pull/110)). Operator-owned state untouched. Opt-out: `LUADCH_AUTOSYNC_SCRIPTS=0`. See [`docs/DOCKER.md`](https://github.com/luadch-ng/luadch/blob/v3.1.5/docs/DOCKER.md).
+
+## Notes
+
+- `user.tbl.bak` now refreshed on every successful save (was: only at `+reload`). Operators relying on `.bak` as a stale-rollback should adjust workflows.
+- Smoke harness: 12 -> 13 tests.
 
 ## Downloads
 
 | File | Platform |
 |---|---|
-| `luadch-v3.1.4-linux-x86_64.tar.gz` | Linux glibc x86_64 |
-| `luadch-v3.1.4-windows-x86_64.zip`  | Windows x86_64 (MinGW UCRT64) |
-| `ghcr.io/luadch-ng/luadch:v3.1.4`   | Container, linux/amd64 + linux/arm64 |
+| `luadch-v3.1.5-linux-x86_64.tar.gz` | Linux glibc x86_64 |
+| `luadch-v3.1.5-windows-x86_64.zip`  | Windows x86_64 (MinGW UCRT64) |
+| `ghcr.io/luadch-ng/luadch:v3.1.5`   | Container, linux/amd64 + linux/arm64 |
 
-Extract the binary tarball / zip anywhere and run `./luadch` (Linux) or `Luadch.exe` (Windows). The trees are self-contained: Lua interpreter, all bundled libs (LuaSec, LuaSocket, basexx, adclib), default configs, scripts, certs helpers.
+## Migration from v3.1.4
 
-For Docker:
-
-```sh
-git clone --branch v3.1.4 https://github.com/luadch-ng/luadch.git
-cd luadch
-cp .env.example .env   # adjust PUID / PGID if `id -u` is not 1000
-mkdir -p cfg scripts certs log secrets
-docker compose up -d
-```
-
-The container's entrypoint seeds empty mounts, generates the TLS cert, and logs the keyprint on first start. See [`docs/DOCKER.md`](https://github.com/luadch-ng/luadch/blob/v3.1.4/docs/DOCKER.md) for the full operator guide.
-
-## Migration from v3.1.3
-
-None required. Drop the new install tree in place of the old one (or `git pull && cmake --build build && cmake --install build` from source). `cfg/`, `certs/`, `master.key`, encrypted `user.tbl` carry over without change.
-
-The `kill_wrong_ips = true` default is the only behaviour change. Most deployments are unaffected (the legitimate `I40.0.0.0` passive-mode case is still allowed; the hub fills in the real IP). If you have users behind symmetric NAT / CGNAT / dual-stack-mismatch / TLS-terminating proxies who were previously surviving the auth flow with mismatched INF IPs, set `kill_wrong_ips = false` in your `cfg/cfg.tbl`. Full rationale in [`docs/SECURITY.md` § 5](https://github.com/luadch-ng/luadch/blob/v3.1.4/docs/SECURITY.md).
-
-If you're still on v3.1.2 or earlier, follow the v3.1.2 / v3.1.3 migration notes:
-<https://github.com/luadch-ng/luadch/releases>
-
-## Full changelog
-
-See [`CHANGELOG.md`](https://github.com/luadch-ng/luadch/blob/v3.1.4/CHANGELOG.md) for the categorised list.
+None required. Drop the new install tree in place of the old one (or `git pull && cmake --build build && cmake --install build` from source). Container users get the auto-sync of bundled `scripts/*.lua` on the next `docker compose up -d` after `pull`.
 
 ## Build from source
 
 ```sh
-git clone --branch v3.1.4 https://github.com/luadch-ng/luadch.git
+git clone --branch v3.1.5 https://github.com/luadch-ng/luadch.git
 cd luadch
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
 cmake --install build
 ```
-
-Output lands in `build/install/luadch/` ready to run. Windows needs `-G "MinGW Makefiles" -DOPENSSL_ROOT_DIR=...` extra, see [`docs/BUILDING.md`](https://github.com/luadch-ng/luadch/blob/v3.1.4/docs/BUILDING.md).
-
-## Credits
-
-All conceptual credit to **blastbeat** and **pulsar**, original authors of luadch. This fork modernises and extends their excellent foundation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The upstream project (`luadch/luadch`) is a separate codebase; its release
 history is at https://github.com/luadch/luadch/releases.
 
+## [v3.1.5] - 2026-05-07
+
+Patch release on top of v3.1.4. Drop-in upgrade. Closes upstream `luadch/luadch#189` (registered users disappearing) and adds image-side auto-sync of bundled plugin code. Smoke 13/13 PASS on Linux + Windows.
+
+### Bugfixes
+
+- [#108](https://github.com/luadch-ng/luadch/issues/108) / [upstream luadch#189](https://github.com/luadch/luadch/issues/189) - registered users no longer disappear from `user.tbl`. Two root causes: stale file-scope `hub.getregusers()` cache in `cmd_nickchange.lua` (saved snapshots over later `+reg` writes), and non-atomic `cfg_users.saveusers` (truncate-during-write left `user.tbl` partial; `checkusers()` then fell back to a weeks-old `.bak`). Now: `cmd_nickchange.lua` fetches `hub.getregusers()` per call; `saveusers()` writes via `.tmp` + `rename(2)`; `user.tbl.bak` refreshes on every successful save and is byte-identical to `user.tbl`.
+
+### Features
+
+- Docker entrypoint auto-syncs bundled `scripts/*.lua` from the image to the mounted `scripts/` directory on every container start. Plugin bug-fixes now reach existing deployments on `docker compose pull` without manual file copies. Operator-owned state (`scripts/lang/`, `scripts/data/`, `scripts/cfg/`, custom `*.lua`, `cfg/`, `certs/`, `secrets/`) is never touched. Opt-out via `LUADCH_AUTOSYNC_SCRIPTS=0`. See [`docs/DOCKER.md`](docs/DOCKER.md).
+
+### Notes
+
+- `user.tbl.bak` is now refreshed on every successful save (was: only at `+reload`). Operators relying on `.bak` as a stale-rollback should adjust workflows.
+- New smoke test: `test_usertbl_bak_atomic_refresh` verifies `.bak` byte-equality with `user.tbl` after writes (12 -> 13 tests).
+
+[v3.1.5]: https://github.com/luadch-ng/luadch/releases/tag/v3.1.5
+
+
 ## [v3.1.4] - 2026-05-07
 
 Patch release on top of v3.1.3. Drop-in upgrade; no cfg / on-disk-format changes. Smoke 12/12 PASS on Linux + Windows. First release with an official container image.

--- a/core/const.lua
+++ b/core/const.lua
@@ -11,7 +11,7 @@
 return {
 
     PROGRAM_NAME = "Luadch",
-    VERSION = "v3.1.4",
+    VERSION = "v3.1.5",
     COPYRIGHT = "by blastbeat and pulsar",
     FORK = "modernised fork by Aybo",
     CONFIG_PATH = "././cfg/",


### PR DESCRIPTION
## Summary

Release-prep for v3.1.5. Patch release on top of v3.1.4. The fixes themselves already landed in #109 and #110.

- VERSION bump in \`core/const.lua\` to \`v3.1.5\`.
- v3.1.5 entry in \`CHANGELOG.md\` (minimal layout: Bugfixes / Features / Notes).
- \`.github/release-body.md\` rewritten in the new minimal style (matches CHANGELOG, no prose \"Highlights\" section, ⚠️ backup warning at top).

## Scope

Pure release-prep. No code changes.

## Test plan

- [x] Smoke 13/13 PASS locally on v3.1.5
- [x] CI: smoke green on Linux + Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)