### PR TITLE
feat(deps): bundle slaxml XML parser at lib/slaxml/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ add_subdirectory(hub)
 # Lua-side helpers
 install(FILES slnunicode/unicode.lua DESTINATION lib/unicode)
 install(FILES basexx/basexx.lua      DESTINATION lib/basexx)
+install(FILES slaxml/slaxml.lua      DESTINATION lib/slaxml)
 
 # Runtime trees
 install(DIRECTORY core/        DESTINATION core)

--- a/slaxml/LICENSE
+++ b/slaxml/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2013-2018 Gavin Kistner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/slaxml/README.md
+++ b/slaxml/README.md
@@ -1,0 +1,32 @@
+# SLAXML
+
+Pure-Lua streaming and DOM XML parser, vendored from
+[Phrogz/SLAXML](https://github.com/Phrogz/SLAXML).
+
+| | |
+|---|---|
+| Version | v0.8 |
+| License | MIT (see `LICENSE`) |
+| Upstream | https://github.com/Phrogz/SLAXML |
+| Last upstream activity | 2018 (still the canonical pure-Lua XML parser - feature-complete; XML grammar does not change) |
+| v0.7 → v0.8 changes (only streaming parser, the file we bundle) | text callback signature extended to `text(text, cdata)`; bugfixes for comments / PIs after the root element and whitespace preservation. The DOM-builder breaking change (`doc.root` removed when `simple=true`) lives in `slaxdom.lua` upstream and is not bundled here. |
+
+Bundled in the hub install tree at `lib/slaxml/slaxml.lua` so plugins
+can `require "slaxml"` without operator-side install steps. The
+`luadch-ng/scripts` plugin
+[`ptx_RSSFeedWatch`](https://github.com/luadch-ng/scripts) uses this
+to parse RSS / Atom feeds; future XML-needing plugins benefit from
+the same bundle.
+
+## Local upgrade procedure
+
+If a future SLAXML release does land:
+
+```sh
+curl -L -o slaxml/slaxml.lua \
+    https://raw.githubusercontent.com/Phrogz/SLAXML/master/slaxml.lua
+# update the version line in this README + the inline header in slaxml.lua
+```
+
+That's it - no Makefile, no build step. The CMake `install(FILES ...)`
+rule in the top-level `CMakeLists.txt` ships it as-is.

--- a/slaxml/slaxml.lua
+++ b/slaxml/slaxml.lua
@@ -1,0 +1,259 @@
+--[=====================================================================[
+v0.8 Copyright © 2013-2018 Gavin Kistner <!@phrogz.net>; MIT Licensed
+See http://github.com/Phrogz/SLAXML for details.
+--]=====================================================================]
+local SLAXML = {
+	VERSION = "0.8",
+	_call = {
+		pi = function(target,content)
+			print(string.format("<?%s %s?>",target,content))
+		end,
+		comment = function(content)
+			print(string.format("<!-- %s -->",content))
+		end,
+		startElement = function(name,nsURI,nsPrefix)
+			                 io.write("<")
+			if nsPrefix then io.write(nsPrefix,":") end
+			                 io.write(name)
+			if nsURI    then io.write(" (ns='",nsURI,"')") end
+			                 print(">")
+		end,
+		attribute = function(name,value,nsURI,nsPrefix)
+			                 io.write('  ')
+			if nsPrefix then io.write(nsPrefix,":") end
+			                 io.write(name,'=',string.format('%q',value))
+			if nsURI    then io.write(" (ns='",nsURI,"')") end
+			                 io.write("\n")
+		end,
+		text = function(text,cdata)
+			print(string.format("  %s: %q",cdata and 'cdata' or 'text',text))
+		end,
+		closeElement = function(name,nsURI,nsPrefix)
+			                 io.write("</")
+			if nsPrefix then io.write(nsPrefix,":") end
+			                 print(name..">")
+		end,
+	}
+}
+
+function SLAXML:parser(callbacks)
+	return { _call=callbacks or self._call, parse=SLAXML.parse }
+end
+
+function SLAXML:parse(xml,options)
+	if not options then options = { stripWhitespace=false } end
+
+	-- Cache references for maximum speed
+	local find, sub, gsub, char, push, pop, concat = string.find, string.sub, string.gsub, string.char, table.insert, table.remove, table.concat
+	local first, last, match1, match2, match3, pos2, nsURI
+	local unpack = unpack or table.unpack
+	local pos = 1
+	local state = "text"
+	local textStart = 1
+	local currentElement={}
+	local currentAttributes={}
+	local currentAttributeCt -- manually track length since the table is re-used
+	local nsStack = {}
+	local anyElement = false
+
+	local utf8markers = { {0x7FF,192}, {0xFFFF,224}, {0x1FFFFF,240} }
+	local function utf8(decimal) -- convert unicode code point to utf-8 encoded character string
+		if decimal<128 then return char(decimal) end
+		local charbytes = {}
+		for bytes,vals in ipairs(utf8markers) do
+			if decimal<=vals[1] then
+				for b=bytes+1,2,-1 do
+					local mod = decimal%64
+					decimal = (decimal-mod)/64
+					charbytes[b] = char(128+mod)
+				end
+				charbytes[1] = char(vals[2]+decimal)
+				return concat(charbytes)
+			end
+		end
+	end
+	local entityMap  = { ["lt"]="<", ["gt"]=">", ["amp"]="&", ["quot"]='"', ["apos"]="'" }
+	local entitySwap = function(orig,n,s) return entityMap[s] or n=="#" and utf8(tonumber('0'..s)) or orig end
+	local function unescape(str) return gsub( str, '(&(#?)([%d%a]+);)', entitySwap ) end
+
+	local function finishText()
+		if first>textStart and self._call.text then
+			local text = sub(xml,textStart,first-1)
+			if options.stripWhitespace then
+				text = gsub(text,'^%s+','')
+				text = gsub(text,'%s+$','')
+				if #text==0 then text=nil end
+			end
+			if text then self._call.text(unescape(text),false) end
+		end
+	end
+
+	local function findPI()
+		first, last, match1, match2 = find( xml, '^<%?([:%a_][:%w_.-]*) ?(.-)%?>', pos )
+		if first then
+			finishText()
+			if self._call.pi then self._call.pi(match1,match2) end
+			pos = last+1
+			textStart = pos
+			return true
+		end
+	end
+
+	local function findComment()
+		first, last, match1 = find( xml, '^<!%-%-(.-)%-%->', pos )
+		if first then
+			finishText()
+			if self._call.comment then self._call.comment(match1) end
+			pos = last+1
+			textStart = pos
+			return true
+		end
+	end
+
+	local function nsForPrefix(prefix)
+		if prefix=='xml' then return 'http://www.w3.org/XML/1998/namespace' end -- http://www.w3.org/TR/xml-names/#ns-decl
+		for i=#nsStack,1,-1 do if nsStack[i][prefix] then return nsStack[i][prefix] end end
+		error(("Cannot find namespace for prefix %s"):format(prefix))
+	end
+
+	local function startElement()
+		anyElement = true
+		first, last, match1 = find( xml, '^<([%a_][%w_.-]*)', pos )
+		if first then
+			currentElement[2] = nil -- reset the nsURI, since this table is re-used
+			currentElement[3] = nil -- reset the nsPrefix, since this table is re-used
+			finishText()
+			pos = last+1
+			first,last,match2 = find(xml, '^:([%a_][%w_.-]*)', pos )
+			if first then
+				currentElement[1] = match2
+				currentElement[3] = match1 -- Save the prefix for later resolution
+				match1 = match2
+				pos = last+1
+			else
+				currentElement[1] = match1
+				for i=#nsStack,1,-1 do if nsStack[i]['!'] then currentElement[2] = nsStack[i]['!']; break end end
+			end
+			currentAttributeCt = 0
+			push(nsStack,{})
+			return true
+		end
+	end
+
+	local function findAttribute()
+		first, last, match1 = find( xml, '^%s+([:%a_][:%w_.-]*)%s*=%s*', pos )
+		if first then
+			pos2 = last+1
+			first, last, match2 = find( xml, '^"([^<"]*)"', pos2 ) -- FIXME: disallow non-entity ampersands
+			if first then
+				pos = last+1
+				match2 = unescape(match2)
+			else
+				first, last, match2 = find( xml, "^'([^<']*)'", pos2 ) -- FIXME: disallow non-entity ampersands
+				if first then
+					pos = last+1
+					match2 = unescape(match2)
+				end
+			end
+		end
+		if match1 and match2 then
+			local currentAttribute = {match1,match2}
+			local prefix,name = string.match(match1,'^([^:]+):([^:]+)$')
+			if prefix then
+				if prefix=='xmlns' then
+					nsStack[#nsStack][name] = match2
+				else
+					currentAttribute[1] = name
+					currentAttribute[4] = prefix
+				end
+			else
+				if match1=='xmlns' then
+					nsStack[#nsStack]['!'] = match2
+					currentElement[2]      = match2
+				end
+			end
+			currentAttributeCt = currentAttributeCt + 1
+			currentAttributes[currentAttributeCt] = currentAttribute
+			return true
+		end
+	end
+
+	local function findCDATA()
+		first, last, match1 = find( xml, '^<!%[CDATA%[(.-)%]%]>', pos )
+		if first then
+			finishText()
+			if self._call.text then self._call.text(match1,true) end
+			pos = last+1
+			textStart = pos
+			return true
+		end
+	end
+
+	local function closeElement()
+		first, last, match1 = find( xml, '^%s*(/?)>', pos )
+		if first then
+			state = "text"
+			pos = last+1
+			textStart = pos
+
+			-- Resolve namespace prefixes AFTER all new/redefined prefixes have been parsed
+			if currentElement[3] then currentElement[2] = nsForPrefix(currentElement[3])    end
+			if self._call.startElement then self._call.startElement(unpack(currentElement)) end
+			if self._call.attribute then
+				for i=1,currentAttributeCt do
+					if currentAttributes[i][4] then currentAttributes[i][3] = nsForPrefix(currentAttributes[i][4]) end
+					self._call.attribute(unpack(currentAttributes[i]))
+				end
+			end
+
+			if match1=="/" then
+				pop(nsStack)
+				if self._call.closeElement then self._call.closeElement(unpack(currentElement)) end
+			end
+			return true
+		end
+	end
+
+	local function findElementClose()
+		first, last, match1, match2 = find( xml, '^</([%a_][%w_.-]*)%s*>', pos )
+		if first then
+			nsURI = nil
+			for i=#nsStack,1,-1 do if nsStack[i]['!'] then nsURI = nsStack[i]['!']; break end end
+		else
+			first, last, match2, match1 = find( xml, '^</([%a_][%w_.-]*):([%a_][%w_.-]*)%s*>', pos )
+			if first then nsURI = nsForPrefix(match2) end
+		end
+		if first then
+			finishText()
+			if self._call.closeElement then self._call.closeElement(match1,nsURI) end
+			pos = last+1
+			textStart = pos
+			pop(nsStack)
+			return true
+		end
+	end
+
+	while pos<#xml do
+		if state=="text" then
+			if not (findPI() or findComment() or findCDATA() or findElementClose()) then
+				if startElement() then
+					state = "attributes"
+				else
+					first, last = find( xml, '^[^<]+', pos )
+					pos = (first and last or pos) + 1
+				end
+			end
+		elseif state=="attributes" then
+			if not findAttribute() then
+				if not closeElement() then
+					error("Was in an element and couldn't find attributes or the close.")
+				end
+			end
+		end
+	end
+
+	if not anyElement then error("Parsing did not discover any elements") end
+	if #nsStack > 0 then error("Parsing ended with unclosed elements") end
+end
+
+return SLAXML

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -640,6 +640,9 @@ def test_canonical_socket_layout(staging_dir: Path):
         "lib/luasec/lua/ssl.lua",
         "lib/luasec/lua/ssl/https.lua",
         "lib/luasec/lua/ssl/options.lua",
+        # SLAXML XML parser (used by ptx_RSSFeedWatch and any future
+        # XML-consuming plugin in luadch-ng/scripts)
+        "lib/slaxml/slaxml.lua",
     ]
     missing = [p for p in expected if not (staging_dir / p).exists()]
     if missing:


### PR DESCRIPTION
## Summary

Pure-Lua streaming + DOM XML parser, vendored from [Phrogz/SLAXML](https://github.com/Phrogz/SLAXML) v0.8 (MIT, last upstream 2018). The companion plugin [\`ptx_RSSFeedWatch\`](https://github.com/luadch-ng/scripts) in \`luadch-ng/scripts\` requires it for RSS / Atom feed parsing.

Pre-bundle, operators had to copy \`slaxml/slaxml.lua\` from the plugin folder to the hub's \`lib/\` directory by hand ("Copy folder slaxml to ../lib/" in the plugin's Readme.txt) - a gotcha not covered by the standard per-plugin install pattern. Real reports surfaced via Hub deployment testing: \`scripts.lua: script error: ./scripts/ptx_RSSFeedWatch.lua:386: module 'slaxml' not found\`.

Bundling at the hub level closes that gap:

- Plugin works out-of-the-box on \`+reload\` once enabled in \`cfg.tbl\`
- Docker auto-sync delivers it on the next image pull (#110)
- Any future XML-consuming plugin in \`luadch-ng/scripts\` has access without per-plugin shipping

## v0.8 vs the plugin's bundled v0.7

ptx_RSSFeedWatch ships its own slaxml v0.7 in-plugin; we ship v0.8 in lib/. The streaming-parser API surface that the plugin uses (\`SLAXML:parser{...}:parse(...)\`) is forward-compatible:

- v0.8 extends the text callback signature: \`text = function(text, cdata)\` (was: \`function(text)\`). Plugin's single-arg callback silently ignores the new \`cdata\` flag - Lua drops extra args.
- The DOM-builder breaking change in v0.8 (\`doc.root\` removed when \`simple=true\`) lives in \`slaxdom.lua\` upstream, **which we do not bundle**. The plugin uses streaming mode only and defines its own \`doc.root\` field in the callback handler.
- v0.8 fixes comments / PIs after the root element + whitespace preservation - low-impact but a free upgrade.

## Layout

Matches the existing \`basexx\` / \`slnunicode\` pattern: top-level \`slaxml/\` directory with \`LICENSE\`, \`README.md\`, and the \`.lua\` source. \`CMakeLists.txt\` installs to \`lib/slaxml/\`.

\`\`\`
slaxml/
├── LICENSE      (MIT, vendored verbatim)
├── README.md    (provenance, version, upgrade procedure)
└── slaxml.lua   (~10 KiB, single file, no native code, no build step)
\`\`\`

## Smoke

\`test_canonical_socket_layout\` extends with one path-existence check for \`lib/slaxml/slaxml.lua\`. Total 13/13 tests still PASS, no new test added (single-file install does not warrant its own test scenario).

## Follow-up in luadch-ng/scripts

\`ptx_RSSFeedWatch\`'s in-plugin \`slaxml/\` folder can stay as a fallback for operators on hubs older than this PR's release. Once we cut a release with this bundled, I'll update \`luadch-ng/scripts/docs/IMPORT_NOTES.md\` to note that hubs at hub-version >= the new release no longer need the manual copy step.

## Closes

(no specific issue, raised in conversation while testing the plugin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)