### PR TITLE
docs: fix grammar 'an user' -> 'a user' (#114)

### DIFF
--- a/examples/etc/other_available_scripts/cmd_sid.lua
+++ b/examples/etc/other_available_scripts/cmd_sid.lua
@@ -2,7 +2,7 @@
 
         cmd_sid.lua v0.02 by blastbeat
 
-        - this script adds a command "+sid" to get the sid of an user
+        - this script adds a command "+sid" to get the sid of a user
         - usage: [+!#]sid nick|cid <nick>|<cid>
 
         - changelog 0.02:

--- a/examples/etc/other_available_scripts/usr_hub_slot_ratio.lua
+++ b/examples/etc/other_available_scripts/usr_hub_slot_ratio.lua
@@ -2,7 +2,7 @@
 
         usr_hub_slot_ratio.lua v0.02 by blastbeat
 
-        - this script checks the hub/slot ratio of an user
+        - this script checks the hub/slot ratio of a user
 
         - changelog 0.02:
           - updated script api

--- a/scripts/bot_session_chat.lua
+++ b/scripts/bot_session_chat.lua
@@ -5,7 +5,7 @@
         - this script can reg session chats
 
         - permissions:
-            - if an user creates a session chat then only he has the permission to add/remove members
+            - if a user creates a session chat then only he has the permission to add/remove members
             - only members can read/write
 
         v0.4:

--- a/scripts/cmd_setpass.lua
+++ b/scripts/cmd_setpass.lua
@@ -2,7 +2,7 @@
 
     cmd_setpas.lua by blastbeat
 
-        - this script adds a command "setpas" to set or change the password of your own or an user by nick
+        - this script adds a command "setpas" to set or change the password of your own or a user by nick
         - usage: [+!#]setpass nick <nick> <password>
         - [+!#]setpass myself <password> sets your own pasword
 

--- a/scripts/cmd_userinfo.lua
+++ b/scripts/cmd_userinfo.lua
@@ -2,7 +2,7 @@
 
     cmd_userinfo.lua by blastbeat
 
-        - this script adds a command "userinfo" get infos about an user
+        - this script adds a command "userinfo" get infos about a user
         - usage: [+!#]userinfo sid|nick|cid <sid>|<nick>|<cid>
         - no arguments means you get info about yourself
 

--- a/scripts/usr_desc_prefix.lua
+++ b/scripts/usr_desc_prefix.lua
@@ -2,7 +2,7 @@
 
     usr_desc_prefix.lua by blastbeat
 
-        - this script adds a prefix to the desc of an user
+        - this script adds a prefix to the desc of a user
         - you can use the prefix table to define different prefixes for different user levels
 
         v0.08: by pulsar

--- a/scripts/usr_nick_prefix.lua
+++ b/scripts/usr_nick_prefix.lua
@@ -2,7 +2,7 @@
 
     usr_nick_prefix.lua by blastbeat
 
-        - this script adds a prefix to the nick of an user
+        - this script adds a prefix to the nick of a user
         - you can use the prefix table to define different prefixes for different user levels
 
         v0.12: by pulsar

--- a/scripts/usr_share.lua
+++ b/scripts/usr_share.lua
@@ -2,7 +2,7 @@
 
     usr_share.lua by blastbeat
 
-        - this script checks the share size of an user
+        - this script checks the share size of a user
 
         v0.11: by pulsar
             - changed visuals

--- a/scripts/usr_slots.lua
+++ b/scripts/usr_slots.lua
@@ -2,7 +2,7 @@
 
     usr_slots.lua by blastbeat
 
-        - this script checks the slots of an user
+        - this script checks the slots of a user
 
         v0.08: by pulsar
             - changed visuals


### PR DESCRIPTION
Closes #114.

## Summary

- 'user' begins with the consonant /j/ sound (yoo-zer), so the correct indefinite article is `a`, not `an`.
- Reporter (Sopor) flagged `scripts/usr_nick_prefix.lua`. Same typo lives in 8 other plugin headers across `scripts/` and `examples/etc/other_available_scripts/` - swept all of them in one go for consistency.

## Files touched (9)

Active plugins (`scripts/`):
- `usr_nick_prefix.lua` (the reported one)
- `usr_slots.lua`, `usr_share.lua`, `usr_desc_prefix.lua`
- `cmd_setpass.lua`, `cmd_userinfo.lua`
- `bot_session_chat.lua`

Archived examples (`examples/etc/other_available_scripts/`):
- `usr_hub_slot_ratio.lua`, `cmd_sid.lua`

## Deliberately NOT touched

- `scripts/cmd_delreg.lua:74` - historical v0.13 changelog block inside the file header.
- `docs/CHANGELOG:3768` - frozen record of a past release.

These are historical artefacts of past releases; rewriting them would falsify the record.

## Test plan

- [x] `git grep "an user"` after the change returns only the two historical entries above.
- No code paths or behaviour touched - comment-only doc fix.