### PR TITLE
fix(usr_nick_length): i18n failure reason + kill message (refs #48)

### DIFF
--- a/scripts/lang/usr_nick_length.lang.de
+++ b/scripts/lang/usr_nick_length.lang.de
@@ -1,0 +1,6 @@
+﻿return {
+
+    msg_failedauth_reason = "Ungültige Nick-Länge: ",
+    msg_invalid_length    = "Ungültige Nick-Länge.",
+
+}

--- a/scripts/lang/usr_nick_length.lang.en
+++ b/scripts/lang/usr_nick_length.lang.en
@@ -1,0 +1,6 @@
+﻿return {
+
+    msg_failedauth_reason = "Invalid nick length: ",
+    msg_invalid_length    = "Invalid nick length.",
+
+}

--- a/scripts/usr_nick_length.lua
+++ b/scripts/usr_nick_length.lua
@@ -1,14 +1,26 @@
-﻿--[[
+--[[
 
     usr_nick_length.lua by blastbeat
 
         - this script checks for proper nicknames onConnect and onInf
 
+        v0.02: by Aybo
+            - i18n the onFailedAuth reason (operator-facing, lands in
+              cmd.log / blacklist scripts) and the ISTA 221 kill message
+              (user-facing). Closes the i18n half of #48 for this script.
+              Both strings now route through scripts/lang/usr_nick_length.lang.{en,de}.
+
 ]]--
 
 
-local scriptname = "usr_nick_length.lua"
-local scriptversion = "0.01"
+local scriptname = "usr_nick_length"
+local scriptversion = "0.02"
+local scriptlang = cfg.get "language"
+
+local lang, err = cfg.loadlanguage( scriptlang, scriptname ); lang = lang or { }; err = err and hub.debug( err )
+
+local msg_failedauth_reason = lang.msg_failedauth_reason or "Invalid nick length: "
+local msg_invalid_length    = hub.escapeto( lang.msg_invalid_length or "Invalid nick length." )
 
 local check = function( user, nick )
     -- min/max_nickname_length is documented in codepoints; use utf.len so
@@ -19,9 +31,8 @@ local check = function( user, nick )
         return nil
     end
     --remember: never fire listenter X inside listener X; will cause infinite loop
-    -- failure-reason string is hardcoded English; i18n tracked in #48.
-    scripts.firelistener( "onFailedAuth", nick, user:ip( ), user:cid( ), "Invalid nick length: " .. len )
-    user:kill( "ISTA 221 " .. hub.escapeto( "Invalid nick length." ) .. "\n", "TL300" )
+    scripts.firelistener( "onFailedAuth", nick, user:ip( ), user:cid( ), msg_failedauth_reason .. len )
+    user:kill( "ISTA 221 " .. msg_invalid_length .. "\n", "TL300" )
     return PROCESSED
 end
 


### PR DESCRIPTION
Refs #48.

Closes the i18n half of #48 for `usr_nick_length`. The byte-vs-codepoint half landed in PR #75 (commit 7d11693).

## Summary

- Two strings localised: the `onFailedAuth` reason (operator-facing - cmd.log + blacklist plugins) and the `ISTA 221` kill message (user-facing - the client's chat shows it).
- Both route through new `scripts/lang/usr_nick_length.lang.{en,de}`, mirroring the pattern `hub_inf_manager` picked up in #75.
- Version bumped 0.01 -> 0.02.
- Cosmetic: dropped the `.lua` suffix from the `scriptname` constant so it matches every other plugin and `cfg.loadlanguage(scriptlang, scriptname)` works without a separate alias.

## Files

- `scripts/usr_nick_length.lua` - load lang file, replace hardcoded strings.
- `scripts/lang/usr_nick_length.lang.en` (new).
- `scripts/lang/usr_nick_length.lang.de` (new).

## Items left in #48 after this

Per the issue's triage comment from 2026-05-05:

- `core/hub.lua:492` reguser regex (architectural, Phase 8+)
- `core/hub.lua:808` `getbot("all")` enumeration (architectural, Phase 8+)
- `core/scripts.lua:130` `removeListener` (architectural, Phase 8+)

All three are tagged Phase 8+ and out of scope for any 3.1.x release.

## Test plan

- [x] `cmake --build build` clean.
- [x] `cmake --install build` puts both new lang files at `scripts/lang/usr_nick_length.lang.{en,de}`.
- [x] `python tests\smoke\run.py build/install/luadch` -> all 14 tests PASS, including "no script errors in log" which would catch a load failure of the script or a missing lang key.
- [x] BOM + LF encoding on both lang files (matches `.gitattributes` `*.lang text eol=lf` plus the BOM-bearing convention of the existing lang files).

## v3.1.6 fit

Operator-friendly cleanup, no behaviour change for English-language hubs (default messages identical). German hubs gain proper localisation for both strings. Fits the 3.1.6 release-prep batch.