### PR TITLE
feat(docker): add-only autosync for bundled scripts/lang/*

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,17 +10,25 @@ PUID=1000
 PGID=1000
 
 # Auto-sync bundled top-level scripts/*.lua from the image to your
-# mounted scripts/ directory on every container start. Default ON (1).
+# mounted scripts/ directory on every container start, plus add-only
+# sync of new bundled scripts/lang/*.lang.* files. Default ON (1).
 #
-# When ON: image upgrades automatically deliver bug-fixes to plugin
-# code. Operator-customizable state (scripts/lang/*, scripts/data/*,
-# scripts/cfg/*, custom *.lua files with their own filename) is never
-# touched.
+# When ON:
+#   - Bundled scripts/*.lua: bug-fixes from image upgrades land on
+#     your mount automatically (overwrites byte-for-byte differences).
+#   - Bundled scripts/lang/*.lang.*: language files that don't exist
+#     on your mount are added; existing translations are NEVER
+#     overwritten. A release that adds i18n to a previously
+#     English-only plugin reaches non-English operators without
+#     manual action, while any operator-customized translations stay.
+#   - Operator-customizable state (scripts/data/*, scripts/cfg/*,
+#     custom *.lua files with their own filename) is never touched.
 #
 # Set to 0 if you have hand-patched bundled .lua files and want to
-# preserve those edits across image upgrades. The recommended pattern
-# for plugin customization is a NEW filename (e.g. cmd_help_custom.lua)
-# rather than editing the bundled scripts; with that pattern you can
-# keep the auto-sync ON.
+# preserve those edits across image upgrades. Disables both the
+# .lua overwrite-on-diff sync and the lang/ add-only sync. The
+# recommended pattern for plugin customization is a NEW filename
+# (e.g. cmd_help_custom.lua) rather than editing the bundled
+# scripts; with that pattern you can keep the auto-sync ON.
 #
 # LUADCH_AUTOSYNC_SCRIPTS=1

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -48,10 +48,12 @@ mkdir -p "${LUADCH_HOME}/log"
 # This block fixes that for the narrow case of TOP-LEVEL .lua files
 # (the bundled plugin code). It does NOT touch:
 #
-#   scripts/lang/*.lang.*  - operator-customized translations / MOTD
 #   scripts/data/*.tbl     - runtime state (bans, regs, plugin caches)
 #   scripts/cfg/*.tbl      - per-plugin operator settings
 #   scripts/<dir>/         - any other subdirectory
+#
+# scripts/lang/*.lang.* is handled separately in block 1c below
+# (add-only, never overwrite).
 #
 # Operators who hand-patched a bundled .lua (rare, discouraged) can
 # disable this with LUADCH_AUTOSYNC_SCRIPTS=0 in their .env. The
@@ -74,6 +76,43 @@ if [ "${LUADCH_AUTOSYNC_SCRIPTS:-1}" = "1" ]; then
     done
     if [ "$updated" -gt 0 ]; then
         log "auto-synced ${updated} bundled scripts from /defaults"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 1c. Auto-add NEW bundled scripts/lang/*.lang.* from /defaults
+# ---------------------------------------------------------------------------
+# When a release ships a new plugin or adds i18n infrastructure to an
+# existing one, the bundled .lua lands via 1b but the matching language
+# files never reach the operator's mounted scripts/lang/ directory -
+# the seed in block 1 only fires for an empty mount. The script then
+# falls back to its hardcoded English defaults, silently for English
+# operators but visibly broken for non-English ones.
+#
+# This block closes the gap with a STRICTLY ADD-ONLY copy: bundled
+# .lang.* files that don't exist on the operator's mount are added,
+# but existing files are NEVER overwritten. That preserves any
+# operator-customized translations / MOTD strings - the same
+# "operator's edits are sacred" rule the lang/ tree was carved out
+# from 1b for.
+#
+# Same LUADCH_AUTOSYNC_SCRIPTS=0 escape hatch as 1b. Idempotent on
+# steady-state restarts (target exists -> skipped).
+if [ "${LUADCH_AUTOSYNC_SCRIPTS:-1}" = "1" ]; then
+    added=0
+    mkdir -p "${LUADCH_HOME}/scripts/lang"
+    for f in "${DEFAULTS}"/scripts/lang/*.lang.*; do
+        [ -f "$f" ] || continue
+        n=$(basename "$f")
+        target="${LUADCH_HOME}/scripts/lang/${n}"
+        if [ ! -e "$target" ]; then
+            cp "$f" "$target"
+            log "auto-added new bundled lang file: ${n}"
+            added=$((added + 1))
+        fi
+    done
+    if [ "$added" -gt 0 ]; then
+        log "auto-added ${added} new bundled lang files from /defaults"
     fi
 fi
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -307,13 +307,21 @@ The container's entrypoint **auto-syncs the bundled top-level
 directory on every start. Bug-fixes we ship in plugin code reach
 your hub on the next image pull without manual action.
 
+In addition, **new bundled `scripts/lang/*.lang.*` files are
+add-only**: language files that don't exist on your mount get copied
+in, but existing translations are NEVER overwritten. This way a
+release that adds i18n to a previously English-only plugin reaches
+non-English operators without them having to chase down the new
+`.lang.de` / `.lang.fr` files manually, while any operator-customized
+translations stay intact.
+
 What is **not** touched:
 
 | Path | Reason |
 |---|---|
 | `cfg/cfg.tbl` | Your settings; new defaults are merged at runtime via the `cfg.get()` fallback path |
 | `cfg/user.tbl`, `cfg/user.tbl.bak` | User database |
-| `scripts/lang/*.lang.*` | Your translations / MOTD customizations |
+| `scripts/lang/*.lang.*` (existing) | Your translations / MOTD customizations stay; only NEW bundled language files are added |
 | `scripts/data/*.tbl` | Plugin runtime state (bans, regs, caches) |
 | `scripts/cfg/*.tbl` | Per-plugin operator settings |
 | `scripts/<your-custom>.lua` | Custom plugins keep their distinct filenames - the auto-sync only touches files that exist in the image's `/defaults/scripts/` |
@@ -325,10 +333,13 @@ The entrypoint logs each updated file:
 ```
 [entrypoint] auto-synced bundled script: cmd_nickchange.lua
 [entrypoint] auto-synced 1 bundled scripts from /defaults
+[entrypoint] auto-added new bundled lang file: usr_nick_length.lang.de
+[entrypoint] auto-added 1 new bundled lang files from /defaults
 ```
 
 If a bundled script's content matches what's already on disk, it is
-skipped (idempotent on restart).
+skipped (idempotent on restart). Lang files are likewise skipped
+when they already exist, regardless of content.
 
 ### Opting out of auto-sync
 
@@ -339,8 +350,10 @@ edits across image upgrades, set in your `.env`:
 LUADCH_AUTOSYNC_SCRIPTS=0
 ```
 
-In that mode, image bug-fixes stop reaching your hub automatically.
-You will need to copy them manually:
+The toggle disables both the `scripts/*.lua` overwrite-on-diff sync
+and the `scripts/lang/*` add-only sync. Image bug-fixes and new
+language files stop reaching your hub automatically. You will need
+to copy them manually:
 
 ```sh
 # Diff: which bundled scripts in your mount differ from the new image
@@ -349,6 +362,14 @@ docker compose exec luadch sh -c '
         n=$(basename "$f")
         cmp -s "$f" "/opt/luadch/scripts/$n" 2>/dev/null \
             || echo "differs: $n"
+    done
+'
+
+# Find: which bundled lang files are missing on your mount
+docker compose exec luadch sh -c '
+    for f in /defaults/scripts/lang/*.lang.*; do
+        n=$(basename "$f")
+        [ -e "/opt/luadch/scripts/lang/$n" ] || echo "missing: $n"
     done
 '
 


### PR DESCRIPTION
Closes the gap that surfaced when reviewing #117: a release that adds i18n to a previously English-only plugin (e.g. `usr_nick_length` getting `lang.{en,de}` files in #117) cannot reach existing Docker deployments via the autosync, because the existing autosync skipped `scripts/lang/` by design.

## What lands

A second, **add-only** sync pass in `docker/entrypoint.sh`:

```sh
for f in "${DEFAULTS}"/scripts/lang/*.lang.*; do
    n=$(basename "$f")
    target="${LUADCH_HOME}/scripts/lang/${n}"
    if [ ! -e "$target" ]; then
        cp "$f" "$target"
        ...
    fi
done
```

- New bundled `*.lang.*` files land on the operator's mount automatically.
- Existing files are **never overwritten** - operator-customized translations / MOTD strings stay intact (the same rule the `scripts/lang/` tree was carved out from the existing `*.lua` autosync for).
- Same `LUADCH_AUTOSYNC_SCRIPTS=0` escape hatch covers this pass too.
- Idempotent: target exists -> skipped, regardless of content.

## Why ADD-only and not overwrite-on-diff

The existing `scripts/*.lua` autosync overwrites bundled-but-different files on the assumption that operator edits to bundled `.lua` files are rare (and discouraged - `etc_my_motd_custom.lua` is the recommended pattern). That assumption is much weaker for translations: operators routinely tune wording in `*.lang.*` for their hub's tone, and those edits are the whole point of the language file split.

So we keep the protection: lang files only land on first sight. If the bundle later changes a default string, operators who care can diff and re-pull manually (the `Opting out of auto-sync` section of `docs/DOCKER.md` shows the diff command).

## Files

- `docker/entrypoint.sh` - new block 1c after the existing 1b. 1b's comment about `scripts/lang/*.lang.*` updated to point at 1c.
- `docs/DOCKER.md` - "What gets updated automatically" describes the add-only behavior; "What is not touched" clarifies that *existing* lang files stay; "Opting out of auto-sync" explicitly mentions both syncs disable together; entrypoint-log example shows the new line; new diff command for finding missing lang files.
- `.env.example` - `LUADCH_AUTOSYNC_SCRIPTS` block updated to describe the dual behavior.

## Test plan

- [x] `sh -n docker/entrypoint.sh` clean.
- [x] Mental walkthrough of three scenarios (fresh container - block 1 seeds everything, block 1c is no-op; upgrade with new lang file - block 1c adds it; restart with no new bundle - block 1c is no-op).

The smoke harness doesn't cover the Docker entrypoint, so the verification is shell-syntax + careful inspection. The change is small and additive.

## v3.1.6 fit

Pairs cleanly with #117 (which adds the first new bundled `*.lang.*` files since the autosync was introduced in #110). Operators upgrading to 3.1.6 get the new `usr_nick_length.lang.{en,de}` automatically; future releases that add i18n elsewhere benefit from the same path.

If we don't merge this for 3.1.6, the release-notes for #117 would need a "manual lang file copy" warning. With this merged, the release-notes can stay clean.