### PR TITLE
fix(security): redact passwords in admin reply paths (refs #95)

### DIFF
--- a/scripts/cmd_accinfo.lua
+++ b/scripts/cmd_accinfo.lua
@@ -5,6 +5,16 @@
         - this script adds a command "accinfo" get infos about a reguser
         - usage: [+!#]accinfo sid|nick <SID>|<NICK> / [+!#]accinfoop sid|nick <SID>|<NICK>
 
+        v0.32: by Aybo
+            - redact the password column in both output formats. The
+              hub stores ADC passwords as cleartext-equivalent (HPAS
+              challenge-response is protocol-mandated; F-AUTH-1) so
+              echoing them back through chat / PM puts copies into
+              client-side chat logs unnecessarily. Admins who genuinely
+              need to know a registered user's password should reset
+              it via +setpass instead of reading it from accinfo.
+              Sub-task of #95.
+
         v0.31: by pulsar
             - added "hub_email" to output msg
                 - request by Sopor / fix #185 -> https://github.com/luadch/luadch/issues/185
@@ -131,7 +141,7 @@
 --------------
 
 local scriptname = "cmd_accinfo"
-local scriptversion = "0.31"
+local scriptversion = "0.32"
 
 local cmd = "accinfo"
 local cmd2 = "accinfoop"
@@ -176,6 +186,7 @@ local msg_hours = lang.msg_hours or " hours, "
 local msg_minutes = lang.msg_minutes or " minutes, "
 local msg_seconds = lang.msg_seconds or " seconds"
 local msg_unknown = lang.msg_unknown or "<UNKNOWN>"
+local msg_redacted = lang.msg_redacted or "<REDACTED>"
 local msg_online = lang.msg_online or "user is online"
 local msg_keyprint = lang.msg_keyprint or "  (with Keyprint)"
 local msg_accinfo = lang.msg_accinfo or [[
@@ -446,7 +457,7 @@ local onbmsg = function( user, command, parameters )
     local accinfo = utf.format(
         msg_accinfo2,
         target.nick or msg_unknown,
-        target.password or msg_unknown,
+        msg_redacted,
         targetlevel or msg_unknown,
         targetlevelname or msg_unknown,
         target.by or msg_unknown,
@@ -508,7 +519,7 @@ hub.setlistener( "onBroadcast", {},
             local accinfo = utf.format(
                 msg_accinfo,
                 target.nick or msg_unknown,
-                target.password or msg_unknown,
+                msg_redacted,
                 targetlevel or msg_unknown,
                 targetlevelname or msg_unknown,
                 target.by or msg_unknown,

--- a/scripts/cmd_setpass.lua
+++ b/scripts/cmd_setpass.lua
@@ -6,6 +6,16 @@
         - usage: [+!#]setpass nick <nick> <password>
         - [+!#]setpass myself <password> sets your own pasword
 
+        v0.21: by Aybo
+            - drop the password echo from the *caller's* reply: when an admin
+              types `+setpass nick Bob ...` they already know the value;
+              echoing it back puts the cleartext into their chat history for
+              no benefit. The *target* (Bob) still gets the new password via
+              msg_ok2 - they need it to log in. Same fix on the
+              `+setpass myself ...` path: caller IS target, knows the value.
+              Closes one of four sub-tasks of #95; cmd_reg auto-generated
+              passwords stay as-is (Phase-8 design call).
+
         v0.20: by pulsar
             - rightclick visibility according to minlevel; fix #179  / thx Sopor
 
@@ -88,7 +98,7 @@
 --------------
 
 local scriptname = "cmd_setpass"
-local scriptversion = "0.20"
+local scriptversion = "0.21"
 
 local cmd = "setpass"
 
@@ -118,7 +128,7 @@ local msg_denied = lang.msg_denied or "You are not allowed to use this command."
 local msg_nochange = lang.msg_nochange or "There are no changes needed."
 local msg_god = lang.msg_god or "You are not allowed to change the nick of this user."
 local msg_reg = lang.msg_reg or "User is not regged or a bot."
-local msg_ok = lang.msg_ok or "Password was changed to: "
+local msg_ok = lang.msg_ok or "Password was changed."
 local msg_ok2 = lang.msg_ok2 or "Your Password was changed to: "
 local msg_usage = lang.msg_usage or "Usage: [+!#]setpass nick <NICK> <PASS>  /  [+!#]setpass nick myself <PASS>"
 local msg_min_length = lang.msg_min_length or "Minimum length of the Password is: %s"
@@ -203,7 +213,7 @@ onbmsg = function( user, command, parameters )
                             return PROCESSED
                         else
                             user_tbl[ k ].password = pass
-                            user:reply( msg_ok .. pass, hub.getbot() )
+                            user:reply( msg_ok, hub.getbot() )
                             cfg.saveusers( user_tbl )
                             return PROCESSED
                         end
@@ -223,7 +233,7 @@ onbmsg = function( user, command, parameters )
                             return PROCESSED
                         else
                             user_tbl[ k ].password = pass
-                            user:reply( msg_ok .. pass, hub.getbot() )
+                            user:reply( msg_ok, hub.getbot() )
                             if target then
                                 target:reply( msg_ok2 .. pass, hub.getbot(), hub.getbot() )
                             end
@@ -250,7 +260,7 @@ onbmsg = function( user, command, parameters )
                                     return PROCESSED
                                 else
                                     user_tbl[ k ].password = pass
-                                    user:reply( msg_ok .. pass, hub.getbot() )
+                                    user:reply( msg_ok, hub.getbot() )
                                     cfg.saveusers( user_tbl )
                                     return PROCESSED
                                 end
@@ -264,7 +274,7 @@ onbmsg = function( user, command, parameters )
                                     return PROCESSED
                                 else
                                     user_tbl[ k ].password = pass
-                                    user:reply( msg_ok .. pass, hub.getbot() )
+                                    user:reply( msg_ok, hub.getbot() )
                                     target:reply( msg_ok2 .. pass, hub.getbot(), hub.getbot() )
                                     cfg.saveusers( user_tbl )
                                     return PROCESSED

--- a/scripts/cmd_usersearch.lua
+++ b/scripts/cmd_usersearch.lua
@@ -4,6 +4,14 @@
 
         usage: [+!#]usersearch <searchstring>
 
+        v1.5: by Aybo
+            - redact the password column in result rows. Permission-denied
+              results still get the existing "<Not allowed to view>" string;
+              permitted results now show "<REDACTED>" instead of the actual
+              password value. Same reasoning as cmd_accinfo: don't echo the
+              cleartext-equivalent password through chat / PM into client
+              chat logs. Sub-task of #95.
+
         v1.4: by pulsar
             - added "years" to util.formatseconds
                 - changed get_lastlogout()
@@ -62,7 +70,7 @@
 --------------
 
 local scriptname = "cmd_usersearch"
-local scriptversion = "1.4"
+local scriptversion = "1.5"
 
 local cmd = "usersearch"
 
@@ -94,6 +102,7 @@ local msg_result_nick = lang.msg_result_nick or "\n\tNick: %s"
 local msg_no_matches = lang.msg_no_matches or "No matches found"
 local msg_no_allowed = lang.msg_no_allowed or "<Not allowed to view>"
 local msg_unknown = lang.msg_unknown or "<unknown>"
+local msg_redacted = lang.msg_redacted or "<REDACTED>"
 local msg_denied = lang.msg_denied or "You are not allowed to use this command."
 local msg_online = lang.msg_online or "user is online"
 
@@ -159,7 +168,7 @@ local onbmsg = function( user, command, parameters )
                         msg_result,
                         u.nick,
                         u.level or msg_unknown,
-                        ( ( user_level == 100 ) or ( user_level > ( u.level or 0 ) ) ) and ( u.password or msg_unknown ) or msg_no_allowed,
+                        ( ( user_level == 100 ) or ( user_level > ( u.level or 0 ) ) ) and msg_redacted or msg_no_allowed,
                         u.by or msg_unknown,
                         u.date or msg_unknown,
                         get_lastlogout( u ) )

--- a/scripts/lang/cmd_accinfo.lang.de
+++ b/scripts/lang/cmd_accinfo.lang.de
@@ -6,6 +6,7 @@
     msg_god = "Du bist nicht befugt die Accinfo dieses Users abzufragen",
 
     msg_unknown = "<UNBEKANNT>",
+    msg_redacted = "<REDACTED>",
     msg_online = "User ist online",
     msg_keyprint = "  (mit Keyprint)",
     msg_accinfo = [[

--- a/scripts/lang/cmd_accinfo.lang.en
+++ b/scripts/lang/cmd_accinfo.lang.en
@@ -6,6 +6,7 @@
     msg_god = "You are not allowed to view the accinfo from this user",
 
     msg_unknown = "<UNKNOWN>",
+    msg_redacted = "<REDACTED>",
     msg_online = "user is online",
     msg_keyprint = "  (with Keyprint)",
     msg_accinfo = [[

--- a/scripts/lang/cmd_setpass.lang.de
+++ b/scripts/lang/cmd_setpass.lang.de
@@ -5,7 +5,7 @@
     msg_usage = "Gebrauch: [+!#]setpass nick <NICK> <PASS>  /  [+!#]setpass nick myself <PASS>",
     msg_god = "Du bist nicht befugt das Passwort dieses Users zu ändern.",
     msg_reg = "User ist nicht gereggt oder ein Bot.",
-    msg_ok = "Passwort wurde geändert zu: ",
+    msg_ok = "Passwort wurde geändert.",
     msg_ok2 = "Dein Passwort wurde geändert zu: ",
     msg_min_length = "Die minimale Passwortlänge ist: %s",
     msg_max_length = "Die maximale Passwortlänge ist: %s",

--- a/scripts/lang/cmd_setpass.lang.en
+++ b/scripts/lang/cmd_setpass.lang.en
@@ -5,7 +5,7 @@
     msg_usage = "Usage: [+!#]setpass nick <NICK> <PASS>  /  [+!#]setpass nick myself <PASS>",
     msg_god = "You are not allowed to change the password of this user.",
     msg_reg = "User is not regged or a bot.",
-    msg_ok = "Password was changed to: ",
+    msg_ok = "Password was changed.",
     msg_ok2 = "Your Password was changed to: ",
     msg_min_length = "Minimum length of the Password is: %s",
     msg_max_length = "Maximum length of the Password is: %s",

--- a/scripts/lang/cmd_usersearch.lang.de
+++ b/scripts/lang/cmd_usersearch.lang.de
@@ -14,6 +14,7 @@
     msg_no_matches = "Keine Übereinstimmung gefunden",
     msg_no_allowed = "Keine ausreichende Berechtigung",
     msg_unknown = "<UNBEKANNT>",
+    msg_redacted = "<REDACTED>",
     msg_denied = "Du bist nicht befugt diesen Befehl zu nutzen.",
     msg_online = "User ist online",
 

--- a/scripts/lang/cmd_usersearch.lang.en
+++ b/scripts/lang/cmd_usersearch.lang.en
@@ -14,6 +14,7 @@
     msg_no_matches = "No matches found",
     msg_no_allowed = "Not allowed to view",
     msg_unknown = "<UNKNOWN>",
+    msg_redacted = "<REDACTED>",
     msg_denied = "You are not allowed to use this command.",
     msg_online = "user is online",
 


### PR DESCRIPTION
Refs #95.

Closes three of four sub-tasks of #95. The fourth - `cmd_reg` auto-generated password delivery - is intentionally deferred. It requires either alternate delivery infrastructure ([#100](https://github.com/luadch-ng/luadch/issues/100) SMTP) or a UX-redesign of the `+reg` flow, both Phase-8+ scope. The auto-generated password still reaches admin AND target via PM so the new user can actually log in.

## What lands

### `cmd_setpass.lua`

Drop the password echo from the **caller's** reply. The caller typed the value themselves; echoing it back puts cleartext into their own chat history for no benefit. The **target's** reply via `msg_ok2` still carries the new password verbatim - the target needs it to log in.

Concrete behaviour:

| Command | Caller's reply | Target's reply |
|---|---|---|
| `+setpass myself geheim2026` | `Password was changed.` | (caller IS target - same line) |
| `+setpass nick Bob geheim2026` | `Password was changed.` | `Your Password was changed to: geheim2026` |

Same fix applied to all four caller-reply sites (myself + admin-target, in both the main and the `nicku`/prefix lookup branches). Default and bundled `msg_ok` adjusted from `"Password was changed to: "` to a complete sentence `"Password was changed."`.

### `cmd_accinfo.lua`

Replace the `Password: %s` column value with `msg_redacted` (`<REDACTED>`) in both `msg_accinfo` and `msg_accinfo2` output formats. ADC mandates the hub know the cleartext password (HPAS challenge-response, F-AUTH-1 disclosure); echoing it back through chat / PM puts client-side copies into chat logs for no good reason. Admins who genuinely need to change a registered user's password should reset it via `+setpass` instead of reading it from accinfo.

### `cmd_usersearch.lua`

Same redaction in the result row. The existing permission gate (caller-level >= target-level required to see password) stays in place:

- Permission-denied result -> `<Not allowed to view>` (unchanged)
- Permission-granted result -> `<REDACTED>` (was: actual password value)

### Lang keys

New bundled key `msg_redacted = "<REDACTED>"` added to:

- `scripts/lang/cmd_accinfo.lang.{en,de}`
- `scripts/lang/cmd_usersearch.lang.{en,de}`

`cmd_setpass` reuses the existing `msg_ok` key with adjusted wording - no new keys, but operators with custom `cmd_setpass.lang.{en,de}` who customized `msg_ok` to read like a sentence-prefix (`"Password was changed to: "`) will see their old wording sit next to a missing value. Cosmetic only; behaviour is correct.

If [#118](https://github.com/luadch-ng/luadch/pull/118) (Docker lang autosync) is merged first, Docker operators get the new lang keys for `cmd_accinfo` and `cmd_usersearch` automatically. Otherwise, operators with German/English customised lang files for those two scripts won't see `<REDACTED>` translated into their custom set until they manually add the key (the script falls back to the hardcoded English `<REDACTED>` default, so it works regardless).

## Test plan

- [x] `cmake --build build` clean.
- [x] `cmake --install build` lands the new lang keys.
- [x] `python tests\smoke\run.py build/install/luadch` -> 14/14 PASS, including the `+setpass preserves encryption` regression test (#92) which exercises the actual setpass path end-to-end.
- [x] Manual code-trace of all four `cmd_setpass` reply sites + the two `cmd_accinfo` format calls + the `cmd_usersearch` ternary.
- [x] `cmd_reg.lua` confirmed untouched (the auto-gen path on lines 300 and 357).

## v3.1.6 fit

Pure-security change, fits the v3.1.6 security-themed batch (alongside #113 TLS-only and #109 atomic write).

## Issue #95 status after this

After merge the issue stays open with three of four acceptance items checked. Comment to add:

```
PR #119 closed:
- [x] +setpass: caller reply no longer contains the new password verbatim.
- [x] +accinfo: password column shows <REDACTED>.
- [x] +usersearch: password column shows <REDACTED>.

Still open (Phase-8+):
- [ ] +reg: auto-generated password still goes to both admin and target
      via PM. Re-design depends on either #100 (SMTP) or a token-based
      first-login flow.
```