### PR TITLE
release: prepare v3.1.6 (TLS-only default + password redaction + Docker lang autosync)

### DIFF
--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,44 +1,76 @@
-# Luadch v3.1.5
+# Luadch v3.1.6
 
-Patch release. Closes upstream `luadch/luadch#189` (registered users disappearing) and adds image-side auto-sync of bundled plugin code on `docker compose pull`.
+Security-themed patch release. Hub now defaults to TLS-only with an auto-generated self-signed cert on first boot, password leakage in admin reply paths is closed for `+setpass` / `+accinfo` / `+usersearch`, and Docker deployments pick up new bundled language files automatically.
 
 ## ⚠️ Before upgrading
 
-Back up your `cfg/`, `scripts/lang/`, `scripts/data/`, `scripts/cfg/`, `certs/`, and `secrets/` directories. Bundled `scripts/*.lua` are auto-synced from the image; everything else is operator-owned and never touched by an upgrade, but a clean snapshot is the safety net for any production hub.
+Back up your `cfg/`, `scripts/lang/`, `scripts/data/`, `scripts/cfg/`, `certs/`, and `secrets/` directories. This release touches lang files in particular - if you have customised translations for `cmd_accinfo`, `cmd_setpass`, or `cmd_usersearch`, see the **Lang file changes** section below before letting the autosync run.
 
 ```sh
 tar -czf "luadch-backup-$(date +%F).tar.gz" cfg scripts certs secrets
 ```
 
-## Bugfixes
+## Lang file changes
 
-- [#108](https://github.com/luadch-ng/luadch/issues/108) / [upstream luadch#189](https://github.com/luadch/luadch/issues/189) - registered users no longer disappear from `user.tbl`. Stale file-scope cache in `cmd_nickchange.lua` + non-atomic `saveusers` were the two root causes; both fixed in [#109](https://github.com/luadch-ng/luadch/pull/109).
+This release adds new lang keys and one renamed value. Operators with stock bundled lang files (`scripts/lang/<plugin>.lang.{en,de}`) get all of this automatically via the Docker autosync introduced in [#118](https://github.com/luadch-ng/luadch/pull/118), or via `cmake --install build` for source builds. Operators with **custom** lang files have a small one-time merge:
+
+| Plugin | What changed |
+|---|---|
+| `cmd_accinfo.lang.{en,de}` | New key: `msg_redacted = "<REDACTED>"`. Falls back to the hardcoded English default if missing. |
+| `cmd_usersearch.lang.{en,de}` | Same new key: `msg_redacted = "<REDACTED>"`. |
+| `cmd_setpass.lang.{en,de}` | Existing `msg_ok` rewritten: `"Password was changed to: "` -> `"Password was changed."` (no longer concatenates the password value). Custom translations that read like a sentence-prefix will sit next to a missing value cosmetically; behaviour is correct regardless. |
+| `usr_nick_length.lang.{en,de}` | New file - previously the script had no lang infrastructure. Two keys: `msg_failedauth_reason`, `msg_invalid_length`. |
+
+## Breaking
+
+- **TLS-only default** ([#77](https://github.com/luadch-ng/luadch/issues/77) / [#113](https://github.com/luadch-ng/luadch/pull/113)) - the bundled `cfg/cfg.tbl` now ships with `tcp_ports = { }`, `ssl_ports = { 5001 }`, `use_ssl = true`. Existing `cfg/cfg.tbl` files are **not migrated** - operators upgrading keep their plain-port settings until they choose to flip. Fresh installs and Docker first-boot are TLS-only by default.
 
 ## Features
 
-- Docker entrypoint auto-syncs bundled `scripts/*.lua` from the image to the mounted `scripts/` directory on every container start ([#110](https://github.com/luadch-ng/luadch/pull/110)). Operator-owned state untouched. Opt-out: `LUADCH_AUTOSYNC_SCRIPTS=0`. See [`docs/DOCKER.md`](https://github.com/luadch-ng/luadch/blob/v3.1.5/docs/DOCKER.md).
+- **Auto-generated self-signed cert on first boot** ([#113](https://github.com/luadch-ng/luadch/pull/113)) - if `certs/servercert.pem` / `serverkey.pem` are missing, the hub generates a P-256 ECDSA pair via adclib's OpenSSL bindings and writes them to disk before the TLS listener binds. Keyprint logged to stdout in the boot banner so `docker compose logs` / the launching terminal shows the `adcs://host:port/?kp=SHA256/<base32>` URL to share with users. `make_cert.{sh,bat}` stay around for manual rotation; the entrypoint no longer runs them.
+- **Slaxml XML parser bundled** ([#112](https://github.com/luadch-ng/luadch/pull/112)) - `lib/slaxml/slaxml.lua` is now part of the install tree. Plugins can `use "slaxml"` for RSS / XML feed parsing without a separate dep install.
+- **Docker autosync extended to lang files** ([#118](https://github.com/luadch-ng/luadch/pull/118)) - new bundled `scripts/lang/*.lang.*` files land on operator mounts automatically. Strictly add-only, existing translations are never overwritten. The same `LUADCH_AUTOSYNC_SCRIPTS=0` opt-out covers both the `*.lua` overwrite-on-diff sync and the new lang add-only sync.
+
+## Bugfixes
+
+- **Password redaction in admin reply paths** ([#95](https://github.com/luadch-ng/luadch/issues/95) partial / [#119](https://github.com/luadch-ng/luadch/pull/119)):
+  - `+setpass` drops the password from the **caller's** reply. The target user still receives the new password via PM (admin-sets-target case) - they need it to log in.
+  - `+accinfo` and `+usersearch` show `<REDACTED>` in the password column instead of the cleartext value.
+  - `+reg` auto-generated password delivery is **intentionally unchanged** - target needs the value to log in. The `cmd_reg` redesign is Phase-8+ scope and depends on either an alternate delivery channel ([#100](https://github.com/luadch-ng/luadch/issues/100) SMTP) or a token-based first-login flow.
+- **`usr_nick_length` localisation** ([#48](https://github.com/luadch-ng/luadch/issues/48) i18n half / [#117](https://github.com/luadch-ng/luadch/pull/117)) - operator-facing `onFailedAuth` reason and user-facing `ISTA 221` kill message now route through the new `scripts/lang/usr_nick_length.lang.{en,de}`.
+- **Plugin-header grammar fix** ([#114](https://github.com/luadch-ng/luadch/issues/114) / [#116](https://github.com/luadch-ng/luadch/pull/116)) - `'an user'` -> `'a user'` across nine bundled plugin headers. Comment-only.
 
 ## Notes
 
-- `user.tbl.bak` now refreshed on every successful save (was: only at `+reload`). Operators relying on `.bak` as a stale-rollback should adjust workflows.
-- Smoke harness: 12 -> 13 tests.
+- Bug-report and feature-request issue templates added under `.github/ISSUE_TEMPLATE/`.
+- Smoke harness: 14/14 PASS on Linux + Windows (no test count change in this release; existing tests cover the new behaviour).
 
 ## Downloads
 
 | File | Platform |
 |---|---|
-| `luadch-v3.1.5-linux-x86_64.tar.gz` | Linux glibc x86_64 |
-| `luadch-v3.1.5-windows-x86_64.zip`  | Windows x86_64 (MinGW UCRT64) |
-| `ghcr.io/luadch-ng/luadch:v3.1.5`   | Container, linux/amd64 + linux/arm64 |
+| `luadch-v3.1.6-linux-x86_64.tar.gz` | Linux glibc x86_64 |
+| `luadch-v3.1.6-windows-x86_64.zip`  | Windows x86_64 (MinGW UCRT64) |
+| `ghcr.io/luadch-ng/luadch:v3.1.6`   | Container, linux/amd64 + linux/arm64 |
 
-## Migration from v3.1.4
+## Migration from v3.1.5
 
-None required. Drop the new install tree in place of the old one (or `git pull && cmake --build build && cmake --install build` from source). Container users get the auto-sync of bundled `scripts/*.lua` on the next `docker compose up -d` after `pull`.
+Drop the new install tree in place of the old one (or `git pull && cmake --build build && cmake --install build` from source). Container users get both the bundled `*.lua` sync and the new lang add-only sync on the next `docker compose up -d` after `pull`.
+
+If you want to flip to TLS-only on an existing deployment, edit `cfg/cfg.tbl`:
+
+```lua
+tcp_ports = { },
+ssl_ports = { 5001 },
+use_ssl = true,
+```
+
+then `+reload` (or restart the container). The hub's auto-cert-gen path picks up the missing `certs/serverkey.pem` / `servercert.pem` and writes a fresh self-signed pair before binding the listener.
 
 ## Build from source
 
 ```sh
-git clone --branch v3.1.5 https://github.com/luadch-ng/luadch.git
+git clone --branch v3.1.6 https://github.com/luadch-ng/luadch.git
 cd luadch
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The upstream project (`luadch/luadch`) is a separate codebase; its release
 history is at https://github.com/luadch/luadch/releases.
 
+## [v3.1.6] - 2026-05-09
+
+Security-themed patch release. Hub now defaults to TLS-only with auto-generated self-signed certs on first boot, the password leakage in admin reply paths is closed for `+setpass` / `+accinfo` / `+usersearch`, and Docker deployments pick up new bundled language files automatically. Smoke 14/14 PASS on Linux + Windows.
+
+### Breaking
+
+- Default `cfg/cfg.tbl` ships TLS-only ([#77](https://github.com/luadch-ng/luadch/issues/77) / [#113](https://github.com/luadch-ng/luadch/pull/113)): `tcp_ports = { }`, `ssl_ports = { 5001 }`, `use_ssl = true`. Existing `cfg/cfg.tbl` files are not migrated - operators upgrading from v3.1.5 keep their plain-port settings unless they choose to flip. Fresh installs and Docker first-boot are TLS-only.
+
+### Features
+
+- Auto-generated self-signed P-256 ECDSA cert on first boot when no `servercert.pem` / `serverkey.pem` exists ([#113](https://github.com/luadch-ng/luadch/pull/113)). Pure-Lua + adclib OpenSSL bindings, no `make_cert.{sh,bat}` needed. Keyprint logged to stdout so `docker compose logs` shows it for the operator to share as `adcs://host:port/?kp=SHA256/<base32>`.
+- Bundled `slaxml` XML parser at `lib/slaxml/` ([#112](https://github.com/luadch-ng/luadch/pull/112)). Plugins that need to parse XML (e.g. RSS feeds) can now `use "slaxml"` without a separate dep install.
+- Docker entrypoint now also adds new bundled `scripts/lang/*.lang.*` files on container start ([#118](https://github.com/luadch-ng/luadch/pull/118)). Strictly add-only - existing translations are never overwritten. Same `LUADCH_AUTOSYNC_SCRIPTS=0` toggle covers both the `*.lua` overwrite-on-diff sync and the new lang add-only sync.
+
+### Bugfixes
+
+- [#95](https://github.com/luadch-ng/luadch/issues/95) - password no longer echoed in admin reply paths ([#119](https://github.com/luadch-ng/luadch/pull/119)). `+setpass` drops the password from the caller's reply (target still receives it via PM, needed for first login); `+accinfo` and `+usersearch` show `<REDACTED>` in the password column. The `+reg` auto-generated password delivery is intentionally unchanged - target needs the value to log in. Three of four sub-tasks of #95 closed.
+- [#48](https://github.com/luadch-ng/luadch/issues/48) - `usr_nick_length` now routes its `onFailedAuth` reason and the `ISTA 221` kill message through `scripts/lang/usr_nick_length.lang.{en,de}` instead of hardcoded English ([#117](https://github.com/luadch-ng/luadch/pull/117)). Operator-facing string lands localised in `cmd.log` and any blacklist plugin listening on `onFailedAuth`.
+- [#114](https://github.com/luadch-ng/luadch/issues/114) - grammar fix `'an user'` -> `'a user'` in nine plugin headers across `scripts/` and `examples/etc/other_available_scripts/` ([#116](https://github.com/luadch-ng/luadch/pull/116)). Comment-only.
+
+### Notes
+
+- New bundled lang files: `scripts/lang/usr_nick_length.lang.{en,de}`. New lang keys: `msg_redacted` in `cmd_accinfo.lang.{en,de}` and `cmd_usersearch.lang.{en,de}`. Modified key: `msg_ok` in `cmd_setpass.lang.{en,de}` (reads as a complete sentence after the password drop). Operators with custom lang files for these scripts: see release-body for the per-script delta.
+- Bug-report and feature-request issue templates added under `.github/ISSUE_TEMPLATE/`.
+
+[v3.1.6]: https://github.com/luadch-ng/luadch/releases/tag/v3.1.6
+
+
 ## [v3.1.5] - 2026-05-07
 
 Patch release on top of v3.1.4. Drop-in upgrade. Closes upstream `luadch/luadch#189` (registered users disappearing) and adds image-side auto-sync of bundled plugin code. Smoke 13/13 PASS on Linux + Windows.

--- a/core/const.lua
+++ b/core/const.lua
@@ -11,7 +11,7 @@
 return {
 
     PROGRAM_NAME = "Luadch",
-    VERSION = "v3.1.5",
+    VERSION = "v3.1.6",
     COPYRIGHT = "by blastbeat and pulsar",
     FORK = "modernised fork by Aybo",
     CONFIG_PATH = "././cfg/",


### PR DESCRIPTION
Release-prep PR for **v3.1.6**.

## Bundled PRs (already merged on master)

| PR | Type | What |
|---|---|---|
| [#112](https://github.com/luadch-ng/luadch/pull/112) | feat(deps) | Bundle slaxml XML parser at `lib/slaxml/` |
| [#113](https://github.com/luadch-ng/luadch/pull/113) | feat(security) | TLS-only default + auto-cert-gen on first boot (closes [#77](https://github.com/luadch-ng/luadch/issues/77)) |
| [#116](https://github.com/luadch-ng/luadch/pull/116) | docs | Grammar fix `'an user'` -> `'a user'` (closes [#114](https://github.com/luadch-ng/luadch/issues/114)) |
| [#117](https://github.com/luadch-ng/luadch/pull/117) | fix | `usr_nick_length` i18n (refs [#48](https://github.com/luadch-ng/luadch/issues/48)) |
| [#118](https://github.com/luadch-ng/luadch/pull/118) | feat(docker) | Add-only autosync for bundled `scripts/lang/*.lang.*` |
| [#119](https://github.com/luadch-ng/luadch/pull/119) | fix(security) | Password redaction in admin reply paths (refs [#95](https://github.com/luadch-ng/luadch/issues/95)) |

Plus issue templates added under `.github/ISSUE_TEMPLATE/` (commit 42ffea0, no PR).

## What this PR does

Three files only - no new code, just the release artifacts:

- `core/const.lua`: `VERSION = "v3.1.5"` -> `"v3.1.6"`
- `CHANGELOG.md`: new section above v3.1.5 with Breaking / Features / Bugfixes / Notes layout
- `.github/release-body.md`: rewritten for v3.1.6, ⚠️ backup section first, **Lang file changes** table flagging the per-script delta for operators with custom translations

## Release narrative

> Security-themed patch release. Hub now defaults to TLS-only with an auto-generated self-signed cert on first boot, password leakage in admin reply paths is closed for `+setpass` / `+accinfo` / `+usersearch`, and Docker deployments pick up new bundled language files automatically.

Notable: this is the first release where the **default config flips a network-listener setting**. Existing `cfg/cfg.tbl` files are not migrated (per #113's design); fresh installs and Docker first-boot are TLS-only out of the box. The release body's Migration section walks through the manual flip for upgraders who want to switch.

## Test plan

- [x] `cmake --build build` clean (no source changes in this PR; verifies the version bump compiles in).
- [x] `cmake --install build` lands `core/const.lua` with `v3.1.6`.
- [x] `python tests\smoke\run.py build/install/luadch` -> 14/14 PASS on Windows. Linux CI run will confirm cross-platform on PR check.
- [x] Release-body backup section warns about `cfg/`, `scripts/lang/`, `scripts/data/`, `scripts/cfg/`, `certs/`, `secrets/` per the project's release-body convention. Lang file changes are explicitly flagged with a per-script table.
- [x] CHANGELOG layout matches the project's Breaking / Features / Bugfixes / Notes style; Breaking listed first because the TLS-only flip is genuinely behaviour-changing for fresh installs.

## After merge

1. Tag `v3.1.6` on master to trigger the release workflow (linux + windows artifacts + GHCR multi-arch image).
2. Verify the auto-generated GitHub release uses `.github/release-body.md` content.
3. Update `docker-compose.yml` example pin in operator-facing docs only after the GHCR tag is confirmed published.