### PR TITLE
fix(scripts): close F-INF-1b/c nil-handling in bundled plugins (refs #121)

### DIFF
--- a/scripts/etc_trafficmanager.lua
+++ b/scripts/etc_trafficmanager.lua
@@ -653,7 +653,9 @@ del = function( firstnick, scriptname, user )
         if desc_prefix_activate and desc_prefix_permission[ target_level ] then
             local prefix = hub.escapeto( flag_blocked )
             local desc_tag = hub.escapeto( desc_prefix_table[ target_level ] )
-            local desc = utf.sub( target:description(), utf.len( desc_tag ) + 1, -1 )
+            -- Phase 8a F-INF-1c: target:description() is nil for clients
+            -- without DE in BINF; coerce to "" so utf.sub does not crash.
+            local desc = utf.sub( target:description() or "", utf.len( desc_tag ) + 1, -1 )
             local desc = utf.sub( desc, utf.len( prefix ) + 1, -1 )
             new_desc = desc_tag .. desc
         else

--- a/scripts/usr_desc_prefix.lua
+++ b/scripts/usr_desc_prefix.lua
@@ -68,7 +68,11 @@ hub.setlistener( "onExit", { },    -- remove prefix on script exit
         for sid, user in pairs( hub.getusers() ) do
             if permission[ user:level() ] then
                 local prefix = hub.escapeto( prefix_table[ user:level() ] ) or default
-                local desc = utf.sub( user:description(), utf.len( prefix ) + 1, -1 )
+                -- Phase 8a F-INF-1c: user:description() is nil for clients
+                -- that did not send DE in BINF; coerce to "" so utf.sub
+                -- does not crash. The user has no prefix to strip in that
+                -- case so the broadcast carries an empty DE.
+                local desc = utf.sub( user:description() or "", utf.len( prefix ) + 1, -1 )
                 user:inf():setnp( "DE", desc or "" )
                 hub.sendtoall( "BINF " .. sid .. " DE" .. desc .. "\n" )
             end

--- a/scripts/usr_hubs.lua
+++ b/scripts/usr_hubs.lua
@@ -117,11 +117,17 @@ Max hubs: %s  |  yours: %s
 local check = function( user )
     local user_nick = user:nick()
     local hn, hr, ho = user:hubs()
-    local hm = hn + hr + ho
+    -- Phase 8a F-INF-1b: a client BINF without the HN/HR/HO triplet
+    -- returns nil from user:hubs(). Pre-fix, the arithmetic on the
+    -- next line crashed with "attempt to perform arithmetic on a nil
+    -- value" before the nil-check below could fire. Reorder so the
+    -- nil-check rejects first.
     if not ( hn and hr and ho ) then
         user:kill( "ISTA 120 " .. msg_invalid .. "\n", "TL300" )
         return PROCESSED
-    elseif ( hn > user_max ) or ( hr > reg_max ) or ( ho > op_max ) or ( hm > hubs_max ) then
+    end
+    local hm = hn + hr + ho
+    if ( hn > user_max ) or ( hr > reg_max ) or ( ho > op_max ) or ( hm > hubs_max ) then
         local hubs = hn .. "/" .. hr .. "/" .. ho
         local hubs_allowed = user_max .. "/" .. reg_max .. "/" .. op_max
         local bantime = block_time * 60


### PR DESCRIPTION
Refs [#121](https://github.com/luadch-ng/luadch/issues/121).

Phase 8a-3 fix wave for the luadch repo. Closes the two open F-INF-1 findings the audit ([`docs/phases/PHASE_8A.md`](https://github.com/luadch-ng/luadch/blob/master/docs/phases/PHASE_8A.md)) left for follow-up after [#123](https://github.com/luadch-ng/luadch/pull/123).

## What lands

### F-INF-1b: `usr_hubs.lua` arithmetic-before-nil-check

**Pre-fix** (lines 119-122):
```lua
local hn, hr, ho = user:hubs()
local hm = hn + hr + ho             -- crashes if any of hn/hr/ho is nil
if not ( hn and hr and ho ) then    -- nil-check happens AFTER the crash
    user:kill( ... )
    return PROCESSED
elseif (...) then ...
```

**Post-fix:** reorder so the nil-check rejects first, then arithmetic on the now-guaranteed-non-nil locals. `elseif` becomes `if` because the nil branch returns.

### F-INF-1c: `utf.sub` on possibly-nil description

Two sites:

- `scripts/usr_desc_prefix.lua:71` (`user:description()` in onExit listener prefix-stripping)
- `scripts/etc_trafficmanager.lua:656` (`target:description()` in tag-stripping path)

Pre-fix passed nil straight into `utf.sub`. Other call sites in the same files already use the `local desc = target:description() or ""` pattern; these two were the divergent ones.

Post-fix: same coercion-to-empty-string before the `utf.sub`.

## What's still open

- **F-INF-1d** (companion `luadch-ng/scripts`): four plugins with the same family of nil-unsafe getters. Filed as a separate PR against that repo.
- **F-INF-2** (per-field numeric range bounds): design call, not a fix.
- **F-INF-3** (8a-1b exhaustive second-pass audit): scheduled after the 8a-3 fix wave closes.

## Test plan

- [x] `cmake --build build` clean.
- [x] `cmake --install build` lands the script changes.
- [x] `python tests/smoke/run.py build/install/luadch` -> **30/30 PASS** on Windows. Linux CI run will confirm cross-platform.
- [x] Manual code-trace of the three modified call sites - the new control flow is identical for valid inputs (full HN/HR/HO triplet / non-nil DE), defensive only for the malformed cases.

## Phase 8a status after merge

| Sub-phase | Status |
|---|---|
| 8a-1 | done ([#124](https://github.com/luadch-ng/luadch/pull/124)) |
| 8a-2 | done ([#123](https://github.com/luadch-ng/luadch/pull/123)) |
| 8a-3 luadch (F-INF-1b/c) | **this PR** |
| 8a-3 companion (F-INF-1d) | next PR (separate repo) |
| 8a-3 design call (F-INF-2) | open |
| 8a-1b exhaustive pass | scheduled |