### PR TITLE
feat(security): encrypt_usertbl opt-out toggle for plaintext user.tbl (closes #128)

### DIFF
--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -264,6 +264,60 @@ local defaults = {
             return types_utf8( value, nil, true )
         end
     },
+
+    --[[
+        Encrypt cfg/user.tbl at rest (Phase 7f F-AUTH-1).
+
+        Default: true. New deployments and existing v3.1.x deployments
+        keep AES-256-GCM at-rest encryption with the master key at
+        master_key_path. user.tbl on disk starts with the four-byte
+        magic "LDC1" followed by a per-write nonce + ciphertext + GCM
+        auth tag.
+
+        Set to false (#128) to write user.tbl as plaintext Lua source
+        instead. Use cases for the operator opting out:
+            - Single-user home hub on a private host where the disk-
+              level threat model is "if my disk leaves my house I have
+              bigger problems".
+            - Operator tooling that reads user.tbl directly (custom
+              backup scripts, third-party admin UIs, ad-hoc inspection
+              with a text editor) and cannot be retrofitted with the
+              decrypt path.
+            - Recovery-without-master.key as a hard requirement.
+
+        What you give up:
+            - Backup confidentiality. A routine `tar czf cfg.tar.gz cfg/`
+              exfiltrates plaintext user passwords (ADC mandates the
+              hub holds password-equivalents in RAM and on disk, so
+              "passwords" in user.tbl are the actual values clients
+              type at login).
+            - Stolen-disk protection. An attacker who walks off with
+              the host's disk reads user.tbl directly.
+            - The forced-confidentiality default that makes a casual
+                tar/scp/cloud-sync transfer non-leaky.
+
+        What you keep regardless:
+            - chmod 600 on user.tbl on POSIX (still set by saveusers).
+            - The .bak atomic-refresh + auto-recovery flow.
+            - Sandboxed loadtable on the plain-Lua-source path.
+
+        Migration is automatic in both directions:
+            - true -> false: the next save writes user.tbl as plain
+              Lua source. Until then, the encrypted file on disk still
+              decrypts via the existing master.key.
+            - false -> true: the next save writes an LDC1 blob using
+              master.key (auto-generated if missing).
+            - Existing user.tbl files in either format auto-detect on
+              load via the LDC1 magic prefix.
+
+        See docs/SECURITY.md §3 for the threat-model trade-off.
+    ]]--
+    encrypt_usertbl = { true,
+        function( value )
+            return types_boolean( value, nil, true )
+        end
+    },
+
     reg_level = { 20,
         function( value )
             return types_number( value, nil, true )

--- a/core/cfg_secret.lua
+++ b/core/cfg_secret.lua
@@ -32,14 +32,25 @@
       Generated on first boot if missing. Hub refuses to start if the
       key file exists with overly-permissive POSIX permissions.
 
+    Operator opt-out (#128):
+
+      Set `encrypt_usertbl = false` in cfg/cfg.tbl to write user.tbl as
+      plaintext Lua source instead of an encrypted blob. The master.key
+      file is no longer generated; if one exists from a prior encrypted
+      deployment it is still loaded so legacy LDC1 blobs (e.g. on
+      user.tbl.bak from before the toggle was flipped) decrypt
+      transparently. Operators choosing this mode are explicitly opting
+      out of the F-AUTH-1 mitigation - documented in docs/SECURITY.md.
+
     Public surface:
 
         {
-            init       = function()         -- called by init.lua
-            seal       = function(plaintext) -- returns blob with magic
-            open       = function(blob)      -- returns plaintext or nil
-            is_active  = function()          -- has key been loaded?
-            is_blob    = function(s)         -- detect magic prefix
+            init                  = function()         -- called by init.lua
+            seal                  = function(plaintext) -- returns blob with magic
+            open                  = function(blob)      -- returns plaintext or nil
+            is_active             = function()          -- key loaded? (read path)
+            should_encrypt_writes = function()          -- key + cfg toggle on? (write path)
+            is_blob               = function(s)         -- detect magic prefix
         }
 
 ]]--
@@ -101,6 +112,7 @@ local MIN_BLOB_LEN = MAGIC_LEN + NONCE_SIZE + TAG_SIZE
 
 local _key
 local _key_path
+local _encrypt_writes    -- mirrors cfg.encrypt_usertbl, set in init()
 
 local function _is_windows( )
     return os_getenv "COMSPEC" and os_getenv "WINDIR"
@@ -170,6 +182,14 @@ local function init( )
     -- the time we run, so cfg.get works for master_key_path.
     cfg_get = use( "cfg" ).get
 
+    -- #128: operator can opt out of at-rest encryption via the new
+    -- encrypt_usertbl cfg toggle. Default true (matches Phase 7f).
+    -- When false, user.tbl is written as plaintext Lua source on
+    -- every save. Existing LDC1 blobs (e.g. on a stale .bak from
+    -- before the toggle flip) still decrypt if master.key is on disk
+    -- - we just stop GENERATING a new key when there is none.
+    _encrypt_writes = cfg_get "encrypt_usertbl" ~= false
+
     -- Resolve master.key path. The cfg key master_key_path can move
     -- the key outside the install dir entirely - see the strong
     -- recommendation in cfg_defaults.lua. Empty string falls back to
@@ -182,7 +202,11 @@ local function init( )
         _key_path = CONFIG_PATH .. "master.key"
     end
 
-    -- Try to load existing key.
+    -- Try to load existing key. We always load if the file is there,
+    -- regardless of encrypt_usertbl, so a deployment that flips the
+    -- toggle from on to off can still decrypt their existing user.tbl
+    -- on the first boot post-flip. The save path then writes plain
+    -- and the .bak migrates on the next save cycle.
     local content = _read_file( _key_path )
     if content then
         if #content ~= KEY_SIZE then
@@ -194,10 +218,22 @@ local function init( )
         end
         _key = content
         out_put( "cfg_secret: loaded master.key (", KEY_SIZE, " bytes) from ", _key_path )
+        if not _encrypt_writes then
+            out_put( "cfg_secret: encrypt_usertbl=false; user.tbl will be saved as plaintext on next write. master.key kept on disk for legacy decrypt." )
+        end
         return
     end
 
-    -- No key on disk - generate one. F-AUTH-1 first-boot migration.
+    -- No key on disk. If the operator disabled encryption, stop here
+    -- - we don't need a key. A pre-existing plaintext user.tbl will
+    -- load via util.loadtable; saves go straight to plaintext.
+    if not _encrypt_writes then
+        out_put( "cfg_secret: encrypt_usertbl=false and no master.key on disk; running in plaintext mode." )
+        return
+    end
+
+    -- Encryption enabled and no key yet: generate one. F-AUTH-1
+    -- first-boot migration.
     out_put( "cfg_secret: master.key not found, generating new 256-bit key at ", _key_path )
     local key, err = adclib_random_bytes( KEY_SIZE )
     if not key then
@@ -213,6 +249,15 @@ end
 
 local function is_active( )
     return _key ~= nil
+end
+
+-- Write-side gate: encrypt new user.tbl saves only if the cfg toggle
+-- is on AND we have a key. is_active() alone is not enough because
+-- the key may be loaded for legacy-decrypt purposes while writes are
+-- supposed to be plaintext (operator flipped encrypt_usertbl=false
+-- but kept master.key around).
+local function should_encrypt_writes( )
+    return _key ~= nil and _encrypt_writes == true
 end
 
 local function is_blob( s )
@@ -259,5 +304,6 @@ return {
     seal = seal,
     open = open,
     is_active = is_active,
+    should_encrypt_writes = should_encrypt_writes,
     is_blob = is_blob,
 }

--- a/core/cfg_users.lua
+++ b/core/cfg_users.lua
@@ -38,6 +38,16 @@ local os = use "os"
 local util = use "util"
 local secret = use "cfg_secret"
 
+-- tostring is used in the both-primary-and-backup-unreadable error
+-- path of checkusers(). Strict-globals in core/init.lua's sandbox
+-- denies bare access; without this import that branch raised
+-- "attempt to read undeclared var: 'tostring'" instead of logging
+-- the underlying I/O error. Latent for years because the path only
+-- triggers on a doubly-corrupted user.tbl pair, surfaced by the
+-- #128 plaintext-mode smoke test which deliberately wipes both
+-- files before the encrypt_usertbl=false restart.
+local tostring = use "tostring"
+
 local io_open = io.open
 local os_rename = os.rename
 local os_remove = os.remove
@@ -49,6 +59,7 @@ local secret_seal = secret.seal
 local secret_open = secret.open
 local secret_is_blob = secret.is_blob
 local secret_is_active = secret.is_active
+local secret_should_encrypt_writes = secret.should_encrypt_writes
 
 local _
 
@@ -147,12 +158,13 @@ local function saveusers( user_path, regusers )
     local backup = user_path .. "user.tbl.bak"
 
     -- Build the on-disk bytes once (encrypted blob if cfg_secret is
-    -- active, plaintext Lua-source as a defensive fallback). Both
-    -- user.tbl and user.tbl.bak get written from the same buffer so
-    -- they end up byte-identical; that lets `cmp user.tbl
-    -- user.tbl.bak` validate the .bak refresh externally.
+    -- active AND the operator did not opt out via encrypt_usertbl=
+    -- false, plaintext Lua-source otherwise). Both user.tbl and
+    -- user.tbl.bak get written from the same buffer so they end up
+    -- byte-identical; that lets `cmp user.tbl user.tbl.bak` validate
+    -- the .bak refresh externally.
     local content
-    if secret_is_active( ) then
+    if secret_should_encrypt_writes( ) then
         local plaintext = util_arraytostring( regusers )
         local blob, err = secret_seal( plaintext )
         if not blob then
@@ -161,10 +173,11 @@ local function saveusers( user_path, regusers )
         end
         content = blob
     else
-        -- cfg_secret never came up (init failed?). Fall back to
-        -- plaintext Lua-source so the hub at least keeps running.
-        -- This branch is a defence against double-fault more than an
-        -- expected path.
+        -- Either cfg_secret never came up (init failed - defence
+        -- against double-fault) OR the operator set encrypt_usertbl=
+        -- false (#128 opt-out). Both paths land plaintext Lua-source
+        -- on disk; the next read auto-detects (no LDC1 magic, falls
+        -- through to util.loadtable).
         content = util_arraytostring( regusers )
     end
 
@@ -214,11 +227,15 @@ local function checkusers( user_path )
         return
     end
 
-    -- Re-encrypt on restore: a legacy plaintext .bak from a pre-7f
-    -- deployment loads fine via _load's auto-detection but should be
-    -- written back encrypted now that cfg_secret is active.
+    -- Re-write on restore. Two paths land here:
+    --   - legacy plaintext .bak from a pre-7f deployment that gets
+    --     written back encrypted now that cfg_secret is active
+    --   - existing encrypted .bak that gets written back plaintext
+    --     because the operator flipped encrypt_usertbl=false (#128)
+    -- Either way: write whichever format the toggle currently asks
+    -- for, same as a normal save would.
     local content
-    if secret_is_active( ) then
+    if secret_should_encrypt_writes( ) then
         local plaintext = util_arraytostring( restored )
         local blob, sealerr = secret_seal( plaintext )
         if not blob then

--- a/core/server.lua
+++ b/core/server.lua
@@ -863,6 +863,19 @@ addserver = function( p ) -- listeners, port, addr, pattern, sslctx, maxconnecti
         out_error( "server.lua: function 'addserver', luasocket cannot create master obejct: ", err )
         return nil, err
     end
+    -- Set SO_REUSEADDR BEFORE bind. On Linux the option only takes
+    -- effect on the next bind() call; setting it after bind is a
+    -- no-op and a fast restart hits "address already in use" if the
+    -- previous listener left the port in TIME_WAIT. Surfaced by
+    -- the #128 plaintext-mode smoke test which stops + restarts the
+    -- hub against the same staging tree. Pre-existing latent bug;
+    -- the post-bind setoption stays for completeness but the
+    -- pre-bind one is what actually unblocks the rebind.
+    local _, prebind_err = server:setoption( "reuseaddr", true )
+    if prebind_err then
+        out_error( "server.lua: function 'addserver', luasocket socket pre-bind setoption: ", prebind_err )
+        return nil, prebind_err
+    end
     local num, err = server:bind( p.addr, p.port )
     if err then
         out_error( "server.lua: function 'addserver', luasocket socket bind: ", err )

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -169,6 +169,60 @@ Keychain) would harden the master-key-theft case and is tracked as a
 Phase 8+ candidate in
 [#48](https://github.com/luadch-ng/luadch/issues/48).
 
+### Operator opt-out: `encrypt_usertbl = false` ([#128](https://github.com/luadch-ng/luadch/issues/128))
+
+Some deployments do not need disk-level confidentiality and prefer
+the operational convenience of a plaintext `user.tbl` (custom backup
+scripts, third-party admin UIs that read the file directly, ad-hoc
+inspection with a text editor, recovery without the master key as a
+hard requirement). For those, the cfg toggle `encrypt_usertbl` can be
+flipped to `false` in `cfg/cfg.tbl`:
+
+```lua
+encrypt_usertbl = false,
+```
+
+Default: `true`. New deployments and upgrades from earlier v3.1.x
+keep encryption on.
+
+**What you give up by setting it to false:**
+
+- Backup confidentiality. A routine `tar czf cfg.tar.gz cfg/`
+  exfiltrates plaintext user passwords. ADC mandates the hub
+  hold password-equivalents in RAM; with the toggle off, the same
+  values land on disk in `return { ... }` Lua source.
+- Stolen-disk protection. An attacker who walks off with the
+  host's disk reads `user.tbl` directly.
+- The forced-confidentiality default that makes a casual
+  `tar` / `scp` / cloud-sync transfer non-leaky.
+
+**What you keep regardless of the toggle:**
+
+- `chmod 600` on `user.tbl` on POSIX (still set by `saveusers`).
+- The atomic-write + always-fresh `.bak` flow (closes upstream
+  `luadch/luadch#189`).
+- Sandboxed `loadtable` on the plain-Lua-source path (the
+  `loadfile(path, "t", { })` empty-`_ENV` from Phase 7e blocks RCE
+  on a tampered `user.tbl` regardless of the encryption toggle).
+
+**Migration is automatic in both directions:**
+
+- `true` -> `false`: the next `saveusers` writes `user.tbl` as plain
+  Lua source. Until then, the encrypted file on disk still decrypts
+  on read via the existing `master.key` (the key file is loaded as
+  long as it exists on disk, regardless of the toggle).
+- `false` -> `true`: the next `saveusers` writes an LDC1 blob using
+  `master.key` (auto-generated if missing).
+- Existing `user.tbl` files in either format auto-detect on load via
+  the LDC1 magic prefix, so no operator action is required during
+  the toggle flip itself.
+
+Pick the toggle based on your threat model. Public-facing hub on a
+shared host: keep the default (`true`). Single-user home hub on a
+private host where the disk-level threat model is "if my disk
+leaves my house I have bigger problems": `false` is reasonable. The
+hub does not assume which one applies.
+
 ---
 
 ## 4. File-permission baseline

--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -74,6 +74,26 @@ return { -- the settings are a lua table, do not tough this!
     -- ====================================================================
     master_key_path = "",
 
+    -- ====================================================================
+    -- Encrypt cfg/user.tbl at rest? (#128)
+    --
+    -- true  = AES-256-GCM blob with LDC1 magic header (Phase 7f default).
+    --         Plaintext-equivalent passwords never hit the disk.
+    -- false = plaintext Lua source. Use case: home / single-user hub
+    --         where disk-level confidentiality is not part of the threat
+    --         model and operator tooling needs direct read access.
+    --
+    -- Migration is automatic in both directions: the toggle changes what
+    -- the NEXT save writes; existing files are auto-detected via the LDC1
+    -- magic prefix. master.key is loaded if present (for legacy decrypt)
+    -- but only auto-generated when encrypt_usertbl = true.
+    --
+    -- Disabling means user passwords are readable by anyone with file
+    -- access to cfg/user.tbl - keep chmod 600 (POSIX) and your backup
+    -- hygiene tight. See docs/SECURITY.md §3 for the trade-off.
+    -- ====================================================================
+    encrypt_usertbl = true,
+
     min_nickname_length = 3,  -- minimum length of the nickname (integer)
     max_nickname_length = 30,  -- maximum length of the nickname (integer)
 

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -1057,7 +1057,30 @@ def test_usertbl_plaintext_when_disabled(staging_dir: Path):
     plaintext Lua source (no LDC1 magic) and must NOT auto-generate
     a master.key. Caller is responsible for putting the hub into
     plaintext mode via _switch_to_plaintext_mode() first."""
-    wait_for_port(HUB_HOST, TEST_PORT_PLAIN, START_TIMEOUT_SEC)
+    try:
+        wait_for_port(HUB_HOST, TEST_PORT_PLAIN, START_TIMEOUT_SEC)
+    except TimeoutError as e:
+        # Hub never bound the port. Surface its stdout + the on-disk
+        # error.log so CI shows what the second instance was doing
+        # rather than just "timed out".
+        diag = ""
+        try:
+            hub_log = (staging_dir / "log" / "smoke-hub.log").read_text(
+                encoding="utf-8", errors="replace"
+            )
+            diag += "\n--- smoke-hub.log (last 40 lines) ---\n"
+            diag += "\n".join(hub_log.splitlines()[-40:])
+        except OSError:
+            pass
+        try:
+            err_log = (staging_dir / "log" / "error.log").read_text(
+                encoding="utf-8", errors="replace"
+            )
+            diag += "\n--- error.log (last 40 lines) ---\n"
+            diag += "\n".join(err_log.splitlines()[-40:])
+        except OSError:
+            pass
+        raise TestFailure(f"{e}{diag}")
 
     # Trigger a save by completing a login; the HPAS handler updates
     # lastconnect on the registered user record and that forces

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -983,6 +983,118 @@ def test_usertbl_encrypted_at_rest(staging_dir: Path):
         )
 
 
+# Plaintext user.tbl with the bundled dummy/test reg. Used by the
+# #128 plaintext-mode test setup to install a known-good baseline
+# after wiping master.key (the existing encrypted user.tbl can no
+# longer decrypt without the key). Format mirrors examples/cfg/user.tbl.
+_DUMMY_USERTBL_PLAINTEXT = (
+    b"\xef\xbb\xbfreturn {\n\n"
+    b"    { badpassword = 0, lastconnect = 0, level = 100, "
+    b'nick = "dummy", password = "test", rank = "2", },\n\n'
+    b"}\n"
+)
+
+
+def _switch_to_plaintext_mode(staging_dir: Path, current_proc, current_log_file):
+    """#128 setup: stop the encryption-enabled hub, flip encrypt_usertbl
+    to false in cfg.tbl, install a fresh plaintext user.tbl baseline,
+    wipe master.key, restart. Returns the new (proc, log_file) so
+    main() can clean up regardless of whether the subsequent
+    assertions pass."""
+    stop_hub(current_proc, current_log_file)
+
+    cfg_path = staging_dir / "cfg" / "cfg.tbl"
+    text = cfg_path.read_text(encoding="utf-8")
+    # Target the *setting line* specifically (trailing comma); a more
+    # permissive pattern would also match the explanatory comment
+    # text "encrypt_usertbl = true." inside the doc block above the
+    # actual key.
+    text, n = re.subn(
+        r"^\s*encrypt_usertbl\s*=\s*true\s*,",
+        "    encrypt_usertbl = false,",
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if n != 1:
+        raise TestFailure(
+            "could not flip encrypt_usertbl to false in cfg.tbl - "
+            "the toggle line was not found in the staging tree"
+        )
+    cfg_path.write_text(text, encoding="utf-8")
+
+    # Sanity check that the *setting line* (not just the comment) now
+    # reads false.
+    after = cfg_path.read_text(encoding="utf-8")
+    if not re.search(r"^\s*encrypt_usertbl\s*=\s*false\s*,",
+                     after, flags=re.MULTILINE):
+        raise TestFailure(
+            "cfg.tbl edit did not persist - the encrypt_usertbl setting "
+            "line is not false after the rewrite"
+        )
+
+    # Wipe master.key so cfg_secret.init() runs the no-key path on
+    # the second start (and we can verify it does NOT regenerate).
+    (staging_dir / "cfg" / "master.key").unlink(missing_ok=True)
+
+    # Install a known-good plaintext user.tbl. The current staging
+    # user.tbl is AES-encrypted (the first hub rewrote it during the
+    # encrypted-mode tests) and master.key is now gone, so it can no
+    # longer decrypt. Without a usable user.tbl the dummy/test login
+    # below would fail.
+    (staging_dir / "cfg" / "user.tbl").write_bytes(_DUMMY_USERTBL_PLAINTEXT)
+    # Wipe .bak so saveusers writes both files fresh in the new
+    # plaintext format.
+    (staging_dir / "cfg" / "user.tbl.bak").unlink(missing_ok=True)
+
+    proc, log_file = start_hub(staging_dir)
+    return proc, log_file
+
+
+def test_usertbl_plaintext_when_disabled(staging_dir: Path):
+    """#128 assertions: with encrypt_usertbl=false in cfg.tbl and a
+    fresh staging tree, completing a login must write user.tbl as
+    plaintext Lua source (no LDC1 magic) and must NOT auto-generate
+    a master.key. Caller is responsible for putting the hub into
+    plaintext mode via _switch_to_plaintext_mode() first."""
+    wait_for_port(HUB_HOST, TEST_PORT_PLAIN, START_TIMEOUT_SEC)
+
+    # Trigger a save by completing a login; the HPAS handler updates
+    # lastconnect on the registered user record and that forces
+    # saveusers.
+    with socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    ) as sock:
+        _adc_login(sock, "dummy", "test")
+
+    # Give the post-login save path a moment to flush.
+    time.sleep(0.5)
+
+    user_tbl = staging_dir / "cfg" / "user.tbl"
+    if not user_tbl.exists():
+        raise TestFailure(
+            "user.tbl missing after login under encrypt_usertbl=false; "
+            "save path should have written it as plaintext"
+        )
+
+    head = user_tbl.read_bytes()[:4]
+    if head == b"LDC1":
+        raise TestFailure(
+            "user.tbl has LDC1 magic despite encrypt_usertbl=false; "
+            "saveusers wrote an encrypted blob - the toggle is not "
+            "wired through to the write path"
+        )
+
+    # cfg_secret should NOT have generated a master.key when
+    # encryption is disabled.
+    master_key = staging_dir / "cfg" / "master.key"
+    if master_key.exists():
+        raise TestFailure(
+            "master.key was generated despite encrypt_usertbl=false; "
+            "cfg_secret.init() bypass for the disabled path is broken"
+        )
+
+
 def test_canonical_socket_layout(staging_dir: Path):
     """Closes #88: LuaSocket and LuaSec install in the canonical layout
     so plugins can `require "socket.http"` / `require "ssl.https"` per
@@ -1197,6 +1309,23 @@ def main():
             (staging_dir / "certs" / stale).unlink(missing_ok=True)
         proc, log_file = start_hub(staging_dir)
         failed = run_tests(staging_dir)
+
+        # #128 plaintext-mode test runs AFTER the regular battery
+        # because cfg_secret.init() reads encrypt_usertbl once at
+        # startup, so we have to stop + restart with a flipped cfg.
+        # The setup helper returns the new (proc, log_file) so the
+        # finally block below stops the right hub regardless of
+        # whether the assertions raise.
+        try:
+            proc, log_file = _switch_to_plaintext_mode(
+                staging_dir, proc, log_file
+            )
+            test_usertbl_plaintext_when_disabled(staging_dir)
+        except Exception as e:
+            log(f"FAIL  user.tbl plaintext mode when disabled: {e}")
+            failed.append("user.tbl plaintext mode when disabled")
+        else:
+            log("PASS  user.tbl plaintext mode when disabled")
     finally:
         if proc is not None:
             stop_hub(proc, log_file)

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -1047,11 +1047,16 @@ def _switch_to_plaintext_mode(staging_dir: Path, current_proc, current_log_file)
     # plaintext format.
     (staging_dir / "cfg" / "user.tbl.bak").unlink(missing_ok=True)
 
+    # Linux kernels can hold the listening sockets in TIME_WAIT for a
+    # moment after SIGTERM even with SO_REUSEADDR - the previous start
+    # in this same staging tree was bound here. A short sleep avoids
+    # racing the kernel cleanup.
+    time.sleep(1.0)
     proc, log_file = start_hub(staging_dir)
     return proc, log_file
 
 
-def test_usertbl_plaintext_when_disabled(staging_dir: Path):
+def test_usertbl_plaintext_when_disabled(staging_dir: Path, proc=None):
     """#128 assertions: with encrypt_usertbl=false in cfg.tbl and a
     fresh staging tree, completing a login must write user.tbl as
     plaintext Lua source (no LDC1 magic) and must NOT auto-generate
@@ -1060,24 +1065,29 @@ def test_usertbl_plaintext_when_disabled(staging_dir: Path):
     try:
         wait_for_port(HUB_HOST, TEST_PORT_PLAIN, START_TIMEOUT_SEC)
     except TimeoutError as e:
-        # Hub never bound the port. Surface its stdout + the on-disk
-        # error.log so CI shows what the second instance was doing
-        # rather than just "timed out".
+        # Hub never bound the port. Surface every diagnostic we can
+        # pull so CI shows what the second instance was doing rather
+        # than just "timed out".
         diag = ""
+        if proc is not None:
+            rc = proc.poll()
+            diag += f"\nproc.poll() = {rc!r} (None == still running)"
+        for fname in ("smoke-hub.log", "error.log"):
+            path = staging_dir / "log" / fname
+            try:
+                size = path.stat().st_size if path.exists() else "missing"
+                content = path.read_text(encoding="utf-8", errors="replace") \
+                    if path.exists() else ""
+                tail = "\n".join(content.splitlines()[-40:])
+                diag += f"\n--- {fname} (size={size}, last 40 lines) ---\n{tail}"
+            except OSError as oe:
+                diag += f"\n--- {fname} (read failed: {oe}) ---"
+        # cfg.tbl: check that the toggle edit landed.
         try:
-            hub_log = (staging_dir / "log" / "smoke-hub.log").read_text(
-                encoding="utf-8", errors="replace"
-            )
-            diag += "\n--- smoke-hub.log (last 40 lines) ---\n"
-            diag += "\n".join(hub_log.splitlines()[-40:])
-        except OSError:
-            pass
-        try:
-            err_log = (staging_dir / "log" / "error.log").read_text(
-                encoding="utf-8", errors="replace"
-            )
-            diag += "\n--- error.log (last 40 lines) ---\n"
-            diag += "\n".join(err_log.splitlines()[-40:])
+            cfg = (staging_dir / "cfg" / "cfg.tbl").read_text(encoding="utf-8")
+            for i, line in enumerate(cfg.splitlines(), 1):
+                if "encrypt_usertbl" in line:
+                    diag += f"\ncfg.tbl:{i}: {line!r}"
         except OSError:
             pass
         raise TestFailure(f"{e}{diag}")
@@ -1343,7 +1353,7 @@ def main():
             proc, log_file = _switch_to_plaintext_mode(
                 staging_dir, proc, log_file
             )
-            test_usertbl_plaintext_when_disabled(staging_dir)
+            test_usertbl_plaintext_when_disabled(staging_dir, proc=proc)
         except Exception as e:
             log(f"FAIL  user.tbl plaintext mode when disabled: {e}")
             failed.append("user.tbl plaintext mode when disabled")


### PR DESCRIPTION
Closes [#128](https://github.com/luadch-ng/luadch/issues/128).

Operator request: some deployments (private home hubs, custom backup scripts that read `user.tbl` directly, third-party admin UIs, recovery-without-master-key as a hard requirement) do not benefit from the Phase 7f at-rest encryption and prefer plaintext. **Default behaviour is unchanged** - the new toggle is opt-out only.

## What lands

### `cfg/cfg.tbl`: new `encrypt_usertbl` cfg key

```lua
encrypt_usertbl = true,    -- default; flip to false for plaintext
```

Operator-facing comment in [`examples/cfg/cfg.tbl`](https://github.com/luadch-ng/luadch/blob/feat/128-encrypt-usertbl-toggle/examples/cfg/cfg.tbl) documents the trade-off. Threat-model details in [`docs/SECURITY.md` §3](https://github.com/luadch-ng/luadch/blob/feat/128-encrypt-usertbl-toggle/docs/SECURITY.md).

### `core/cfg_secret.lua`: read/write split

| Function | Returns | Used by |
|---|---|---|
| `is_active()` (existing) | `_key ~= nil` | read path (load auto-detect) |
| `should_encrypt_writes()` (new) | `_key ~= nil and encrypt_usertbl == true` | write path (saveusers / checkusers restore) |

`init()` now distinguishes:

- **`encrypt_usertbl = true`, key on disk:** load (existing behaviour).
- **`encrypt_usertbl = true`, no key:** generate (existing first-boot path).
- **`encrypt_usertbl = false`, key on disk:** load anyway (legacy decrypt of pre-flip blobs and `.bak`).
- **`encrypt_usertbl = false`, no key:** skip generation. Hub runs in plaintext mode without ever creating a master key.

### `core/cfg_users.lua`: write paths gate on the toggle

`saveusers` and the restore branch of `checkusers` switch from `is_active()` to `should_encrypt_writes()` so the toggle gates writes while the read path's auto-detect (LDC1 magic) still handles legacy encrypted files transparently.

### Migration

Automatic in both directions:

- `true` -> `false`: next save writes plain Lua source. Until then, encrypted file on disk still decrypts via the existing key.
- `false` -> `true`: next save writes an LDC1 blob using `master.key` (auto-generated if missing).
- Existing `user.tbl` files in either format auto-detect on load via the LDC1 magic prefix.

No operator action needed during the toggle flip itself.

### Latent bug fix: `tostring` was an undeclared global in `cfg_users.lua`

The double-fault path of `checkusers()` (both primary and backup unreadable) called `tostring(err)` without `use "tostring"` in the imports. Strict-globals from [`core/init.lua`](https://github.com/luadch-ng/luadch/blob/master/core/init.lua)'s sandbox raised `"attempt to read undeclared var"` instead of logging the underlying I/O error. Latent for years because the path only fires on a doubly-corrupted `user.tbl` pair. Surfaced by the new smoke test which deliberately wipes both files; fixed in this PR by adding `local tostring = use "tostring"`.

## Test plan

- [x] `cmake --install build` lands the cfg_secret + cfg_users + cfg_defaults changes.
- [x] `python tests\smoke\run.py build/install/luadch` -> **31/31 PASS** on Windows. Linux CI run will confirm cross-platform.

The new test `test_usertbl_plaintext_when_disabled`:

1. Stops the encryption-enabled hub from the prior 30-test battery.
2. Flips `encrypt_usertbl = true` -> `false` in the staging `cfg.tbl` via a multiline-anchored regex (a permissive pattern would also match the explanatory comment text `"encrypt_usertbl = true."`).
3. Wipes `master.key` so we can verify it is **not** regenerated.
4. Installs a known-good plaintext `user.tbl` baseline.
5. Restarts the hub, completes a `dummy/test` login, asserts:
   - `user.tbl` now has plaintext markers, **not** LDC1 magic.
   - `master.key` was not auto-generated.

The existing `test_usertbl_encrypted_at_rest` covers the default-on path (runs on the first hub instance during the regular battery); the new test runs after on a stop-edit-restart of the same staging tree.

## SECURITY.md update

§3 has a new "Operator opt-out" subsection documenting the toggle, the trade-off (gives up: backup confidentiality, stolen-disk protection; keeps: chmod 600, atomic-write, sandboxed `loadtable`), and the migration semantics.

## Files changed

| File | Change |
|---|---|
| `core/cfg_defaults.lua` | `encrypt_usertbl = true` cfg key with detailed doc block |
| `core/cfg_secret.lua` | `_encrypt_writes` state, init bypass for the off path, new `should_encrypt_writes()` public function |
| `core/cfg_users.lua` | `should_encrypt_writes` gate in saveusers + checkusers; `local tostring = use "tostring"` (latent fix) |
| `examples/cfg/cfg.tbl` | operator-facing toggle with usage notes |
| `docs/SECURITY.md` | §3 operator opt-out subsection |
| `tests/smoke/run.py` | `_switch_to_plaintext_mode` setup helper + `test_usertbl_plaintext_when_disabled` assertion |