### PR TITLE
fix(util): atomic-by-default for savearray / savetable (F-PLG-1 of #133)

### DIFF
--- a/core/cfg_users.lua
+++ b/core/cfg_users.lua
@@ -34,7 +34,6 @@
 
 local use = use
 local io = use "io"
-local os = use "os"
 local util = use "util"
 local secret = use "cfg_secret"
 
@@ -49,12 +48,11 @@ local secret = use "cfg_secret"
 local tostring = use "tostring"
 
 local io_open = io.open
-local os_rename = os.rename
-local os_remove = os.remove
 local util_loadtable = util.loadtable
 local util_loadtable_string = util.loadtable_string
 local util_arraytostring = util.arraytostring
 local util_chmod_secret = util.chmod_secret
+local util_atomic_write = util.atomic_write
 local secret_seal = secret.seal
 local secret_open = secret.open
 local secret_is_blob = secret.is_blob
@@ -85,41 +83,17 @@ local function _read_raw( path )
     return content
 end
 
--- Write `content` to `path` as binary. chmod 600 on POSIX since
--- this file holds the encrypted user db with embedded plaintext
--- passwords.
-local function _write_raw( path, content )
-    local f, err = io_open( path, "wb" )
-    if not f then return false, err end
-    f:write( content )
-    f:close( )
+-- Atomic write + chmod 600 on the resulting file. The tmp+rename
+-- mechanics live in util.atomic_write since F-PLG-1 (#133); we just
+-- chmod the final path afterwards. chmod on the inode is preserved
+-- across the rename on POSIX, but applying it post-rename is the
+-- cleanest order regardless (and matches what the cfg_secret save
+-- path expects: the user.tbl that lands on disk is 0600).
+local function _atomic_write( path, content )
+    local ok, err = util_atomic_write( path, content )
+    if not ok then return false, err end
     util_chmod_secret( path )
     return true
-end
-
--- Atomically replace `path` with new `content`. Writes to
--- `path .. ".tmp"` first, then rename(2) the sidecar over the
--- target. POSIX guarantees atomicity (same filesystem); Windows
--- rename errors when the target exists, so we fall back to a
--- remove-then-rename on that platform - that loses the strict
--- atomicity guarantee but still avoids the open(W)+truncate
--- corruption window of the naive write path.
-local function _atomic_write( path, content )
-    local tmp = path .. ".tmp"
-    local ok, err = _write_raw( tmp, content )
-    if not ok then
-        os_remove( tmp )    -- best-effort cleanup
-        return false, err
-    end
-    -- POSIX: succeeds and atomically replaces.
-    local rok = os_rename( tmp, path )
-    if rok then return true end
-    -- Windows fallback: remove target first, then rename.
-    os_remove( path )
-    rok, err = os_rename( tmp, path )
-    if rok then return true end
-    os_remove( tmp )    -- best-effort cleanup on full failure
-    return false, err or "rename failed"
 end
 
 -- Internal load: returns (table, err). Detects encrypted vs plaintext

--- a/core/util.lua
+++ b/core/util.lua
@@ -102,6 +102,8 @@ local io_open = io.open
 local os_time = os.time
 local os_date = os.date
 local os_difftime = os.difftime
+local os_rename = os.rename
+local os_remove = os.remove
 local math_floor = math.floor
 local string_byte = string.byte
 local table_sort = table.sort
@@ -153,6 +155,8 @@ local loadtable_string
 local savetable
 local savearray
 local arraytostring
+local tabletostring
+local atomic_write
 local maketable
 
 local formatseconds
@@ -325,19 +329,79 @@ loadtable = function( path )
     return nil, err
 end
 
---// saves a table to a local file
+-- Atomically replace `path` with `content` via tmp + rename
+-- (F-PLG-1, issue #133). Pattern mirrors cfg_users.lua's pre-existing
+-- helper that closed the F-AUTH-1 / luadch#189 partial-write window
+-- for user.tbl; now used by savetable / savearray so every plugin
+-- save inherits the same crash-safety.
+--
+-- POSIX rename(2) is atomic on the same filesystem. Windows rename
+-- errors when the target exists; fall back to remove-then-rename
+-- which loses the strict atomicity guarantee but still avoids the
+-- open(W)+truncate corruption window of the naive write path.
+--
+-- chmod is intentionally NOT applied here - cfg_users.lua handles
+-- the user.tbl chmod 600 via util.chmod_secret separately, and
+-- generic plugin .tbl files do not need restrictive perms.
+--
+-- Returns true on success, (false, err) on failure.
+atomic_write = function( path, content )
+    local tmp = path .. ".tmp"
+    local f, err = io_open( tmp, "wb" )
+    if not f then
+        return false, err
+    end
+    local ok, werr = f:write( content )
+    f:close( )
+    if not ok then
+        os_remove( tmp )
+        return false, werr
+    end
+    -- POSIX: succeeds and atomically replaces.
+    if os_rename( tmp, path ) then return true end
+    -- Windows fallback: remove target first, then rename.
+    os_remove( path )
+    local rok, rerr = os_rename( tmp, path )
+    if rok then return true end
+    os_remove( tmp )    -- best-effort cleanup on full failure
+    return false, rerr or "rename failed"
+end
+
+-- Internal: emit a savetable-shaped serialisation to any writer that
+-- accepts :write(...). Used by both savetable (file-backed) and
+-- tabletostring (in-memory builder). Wraps sortserialize with the
+-- `local <name>` / `return <name>` envelope that loadtable expects.
+local _writetable = function( tbl, name, writer )
+    writer:write( "local ", name, "\n\n" )
+    sortserialize( tbl, name, writer, "" )
+    writer:write( "\n\nreturn ", name )
+end
+
+-- Memory-buffer mirror of the savetable serialisation. Lets
+-- savetable build the full content as a string before handing it to
+-- atomic_write, so we never half-write the target file.
+tabletostring = function( tbl, name )
+    local sb = { buf = { }, n = 0 }
+    function sb:write( ... )
+        local n = select( "#", ... )
+        for i = 1, n do
+            self.n = self.n + 1
+            self.buf[ self.n ] = tostring( ( select( i, ... ) ) or "" )
+        end
+    end
+    _writetable( tbl, name, sb )
+    return table_concat( sb.buf, "", 1, sb.n )
+end
+
+--// saves a table to a local file (F-PLG-1: atomic via tmp + rename)
 savetable = function( tbl, name, path )
-    local file, err = io_open( path, "w+" )
-    if file then
-        file:write( "local ", name, "\n\n" )
-        sortserialize( tbl, name, file, "" )
-        file:write( "\n\nreturn ", name )
-        file:close( )
-        return true
-    else
+    local content = tabletostring( tbl, name )
+    local ok, err = atomic_write( path, content )
+    if not ok then
         out_error( "util.lua: function 'savetable': error in ", path, ": ", err, " (savetable)" )
         return false, err
     end
+    return true
 end
 
 -- Internal: emit a savearray-shaped serialisation to any writer that
@@ -419,15 +483,14 @@ loadtable_string = function( content, name )
     return nil, "invalid table"
 end
 
---// saves an array to a local file
+--// saves an array to a local file (F-PLG-1: atomic via tmp + rename)
 savearray = function( array, path )
-    local file, err = io_open( path, "w+" )
-    if not file then
+    local content = arraytostring( array )
+    local ok, err = atomic_write( path, content )
+    if not ok then
         out_error( "util.lua: function 'savearray': error in ", path, ": ", err, " (savearray)" )
         return false, err
     end
-    _writearray( array, file )
-    file:close( )
     return true
 end
 
@@ -771,6 +834,8 @@ return {
     serialize = serialize,
     savearray = savearray,
     arraytostring = arraytostring,
+    tabletostring = tabletostring,
+    atomic_write = atomic_write,
     formatseconds = formatseconds,
     formatbytes = formatbytes,
     generatepass = generatepass,


### PR DESCRIPTION
Part of #133 (F-PLG-1). Atomic-by-default for plugin saves.

## Lands

- New `util.atomic_write(path, content)` helper in `core/util.lua` - tmp + rename with Windows fallback. No chmod (cfg_users.lua keeps its 0600 separately via `util.chmod_secret`).
- `util.savearray` and `util.savetable` route their final write through `atomic_write`. **21 plugin save sites get crash-safe saves automatically, zero call-site changes.**
- `core/cfg_users.lua` refactored to delegate to `util.atomic_write` instead of its own copy of the tmp+rename logic - single source of truth for the Windows fallback.
- New `util.tabletostring(tbl, name)` builder mirroring `util.arraytostring`. Both savetable + savearray now serialise to memory first, never half-write the target.

## Test plan

- [x] Smoke 31/31 PASS on Windows.
- [x] `user.tbl.bak atomic refresh` test validates cfg_users.lua still produces atomic .bak writes through the new helper.
- [x] `+setpass preserves encryption` test validates the encrypted-blob save path still works end-to-end.
- No new tests added (per audit discussion - don't grow testbench).

## Plugins covered

`bot_opchat`, `bot_regchat`, `bot_session_chat`, `cmd_ban`, `cmd_delreg`, `cmd_gag`, `cmd_hubinfo`, `cmd_hubstats`, `cmd_nickchange`, `cmd_reg`, `cmd_topic`, `cmd_uptime`, `cmd_usercleaner`, `etc_blacklist`, `etc_chatlog`, `etc_msgmanager`, `etc_records`, `etc_trafficmanager`, `hub_runtime`, `usr_hide_share`, `usr_uptime`

## Issue #133 status after merge

- [x] F-PLG-1 atomic save - **this PR**
- [ ] F-PLG-2 loadtable nil-handling
- [ ] F-PLG-3 silent no-op on incomplete +cmd
