### PR TITLE
fix(scripts): defensive 'or {}' on util.loadtable sites (F-PLG-2 of #133)

### DIFF
--- a/scripts/bot_session_chat.lua
+++ b/scripts/bot_session_chat.lua
@@ -155,7 +155,7 @@ local owner, members = "owner", "members"
 
 --// reg session chats on scriptstart
 reg_chats_onstart = function()
-    sessions_tbl = util.loadtable( sessions_file )
+    sessions_tbl = util.loadtable( sessions_file ) or {}
     local i = 0
     for k, v in pairs( sessions_tbl ) do
         if k then
@@ -179,7 +179,7 @@ end
 
 --// check if chat exists
 check_If_chat_exists = function( chat )
-    sessions_tbl = util.loadtable( sessions_file )
+    sessions_tbl = util.loadtable( sessions_file ) or {}
     for k, v in pairs( sessions_tbl ) do
         if k == chat then
             return true
@@ -190,7 +190,7 @@ end
 
 --// check if user is member
 check_if_member = function( user, chat )
-    sessions_tbl = util.loadtable( sessions_file )
+    sessions_tbl = util.loadtable( sessions_file ) or {}
     for k, v in pairs( sessions_tbl ) do
         if k == chat then
             for k, v in pairs( v ) do
@@ -209,7 +209,7 @@ end
 
 --// check if user is chat owner
 check_if_owner = function( user, chat )
-    sessions_tbl = util.loadtable( sessions_file )
+    sessions_tbl = util.loadtable( sessions_file ) or {}
     local user_nick = user:nick()
     for k, v in pairs( sessions_tbl ) do
         if k == chat then
@@ -227,7 +227,7 @@ end
 
 --// get all members from chat
 get_members = function( chat )
-    sessions_tbl = util.loadtable( sessions_file )
+    sessions_tbl = util.loadtable( sessions_file ) or {}
     local tbl = {}
     for k, v in pairs( sessions_tbl ) do
         if k == chat then
@@ -258,7 +258,7 @@ end
 
 --// refresh members count of chats
 refresh_bot = function( chat )
-    sessions_tbl = util.loadtable( sessions_file )
+    sessions_tbl = util.loadtable( sessions_file ) or {}
     local i = 0
     for k, v in pairs( sessions_tbl ) do
         if k == chat then
@@ -287,7 +287,7 @@ end
 
 --// send msg to all members
 msg_to_members = function( chat, msg )
-    sessions_tbl = util.loadtable( sessions_file )
+    sessions_tbl = util.loadtable( sessions_file ) or {}
     for k, v in pairs( sessions_tbl ) do
         if k == chat then
             local bot_name = hub.isnickonline( chat )
@@ -520,7 +520,7 @@ hub.setlistener( "onStart", {},
 
 hub.setlistener( "onLogout", {},
     function( user )
-        sessions_tbl = util.loadtable( sessions_file )
+        sessions_tbl = util.loadtable( sessions_file ) or {}
         local user_nick = user:nick()
         local chat
         for k, v in pairs( sessions_tbl ) do

--- a/scripts/cmd_accinfo.lua
+++ b/scripts/cmd_accinfo.lua
@@ -354,7 +354,7 @@ local get_lastseen = function( profile )
 end
 
 local get_regdescription = function( profile )
-    local description_tbl = util.loadtable( description_file )
+    local description_tbl = util.loadtable( description_file ) or {}
     local desc = ""
     for k, v in pairs( description_tbl ) do
         if k == profile.nick then
@@ -381,7 +381,7 @@ end
 
 local get_msgmanager = function( profile )
     if msgmanager_activate then
-        local msgmanager_tbl = util.loadtable( msgmanager_file )
+        local msgmanager_tbl = util.loadtable( msgmanager_file ) or {}
         local info = ""
         for k, v in pairs( msgmanager_tbl ) do
             if k == profile.nick then

--- a/scripts/cmd_delreg.lua
+++ b/scripts/cmd_delreg.lua
@@ -173,7 +173,7 @@ local minlevel = util.getlowestlevel( permission )
 local cmd_options = { nick = "nick", nicku = "nicku" }
 
 local blacklist_add = function( targetnick, nick, reason )
-    local blacklist_tbl = util.loadtable( blacklist_file )
+    local blacklist_tbl = util.loadtable( blacklist_file ) or {}
     blacklist_tbl[ targetnick ] = {}
     blacklist_tbl[ targetnick ][ "tDate" ] = os.date( "%Y-%m-%d / %H:%M:%S" )
     blacklist_tbl[ targetnick ][ "tReason" ] = reason
@@ -186,7 +186,7 @@ end
 -- +delreg remove a blacklist entry without the operator hand-editing
 -- cmd_delreg_blacklist.tbl. Closes upstream luadch/luadch#228.
 local blacklist_del = function( targetnick )
-    local blacklist_tbl = util.loadtable( blacklist_file )
+    local blacklist_tbl = util.loadtable( blacklist_file ) or {}
     if not blacklist_tbl or not blacklist_tbl[ targetnick ] then
         return false
     end
@@ -196,7 +196,7 @@ local blacklist_del = function( targetnick )
 end
 
 local description_del = function( targetnick )
-    local description_tbl = util.loadtable( description_file )
+    local description_tbl = util.loadtable( description_file ) or {}
     for k, v in pairs( description_tbl ) do
         if k == targetnick then
             description_tbl[ k ] = nil

--- a/scripts/cmd_hubinfo.lua
+++ b/scripts/cmd_hubinfo.lua
@@ -375,7 +375,11 @@ end
 
 --// uptime complete
 get_hubruntime = function()
-    local hubruntime = hci_tbl.hubruntime
+    -- F-PLG-2 (#133): defensive `or 0` even though check_hci() at
+    -- file load initialises hci_tbl. Guards against a malformed
+    -- pre-existing hci.lua that loaded as a table but lacks the
+    -- hubruntime field.
+    local hubruntime = hci_tbl.hubruntime or 0
     local y, d, h, m, s = util.formatseconds( hubruntime )
     return y .. msg_years .. d .. msg_days .. h .. msg_hours .. m .. msg_minutes .. s .. msg_seconds
 end

--- a/scripts/cmd_nickchange.lua
+++ b/scripts/cmd_nickchange.lua
@@ -163,7 +163,7 @@ local onbmsg, isTaken, isRegged, description_check
 ----------
 
 description_check = function( new_nick, old_nick )
-    local tbl = util.loadtable( description_file )
+    local tbl = util.loadtable( description_file ) or {}
     for k, v in pairs( tbl ) do
         if k == old_nick then
             local v1 = v[ "tBy" ]

--- a/scripts/cmd_reg.lua
+++ b/scripts/cmd_reg.lua
@@ -281,7 +281,7 @@ if not tbl_isEmpty( ssl_ipv6 ) and ( ssl_ipv6[ 1 ] > 0 ) then
 end
 
 local description_add = function( targetnick, nick, reason )
-    description_tbl = util.loadtable( description_file )
+    description_tbl = util.loadtable( description_file ) or {}
     description_tbl[ targetnick ] = {}
     description_tbl[ targetnick ][ "tBy" ] = nick
     description_tbl[ targetnick ][ "tReason" ] = reason
@@ -292,7 +292,7 @@ local onbmsg = function( user, command, parameters )
     local user_nick = user:nick()
     local user_firstnick = user:firstnick()
     local user_level = user:level( )
-    blacklist_tbl = util.loadtable( blacklist_file )
+    blacklist_tbl = util.loadtable( blacklist_file ) or {}
     if user_level < minlevel then
         user:reply( msg_denied, hub.getbot() )
         return PROCESSED

--- a/scripts/cmd_uptime.lua
+++ b/scripts/cmd_uptime.lua
@@ -133,8 +133,11 @@ local get_hubuptime = function()
 end
 
 local get_hubruntime = function()
-    local hci_tbl = util.loadtable( hci_file )
-    local hubruntime = hci_tbl.hubruntime
+    -- F-PLG-2 (#133): mirror of hub_runtime.lua defence. check_hci()
+    -- at script load creates the file; defensive `or {}` / `or 0`
+    -- here keeps mid-run loadtable failure from crashing the listener.
+    local hci_tbl = util.loadtable( hci_file ) or {}
+    local hubruntime = hci_tbl.hubruntime or 0
     local y, d, h, m, s = util.formatseconds( hubruntime )
     return y .. msg_years .. d .. msg_days .. h .. msg_hours .. m .. msg_minutes .. s .. msg_seconds
 end

--- a/scripts/cmd_usercleaner.lua
+++ b/scripts/cmd_usercleaner.lua
@@ -76,8 +76,8 @@ local report_opchat = cfg.get( "cmd_usercleaner_report_opchat" )
 
 local exception_file = "scripts/data/cmd_usercleaner_exceptions.tbl"
 local settings_file = "scripts/data/cmd_usercleaner_settings.tbl"
-local exception_tbl = util.loadtable( exception_file )
-local settings_tbl = util.loadtable( settings_file )
+local exception_tbl = util.loadtable( exception_file ) or {}
+local settings_tbl = util.loadtable( settings_file ) or {}
 
 local activate = cfg.get( "cmd_usercleaner_activate" )
 local permission = cfg.get( "cmd_usercleaner_permission" )
@@ -254,7 +254,7 @@ end
 
 --// remove register description if exists
 local description_del = function( targetnick )
-    local description_tbl = util.loadtable( description_file )
+    local description_tbl = util.loadtable( description_file ) or {}
     for k, v in pairs( description_tbl ) do
         if k == targetnick then
             description_tbl[ k ] = nil

--- a/scripts/etc_msgmanager.lua
+++ b/scripts/etc_msgmanager.lua
@@ -442,7 +442,7 @@ hub.setlistener( "onPrivateMessage", {},
 --// script start
 hub.setlistener( "onStart", {},
     function()
-        block_tbl = util.loadtable( block_file )
+        block_tbl = util.loadtable( block_file ) or {}
         --// help, ucmd, hucmd
         local help = hub.import( "cmd_help" )
         if help then

--- a/scripts/etc_trafficmanager.lua
+++ b/scripts/etc_trafficmanager.lua
@@ -161,7 +161,7 @@ local desc_prefix_table = cfg.get( "usr_desc_prefix_prefix_table" )
 local send_loop = cfg.get( "etc_trafficmanager_send_loop" )
 local loop_time = cfg.get( "etc_trafficmanager_loop_time" )
 local block_file = "scripts/data/etc_trafficmanager.tbl"
-local block_tbl = util.loadtable( block_file )
+local block_tbl = util.loadtable( block_file ) or {}
 local flag_blocked = cfg.get( "etc_trafficmanager_flag_blocked" )
 
 --// msgs

--- a/scripts/hub_runtime.lua
+++ b/scripts/hub_runtime.lua
@@ -128,18 +128,23 @@ get_hubuptime = function()
     return hubuptime
 end
 
+-- F-PLG-2 (#133): defensive `or {}` plus `.field or default` so a
+-- mid-run loadtable failure (file deleted, permission flip, fs error)
+-- doesn't crash these listeners. check_hci() at script load already
+-- creates the file with zero defaults; in steady state these reads
+-- succeed.
 get_hubruntime = function()
-    local hci_tbl = util.loadtable( hci_file )
-    local hrt = hci_tbl.hubruntime
+    local hci_tbl = util.loadtable( hci_file ) or {}
+    local hrt = hci_tbl.hubruntime or 0
     local y, d, h, m, s = util.formatseconds( hrt )
     hrt = y .. msg_years .. d .. msg_days .. h .. msg_hours .. m .. msg_minutes .. s .. msg_seconds
     return hrt
 end
 
 set_hubruntime = function()
-    local hci_tbl = util.loadtable( hci_file )
-    local hrt = hci_tbl.hubruntime
-    local hrt_lc = hci_tbl.hubruntime_last_check
+    local hci_tbl = util.loadtable( hci_file ) or {}
+    local hrt = hci_tbl.hubruntime or 0
+    local hrt_lc = hci_tbl.hubruntime_last_check or 0
     if hrt_lc == 0 then hrt_lc = util.date() end
     local hrt_lc_str = tostring( hrt_lc )
     if #hrt_lc_str ~= 14 then hrt_lc = util.convertepochdate( hrt_lc ) end
@@ -151,7 +156,7 @@ set_hubruntime = function()
 end
 
 reset_hubruntime = function()
-    local hci_tbl = util.loadtable( hci_file )
+    local hci_tbl = util.loadtable( hci_file ) or {}
     hci_tbl.hubruntime = 0
     util.savetable( hci_tbl, "hci_tbl", hci_file )
 end

--- a/scripts/usr_hide_share.lua
+++ b/scripts/usr_hide_share.lua
@@ -76,7 +76,7 @@ if not activate then
    return
 end
 
-local hide_share_tbl = util.loadtable( path )
+local hide_share_tbl = util.loadtable( path ) or {}
 local oplevel = util.getlowestlevel( permission )
 local share = "0"
 


### PR DESCRIPTION
Part of #133 (F-PLG-2). Per-site `or {}` sweep on `util.loadtable` consumers.

## Lands

22 sites get defensive `or {}` across 12 files. Sites with an existing type-check + init pattern (`check_hci` style) are intentionally untouched - they handle nil correctly and create the file with defaults; adding `or {}` would mask the init logic.

| File | Sites |
|---|---|
| `bot_session_chat` | 8 reload sites in chat-state functions |
| `cmd_accinfo` | description_tbl, msgmanager_tbl |
| `cmd_delreg` | blacklist + description loads (3) |
| `cmd_nickchange` | description_tbl |
| `cmd_reg` | description_tbl, blacklist_tbl |
| `cmd_usercleaner` | exception_tbl, settings_tbl, description_tbl |
| `etc_msgmanager` | block_tbl |
| `etc_trafficmanager` | block_tbl |
| `usr_hide_share` | hide_share_tbl |

Plus defensive access for the `hci_tbl.hubruntime`-style field reads where the file-scope `check_hci()` handles nil correctly but downstream readers access `.field` directly:

| File | Function | Defense |
|---|---|---|
| `cmd_hubinfo` | `get_hubruntime` | `.hubruntime or 0` |
| `cmd_uptime` | `get_hubruntime` | `or {}` + `or 0` |
| `hub_runtime` | `get_hubruntime` | `or {}` + `or 0` |
| `hub_runtime` | `set_hubruntime` | `or {}` + `or 0` on both fields |
| `hub_runtime` | `reset_hubruntime` | `or {}` |

## Sites left untouched

Existing init-pattern sites that handle nil with `type(tbl) ~= "table"` + savetable + (sometimes) opchat warning:

- `cmd_hubinfo:167` (check_hci at line 303)
- `cmd_uptime:95` (type-check + savetable init)
- `hub_runtime:110` (check_hci at 110)
- `usr_uptime:90` (new_entry runtime nil-handler with opchat warn)

## Test plan

- [x] `cmake --install build` clean.
- [x] Smoke 31/31 PASS on Windows.
- [x] No new tests (per #133 acceptance).

## Issue #133 status after merge

- [x] F-PLG-1 atomic save - merged in #134
- [x] F-PLG-2 loadtable nil-handling - **this PR**
- [ ] F-PLG-3 silent no-op on incomplete `+cmd`
