### PR TITLE
feat(ratelimit): split DMSG/EMSG into a dedicated PM bucket (PR 1/4 of #80)

### DIFF
--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -3215,13 +3215,26 @@ local defaults = {
             return types_number( value, nil, true )
         end
     },
-    -- Per-user chat (BMSG / EMSG / DMSG) rate.
+    -- Per-user mainchat (BMSG) rate.
     ratelimit_user_msg_rate = { 5,
         function( value )
             return types_number( value, nil, true )
         end
     },
     ratelimit_user_msg_burst = { 10,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+    -- Per-user PM (DMSG / EMSG) rate. Split out of the mainchat bucket
+    -- in #80 so DMs and broadcasts can be tuned independently. Defaults
+    -- match user_msg for behaviour-equivalence with v3.1.7.
+    ratelimit_user_pm_rate = { 5,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+    ratelimit_user_pm_burst = { 10,
         function( value )
             return types_number( value, nil, true )
         end

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -62,6 +62,7 @@ local cfg_get = cfg.get
 local cfg_saveusers = cfg.saveusers
 
 local ratelimit_user_msg = ratelimit.user_msg
+local ratelimit_user_pm = ratelimit.user_pm
 local ratelimit_user_search = ratelimit.user_search
 local ratelimit_record_authfail = ratelimit.record_authfail
 
@@ -436,14 +437,17 @@ _verify = {
 
 }
 
--- Phase 7c F-RL-1 / F-RL-2 helpers. Token-bucket-protected entry points
--- to the BMSG / EMSG / DMSG / *SCH listeners. Returning `true` from the
--- handler tells incoming() the message has been handled (so the
--- broadcast / fan-out is suppressed) without disconnecting the user.
--- Op-level users (>= ratelimit_bypass_level) bypass the check inside
--- ratelimit.user_msg / user_search.
+-- Phase 7c F-RL-1 / F-RL-2 helpers, plus the #80 PM-split. Token-bucket-
+-- protected entry points to the BMSG / EMSG / DMSG / *SCH listeners.
+-- Returning `true` from the handler tells incoming() the message has
+-- been handled (so the broadcast / fan-out is suppressed) without
+-- disconnecting the user. Op-level users (>= ratelimit_bypass_level)
+-- bypass the check inside the ratelimit module.
 local function rl_msg_drop( user )
     return not ratelimit_user_msg( user.cid( ), user.level( ) )
+end
+local function rl_pm_drop( user )
+    return not ratelimit_user_pm( user.cid( ), user.level( ) )
 end
 local function rl_search_drop( user )
     return not ratelimit_user_search( user.cid( ), user.level( ) )
@@ -463,11 +467,11 @@ _normal = {
     --    return scripts_firelistener( "onBroadcast", user, adccmd, escapefrom( adccmd[ 8 ] ) )
     --end,
     EMSG = function( user, adccmd, targetuser )
-        if rl_msg_drop( user ) then return true end
+        if rl_pm_drop( user ) then return true end
         return scripts_firelistener( "onPrivateMessage", user, targetuser, adccmd, escapefrom( adccmd[ 8 ] ) )
     end,
     DMSG = function( user, adccmd, targetuser )
-        if rl_msg_drop( user ) then return true end
+        if rl_pm_drop( user ) then return true end
         return scripts_firelistener( "onPrivateMessage", user, targetuser, adccmd, escapefrom( adccmd[ 8 ] ) )
     end,
     -- ADC: 6.3.8. CTM

--- a/core/ratelimit.lua
+++ b/core/ratelimit.lua
@@ -68,6 +68,7 @@ local handshake_started
 local handshake_finished
 local expired_handshakes
 local user_msg
+local user_pm
 local user_search
 local record_authfail
 local tick
@@ -92,6 +93,8 @@ local _authfail_burst
 local _authfail_lockout
 local _msg_rate
 local _msg_burst
+local _pm_rate
+local _pm_burst
 local _search_rate_per_sec
 local _search_burst
 
@@ -204,12 +207,26 @@ expired_handshakes = function( )
     return result
 end
 
--- Per-user chat-rate (F-RL-1). level >= bypass_level skips the check.
+-- Per-user mainchat-rate (F-RL-1). level >= bypass_level skips the check.
+-- Gates BMSG only - the PM types (DMSG/EMSG) used to share this bucket
+-- but have their own user_pm bucket since #80 so operators can tune them
+-- independently.
 user_msg = function( cid, level )
     if not _activate then return true end
     if level and level >= _bypass_level then return true end
     if not cid or cid == "" then return true end
     return _consume( "user:" .. cid, "msg", _msg_burst, _msg_rate )
+end
+
+-- Per-user PM-rate (#80, PM-Flood split). Gates DMSG/EMSG. level >=
+-- bypass_level skips the check. Defaults are the same as user_msg for
+-- behaviour-equivalence with the pre-split v3.1.7 release; operators
+-- can tune them tighter independently of the mainchat bucket.
+user_pm = function( cid, level )
+    if not _activate then return true end
+    if level and level >= _bypass_level then return true end
+    if not cid or cid == "" then return true end
+    return _consume( "user:" .. cid, "pm", _pm_burst, _pm_rate )
 end
 
 -- Per-user search-rate (F-RL-2). level >= bypass_level skips the check.
@@ -268,6 +285,8 @@ init = function( )
     _authfail_lockout = cfg_get "ratelimit_authfail_lockout"
     _msg_rate = cfg_get "ratelimit_user_msg_rate"
     _msg_burst = cfg_get "ratelimit_user_msg_burst"
+    _pm_rate = cfg_get "ratelimit_user_pm_rate"
+    _pm_burst = cfg_get "ratelimit_user_pm_burst"
     -- search is configured as "one per N seconds" for legibility; convert
     -- to fill-rate per second.
     local search_period = cfg_get "ratelimit_user_search_period"
@@ -289,6 +308,7 @@ return {
     handshake_finished = handshake_finished,
     expired_handshakes = expired_handshakes,
     user_msg = user_msg,
+    user_pm = user_pm,
     user_search = user_search,
     record_authfail = record_authfail,
     tick = tick,

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -759,6 +759,30 @@ def test_neg_post_login_search_burst():
         _neg_drain_briefly(sock)
 
 
+def test_neg_post_login_pm_burst():
+    """After a clean login, fire 50 DMSG private messages back-to-back at
+    a non-existent SID. Tests that the PM bucket (#80 split from msg)
+    rate-limits / absorbs without crashing the dispatcher. Independent of
+    the BMSG bucket exercised by other tests."""
+    with socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    ) as sock:
+        try:
+            sid, _reader = _adc_login(sock, "dummy", "test")
+        except TestFailure:
+            return
+        for i in range(50):
+            try:
+                # ZZZZ is a syntactically-valid SID slot with no logged-in
+                # client; the dispatcher rate-checks before target lookup.
+                sock.sendall(
+                    f"DMSG {sid} ZZZZ hello{i}\n".encode("utf-8")
+                )
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                return
+        _neg_drain_briefly(sock)
+
+
 def test_neg_post_login_ctm_burst():
     """After a clean login, fire 50 BCTM commands at non-existent SIDs.
     Same rationale as the SCH burst - rate-limit / absorb / disconnect,
@@ -1239,6 +1263,7 @@ TESTS = [
     ("neg: post-login oversized BMSG", test_neg_post_login_oversized_msg),
     ("neg: post-login oversized BSCH", test_neg_post_login_oversized_search),
     ("neg: post-login BSCH burst", test_neg_post_login_search_burst),
+    ("neg: post-login DMSG burst (#80 PM bucket)", test_neg_post_login_pm_burst),
     ("neg: post-login DCTM burst", test_neg_post_login_ctm_burst),
     ("neg: canary - hub still alive after fuzz battery", test_neg_canary_hub_alive),
 ]


### PR DESCRIPTION
First of four sub-PRs for the ratelimit v2 work tracked in #80.

## Why

Since Phase 7c (#73) DMSG and EMSG have been rate-limited, but they shared the same per-user token bucket as BMSG (mainchat). One bucket, one knob - operators couldn't tune chat-flood and PM-flood independently. PMs are a different abuse surface (harder to observe publicly, higher per-recipient cost), so they deserve their own throttle.

## Lands

| File | Change |
|---|---|
| \`core/ratelimit.lua\` | New public \`user_pm(cid, level)\` mirroring \`user_msg\`, with its own \`_pm_rate\` / \`_pm_burst\` scalars. Same bypass-by-level semantics, same \`_consume\` machinery under a separate bucket kind \"pm\" so counters don't cross. |
| \`core/cfg_defaults.lua\` | Two new keys \`ratelimit_user_pm_rate\` (default 5) and \`ratelimit_user_pm_burst\` (default 10). Match the existing \`user_msg\` defaults for behaviour-equivalence with v3.1.7. |
| \`core/hub_dispatch.lua\` | DMSG/EMSG switch from \`rl_msg_drop\` to new \`rl_pm_drop\`. BMSG stays on \`rl_msg_drop\`. |
| \`tests/smoke/run.py\` | New \`test_neg_post_login_pm_burst\` confirms PM bucket absorbs a 50-DMSG burst. Smoke suite 31 -> 32 tests. |

## Operator impact

**None at defaults.** Both new cfg keys default to the existing chat values, so a v3.1.7 -> next upgrade keeps the same throughput. Operators can dial PM tighter or looser at their leisure.

## Test plan

- [x] Lua syntax OK (\`lua54 -e loadfile\` on all three changed core files)
- [x] Local smoke 32/32 PASS on Windows (Lua 5.4.8 / MinGW UCRT64)
- [ ] CI Linux smoke
- [ ] CI Windows smoke

## #80 status after merge

- [x] **PR 1/4**: PM bucket - **this PR**
- [ ] PR 2/4: INF-update flood
- [ ] PR 3/4: CTM/RCM flood
- [ ] PR 4/4: per-userlevel tier model (refactors msg/pm/search/inf/ctm to share tier-mapping)