### PR TITLE
feat(ratelimit): per-user BINF-update bucket (PR 2/4 of #80)

### DIFF
--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -3239,6 +3239,22 @@ local defaults = {
             return types_number( value, nil, true )
         end
     },
+    -- Per-user BINF-update rate (#80, post-login only). Defaults are
+    -- deliberately lenient: watch-folders emit a BINF on every share-
+    -- size change, and starting N parallel downloads emits N quick
+    -- slot-count updates. burst=20 absorbs that without flagging
+    -- legitimate users; rate=2/s lets steady-state churn through and
+    -- caps any flood at ~120/min after the burst is exhausted.
+    ratelimit_user_inf_rate = { 2,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+    ratelimit_user_inf_burst = { 20,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
     -- Per-user search (BSCH / FSCH / DSCH) cooldown. The bucket fills
     -- at one token every ratelimit_user_search_period seconds.
     ratelimit_user_search_period = { 2,

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -63,6 +63,7 @@ local cfg_saveusers = cfg.saveusers
 
 local ratelimit_user_msg = ratelimit.user_msg
 local ratelimit_user_pm = ratelimit.user_pm
+local ratelimit_user_inf = ratelimit.user_inf
 local ratelimit_user_search = ratelimit.user_search
 local ratelimit_record_authfail = ratelimit.record_authfail
 
@@ -449,6 +450,9 @@ end
 local function rl_pm_drop( user )
     return not ratelimit_user_pm( user.cid( ), user.level( ) )
 end
+local function rl_inf_drop( user )
+    return not ratelimit_user_inf( user.cid( ), user.level( ) )
+end
 local function rl_search_drop( user )
     return not ratelimit_user_search( user.cid( ), user.level( ) )
 end
@@ -456,6 +460,7 @@ end
 _normal = {
     -- ADC: 6.3.4. INF
     BINF = function( user, adccmd )
+        if rl_inf_drop( user ) then return true end
         return scripts_firelistener( "onInf", user, adccmd )
     end,
     -- ADC: 6.3.5. MSG

--- a/core/ratelimit.lua
+++ b/core/ratelimit.lua
@@ -69,6 +69,7 @@ local handshake_finished
 local expired_handshakes
 local user_msg
 local user_pm
+local user_inf
 local user_search
 local record_authfail
 local tick
@@ -95,6 +96,8 @@ local _msg_rate
 local _msg_burst
 local _pm_rate
 local _pm_burst
+local _inf_rate
+local _inf_burst
 local _search_rate_per_sec
 local _search_burst
 
@@ -229,6 +232,21 @@ user_pm = function( cid, level )
     return _consume( "user:" .. cid, "pm", _pm_burst, _pm_rate )
 end
 
+-- Per-user BINF-update rate (#80, INF-Update flood). Gates post-login
+-- BINFs only - the login BINF runs through the IDENTIFY/VERIFY state
+-- machine before normal-state dispatch, so a tight bucket here cannot
+-- block legitimate logins. Defaults are deliberately lenient (2/s,
+-- burst 20) to tolerate legitimate share-state churn: watch-folders
+-- emit a BINF whenever the share size changes, and a user starting
+-- ten parallel downloads emits ten quick slot-count updates. Operators
+-- on quiet hubs can tighten. level >= bypass_level skips the check.
+user_inf = function( cid, level )
+    if not _activate then return true end
+    if level and level >= _bypass_level then return true end
+    if not cid or cid == "" then return true end
+    return _consume( "user:" .. cid, "inf", _inf_burst, _inf_rate )
+end
+
 -- Per-user search-rate (F-RL-2). level >= bypass_level skips the check.
 user_search = function( cid, level )
     if not _activate then return true end
@@ -287,6 +305,8 @@ init = function( )
     _msg_burst = cfg_get "ratelimit_user_msg_burst"
     _pm_rate = cfg_get "ratelimit_user_pm_rate"
     _pm_burst = cfg_get "ratelimit_user_pm_burst"
+    _inf_rate = cfg_get "ratelimit_user_inf_rate"
+    _inf_burst = cfg_get "ratelimit_user_inf_burst"
     -- search is configured as "one per N seconds" for legibility; convert
     -- to fill-rate per second.
     local search_period = cfg_get "ratelimit_user_search_period"
@@ -309,6 +329,7 @@ return {
     expired_handshakes = expired_handshakes,
     user_msg = user_msg,
     user_pm = user_pm,
+    user_inf = user_inf,
     user_search = user_search,
     record_authfail = record_authfail,
     tick = tick,

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -759,6 +759,32 @@ def test_neg_post_login_search_burst():
         _neg_drain_briefly(sock)
 
 
+def test_neg_post_login_inf_burst():
+    """After a clean login, fire 50 BINF updates back-to-back. Tests that
+    the INF bucket (#80) absorbs share-state-update floods without
+    crashing the dispatcher. The first ~burst go through to onInf
+    listeners, the rest are silently dropped by rl_inf_drop. Hub must
+    stay alive."""
+    with socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    ) as sock:
+        try:
+            sid, _reader = _adc_login(sock, "dummy", "test")
+        except TestFailure:
+            return
+        for i in range(50):
+            try:
+                # Vary SS (share size) to look like a watch-folder
+                # churning files in / out - the legitimate-use case the
+                # bucket is sized to tolerate up to its burst.
+                sock.sendall(
+                    f"BINF {sid} SS{1000 + i}\n".encode("utf-8")
+                )
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                return
+        _neg_drain_briefly(sock)
+
+
 def test_neg_post_login_pm_burst():
     """After a clean login, fire 50 DMSG private messages back-to-back at
     a non-existent SID. Tests that the PM bucket (#80 split from msg)
@@ -1264,6 +1290,7 @@ TESTS = [
     ("neg: post-login oversized BSCH", test_neg_post_login_oversized_search),
     ("neg: post-login BSCH burst", test_neg_post_login_search_burst),
     ("neg: post-login DMSG burst (#80 PM bucket)", test_neg_post_login_pm_burst),
+    ("neg: post-login BINF burst (#80 INF bucket)", test_neg_post_login_inf_burst),
     ("neg: post-login DCTM burst", test_neg_post_login_ctm_burst),
     ("neg: canary - hub still alive after fuzz battery", test_neg_canary_hub_alive),
 ]


### PR DESCRIPTION
Second of four sub-PRs for the ratelimit v2 work tracked in #80.

## Why

BINF updates were not rate-limited. A misbehaving client (or an attacker) could emit hundreds of BINFs per second, each firing the onInf listener chain (\`hub_inf_manager\`, \`etc_clientblocker\`, \`usr_uptime\`, \`hub_share\`). Even when each handler is cheap, the multiplier over plugin count amplifies a flood into a real load spike on a single-threaded hub.

## Lands

| File | Change |
|---|---|
| \`core/ratelimit.lua\` | New public \`user_inf(cid, level)\` mirroring \`user_msg\`/\`user_pm\`. Own bucket kind \"inf\", own \`_inf_rate\` / \`_inf_burst\` scalars, same bypass-by-level. |
| \`core/cfg_defaults.lua\` | \`ratelimit_user_inf_rate\` (default **2/s**) and \`ratelimit_user_inf_burst\` (default **20**). Lenient defaults per the open question on the issue. |
| \`core/hub_dispatch.lua\` | New \`rl_inf_drop\` helper. BINF in \`_normal\` gates through it before \`scripts_firelistener(\"onInf\", ...)\`. The login BINF runs through IDENTIFY/VERIFY before reaching \`_normal\`, so this never rejects a legitimate login. |
| \`tests/smoke/run.py\` | \`test_neg_post_login_inf_burst\`: 50 BINF updates back-to-back varying \`SS\` to mimic watch-folder churn. Smoke suite 32 -> 33 tests. |

## Default tuning rationale

Closes the open question in #80 (\"INF bucket has to tolerate legitimate INF resends on share-state changes\"):

- **Watch-folder churn**: a user with auto-share emits a BINF per share-size change. burst=20 absorbs the busiest moments.
- **Parallel-download startup**: starting 10 simultaneous downloads emits ~10 slot-count BINFs within a second; well inside burst.
- **Sustained flood cap**: after burst is exhausted, the bucket drips at 2/s = 120/min. Bounded dispatch work, but legitimate steady-state still gets through.

Operators on quiet hubs (low file churn) can tighten via cfg. Op-level users (>= \`ratelimit_bypass_level\`) bypass the check entirely.

## Operator impact at defaults

**None for typical users.** Even an active sharer rarely sustains more than 1 BINF/sec; 2/s with burst 20 is comfortably above that.

## Test plan

- [x] Lua syntax OK on all three changed core files
- [x] Local smoke 33/33 PASS on Windows
- [ ] CI Linux smoke
- [ ] CI Windows smoke

## #80 status after merge

- [x] PR 1/4: PM bucket - #138 merged
- [x] **PR 2/4**: INF-update bucket - **this PR**
- [ ] PR 3/4: CTM/RCM flood
- [ ] PR 4/4: per-userlevel tier model