### PR TITLE
feat(ratelimit): per-user CTM/RCM bucket (PR 3/4 of #80)

### DIFF
--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -3255,6 +3255,23 @@ local defaults = {
             return types_number( value, nil, true )
         end
     },
+    -- Per-user connection-setup rate (#80). Shared bucket for DCTM and
+    -- DRCM since they are alternatives for the same primitive (peer
+    -- connection initiation, choice depends on NAT routing). burst=30
+    -- tolerates the explicit use case from the issue: a user firing
+    -- many CTMs when their search results resolve to lots of peers,
+    -- or kicking off a deep download queue. rate=2/s caps a malicious
+    -- crawler at ~120 attempts per minute after the burst.
+    ratelimit_user_ctm_rate = { 2,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+    ratelimit_user_ctm_burst = { 30,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
     -- Per-user search (BSCH / FSCH / DSCH) cooldown. The bucket fills
     -- at one token every ratelimit_user_search_period seconds.
     ratelimit_user_search_period = { 2,

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -64,6 +64,7 @@ local cfg_saveusers = cfg.saveusers
 local ratelimit_user_msg = ratelimit.user_msg
 local ratelimit_user_pm = ratelimit.user_pm
 local ratelimit_user_inf = ratelimit.user_inf
+local ratelimit_user_ctm = ratelimit.user_ctm
 local ratelimit_user_search = ratelimit.user_search
 local ratelimit_record_authfail = ratelimit.record_authfail
 
@@ -453,6 +454,9 @@ end
 local function rl_inf_drop( user )
     return not ratelimit_user_inf( user.cid( ), user.level( ) )
 end
+local function rl_ctm_drop( user )
+    return not ratelimit_user_ctm( user.cid( ), user.level( ) )
+end
 local function rl_search_drop( user )
     return not ratelimit_user_search( user.cid( ), user.level( ) )
 end
@@ -481,6 +485,7 @@ _normal = {
     end,
     -- ADC: 6.3.8. CTM
     DCTM = function( user, adccmd, targetuser )
+        if rl_ctm_drop( user ) then return true end
         return scripts_firelistener( "onConnectToMe", user, targetuser, adccmd )
     end,
     --ECTM = function( user, adccmd, targetuser ) -- new
@@ -488,6 +493,7 @@ _normal = {
     --end,
     -- ADC: 6.3.9. RCM
     DRCM = function( user, adccmd, targetuser )
+        if rl_ctm_drop( user ) then return true end
         return scripts_firelistener( "onRevConnectToMe", user, targetuser,adccmd )
     end,
     --ERCM = function( user, adccmd, targetuser ) -- new

--- a/core/ratelimit.lua
+++ b/core/ratelimit.lua
@@ -70,6 +70,7 @@ local expired_handshakes
 local user_msg
 local user_pm
 local user_inf
+local user_ctm
 local user_search
 local record_authfail
 local tick
@@ -98,6 +99,8 @@ local _pm_rate
 local _pm_burst
 local _inf_rate
 local _inf_burst
+local _ctm_rate
+local _ctm_burst
 local _search_rate_per_sec
 local _search_burst
 
@@ -247,6 +250,24 @@ user_inf = function( cid, level )
     return _consume( "user:" .. cid, "inf", _inf_burst, _inf_rate )
 end
 
+-- Per-user connection-setup rate (#80, CTM/RCM-Flood). Gates DCTM
+-- and DRCM (both directions of the peer-connection initiation
+-- handshake) through the same bucket - semantically a user picks one
+-- or the other per peer based on NAT/routing, so abusing them
+-- separately makes no sense and a shared limit keeps the cfg surface
+-- small. Defaults (2/s, burst 30) tolerate the explicit use case
+-- called out in #80: a user firing 20-30 connection attempts when
+-- their search results page resolves to many peers, or starting many
+-- parallel downloads from a download queue. Sustained 2/s caps a
+-- malicious crawler at ~120 connection attempts per minute after the
+-- burst is exhausted. level >= bypass_level skips the check.
+user_ctm = function( cid, level )
+    if not _activate then return true end
+    if level and level >= _bypass_level then return true end
+    if not cid or cid == "" then return true end
+    return _consume( "user:" .. cid, "ctm", _ctm_burst, _ctm_rate )
+end
+
 -- Per-user search-rate (F-RL-2). level >= bypass_level skips the check.
 user_search = function( cid, level )
     if not _activate then return true end
@@ -307,6 +328,8 @@ init = function( )
     _pm_burst = cfg_get "ratelimit_user_pm_burst"
     _inf_rate = cfg_get "ratelimit_user_inf_rate"
     _inf_burst = cfg_get "ratelimit_user_inf_burst"
+    _ctm_rate = cfg_get "ratelimit_user_ctm_rate"
+    _ctm_burst = cfg_get "ratelimit_user_ctm_burst"
     -- search is configured as "one per N seconds" for legibility; convert
     -- to fill-rate per second.
     local search_period = cfg_get "ratelimit_user_search_period"
@@ -330,6 +353,7 @@ return {
     user_msg = user_msg,
     user_pm = user_pm,
     user_inf = user_inf,
+    user_ctm = user_ctm,
     user_search = user_search,
     record_authfail = record_authfail,
     tick = tick,

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -810,9 +810,10 @@ def test_neg_post_login_pm_burst():
 
 
 def test_neg_post_login_ctm_burst():
-    """After a clean login, fire 50 BCTM commands at non-existent SIDs.
-    Same rationale as the SCH burst - rate-limit / absorb / disconnect,
-    but never crash."""
+    """After a clean login, fire 50 DCTM commands at non-existent SIDs.
+    Confirms the #80 CTM bucket absorbs a connection-setup flood
+    without crashing the dispatcher. First ~burst go through to onCTM
+    listeners, the rest are silently dropped by rl_ctm_drop."""
     with socket.create_connection(
         (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
     ) as sock:
@@ -825,6 +826,26 @@ def test_neg_post_login_ctm_burst():
             # correspond to any logged-in client.
             try:
                 sock.sendall(f"DCTM {sid} ZZZZ ADC/1.0 12345\n".encode("utf-8"))
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                return
+        _neg_drain_briefly(sock)
+
+
+def test_neg_post_login_rcm_burst():
+    """After a clean login, fire 50 DRCM commands at non-existent SIDs.
+    DRCM shares the CTM bucket since both are peer-connection
+    initiation primitives. Tests the second code path through
+    rl_ctm_drop."""
+    with socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    ) as sock:
+        try:
+            sid, _reader = _adc_login(sock, "dummy", "test")
+        except TestFailure:
+            return
+        for i in range(50):
+            try:
+                sock.sendall(f"DRCM {sid} ZZZZ ADC/1.0\n".encode("utf-8"))
             except (BrokenPipeError, ConnectionResetError, OSError):
                 return
         _neg_drain_briefly(sock)
@@ -1291,7 +1312,8 @@ TESTS = [
     ("neg: post-login BSCH burst", test_neg_post_login_search_burst),
     ("neg: post-login DMSG burst (#80 PM bucket)", test_neg_post_login_pm_burst),
     ("neg: post-login BINF burst (#80 INF bucket)", test_neg_post_login_inf_burst),
-    ("neg: post-login DCTM burst", test_neg_post_login_ctm_burst),
+    ("neg: post-login DCTM burst (#80 CTM bucket)", test_neg_post_login_ctm_burst),
+    ("neg: post-login DRCM burst (#80 CTM bucket)", test_neg_post_login_rcm_burst),
     ("neg: canary - hub still alive after fuzz battery", test_neg_canary_hub_alive),
 ]
 


### PR DESCRIPTION
Third of four sub-PRs for the ratelimit v2 work tracked in #80.

## Why

DCTM and DRCM were the last two unprotected dispatch paths in \`_normal\`. Both are peer-connection initiation primitives:
- \`DCTM\` = \"you connect to me at X:Y\"
- \`DRCM\` = \"you ask me to connect first\" (NAT inversion)

The choice between them depends on the pair's NAT/routing situation, so a malicious client abusing one would just switch to the other if they were on separate buckets. Single shared bucket = same protection, smaller cfg surface.

## Lands

| File | Change |
|---|---|
| \`core/ratelimit.lua\` | New public \`user_ctm(cid, level)\`. Own bucket kind \"ctm\", own \`_ctm_rate\` / \`_ctm_burst\` scalars. Same bypass-by-level semantics. |
| \`core/cfg_defaults.lua\` | \`ratelimit_user_ctm_rate\` (default **2/s**), \`ratelimit_user_ctm_burst\` (default **30**). Defaults sized to tolerate parallel downloads. |
| \`core/hub_dispatch.lua\` | New \`rl_ctm_drop\` helper. DCTM and DRCM in \`_normal\` both gate through it before \`scripts_firelistener\`. |
| \`tests/smoke/run.py\` | Existing \`test_neg_post_login_ctm_burst\` docstring updated to name the new bucket; new \`test_neg_post_login_rcm_burst\` covers the second code path. Smoke suite 33 -> 34 tests. |

## Default tuning rationale

Closes the open question in #80 (\"CTM/RCM rate must not break legitimate burst use (parallel downloads)\"):

- **Queue startup**: a user kicking off 10-20 parallel downloads emits 10-20 CTMs/RCMs within a second. burst=30 covers it.
- **\"Download all from search\"**: search results page with many sources -> burst of CTMs as DC++ probes peers. burst=30 still absorbs.
- **Sustained flood cap**: after burst is exhausted, the bucket drips at 2/s = 120/min. Bounded dispatch work, but legitimate users rarely sustain anywhere near that.

Operators with users running aggressive queues (DC++ default queue size is high) can dial \`ratelimit_user_ctm_burst\` up; quiet hubs can dial down. Op-level users (>= \`ratelimit_bypass_level\`) bypass entirely.

## Operator impact at defaults

**None for typical users.** Even an active downloader rarely emits more than 1-2 connection attempts per second sustained; 2/s rate with 30 burst is comfortably above.

## Test plan

- [x] Lua syntax OK
- [x] Local smoke 34/34 PASS on Windows
- [ ] CI Linux smoke
- [ ] CI Windows smoke

## #80 status after merge

- [x] PR 1/4: PM bucket - #138 merged
- [x] PR 2/4: INF-update bucket - #139 merged
- [x] **PR 3/4**: CTM/RCM bucket - **this PR**
- [ ] PR 4/4: per-userlevel tier model (refactors msg/pm/inf/ctm/search to share tier-mapping cfg)

After this merges, all four dispatch paths in \`_normal\` that fire scripts have rate-limit coverage. PR 4/4 refactors the five existing scalar bucket configs into a unified per-userlevel tier model.