### PR TITLE
fix(ratelimit): tier whitelist + plugin-contract docs + tier smoke test (post-#80 review followups)

### DIFF
--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -60,6 +60,21 @@ local function ratelimit_pos_number( value )
     return types_number( value, nil, true ) and value > 0
 end
 
+-- Tier-table inner field whitelist. Operator typos like `msg_brust = 5`
+-- used to pass the type-check and then silently get ignored (scalar
+-- fallback) - operators only noticed when their tier didn't behave.
+-- A whitelist makes the typo a cfg-load error, surfaced via out_error
+-- + default-fallback in cfg.lua:checkcfg(). Keep this list in sync
+-- with the field names consumed by core/ratelimit.lua's user_X
+-- functions and the _tier_or_scalar helper.
+local _RATELIMIT_TIER_FIELDS = {
+    msg_rate = true, msg_burst = true,
+    pm_rate = true, pm_burst = true,
+    inf_rate = true, inf_burst = true,
+    ctm_rate = true, ctm_burst = true,
+    search_period = true, search_burst = true,
+}
+
 -- Late-bound: types.add("adcstr", ...) is registered by core/adc.lua,
 -- which loads after us. cfg.init() calls bind_late() at the right
 -- time, after which all closures referencing types_adcstr see it.
@@ -3322,6 +3337,11 @@ local defaults = {
                 if not types_table( tier ) then return false end
                 for k, v in pairs( tier ) do
                     if type( k ) ~= "string" then return false end
+                    -- Typo guard: only the 10 known field names from
+                    -- _RATELIMIT_TIER_FIELDS get through. msg_brust=5
+                    -- (typo) raises here instead of silently falling
+                    -- back to the global scalar.
+                    if not _RATELIMIT_TIER_FIELDS[ k ] then return false end
                     -- Inner values feed the token bucket directly; same
                     -- strict-positive guard as the global scalar keys
                     -- above. msg_rate=0 / msg_burst=-1 in a tier would

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -439,12 +439,21 @@ _verify = {
 
 }
 
--- Phase 7c F-RL-1 / F-RL-2 helpers, plus the #80 PM-split. Token-bucket-
--- protected entry points to the BMSG / EMSG / DMSG / *SCH listeners.
--- Returning `true` from the handler tells incoming() the message has
--- been handled (so the broadcast / fan-out is suppressed) without
--- disconnecting the user. Op-level users (>= ratelimit_bypass_level)
--- bypass the check inside the ratelimit module.
+-- Phase 7c F-RL-1 / F-RL-2 helpers, plus the #80 PM/INF/CTM splits.
+-- Token-bucket-protected entry points to the BMSG / EMSG / DMSG /
+-- BINF / DCTM / DRCM / *SCH listeners. Returning `true` from the
+-- handler tells incoming() the message has been handled (so the
+-- broadcast / fan-out is suppressed) without disconnecting the user.
+-- Op-level users (>= ratelimit_bypass_level) bypass the check inside
+-- the ratelimit module.
+--
+-- IMPORTANT: a `true` return here also skips the plugin listener fan-
+-- out (scripts_firelistener is not called). Throttled messages do not
+-- reach onBroadcast / onPrivateMessage / onInf / onConnectToMe /
+-- onRevConnectToMe listeners. Documented in docs/SECURITY.md "Rate-
+-- limit and plugin contract" - plugins doing count-based heuristics
+-- on per-user messages need to be aware that the hub-level drop hides
+-- the post-burst tail from them.
 local function rl_msg_drop( user )
     return not ratelimit_user_msg( user.cid( ), user.level( ) )
 end

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -277,8 +277,13 @@ the same `icacls` line there. The same recipe lives in
 | TLS handshake wallclock deadline | same | `ratelimit_handshake_timeout` (default 10s) |
 | Per-IP failed-auth tracking + sticky lockout | [`core/hub_dispatch.lua` HPAS](../core/hub_dispatch.lua) | `ratelimit_perip_authfail_*`, `ratelimit_authfail_lockout` |
 | Per-account bad-password lockout (independent of per-IP) | same | `max_bad_password`, `bad_pass_timeout` |
-| Per-user chat / search rate-limit | [`core/hub_dispatch.lua` BMSG/BSCH](../core/hub_dispatch.lua) | `ratelimit_user_msg_*`, `ratelimit_user_search_*` |
-| Op-level bypass of per-user limits | same | `ratelimit_bypass_level` (default 60) |
+| Per-user mainchat rate-limit | [`core/hub_dispatch.lua` BMSG](../core/hub_dispatch.lua) | `ratelimit_user_msg_*` |
+| Per-user PM rate-limit ([#80](https://github.com/luadch-ng/luadch/issues/80)) | [`core/hub_dispatch.lua` DMSG/EMSG](../core/hub_dispatch.lua) | `ratelimit_user_pm_*` |
+| Per-user BINF-update rate-limit ([#80](https://github.com/luadch-ng/luadch/issues/80)) | [`core/hub_dispatch.lua` BINF](../core/hub_dispatch.lua) | `ratelimit_user_inf_*` |
+| Per-user CTM/RCM rate-limit ([#80](https://github.com/luadch-ng/luadch/issues/80)) | [`core/hub_dispatch.lua` DCTM/DRCM](../core/hub_dispatch.lua) | `ratelimit_user_ctm_*` |
+| Per-user search rate-limit | [`core/hub_dispatch.lua` BSCH](../core/hub_dispatch.lua) | `ratelimit_user_search_*` |
+| Per-userlevel tier overlay ([#80](https://github.com/luadch-ng/luadch/issues/80)) | [`core/ratelimit.lua` init](../core/ratelimit.lua) | `ratelimit_tiers`, `ratelimit_tier_for_level` |
+| Op-level bypass of per-user limits | [`core/ratelimit.lua`](../core/ratelimit.lua) | `ratelimit_bypass_level` (default 60) |
 | Parser-side message-size cap | [`core/adc.lua` parse](../core/adc.lua) | hardcoded 64 KiB |
 | Connection read-buffer cap | [`core/server.lua`](../core/server.lua) | hardcoded 1 MiB |
 | INF-IP consistency check (kick on TCP-source vs INF-claim mismatch) | [`core/hub_dispatch.lua` BINF](../core/hub_dispatch.lua) + [`scripts/hub_inf_manager.lua`](../scripts/hub_inf_manager.lua) | `kill_wrong_ips` (default **true** since v3.1.4) |
@@ -318,6 +323,38 @@ blocklist matches, abuse logs, and any plugin reading
 `user:ip()` operate on the **TCP source IP** anyway, so the check
 is purely defence-in-depth against IP-spoofing INFs - the rest of
 the stack stays sound.
+
+### Rate-limit and plugin contract ([#80](https://github.com/luadch-ng/luadch/issues/80))
+
+Per-user rate limits fire **before** the plugin listener chain
+inside [`core/hub_dispatch.lua`](../core/hub_dispatch.lua). When a
+bucket is exhausted, the dispatcher returns from the handler with
+`true` (handled), which suppresses both the rest of the dispatch
+**and** the plugin `onBroadcast` / `onPrivateMessage` / `onInf` /
+`onConnectToMe` / `onRevConnectToMe` listeners. Throttled messages
+do not reach plugins at all.
+
+For most plugins this is the correct semantic and matches the
+pre-#80 behaviour for `BMSG` (which was already throttled). The
+edge cases worth knowing about:
+
+- **Plugins doing count-based heuristics on per-user messages**
+  (e.g. "block after N suspicious CTMs from one user") see only the
+  pre-throttle subset of traffic. Attackers exceeding the bucket
+  hit the hub-level drop and never reach the plugin's counter.
+  Operationally that's still a defence (hub drops the abuse) but
+  the plugin's own logs / counters undercount.
+- **Bundled plugins audited for #80 are unaffected in practice**:
+  `etc_trafficmanager` does first-hit blocklist lookup (static, not
+  cumulative); `hub_inf_manager` writes user state on each BINF and
+  just sees a slightly stale state for one bucket-cycle until the
+  next legitimate BINF; `usr_uptime` is timer-driven, not BINF-
+  driven; the rest of the `usr_*` / `etc_*` plugins reading INF
+  fields tolerate stale state until the next non-throttled update.
+
+If you write a plugin and need exact message accounting, do not
+rely on the dispatcher's listener fan-out alone - it is rate-
+limited at the hub boundary by design.
 
 ---
 

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -1205,6 +1205,109 @@ def test_usertbl_plaintext_when_disabled(staging_dir: Path, proc=None):
         )
 
 
+def _switch_to_tier_mode(staging_dir: Path, current_proc, current_log_file):
+    """#80 PR4 setup: stop the hub, append a strict-tier definition for
+    level 100 (dummy) to cfg.tbl, bump bypass_level above 100 so the
+    op-bypass does not skip the check, restart. Returns the new
+    (proc, log_file) so main() can clean up regardless of whether the
+    subsequent assertions pass."""
+    stop_hub(current_proc, current_log_file)
+
+    cfg_path = staging_dir / "cfg" / "cfg.tbl"
+    text = cfg_path.read_text(encoding="utf-8")
+
+    # Append the three keys just before the final closing brace. The
+    # bundled cfg.tbl has no ratelimit_* lines at all (it inherits the
+    # defaults from core/cfg_defaults.lua), so this is purely additive
+    # - we are not editing an existing setting line.
+    tier_block = (
+        "\n    -- inserted by smoke harness for the tier-overlay test\n"
+        "    ratelimit_bypass_level = 200,\n"
+        '    ratelimit_tier_for_level = { [100] = "strict" },\n'
+        '    ratelimit_tiers = { strict = { msg_burst = 2, msg_rate = 0.1 } },\n'
+    )
+    new_text, n = re.subn(
+        r"(\n)\}\s*$",
+        tier_block + r"\1}\n",
+        text,
+        count=1,
+    )
+    if n != 1:
+        raise TestFailure(
+            "could not inject tier block into cfg.tbl - the final "
+            "closing brace was not found at the end of the file"
+        )
+    cfg_path.write_text(new_text, encoding="utf-8")
+
+    # Same TIME_WAIT consideration as the plaintext-mode switch above.
+    time.sleep(1.0)
+    proc, log_file = start_hub(staging_dir)
+    return proc, log_file
+
+
+def test_ratelimit_tier_msg_throttle(staging_dir: Path, proc=None):
+    """#80 PR4 assertion: with bypass_level=200 and a tier mapping
+    level 100 -> { msg_burst=2 }, dummy (level 100) sending 5 BMSGs in
+    rapid succession should see exactly 2 broadcasts echoed back. The
+    other 3 are dropped at the hub by rl_msg_drop because the bucket
+    is exhausted and the rate is too low (0.1/s) for any refill in the
+    test's wall-clock duration. Confirms the tier overlay actually
+    replaces the global msg_burst=10 scalar instead of silently falling
+    back to it. Caller is responsible for putting the hub into tier
+    mode via _switch_to_tier_mode() first."""
+    try:
+        wait_for_port(HUB_HOST, TEST_PORT_PLAIN, START_TIMEOUT_SEC)
+    except TimeoutError as e:
+        diag = ""
+        if proc is not None:
+            rc = proc.poll()
+            diag += f"\nproc.poll() = {rc!r} (None == still running)"
+        for fname in ("smoke-hub.log", "error.log"):
+            path = staging_dir / "log" / fname
+            try:
+                size = path.stat().st_size if path.exists() else "missing"
+                content = path.read_text(encoding="utf-8", errors="replace") \
+                    if path.exists() else ""
+                tail = "\n".join(content.splitlines()[-40:])
+                diag += f"\n--- {fname} (size={size}, last 40 lines) ---\n{tail}"
+            except OSError as oe:
+                diag += f"\n--- {fname} (read failed: {oe}) ---"
+        raise TestFailure(f"{e}{diag}")
+
+    with socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    ) as sock:
+        sid, _reader = _adc_login(sock, "dummy", "test")
+        # Unique per-test marker so we don't collide with anything else
+        # the hub may be broadcasting on this connection.
+        marker = "tiertest" + secrets.token_hex(4)
+        for i in range(5):
+            sock.sendall(f"BMSG {sid} {marker}{i}\n".encode("utf-8"))
+        # Give the hub a moment to dispatch + echo whatever it accepts.
+        time.sleep(0.5)
+        sock.settimeout(0.5)
+        buf = b""
+        try:
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                buf += chunk
+        except (socket.timeout, TimeoutError):
+            pass
+        echoes = sum(1 for i in range(5) if f"{marker}{i}".encode() in buf)
+        if echoes != 2:
+            raise TestFailure(
+                f"tier overlay did not throttle BMSG as expected: "
+                f"with msg_burst=2 in the strict tier for level 100, "
+                f"5 BMSGs should produce exactly 2 echoes, got {echoes}. "
+                f"Either the tier mapping never resolved (fallback to "
+                f"global msg_burst=10 = all 5 echo) or the bypass-level "
+                f"check let dummy through (level 100 should NOT bypass "
+                f"with bypass_level=200). Buffer sample: {buf[:200]!r}"
+            )
+
+
 def test_canonical_socket_layout(staging_dir: Path):
     """Closes #88: LuaSocket and LuaSec install in the canonical layout
     so plugins can `require "socket.http"` / `require "ssl.https"` per
@@ -1439,6 +1542,22 @@ def main():
             failed.append("user.tbl plaintext mode when disabled")
         else:
             log("PASS  user.tbl plaintext mode when disabled")
+
+        # #80 PR4 tier-overlay test: same restart pattern as plaintext
+        # mode. We inject a strict tier for level 100 (dummy) so that
+        # sending more than burst BMSGs gets throttled at the hub
+        # before the broadcast fan-out, proving the overlay path
+        # actually replaces the global msg_burst=10 scalar.
+        try:
+            proc, log_file = _switch_to_tier_mode(
+                staging_dir, proc, log_file
+            )
+            test_ratelimit_tier_msg_throttle(staging_dir, proc=proc)
+        except Exception as e:
+            log(f"FAIL  ratelimit tier overlay throttles BMSG: {e}")
+            failed.append("ratelimit tier overlay throttles BMSG")
+        else:
+            log("PASS  ratelimit tier overlay throttles BMSG")
     finally:
         if proc is not None:
             stop_hub(proc, log_file)


### PR DESCRIPTION
Follow-up to the post-#80 code review covering the remaining three items. Stacked on top of #142 because the tier-validator change in commit 1 overlaps with that PR's strict-positive validator hardening. **Merge #142 first; this PR rebases trivially against master after.**

## Items addressed

### 1. Tier-field whitelist (commit `ff87576`)

`core/cfg_defaults.lua`: new local `_RATELIMIT_TIER_FIELDS` whitelist (10 known fields). Tier validator rejects unknown field names. Operator typo \`msg_brust = 5\` now lands in \`error.log\` via the existing \`cfg.lua:checkcfg() -> out_error + default fallback\` machinery, instead of silently being ignored.

### 2. Plugin-contract documentation (commit `7c2c9cb`)

Two changes:
- \`docs/SECURITY.md\` section 5: network-defenses table updated to list all five rate-limit buckets (msg, pm, inf, ctm, search) + the tier overlay. New sub-section **\"Rate-limit and plugin contract\"** documents that throttled messages don't reach \`onBroadcast\` / \`onPrivateMessage\` / \`onInf\` / \`onConnectToMe\` / \`onRevConnectToMe\` listeners. Bundled-plugin impact audit inline (\`etc_trafficmanager\` / \`hub_inf_manager\` / \`usr_uptime\` unaffected in practice).
- \`core/hub_dispatch.lua\`: inline comment block at the \`rl_X_drop\` helper definition noting the listener-skip semantic with a pointer to the SECURITY.md section. Future readers of the dispatcher code see the contract.

### 3. Tier-overlay smoke test (commit `0398103`)

\`tests/smoke/run.py\`: new \`_switch_to_tier_mode\` helper + \`test_ratelimit_tier_msg_throttle\` test, running as a third hub-restart phase after the existing plaintext-mode phase. Injects \`bypass_level=200\`, \`tier_for_level={[100]=\"strict\"}\`, \`tiers={strict={msg_burst=2,msg_rate=0.1}}\` into cfg.tbl, restarts, logs in dummy (level 100), sends 5 BMSGs, verifies exactly 2 echo back. msg_rate=0.1 keeps the remaining 3 reliably throttled within test wall-clock.

Failure mode messaging names both candidate root causes (tier mapping didn't resolve / bypass-level kicked in) so a future regression triages from smoke output alone.

## Lands

| File | Change |
|---|---|
| \`core/cfg_defaults.lua\` | Tier-field whitelist (\`_RATELIMIT_TIER_FIELDS\`) + tier validator reject of unknown keys |
| \`docs/SECURITY.md\` | Section 5 table updated + new \"Rate-limit and plugin contract\" sub-section |
| \`core/hub_dispatch.lua\` | Inline comment block at \`rl_X_drop\` helpers noting listener-skip semantic |
| \`tests/smoke/run.py\` | \`_switch_to_tier_mode\` + \`test_ratelimit_tier_msg_throttle\` + main() phase 3 |

## Test plan

- [x] Lua syntax OK on all changed core files
- [x] Local smoke 35/35 PASS on Windows (34 -> 35 with the new tier test)
- [ ] CI Linux smoke
- [ ] CI Windows smoke

## Dependencies

- Stacked on #142 (strict-positive validator). The whitelist commit touches the same tier validator function that #142 added strict-positive checks to - merging this PR before #142 would create conflicts. After #142 merges, rebase this branch onto master and the conflict drops.

## #80 review status after merge

All four review findings closed:

- [x] Strict-positive validator - #142
- [x] Tier-field whitelist - **this PR**
- [x] Plugin-contract docs - **this PR**
- [x] Tier-overlay smoke test - **this PR**