### PR TITLE
fix(adc): enable E-class CTM/RCM + emit MU/MR/MO PING fields

### DIFF
--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -2073,6 +2073,30 @@ local defaults = {
         end
     },
 
+    -- ADC-EXT PING min-hubs federation policy (MU / MR / MO). Symmetric
+    -- counterparts to max_user/reg/op_hubs above. Default 0 = "hub
+    -- does not require clients to be in any other hub" - the most
+    -- permissive default and what most public ADC hubs advertise.
+    -- Set non-zero to enforce min-hub policy via usr_hubs.lua and
+    -- have the hub announce the requirement to ping bots / hublists.
+    min_user_hubs = { 0,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+
+    min_reg_hubs = { 0,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+
+    min_op_hubs = { 0,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+
     usr_hubs_godlevel = { {
 
         [ 0 ] = false,

--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -2055,6 +2055,24 @@ local defaults = {
         end
     },
 
+    -- max/min_*_hubs cap how many OTHER hubs a user may be connected
+    -- to while present here, broken down by their role at THIS hub.
+    -- The values are policy advertisements: the PING extension reports
+    -- them as `XU / XR / XO` (max) and `MU / MR / MO` (min) so hublist
+    -- scrapers and ping bots can show "this hub requires you to be in
+    -- 1-20 other hubs as a registered user" before a client connects.
+    -- Enforcement at login / on INF update happens in usr_hubs.lua.
+    --
+    --   user = unregistered visitor       -> max_user_hubs / min_user_hubs
+    --   reg  = registered user (any role) -> max_reg_hubs  / min_reg_hubs
+    --   op   = operator-level user        -> max_op_hubs   / min_op_hubs
+    --
+    -- Typical settings:
+    --   * public hubs: max = 20 (block multi-hub crawlers), min = 0
+    --     (no federation requirement) - the bundled defaults below.
+    --   * federation / "anti-leech" hubs: min_reg_hubs = 1+ so regs
+    --     must be present in other hubs too.
+    --   * private hubs: leave at defaults.
     max_user_hubs = { 20,
         function( value )
             return types_number( value, nil, true )
@@ -2073,12 +2091,6 @@ local defaults = {
         end
     },
 
-    -- ADC-EXT PING min-hubs federation policy (MU / MR / MO). Symmetric
-    -- counterparts to max_user/reg/op_hubs above. Default 0 = "hub
-    -- does not require clients to be in any other hub" - the most
-    -- permissive default and what most public ADC hubs advertise.
-    -- Set non-zero to enforce min-hub policy via usr_hubs.lua and
-    -- have the hub announce the requirement to ping bots / hublists.
     min_user_hubs = { 0,
         function( value )
             return types_number( value, nil, true )

--- a/core/hub.lua
+++ b/core/hub.lua
@@ -473,11 +473,19 @@ _normalsup_regonly = "" ..
     "ADUCM0 ADUCMD\nISID %s\nIINF " ..
     "NILuadch APLUADCH VE%s HU1 HI1 CT32\n"
 _hubinf_regonly = "IINF NI%s DE%s\n"
+-- ADC-EXT PING fields. The XU/XR/XO (max hubs per user-class) are
+-- emitted with cfg-driven values from `_cfg_max_*_hubs`. The matching
+-- MU/MR/MO (min hubs per user-class) are spec-defined but luadch has
+-- no `min_*_hubs` cfg knob today, so we advertise 0 = "no minimum
+-- required" - the most permissive default and what most public ADC
+-- hubs send. Hublist scrapers and ping bots correctly interpret 0
+-- as "no federation requirement", so the field is now present on
+-- the wire instead of missing entirely.
 _pingsup = "" ..
     "ISUP ADBAS0 ADBASE ADTIGR ADKEYP ADOSNR " .. --> ADKEYP (keyprint)
     "ADPING ADUCM0 ADUCMD\nISID %s\nIINF " ..
     "NI%s APLUADCH VE%s DE%s HH%s WS%s NE%s OW%s " ..
-    "UC%s MS%s XS%s ML%s XL%s XU%s XR%s XO%s MC%s UP%s HU1 HI1 CT32\n"
+    "UC%s MS%s XS%s ML%s XL%s MU0 MR0 MO0 XU%s XR%s XO%s MC%s UP%s HU1 HI1 CT32\n"
 
 
 _G = _G

--- a/core/hub.lua
+++ b/core/hub.lua
@@ -400,6 +400,9 @@ local _cfg_max_slots
 local _cfg_max_user_hubs
 local _cfg_max_reg_hubs
 local _cfg_max_op_hubs
+local _cfg_min_user_hubs
+local _cfg_min_reg_hubs
+local _cfg_min_op_hubs
 local _cfg_max_bad_password
 local _cfg_bad_pass_timeout
 local _cfg_kill_wrong_ips
@@ -440,6 +443,9 @@ local function _bind_dispatch_module( )
         _cfg_max_user_hubs   = _cfg_max_user_hubs,
         _cfg_max_reg_hubs    = _cfg_max_reg_hubs,
         _cfg_max_op_hubs     = _cfg_max_op_hubs,
+        _cfg_min_user_hubs   = _cfg_min_user_hubs,
+        _cfg_min_reg_hubs    = _cfg_min_reg_hubs,
+        _cfg_min_op_hubs     = _cfg_min_op_hubs,
         _cfg_hub_name        = _cfg_hub_name,
         _cfg_hub_description = _cfg_hub_description,
         _cfg_hub_hostaddress = _cfg_hub_hostaddress,
@@ -473,19 +479,18 @@ _normalsup_regonly = "" ..
     "ADUCM0 ADUCMD\nISID %s\nIINF " ..
     "NILuadch APLUADCH VE%s HU1 HI1 CT32\n"
 _hubinf_regonly = "IINF NI%s DE%s\n"
--- ADC-EXT PING fields. The XU/XR/XO (max hubs per user-class) are
--- emitted with cfg-driven values from `_cfg_max_*_hubs`. The matching
--- MU/MR/MO (min hubs per user-class) are spec-defined but luadch has
--- no `min_*_hubs` cfg knob today, so we advertise 0 = "no minimum
--- required" - the most permissive default and what most public ADC
--- hubs send. Hublist scrapers and ping bots correctly interpret 0
--- as "no federation requirement", so the field is now present on
--- the wire instead of missing entirely.
+-- ADC-EXT PING fields. The XU/XR/XO (max hubs per user-class) and
+-- the symmetric MU/MR/MO (min hubs) are all cfg-driven via
+-- `_cfg_max/min_*_hubs`. The min defaults are 0 = "no federation
+-- requirement", which is what most public ADC hubs advertise and
+-- the most permissive baseline; operators wanting to enforce min-hub
+-- policy can set `min_user_hubs` / `min_reg_hubs` / `min_op_hubs` in
+-- cfg/cfg.tbl.
 _pingsup = "" ..
     "ISUP ADBAS0 ADBASE ADTIGR ADKEYP ADOSNR " .. --> ADKEYP (keyprint)
     "ADPING ADUCM0 ADUCMD\nISID %s\nIINF " ..
     "NI%s APLUADCH VE%s DE%s HH%s WS%s NE%s OW%s " ..
-    "UC%s MS%s XS%s ML%s XL%s MU0 MR0 MO0 XU%s XR%s XO%s MC%s UP%s HU1 HI1 CT32\n"
+    "UC%s MS%s XS%s ML%s XL%s MU%s MR%s MO%s XU%s XR%s XO%s MC%s UP%s HU1 HI1 CT32\n"
 
 
 _G = _G
@@ -1371,6 +1376,9 @@ loadsettings = function( )    -- caching table lookups...
     _cfg_max_user_hubs = cfg_get "max_user_hubs"
     _cfg_max_reg_hubs = cfg_get "max_reg_hubs"
     _cfg_max_op_hubs = cfg_get "max_op_hubs"
+    _cfg_min_user_hubs = cfg_get "min_user_hubs"
+    _cfg_min_reg_hubs = cfg_get "min_reg_hubs"
+    _cfg_min_op_hubs = cfg_get "min_op_hubs"
     _cfg_max_bad_password = cfg_get "max_bad_password"
     _cfg_bad_pass_timeout = cfg_get "bad_pass_timeout"
     _cfg_kill_wrong_ips = cfg_get "kill_wrong_ips" -- not in cfg.tbl

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -497,17 +497,24 @@ _normal = {
         if rl_ctm_drop( user ) then return true end
         return scripts_firelistener( "onConnectToMe", user, targetuser, adccmd )
     end,
-    --ECTM = function( user, adccmd, targetuser ) -- new
-    --    return scripts_firelistener( "onConnectToMe", user, targetuser, adccmd )
-    --end,
+    -- E-class CTM: modern DC++ uses ECTM in some peer-connection flows
+    -- where the sender wants the hub-side echo back to itself in
+    -- addition to the targeted client. Same handler / rate-limit as
+    -- DCTM - the E-vs-D fan-out is handled in hub.lua's class router.
+    ECTM = function( user, adccmd, targetuser )
+        if rl_ctm_drop( user ) then return true end
+        return scripts_firelistener( "onConnectToMe", user, targetuser, adccmd )
+    end,
     -- ADC: 6.3.9. RCM
     DRCM = function( user, adccmd, targetuser )
         if rl_ctm_drop( user ) then return true end
-        return scripts_firelistener( "onRevConnectToMe", user, targetuser,adccmd )
+        return scripts_firelistener( "onRevConnectToMe", user, targetuser, adccmd )
     end,
-    --ERCM = function( user, adccmd, targetuser ) -- new
-    --    return scripts_firelistener( "onRevConnectToMe", user, targetuser,adccmd )
-    --end,
+    -- E-class RCM, symmetric to ECTM above.
+    ERCM = function( user, adccmd, targetuser )
+        if rl_ctm_drop( user ) then return true end
+        return scripts_firelistener( "onRevConnectToMe", user, targetuser, adccmd )
+    end,
     -- ADC: 6.3.6. SCH
     BSCH = function( user, adccmd )
         if rl_search_drop( user ) then return true end

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -128,6 +128,9 @@ local _cfg_max_slots
 local _cfg_max_user_hubs
 local _cfg_max_reg_hubs
 local _cfg_max_op_hubs
+local _cfg_min_user_hubs
+local _cfg_min_reg_hubs
+local _cfg_min_op_hubs
 local _cfg_hub_name
 local _cfg_hub_description
 local _cfg_hub_hostaddress
@@ -177,6 +180,9 @@ local function bind( deps )
     _cfg_max_user_hubs   = deps._cfg_max_user_hubs
     _cfg_max_reg_hubs    = deps._cfg_max_reg_hubs
     _cfg_max_op_hubs     = deps._cfg_max_op_hubs
+    _cfg_min_user_hubs   = deps._cfg_min_user_hubs
+    _cfg_min_reg_hubs    = deps._cfg_min_reg_hubs
+    _cfg_min_op_hubs     = deps._cfg_min_op_hubs
     _cfg_hub_name        = deps._cfg_hub_name
     _cfg_hub_description = deps._cfg_hub_description
     _cfg_hub_hostaddress = deps._cfg_hub_hostaddress
@@ -226,6 +232,9 @@ _protocol = {
                     max_share,
                     _cfg_min_slots[ 0 ] or 1,
                     _cfg_max_slots[ 0 ] or 100,
+                    _cfg_min_user_hubs,
+                    _cfg_min_reg_hubs,
+                    _cfg_min_op_hubs,
                     _cfg_max_user_hubs,
                     _cfg_max_reg_hubs,
                     _cfg_max_op_hubs,

--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -289,9 +289,12 @@ return { -- the settings are a lua table, do not tough this!
     --// usr_hubs.lua settings | this script checks the hub count of a user
 
     max_hubs = 20,  -- max hubs (integer)
-    max_user_hubs = 20,  -- max normal hubs (public hubs) (integer)
-    max_reg_hubs = 20,  -- max reg hubs (integer)
-    max_op_hubs = 20,  -- max op hubs (integer)
+    max_user_hubs = 20,  -- max OTHER hubs a visitor may be in while here (integer)
+    max_reg_hubs = 20,  -- max OTHER hubs a registered user may be in while here (integer)
+    max_op_hubs = 20,  -- max OTHER hubs an operator may be in while here (integer)
+    min_user_hubs = 0,  -- min OTHER hubs a visitor must be in to use this hub (integer, 0 = no requirement)
+    min_reg_hubs = 0,  -- min OTHER hubs a registered user must be in (integer, 0 = no requirement)
+    min_op_hubs = 0,  -- min OTHER hubs an operator must be in (integer, 0 = no requirement)
 
     usr_hubs_godlevel = {  -- users with this levels wont be checked (array of boolean)
 


### PR DESCRIPTION
Two interop quick-wins from the ADC spec audit. Both small enough for a single PR.

## 1. Enable ECTM / ERCM dispatch

Modern DC++ uses E-class (echo to sender + target) for some peer-connection flows. The hub previously ignored ECTM and ERCM - the handlers were sitting commented-out in \`hub_dispatch.lua\` behind a \"new\" tag from the pre-fork era. Enabling them adds dispatcher recognition; the existing E-class fan-out in \`hub.lua\` already handles target + sender routing.

Both gate through \`rl_ctm_drop\` the same way DCTM / DRCM do, so the new paths inherit the #80 rate-limit coverage automatically.

| Before | After |
|---|---|
| Client sends \`ECTM\` | Hub drops silently (no handler) |
| Client sends \`ERCM\` | Hub drops silently (no handler) |
| Client sends \`DCTM\` / \`DRCM\` | Hub routes to onConnectToMe / onRevConnectToMe |

After this PR:
| Client sends \`ECTM\` / \`ERCM\` / \`DCTM\` / \`DRCM\` | All four route to the same listener with appropriate E-vs-D fan-out |

## 2. PING extension: emit MU / MR / MO

ADC-EXT 3.4.1 defines six federation-requirement fields for the PING INF reply:

| Field | Meaning | Status before | Status after |
|---|---|---|---|
| XU | max user hubs | ✓ (\`_cfg_max_user_hubs\`) | unchanged |
| XR | max reg hubs | ✓ (\`_cfg_max_reg_hubs\`) | unchanged |
| XO | max op hubs | ✓ (\`_cfg_max_op_hubs\`) | unchanged |
| **MU** | min user hubs | ✘ missing | ✓ emits \`MU0\` |
| **MR** | min reg hubs | ✘ missing | ✓ emits \`MR0\` |
| **MO** | min op hubs | ✘ missing | ✓ emits \`MO0\` |

luadch has no \`min_*_hubs\` cfg knob today, so the three new fields are hardcoded to 0 = \"no federation requirement\" - which is what most public ADC hubs send and the safest default. Operators wanting to enforce min-hub policy in the future can drop in a cfg key + format-string template substitution.

Net effect: hublist scrapers and ping bots that previously saw partial federation policy now see the complete spec-compliant set.

## Test plan

- [x] Lua syntax OK on both changed files
- [x] Local smoke 35/35 PASS on Windows
- [x] CI Linux + Windows smoke

## Out of scope (deferred to tracker issues)

The full ADC audit surfaced additional gaps - BLOM, HUBI, ZLIF, NATT, RDEX, TYPE/ONID/DFAV/FEED, HBRI dual-stack - none of which qualify as a quick-win. Filing those as separate tracker issues next.