### PR TITLE
feat(adc): NATT relay (DNAT / DRNT) - T1.1 of #147

### DIFF
--- a/core/adc.lua
+++ b/core/adc.lua
@@ -413,6 +413,40 @@ _protocol = {
             nonpclones = false,
 
         },
+        -- ADC-EXT 3.9 NATT. Hub-relay-only NAT-traversal. NAT is the
+        -- initiator-to-target request, RNT is the target-to-initiator
+        -- response; both share the same wire shape as CTM (protocol /
+        -- port / token). D-class only per spec.
+        NAT = {
+
+            pp = {
+
+                _regex.default,
+                _regex.integer,
+                _regex.default,
+
+                len = 3,
+
+            },
+            np = { },
+            nonpclones = false,
+
+        },
+        RNT = {
+
+            pp = {
+
+                _regex.default,
+                _regex.integer,
+                _regex.default,
+
+                len = 3,
+
+            },
+            np = { },
+            nonpclones = false,
+
+        },
         SCH = {
 
             pp = { len = 0, },
@@ -491,6 +525,8 @@ _protocol = {
         RES = _regex.context.direct,
         CTM = _regex.context.direct,
         RCM = _regex.context.direct,
+        NAT = _regex.context.direct,    -- ADC-EXT NATT
+        RNT = _regex.context.direct,    -- ADC-EXT NATT
         GPA = _regex.context.hub,
         PAS = _regex.context.hub,
         QUI = _regex.context.hub,

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -524,6 +524,21 @@ _normal = {
         if rl_ctm_drop( user ) then return true end
         return scripts_firelistener( "onRevConnectToMe", user, targetuser, adccmd )
     end,
+    -- ADC-EXT 3.9 NATT. Hub-relay-only NAT-traversal between two peers.
+    -- DNAT is the initiator-to-target traversal request; DRNT is the
+    -- target-to-initiator response. Hub does not advertise NATT in
+    -- ISUP - the spec signals NATT support per-user via INF.SU, the
+    -- hub is just a relay. Both gate through the same rate-limit
+    -- bucket as DCTM/DRCM since they are semantically peer-connection
+    -- setup.
+    DNAT = function( user, adccmd, targetuser )
+        if rl_ctm_drop( user ) then return true end
+        return scripts_firelistener( "onNatTraversal", user, targetuser, adccmd )
+    end,
+    DRNT = function( user, adccmd, targetuser )
+        if rl_ctm_drop( user ) then return true end
+        return scripts_firelistener( "onNatTraversalReply", user, targetuser, adccmd )
+    end,
     -- ADC: 6.3.6. SCH
     BSCH = function( user, adccmd )
         if rl_search_drop( user ) then return true end

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -851,6 +851,31 @@ def test_neg_post_login_rcm_burst():
         _neg_drain_briefly(sock)
 
 
+def test_neg_post_login_natt_burst():
+    """After a clean login, fire 50 mixed DNAT / DRNT commands (ADC-EXT
+    NATT, T1.1 of #147) at non-existent SIDs. Both new dispatch routes
+    share the CTM bucket (peer-connection setup); confirms NATT relay
+    absorbs floods the same way DCTM / DRCM do without crashing."""
+    with socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    ) as sock:
+        try:
+            sid, _reader = _adc_login(sock, "dummy", "test")
+        except TestFailure:
+            return
+        for i in range(50):
+            # Alternate the two new commands so the test exercises both
+            # dispatch paths through rl_ctm_drop, not just one.
+            cmd = "DNAT" if i % 2 == 0 else "DRNT"
+            try:
+                sock.sendall(
+                    f"{cmd} {sid} ZZZZ ADC/1.0 12345 tok{i}\n".encode("utf-8")
+                )
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                return
+        _neg_drain_briefly(sock)
+
+
 def test_neg_canary_hub_alive():
     """After the negative-test battery, the hub must still accept a clean
     login. This is the canary that catches any of the above tests having
@@ -1417,6 +1442,7 @@ TESTS = [
     ("neg: post-login BINF burst (#80 INF bucket)", test_neg_post_login_inf_burst),
     ("neg: post-login DCTM burst (#80 CTM bucket)", test_neg_post_login_ctm_burst),
     ("neg: post-login DRCM burst (#80 CTM bucket)", test_neg_post_login_rcm_burst),
+    ("neg: post-login NATT burst (#147 T1.1)", test_neg_post_login_natt_burst),
     ("neg: canary - hub still alive after fuzz battery", test_neg_canary_hub_alive),
 ]
 


### PR DESCRIPTION
First T1 item from the [#147](https://github.com/luadch-ng/luadch/issues/147) ADC coverage tracker.

## What ADC-EXT 3.9 NATT does

NATT enables peer-to-peer connections between two clients that are both behind NAT (passive-passive transfers, which otherwise fail). The hub acts as a coordinator:

1. Client A wants to talk to client B; both are behind NAT.
2. A sends \`DNAT\` to B via the hub (target SID, protocol, port, token).
3. Hub relays it to B.
4. B replies with \`DRNT\` (same shape).
5. Hub relays back to A.
6. Both then immediately punch UDP packets at each other's published IP/port to open the NAT pinhole, enabling the actual TCP connection.

## Lands

| File | Change |
|---|---|
| \`core/adc.lua\` | Register \`NAT\` and \`RNT\` in the command-shape table (identical to \`CTM\`: 3 positional params - protocol / port-int / token, no NPs). Add both to the context table as direct-only. |
| \`core/hub_dispatch.lua\` | \`DNAT\` and \`DRNT\` handlers in \`_normal\` state. Both gate through \`rl_ctm_drop\` (the #80 CTM/RCM bucket) since they are semantically peer-connection setup. Different listener event names (\`onNatTraversal\`, \`onNatTraversalReply\`) so plugins can intercept NATT separately from CTM/RCM. |
| \`tests/smoke/run.py\` | \`test_neg_post_login_natt_burst\` fires 50 mixed DNAT/DRNT at non-existent SIDs. Validates both new dispatch paths absorb floods through the shared bucket without crashing. Suite 35 -> 36 tests. |

## What this PR explicitly does NOT do

- **No ISUP advertisement.** Per spec, NATT is per-user via \`INF.SU\`, not per-hub. The hub supporting the relay is enough; clients signal their own NATT capability via their INF.
- **No new cfg keys.** The shared rate-limit bucket with DCTM/DRCM is the correct design - NATT is functionally peer-connection setup, operators tune the same knob.
- **No protocol-level validation/transformation.** Hub is pure relay per spec section 3.9.

## Rate-limit semantics

NATT shares \`rl_ctm_drop\` with DCTM/DRCM (the #80 CTM/RCM bucket, default rate 2/s burst 30). Per-userlevel tiers and the existing bypass-level apply identically. A user can't bypass the CTM rate-limit by switching to NATT - they're the same bucket.

## Methodology check

This is T1.1 of #147 - the first item in the \"safe for 3.1.x\" tier. The change pattern (register command shape + add dispatcher handlers + smoke test) is identical to the ECTM/ERCM work in #146, so the methodology is validated by precedent.

## Test plan

- [x] Lua syntax OK on both changed core files
- [x] Local smoke 36/36 PASS on Windows
- [ ] CI Linux + Windows smoke

## #147 status after merge

- [x] **T1.1 NATT** - this PR
- [ ] T1.2 RDEX
- [ ] T1.3 PING SS/SF aggregate
- [ ] T1.4 PING HE field
- [ ] T1.5 STA emission codes
- [ ] T1.6 FRES routing
- [ ] T1.7 QUI from client honor
- [ ] T1.8 Minor extensions awareness
- [ ] T2.x / T3.x deferred