### PR TITLE
feat(adc): RDEX rich-redirect + IINF.RP advertisement (T1.2 of #147)

### DIFF
--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -2109,6 +2109,40 @@ local defaults = {
         end
     },
 
+    -- ADC-EXT RDEX (3.32) - rich redirect.
+    --
+    -- hub_redirect_protocols: bitmask of redirect URI schemes this hub
+    -- advertises support for. Emitted as IINF.RP so clients (and other
+    -- hubs redirecting users here) know which URL scheme to use.
+    --   1 = ADC, 2 = ADCS, 4 = NEODC (legacy), sum for combinations.
+    --   Default 3 = ADC + ADCS (what luadch itself speaks).
+    -- hub_redirect_alternatives: list of alternative redirect URLs
+    -- attached as IQUI.RX on every kick/redirect (cmd_redirect etc).
+    -- Clients use these as fallback targets if the primary RD URL is
+    -- unreachable. Default empty (RX field omitted).
+    -- hub_redirect_permanent: if true, IQUI carries PT1 so the client
+    -- treats the redirect as permanent (e.g. updates its bookmark).
+    -- Default false.
+    hub_redirect_protocols = { 3,
+        function( value )
+            return types_number( value, nil, true ) and value >= 0 and value <= 7
+        end
+    },
+    hub_redirect_alternatives = { { },
+        function( value )
+            if not types_table( value ) then return false end
+            for _, v in pairs( value ) do
+                if type( v ) ~= "string" then return false end
+            end
+            return true
+        end
+    },
+    hub_redirect_permanent = { false,
+        function( value )
+            return types_boolean( value, nil, true )
+        end
+    },
+
     usr_hubs_godlevel = { {
 
         [ 0 ] = false,

--- a/core/hub.lua
+++ b/core/hub.lua
@@ -403,6 +403,7 @@ local _cfg_max_op_hubs
 local _cfg_min_user_hubs
 local _cfg_min_reg_hubs
 local _cfg_min_op_hubs
+local _cfg_hub_redirect_protocols
 local _cfg_max_bad_password
 local _cfg_bad_pass_timeout
 local _cfg_kill_wrong_ips
@@ -446,6 +447,7 @@ local function _bind_dispatch_module( )
         _cfg_min_user_hubs   = _cfg_min_user_hubs,
         _cfg_min_reg_hubs    = _cfg_min_reg_hubs,
         _cfg_min_op_hubs     = _cfg_min_op_hubs,
+        _cfg_hub_redirect_protocols = _cfg_hub_redirect_protocols,
         _cfg_hub_name        = _cfg_hub_name,
         _cfg_hub_description = _cfg_hub_description,
         _cfg_hub_hostaddress = _cfg_hub_hostaddress,
@@ -470,14 +472,17 @@ end
 
 _user_count = 0
 
+-- IINF.RP (#147 T1.2 / ADC-EXT 3.32 RDEX) advertises the redirect URI
+-- schemes the hub accepts. cfg-driven bitmask: 1 = ADC, 2 = ADCS,
+-- 4 = NEODC (legacy), default 3 (ADC + ADCS).
 _normalsup = "" ..
     "ISUP ADBAS0 ADBASE ADTIGR ADKEYP ADOSNR ".. --> ADKEYP (keyprint)
     "ADUCM0 ADUCMD\nISID %s\nIINF " ..
-    "NI%s APLUADCH VE%s DE%s HU1 HI1 CT32\n"
+    "NI%s APLUADCH VE%s DE%s RP%s HU1 HI1 CT32\n"
 _normalsup_regonly = "" ..
     "ISUP ADBAS0 ADBASE ADTIGR ADKEYP ADOSNR ".. --> ADKEYP (keyprint)
     "ADUCM0 ADUCMD\nISID %s\nIINF " ..
-    "NILuadch APLUADCH VE%s HU1 HI1 CT32\n"
+    "NILuadch APLUADCH VE%s RP%s HU1 HI1 CT32\n"
 _hubinf_regonly = "IINF NI%s DE%s\n"
 -- ADC-EXT PING fields. The XU/XR/XO (max hubs per user-class) and
 -- the symmetric MU/MR/MO (min hubs) are all cfg-driven via
@@ -489,7 +494,7 @@ _hubinf_regonly = "IINF NI%s DE%s\n"
 _pingsup = "" ..
     "ISUP ADBAS0 ADBASE ADTIGR ADKEYP ADOSNR " .. --> ADKEYP (keyprint)
     "ADPING ADUCM0 ADUCMD\nISID %s\nIINF " ..
-    "NI%s APLUADCH VE%s DE%s HH%s WS%s NE%s OW%s " ..
+    "NI%s APLUADCH VE%s DE%s HH%s WS%s NE%s OW%s RP%s " ..
     "UC%s MS%s XS%s ML%s XL%s MU%s MR%s MO%s XU%s XR%s XO%s MC%s UP%s HU1 HI1 CT32\n"
 
 
@@ -1379,6 +1384,7 @@ loadsettings = function( )    -- caching table lookups...
     _cfg_min_user_hubs = cfg_get "min_user_hubs"
     _cfg_min_reg_hubs = cfg_get "min_reg_hubs"
     _cfg_min_op_hubs = cfg_get "min_op_hubs"
+    _cfg_hub_redirect_protocols = cfg_get "hub_redirect_protocols"
     _cfg_max_bad_password = cfg_get "max_bad_password"
     _cfg_bad_pass_timeout = cfg_get "bad_pass_timeout"
     _cfg_kill_wrong_ips = cfg_get "kill_wrong_ips" -- not in cfg.tbl

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -131,6 +131,7 @@ local _cfg_max_op_hubs
 local _cfg_min_user_hubs
 local _cfg_min_reg_hubs
 local _cfg_min_op_hubs
+local _cfg_hub_redirect_protocols
 local _cfg_hub_name
 local _cfg_hub_description
 local _cfg_hub_hostaddress
@@ -183,6 +184,7 @@ local function bind( deps )
     _cfg_min_user_hubs   = deps._cfg_min_user_hubs
     _cfg_min_reg_hubs    = deps._cfg_min_reg_hubs
     _cfg_min_op_hubs     = deps._cfg_min_op_hubs
+    _cfg_hub_redirect_protocols = deps._cfg_hub_redirect_protocols
     _cfg_hub_name        = deps._cfg_hub_name
     _cfg_hub_description = deps._cfg_hub_description
     _cfg_hub_hostaddress = deps._cfg_hub_hostaddress
@@ -227,6 +229,7 @@ _protocol = {
                     _cfg_hub_website,
                     _cfg_hub_network,
                     _cfg_hub_owner,
+                    _cfg_hub_redirect_protocols,
                     tablesize( _normalstatesids ),
                     min_share,
                     max_share,
@@ -246,12 +249,14 @@ _protocol = {
                     user.sid( ),
                     _cfg_hub_name,
                     adclib_escape( VERSION ),
-                    _cfg_hub_description
+                    _cfg_hub_description,
+                    _cfg_hub_redirect_protocols
                 )
             elseif _cfg_reg_only then
                 response = utf_format( _normalsup_regonly,
                     user.sid( ),
-                    adclib_escape( VERSION )
+                    adclib_escape( VERSION ),
+                    _cfg_hub_redirect_protocols
                 )
             end
             user.write( response )

--- a/core/hub_user_object.lua
+++ b/core/hub_user_object.lua
@@ -303,16 +303,32 @@ local function createuser( _client, _sid )
         user:kill( "IQUI " .. _sid .. " RD" .. adclib_escape( url ) .. "\n" )
     end
     ]]
+    -- ADC-EXT 3.32 RDEX. Builds an IQUI redirect with RD (primary URL)
+    -- plus optional RX (alternative URLs) and PT (permanent flag) NPs
+    -- driven from cfg. The legacy MS quitmsg stays as the trailing
+    -- field. Cfg is looked up at call time so a +reload picks up new
+    -- alternatives / permanent toggle without a hub restart.
     user.redirect = function( _, url, quitmsg )
         types_utf8( url )
-        url = " RD" .. adclib_escape( url )
+        local parts = { "IQUI ", _sid, " RD", adclib_escape( url ) }
+        local alts = cfg.get "hub_redirect_alternatives"
+        if alts then
+            for _, alt in pairs( alts ) do
+                types_utf8( alt )
+                parts[ #parts + 1 ] = " RX"
+                parts[ #parts + 1 ] = adclib_escape( alt )
+            end
+        end
+        if cfg.get "hub_redirect_permanent" then
+            parts[ #parts + 1 ] = " PT1"
+        end
         if quitmsg then
             types_utf8( quitmsg )
-            quitmsg = " MS" .. quitmsg
-        else
-            quitmsg = ""
+            parts[ #parts + 1 ] = " MS"
+            parts[ #parts + 1 ] = quitmsg
         end
-        user:kill( "IQUI " .. _sid .. url .. quitmsg .. "\n" )
+        parts[ #parts + 1 ] = "\n"
+        user:kill( table_concat( parts ) )
     end
     user.salt = function( _, data )
         if data then

--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -296,6 +296,13 @@ return { -- the settings are a lua table, do not tough this!
     min_reg_hubs = 0,  -- min OTHER hubs a registered user must be in (integer, 0 = no requirement)
     min_op_hubs = 0,  -- min OTHER hubs an operator must be in (integer, 0 = no requirement)
 
+    ---------------------------------------------------------------------------------------------------------------------------------
+    --// ADC-EXT RDEX (rich redirect) settings
+
+    hub_redirect_protocols = 3,  -- bitmask of redirect URI schemes (ADC=1, ADCS=2, NEODC=4, sum). Default 3 = ADC + ADCS.
+    hub_redirect_alternatives = { },  -- list of alternative redirect URLs attached as IQUI.RX on every redirect (array of strings)
+    hub_redirect_permanent = false,  -- if true, IQUI carries PT1 so client treats redirect as permanent (boolean)
+
     usr_hubs_godlevel = {  -- users with this levels wont be checked (array of boolean)
 
         [ 0 ] = false,  -- unreg


### PR DESCRIPTION
Second T1 item from the #147 ADC coverage tracker. ADC-EXT 3.32 RDEX (Rich Redirect).

## What RDEX does

The hub gains two pieces of redirect machinery:

### IINF.RP - which URI schemes the hub speaks

Advertised in every IINF the hub emits. Bitmask:
- 1 = ADC, 2 = ADCS, 4 = NEODC (legacy)

Default 3 (ADC + ADCS) - matches what luadch listens on. Operators on a TLS-only deployment can set \`hub_redirect_protocols = 2\` so other hubs redirecting users here don't try \`adc://\` URLs.

### IQUI.RX / PT - rich redirect on every kick

When the hub kicks/redirects a user (\`cmd_redirect\`, ratelimit lockout, manual kicks), the IQUI line now optionally carries:
- \`RX\` = alternative redirect URLs (list). Fallback if primary RD URL fails.
- \`PT1\` = permanent flag. Client treats redirect as permanent (bookmark update).

Both cfg-driven so the operator sets them once and **every** redirect path picks them up automatically.

## Lands

| File | Change |
|---|---|
| \`core/cfg_defaults.lua\` | Three new keys with validators: \`hub_redirect_protocols\` (bitmask 0-7, default 3), \`hub_redirect_alternatives\` (list-of-strings, default empty), \`hub_redirect_permanent\` (boolean, default false). |
| \`core/hub.lua\` | RP%s in _normalsup / _normalsup_regonly / _pingsup format strings. New \`_cfg_hub_redirect_protocols\` upvalue. |
| \`core/hub_dispatch.lua\` | Matching local + bind + one extra arg in each of the three utf_format calls. |
| \`core/hub_user_object.lua\` | \`user.redirect()\` rewritten with a parts-array builder for the IQUI string. Same RD + optional MS as before, plus optional RX (one per cfg alternative) and PT1. cfg looked up at call time so \`+reload\` works without restart. |
| \`examples/cfg/cfg.tbl\` | Three new keys documented under their own header block. |

## Operator example

Hub-pool deployment with TLS-only primary + clear-text fallback:

\`\`\`lua
hub_redirect_protocols = 3,                            -- accept ADC + ADCS
hub_redirect_alternatives = {
    \"adc://backup.example.com:5000\",
    \"adcs://backup.example.com:5001\",
},
hub_redirect_permanent = false,                        -- regular redirects, not bookmark-flipping
\`\`\`

After this, every kick / \`+redirect <nick> adcs://primary.example.com:5001\` emits an IQUI with the primary, both alternatives, and no PT.

## Operator impact at defaults

- \`hub_redirect_alternatives = {}\` - no RX field emitted (one extra ~30 bytes per IINF for the RP3 field, no change to QUI lines).
- \`hub_redirect_permanent = false\` - no PT field emitted.

So bandwidth and behavior are essentially identical to before this PR for operators who don't touch the keys. RP3 in IINF is the only wire-level change at defaults.

## Test plan

- [x] Lua syntax OK on all four changed core files
- [x] Local smoke 36/36 PASS on Windows (handshake tests verify the new format strings parse)
- [x] CI Linux + Windows smoke

## Spec quirks called out

- RDEX has no SUP advertisement per spec - support is signaled by the *presence* of the RP field in INF. We don't add ADRDEX to ISUP.
- The spec example \`IQUI BBBB IDAAAA RDadc://example.com:1001 RXadcs://example.com:1002 PT1\` matches the order this PR emits (RD, then RX*, then PT1, then optional MS).
- NEODC (4) in the RP bitmask is legacy and luadch doesn't speak it. Operators can include it in their bitmask if they explicitly want to invite NEODC-speaking clients to redirect here.

## #147 status after merge

- [x] T1.1 NATT - #148 merged
- [x] **T1.2 RDEX** - this PR
- [ ] T1.3 PING SS/SF aggregate
- [ ] T1.4 PING HE field
- [ ] T1.5 STA emission codes
- [ ] T1.6 FRES routing
- [ ] T1.7 QUI from client honor
- [ ] T1.8 Minor extensions awareness
- [ ] T2.x / T3.x deferred