### PR TITLE
feat(adc): PING SS / SF aggregate + HE email (T1.3 + T1.4 of #147)

### DIFF
--- a/core/hub.lua
+++ b/core/hub.lua
@@ -404,6 +404,7 @@ local _cfg_min_user_hubs
 local _cfg_min_reg_hubs
 local _cfg_min_op_hubs
 local _cfg_hub_redirect_protocols
+local _cfg_hub_email
 local _cfg_max_bad_password
 local _cfg_bad_pass_timeout
 local _cfg_kill_wrong_ips
@@ -448,6 +449,7 @@ local function _bind_dispatch_module( )
         _cfg_min_reg_hubs    = _cfg_min_reg_hubs,
         _cfg_min_op_hubs     = _cfg_min_op_hubs,
         _cfg_hub_redirect_protocols = _cfg_hub_redirect_protocols,
+        _cfg_hub_email       = _cfg_hub_email,
         _cfg_hub_name        = _cfg_hub_name,
         _cfg_hub_description = _cfg_hub_description,
         _cfg_hub_hostaddress = _cfg_hub_hostaddress,
@@ -491,11 +493,17 @@ _hubinf_regonly = "IINF NI%s DE%s\n"
 -- the most permissive baseline; operators wanting to enforce min-hub
 -- policy can set `min_user_hubs` / `min_reg_hubs` / `min_op_hubs` in
 -- cfg/cfg.tbl.
+-- T1.3 / T1.4 of #147: PING now also emits SS (total bytes shared
+-- across the hub), SF (total files shared), and HE (hub email /
+-- contact). All three are spec-defined in ADC-EXT 3.4.1 and round
+-- out the PING reply with the data hublist scrapers expect. SS/SF
+-- are aggregated over online users at PING-time; HE comes from the
+-- `hub_email` cfg key already used elsewhere.
 _pingsup = "" ..
     "ISUP ADBAS0 ADBASE ADTIGR ADKEYP ADOSNR " .. --> ADKEYP (keyprint)
     "ADPING ADUCM0 ADUCMD\nISID %s\nIINF " ..
-    "NI%s APLUADCH VE%s DE%s HH%s WS%s NE%s OW%s RP%s " ..
-    "UC%s MS%s XS%s ML%s XL%s MU%s MR%s MO%s XU%s XR%s XO%s MC%s UP%s HU1 HI1 CT32\n"
+    "NI%s APLUADCH VE%s DE%s HH%s WS%s NE%s OW%s HE%s RP%s " ..
+    "UC%s SS%s SF%s MS%s XS%s ML%s XL%s MU%s MR%s MO%s XU%s XR%s XO%s MC%s UP%s HU1 HI1 CT32\n"
 
 
 _G = _G
@@ -1385,6 +1393,7 @@ loadsettings = function( )    -- caching table lookups...
     _cfg_min_reg_hubs = cfg_get "min_reg_hubs"
     _cfg_min_op_hubs = cfg_get "min_op_hubs"
     _cfg_hub_redirect_protocols = cfg_get "hub_redirect_protocols"
+    _cfg_hub_email = cfg_get "hub_email"
     _cfg_max_bad_password = cfg_get "max_bad_password"
     _cfg_bad_pass_timeout = cfg_get "bad_pass_timeout"
     _cfg_kill_wrong_ips = cfg_get "kill_wrong_ips" -- not in cfg.tbl

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -132,6 +132,7 @@ local _cfg_min_user_hubs
 local _cfg_min_reg_hubs
 local _cfg_min_op_hubs
 local _cfg_hub_redirect_protocols
+local _cfg_hub_email
 local _cfg_hub_name
 local _cfg_hub_description
 local _cfg_hub_hostaddress
@@ -185,6 +186,7 @@ local function bind( deps )
     _cfg_min_reg_hubs    = deps._cfg_min_reg_hubs
     _cfg_min_op_hubs     = deps._cfg_min_op_hubs
     _cfg_hub_redirect_protocols = deps._cfg_hub_redirect_protocols
+    _cfg_hub_email       = deps._cfg_hub_email
     _cfg_hub_name        = deps._cfg_hub_name
     _cfg_hub_description = deps._cfg_hub_description
     _cfg_hub_hostaddress = deps._cfg_hub_hostaddress
@@ -220,6 +222,17 @@ _protocol = {
                 local max_share = _cfg_max_share[ 0 ] or 100
                 min_share = min_share * 1024^3
                 max_share = max_share * 1024^4
+                -- T1.3 of #147: aggregate SS / SF over online users.
+                -- Bots have no INF and their share/files getters
+                -- return nil, so we skip them implicitly. Cost is
+                -- O(N) once per PING handshake - not a hot path.
+                local total_ss, total_sf = 0, 0
+                for _, u in pairs( _normalstatesids ) do
+                    local s = u.share and u:share()
+                    local f = u.files and u:files()
+                    if s then total_ss = total_ss + s end
+                    if f then total_sf = total_sf + f end
+                end
                 response = utf_format( _pingsup,
                     user.sid( ),
                     _cfg_hub_name,
@@ -229,8 +242,11 @@ _protocol = {
                     _cfg_hub_website,
                     _cfg_hub_network,
                     _cfg_hub_owner,
+                    adclib_escape( _cfg_hub_email or "" ),
                     _cfg_hub_redirect_protocols,
                     tablesize( _normalstatesids ),
+                    total_ss,
+                    total_sf,
                     min_share,
                     max_share,
                     _cfg_min_slots[ 0 ] or 1,

--- a/core/hub_user_object.lua
+++ b/core/hub_user_object.lua
@@ -229,6 +229,12 @@ local function createuser( _client, _sid )
     user.share = function( _ )
         return _inf and tonumber( _inf:getnp "SS" )
     end
+    -- ADC INF.SF = number of shared files. Public for plugins and used
+    -- by the hub itself to compute the aggregate SF field in PING
+    -- replies (T1.3 of #147).
+    user.files = function( _ )
+        return _inf and tonumber( _inf:getnp "SF" )
+    end
     user.slots = function( _ )
         return _inf and tonumber( _inf:getnp "SL" )
     end


### PR DESCRIPTION
Third and fourth T1 items from the #147 ADC coverage tracker, bundled because both touch only the PING handshake reply. Round out the spec-defined INF fields the hub advertises on \`ADPING\` requests.

## What's new on the wire

| Field | Spec | Source | Status |
|---|---|---|---|
| **SS** | total bytes shared across the hub | aggregate over online users' \`INF.SS\` | new |
| **SF** | total files shared across the hub | aggregate over online users' \`INF.SF\` | new |
| **HE** | hub email / contact address | \`hub_email\` cfg key (exists since v0.x) | new in PING |

The audit flagged all three as missing from \`_pingsup\`. Hublists scraping the hub will now see the full \"this hub holds N TB across N files\" headline plus an operator contact line. Bots have no INF and their getters return nil, so they're skipped implicitly in the aggregation - the math comes out the same as iterating non-bot users explicitly.

## Lands

| File | Change |
|---|---|
| \`core/hub_user_object.lua\` | New public \`user.files()\` getter returning \`INF.SF\` as a number (or nil). Mirrors \`user.share()\`. Available to plugins. |
| \`core/hub.lua\` | \`_pingsup\` format string adds \`HE%s\` between OW and RP, plus \`SS%s SF%s\` after UC. New \`_cfg_hub_email\` upvalue populated in \`loadsettings()\`. |
| \`core/hub_dispatch.lua\` | Matching local + bind entry. One pass over \`_normalstatesids\` computes \`total_ss\` and \`total_sf\` inside the HSUP \`ADPING\` branch. Three new args threaded into \`utf_format(_pingsup, ...)\`. \`hub_email\` is \`adclib_escape()\`d in case operators include \`\s\` or newlines. |

## Operator impact at defaults

- **Operators using PING-scraping hublists**: visible improvement - hub now reports full SS/SF aggregate (previously 0) and HE contact (previously absent).
- **Everyone else**: zero change. \`_normalsup\` and \`_normalsup_regonly\` are unchanged - the SS/SF/HE additions are PING-only.
- **No new cfg keys** - HE reuses the existing \`hub_email\` key already used by \`hub_bot_object.lua\` for the EM field.

## Performance

The SS/SF aggregation walks \`_normalstatesids\` once per PING handshake. That happens at most once per client connect, not on any hot path. O(N) with N = currently logged-in users (incl. bots, but bot.share/files return nil and are skipped).

## Test plan

- [x] Lua syntax OK on all three changed core files
- [x] Local smoke 36/36 PASS on Windows (existing handshake tests verify the new format string parses)
- [x] CI Linux + Windows smoke

## #147 status after merge

- [x] T1.1 NATT - #148 merged
- [x] T1.2 RDEX - #149 merged
- [x] **T1.3 PING SS/SF aggregate** - this PR
- [x] **T1.4 PING HE field** - this PR
- [ ] T1.5 STA emission codes
- [ ] T1.6 FRES routing
- [ ] T1.7 QUI from client honor
- [ ] T1.8 Minor extensions awareness