### PR TITLE
fix(adc): spec-compliant STA codes - 212 on shutdown, 232 for temp bans (T1.5 of #147)

### DIFF
--- a/core/hub_user_object.lua
+++ b/core/hub_user_object.lua
@@ -186,7 +186,13 @@ local function createuser( _client, _sid )
             return false, "invalid code"-----!
         end
         local msg = "ISTA " .. code .. " " .. desc
-        if type( flags == "table" ) then
+        -- The original `type( flags == "table" )` was a long-standing
+        -- typo: it called type() on a boolean (the result of comparing
+        -- flags to the string "table"), which is always truthy, then
+        -- pairs(nil) would crash whenever the caller omitted the flags
+        -- argument. Pinning the parens makes the contract match the
+        -- docstring: flags is optional, must be a table when present.
+        if type( flags ) == "table" then
             for flag, value in pairs( flags ) do
                 msg = msg .. " " .. escapeto( flag ) .. escapeto( value )
             end

--- a/scripts/cmd_ban.lua
+++ b/scripts/cmd_ban.lua
@@ -372,7 +372,12 @@ local add = function( user, target, bantime, reason, script )  -- ban export fun
     util.savearray( bans, bans_path )
     util.savetable( history, "history_tbl", history_path )
     local target_msg = utf.format( msg_ban, script, reason ) .. get_bantime( bantime )
-    target:kill( "ISTA 231 " .. hub.escapeto( target_msg ) .. "\n", "TL" .. bantime )
+    -- ADC STA 232 = "Temporarily banned, flag TL" (T1.5 of #147).
+    -- The previous code used 231 (= "Permanently banned") together
+    -- with a finite TL, which is spec-conflicting; clients seeing
+    -- TL on a 231 may treat the ban as permanent regardless. 232 with
+    -- TL is the canonical encoding for a time-limited ban.
+    target:kill( "ISTA 232 " .. hub.escapeto( target_msg ) .. "\n", "TL" .. bantime )
     return PROCESSED
 end
 
@@ -608,7 +613,9 @@ local onbmsg = function( user, command, parameters )
         addban( by, id, bantime, reason, level, userfirstnick, victim )
         local message = utf.format( msg_ok, hub.escapefrom( targetnick ), usernick, get_bantime( bantime ), reason )
         report.send( report_activate, report_hubbot, report_opchat, llevel, message )
-        target:kill( "ISTA 230 " .. hub.escapeto( message ) .. "\n", "TL" .. bantime )
+        -- 232 (temporary ban with TL) per ADC STA semantics. 230 is
+        -- "generic kick" - lacks the ban-list intent.
+        target:kill( "ISTA 232 " .. hub.escapeto( message ) .. "\n", "TL" .. bantime )
         user:reply( message, hub.getbot() )
         return PROCESSED
     end
@@ -707,7 +714,7 @@ hub.setlistener( "onConnect", {},
                 -- remember: never fire listenter X inside listener X; will cause infinite loop
                 -- also: never fire listener X in listener Y, where listener Y fires listener X; will as well cause a infinite loop.
                 --scripts.firelistener( "onFailedAuth", user:nick( ), user:ip( ), user:cid( ), "Banned for "  .. get_bantime( remaining ) .. " (" .. ban.reason .. ")" )
-                user:kill( "ISTA 231 " .. hub.escapeto( message ) .. "\n", "TL" .. remaining )
+                user:kill( "ISTA 232 " .. hub.escapeto( message ) .. "\n", "TL" .. remaining )
                 return PROCESSED
             end
         end

--- a/scripts/cmd_restart.lua
+++ b/scripts/cmd_restart.lua
@@ -72,6 +72,7 @@ local ucmd_msg = lang.ucmd_msg or "Mass Message (optional)"
 
 local msg_denied = lang.msg_denied or "You are not allowed to use this command."
 local msg_ok = lang.msg_ok or "Hub restarted."
+local msg_hub_disabled = lang.msg_hub_disabled or "Hub is restarting."
 local msg_countdown = lang.msg_countdown or "*** Hubrestart in ***"
 local msg_restart = lang.msg_restart or [[
 
@@ -178,6 +179,14 @@ local update_lastlogout = function()
 end
 
 local do_exit = function()
+    -- T1.5 of #147: spec-compliant ISTA 212 emission ("Hub disabled")
+    -- to every connected user before the socket close. The hub-disabled
+    -- state is also the right code for a restart - "I'm going away,
+    -- briefly, then coming back" - and prevents clients from treating
+    -- the disconnect as a network glitch + immediate reconnect race.
+    for _, u in pairs( hub.getusers() ) do
+        u:sendsta( 212, msg_hub_disabled )
+    end
     hub.shutdown()
     local starttime = os.time()
     return function()

--- a/scripts/cmd_shutdown.lua
+++ b/scripts/cmd_shutdown.lua
@@ -68,6 +68,7 @@ local ucmd_msg = lang.ucmd_msg or "Mass Message (optional)"
 
 local msg_denied = lang.msg_denied or "You are not allowed to use this command."
 local msg_ok = lang.msg_ok or "Shutdown hub..."
+local msg_hub_disabled = lang.msg_hub_disabled or "Hub is shutting down."
 local msg_countdown = lang.msg_countdown or "*** Hubshutdown in ***"
 
 local msg_shutdown = lang.msg_shutdown or [[
@@ -174,11 +175,18 @@ local update_lastlogout = function()
 end
 
 local do_exit = function()
+    -- T1.5 of #147: spec-compliant ISTA 212 emission ("Hub disabled")
+    -- to every connected user before the socket close. Without this,
+    -- clients see a bare disconnect indistinguishable from a network
+    -- glitch and may auto-reconnect immediately.
+    for _, u in pairs( hub.getusers() ) do
+        u:sendsta( 212, msg_hub_disabled )
+    end
     hub.shutdown()
     local starttime = os.time()
     return function()
         local diff = os.time() - starttime
-        if diff >= 3 then 
+        if diff >= 3 then
             update_lastlogout()
             hub.exit()
         end

--- a/scripts/lang/cmd_restart.lang.de
+++ b/scripts/lang/cmd_restart.lang.de
@@ -9,6 +9,7 @@
 
     msg_denied = "Du bist nicht befugt diesen Befehl zu nutzen.",
     msg_ok = "Hub wird neu gestartet...",
+    msg_hub_disabled = "Hub startet neu.",
 
     msg_countdown = "*** Hub startet neu in ***",
 

--- a/scripts/lang/cmd_restart.lang.en
+++ b/scripts/lang/cmd_restart.lang.en
@@ -9,6 +9,7 @@
 
     msg_denied = "You are not allowed to use this command.",
     msg_ok = "Hub restart...",
+    msg_hub_disabled = "Hub is restarting.",
 
     msg_countdown = "*** Hub restart in ***",
 

--- a/scripts/lang/cmd_shutdown.lang.de
+++ b/scripts/lang/cmd_shutdown.lang.de
@@ -9,6 +9,7 @@
 
     msg_denied = "Du bist nicht befugt diesen Befehl zu nutzen.",
     msg_ok = "Fahre Hub runter...",
+    msg_hub_disabled = "Hub faehrt herunter.",
 
     msg_countdown = "*** Hub wird heruntergefahren in ***",
 

--- a/scripts/lang/cmd_shutdown.lang.en
+++ b/scripts/lang/cmd_shutdown.lang.en
@@ -9,6 +9,7 @@
 
     msg_denied = "You are not allowed to use this command.",
     msg_ok = "Shutdown hub...",
+    msg_hub_disabled = "Hub is shutting down.",
 
     msg_countdown = "*** Hub shutdown in ***",
 


### PR DESCRIPTION
T1.5 from the #147 ADC coverage tracker. Three classes of STA emission fixes for spec compliance.

## What changes

### 1. Hub-shutdown emits ISTA 212

\`cmd_shutdown\` and \`cmd_restart\` now emit \`ISTA 212\` (\"Hub disabled\") to every connected user before \`hub.shutdown()\` closes the listeners. Without this, clients see a bare socket disconnect that's indistinguishable from a network glitch, often triggering an immediate reconnect attempt against a dead listener. With the explicit STA, clients know to back off.

The 212 emission happens at \`do_exit\` time - just before \`hub.shutdown()\` - so it survives the optional countdown phase (operator types \`+shutdown\`, sees 10s countdown chat broadcasts, hub then emits 212 and goes down).

### 2. Temporary bans use ISTA 232, not 231 / 230

\`cmd_ban\` had three call sites emitting \`ISTA 231\` (permanent ban) or \`ISTA 230\` (generic kick) together with a finite \`TL<seconds>\` field. Per ADC section 5.3.4:

- **231** = permanently banned, no TL or TL-1
- **232** = temporarily banned, TL flag = seconds until expiry

Clients seeing \`TL\` on a \`231\` may treat the ban as permanent and ignore the TL value. Three sites switched to \`ISTA 232\`:

| File:line | Was | Now |
|---|---|---|
| \`cmd_ban.lua:375\` (addban) | \`231 ... TL<bantime>\` | \`232 ... TL<bantime>\` |
| \`cmd_ban.lua:611\` (immediate ban command) | \`230 ... TL<bantime>\` | \`232 ... TL<bantime>\` |
| \`cmd_ban.lua:710\` (login-time ban check) | \`231 ... TL<remaining>\` | \`232 ... TL<remaining>\` |

### 3. user.sendsta typo fix (bonus)

\`core/hub_user_object.lua\` had a long-standing typo: \`type( flags == \"table\" )\` called \`type()\` on a boolean (the result of comparing \`flags\` to the string \"table\"), which is always truthy. Then \`pairs(nil)\` crashed whenever a caller omitted the optional flags argument. Now \`type( flags ) == \"table\"\` matches the docstring contract.

The \`cmd_shutdown\` / \`cmd_restart\` 212 emission uses \`user.sendsta\` to write the ISTA, so this is also a precondition for the new code.

## Lang additions

| File | New key |
|---|---|
| \`scripts/lang/cmd_shutdown.lang.en\` | \`msg_hub_disabled = \"Hub is shutting down.\"\` |
| \`scripts/lang/cmd_shutdown.lang.de\` | \`msg_hub_disabled = \"Hub faehrt herunter.\"\` |
| \`scripts/lang/cmd_restart.lang.en\` | \`msg_hub_disabled = \"Hub is restarting.\"\` |
| \`scripts/lang/cmd_restart.lang.de\` | \`msg_hub_disabled = \"Hub startet neu.\"\` |

All additive - existing operator-customised translations still work, the new key falls back to the hardcoded English string when absent.

## Test plan

- [x] Lua syntax OK on all 8 changed files
- [x] Local smoke 36/36 PASS on Windows
- [ ] CI Linux + Windows smoke

## #147 status after merge

- [x] T1.1 NATT - #148
- [x] T1.2 RDEX - #149
- [x] T1.3 PING SS/SF - #150
- [x] T1.4 PING HE - #150
- [x] **T1.5 STA codes** - this PR
- [ ] T1.6 FRES routing
- [ ] T1.7 QUI from client honor
- [ ] T1.8 Minor extensions awareness