### PR TITLE
feat(adc): FRES routing - feature-filtered search results (T1.6 of #147)

### DIFF
--- a/core/adc.lua
+++ b/core/adc.lua
@@ -238,6 +238,7 @@ _regex = {
         bcast = "[BF]",
         direct = "[DE]",
         hubdirect = "[HDE]",
+        result = "[FD]",        -- ADC 5.3.6 RES: D (direct) + F (feature-filtered)
 
     },
 
@@ -522,7 +523,7 @@ _protocol = {
         INF = _regex.context.bcast,
         MSG = _regex.context.send,
         SCH = _regex.context.send,
-        RES = _regex.context.direct,
+        RES = _regex.context.result,
         CTM = _regex.context.direct,
         RCM = _regex.context.direct,
         NAT = _regex.context.direct,    -- ADC-EXT NATT

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -573,9 +573,21 @@ _normal = {
         if rl_search_drop( user ) then return true end
         return scripts_firelistener( "onSearch", user, adccmd )
     end,
-    -- ADC: 6.3.7. RES
+    -- ADC: 6.3.7. RES (D-class single-recipient + F-class feature-
+    -- filtered fan-out via #147 T1.6).
     DRES = function( user, adccmd, targetuser )
         return scripts_firelistener( "onSearchResult", user, targetuser, adccmd )
+    end,
+    -- F-class search-result. Sent when the responder wants the result
+    -- delivered to a set of clients matching feature flags rather
+    -- than a single SID (e.g. delivering NMDC-bridged results only
+    -- to ADC clients that support the bridge). The feature-fan-out
+    -- itself happens in hub.lua's class router; the dispatcher just
+    -- has to recognise the command. Fire the onSearchResult listener
+    -- with nil targetuser so plugins can distinguish F-class
+    -- (multi-target) from D-class (single-target) results.
+    FRES = function( user, adccmd )
+        return scripts_firelistener( "onSearchResult", user, nil, adccmd )
     end,
     --URES = function( user, adccmd, targetuser ) -- new
     --    return scripts_firelistener( "onSearchResult", user, targetuser, adccmd )


### PR DESCRIPTION
T1.6 from the #147 ADC coverage tracker. Trivial completion of RES routing - the hub now accepts both D-class and F-class result delivery.

## Spec basis

ADC 5.3.6 RES is sent by the responder back to the searcher. Two valid classes:
- **D-class** (\`DRES\`): single SID recipient
- **F-class** (\`FRES\`): feature-filtered fan-out to clients matching a feature mask (e.g. delivering NMDC-bridged results only to ADC clients that speak the bridge feature)

The hub previously only routed DRES; FRES from a client was rejected at the parser context-check (\`[DE]\` doesn't match \`F\`) and silently dropped before reaching the dispatcher.

## Lands

| File | Change |
|---|---|
| \`core/adc.lua\` | New context entry \`result = \"[FD]\"\` and switch \`RES\` to it. F-class added, E-class removed (ERES has no spec semantic). CTM / RCM / NAT / RNT keep the existing \`direct = \"[DE]\"\` context unchanged. |
| \`core/hub_dispatch.lua\` | New \`FRES\` handler in the \`_normal\` table. Fires the same \`onSearchResult\` listener as \`DRES\`, but passes \`nil\` for the targetuser arg so plugins can branch \`if targetuser then ... end\` to distinguish D-class (single-target) from F-class (multi-target) results. |

## Plugin signature compatibility

The bundled \`hub_cmd_manager.lua\` is the only plugin in the tree that listens for \`onSearchResult\`, and it only reads the first arg (\`user\`). The 2-arg / 3-arg signature difference between FRES and DRES is therefore transparent.

Third-party plugins that read \`targetuser\` can simply check for nil to detect F-class:

\`\`\`lua
hub.setlistener(\"onSearchResult\", {}, function(user, targetuser, adccmd)
    if targetuser then
        -- D-class: single recipient
    else
        -- F-class: multi-target via feature filter
    end
end)
\`\`\`

## Test plan

- [x] Lua syntax OK on both changed files
- [x] Local smoke 36/36 PASS on Windows (parser change verified by handshake tests)
- [x] CI Linux + Windows smoke

## #147 status after merge

- [x] T1.1 NATT - #148
- [x] T1.2 RDEX - #149
- [x] T1.3 PING SS/SF - #150
- [x] T1.4 PING HE - #150
- [x] T1.5 STA codes - #151
- [x] **T1.6 FRES routing** - this PR
- [ ] T1.7 QUI from client honor
- [ ] T1.8 Minor extensions awareness