### PR TITLE
feat(adc): honor client-initiated QUI (T1.7 of #147)

### DIFF
--- a/core/adc.lua
+++ b/core/adc.lua
@@ -513,6 +513,27 @@ _protocol = {
             nonpclones = true,
 
         },
+        -- ADC 6.3.10 QUI. Hub-direction (IQUI) is built directly via
+        -- string concat in disconnect() and user.kill, but the
+        -- parser also needs the shape so client-direction (HQUI =
+        -- "I'm leaving") parses through to the dispatcher instead
+        -- of being dropped as unknown. pp is the leaving user's SID;
+        -- np = empty lets the default validator pass any spec-defined
+        -- flag (RD / TL / MS / ID / RDEX RX-PT-RP) without enumerating
+        -- them here. T1.7 of #147.
+        QUI = {
+
+            pp = {
+
+                _regex.sid,
+
+                len = 1,
+
+            },
+            np = { },
+            nonpclones = false,
+
+        },
 
     },
     contexts = {

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -595,6 +595,21 @@ _normal = {
     --CRES = function( user, adccmd, targetuser ) -- new
     --    return scripts_firelistener( "onSearchResult", user, targetuser, adccmd )
     --end,
+    -- ADC 6.3.10 QUI (client-initiated). Spec lists QUI as permitted
+    -- in any state and the hub's expected reaction is to close the
+    -- connection. Before this handler the parser accepted HQUI but
+    -- the dispatcher had no entry, so the hub answered ISTA 125
+    -- (unknown command) instead of treating QUI as the polite
+    -- goodbye it is.
+    --
+    -- We just close the client here. server.lua's read loop catches
+    -- the resulting EOF and calls disconnect(), which broadcasts
+    -- IQUI <sid> to the remaining users and fires onLogout via the
+    -- normal cleanup path. T1.7 of #147.
+    HQUI = function( user, adccmd )
+        user:client():close()
+        return true
+    end,
 
 }
 

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -851,6 +851,43 @@ def test_neg_post_login_rcm_burst():
         _neg_drain_briefly(sock)
 
 
+def test_hqui_from_client_honored():
+    """ADC 6.3.10: client-initiated HQUI must be honored - hub closes
+    the connection cleanly without replying ISTA 125 (unknown command).
+    Before T1.7 of #147 the parser accepted HQUI but the dispatcher
+    had no entry, so the hub answered with the catch-all unknown-
+    command STA instead of treating QUI as a polite goodbye."""
+    with socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    ) as sock:
+        sid, _reader = _adc_login(sock, "dummy", "test")
+        try:
+            sock.sendall(f"HQUI {sid}\n".encode("utf-8"))
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            return
+        # Drain whatever the hub still has buffered for us before the
+        # close. Should be empty or contain only normal logout
+        # broadcasts, never ISTA 125.
+        sock.settimeout(2.0)
+        buf = b""
+        try:
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                buf += chunk
+        except (socket.timeout, TimeoutError):
+            raise TestFailure(
+                "hub did not close socket within 2s after HQUI; "
+                "T1.7 dispatcher likely not wired correctly"
+            )
+        if b"ISTA 125" in buf:
+            raise TestFailure(
+                f"hub rejected client HQUI as unknown command "
+                f"(ISTA 125 in tail): {buf[:200]!r}"
+            )
+
+
 def test_neg_post_login_natt_burst():
     """After a clean login, fire 50 mixed DNAT / DRNT commands (ADC-EXT
     NATT, T1.1 of #147) at non-existent SIDs. Both new dispatch routes
@@ -1443,6 +1480,7 @@ TESTS = [
     ("neg: post-login DCTM burst (#80 CTM bucket)", test_neg_post_login_ctm_burst),
     ("neg: post-login DRCM burst (#80 CTM bucket)", test_neg_post_login_rcm_burst),
     ("neg: post-login NATT burst (#147 T1.1)", test_neg_post_login_natt_burst),
+    ("HQUI from client closes cleanly (#147 T1.7)", test_hqui_from_client_honored),
     ("neg: canary - hub still alive after fuzz battery", test_neg_canary_hub_alive),
 ]
 


### PR DESCRIPTION
T1.7 from the #147 ADC coverage tracker. Hub now treats client-direction \`HQUI\` as a polite goodbye instead of silently dropping it.

## Before / after

| Step | Before | After |
|---|---|---|
| Client sends \`HQUI <my-sid>\` | Parser drops as unknown command (\`QUI\` not in \`_protocol.commands\`) | Parser routes to dispatcher |
| Dispatcher | (never reached) | \`HQUI\` handler closes the client |
| Client sees | nothing - socket eventually closes when client itself closes or hub's keepalive triggers | hub closes socket; read returns EOF |
| Other users see | \`IQUI <sid>\` once hub's read loop catches the EOF (delayed) | \`IQUI <sid>\` after the close hits server.lua's disconnect path (immediate) |
| Plugin \`onLogout\` | Fires whenever the disconnect is detected | Same - same code path, just triggered earlier |

## Lands

| File | Change |
|---|---|
| \`core/adc.lua\` | New \`QUI\` entry in \`_protocol.commands\`. \`pp = 1 SID\`, \`np = {}\` (default validator passes spec flags like ID / TL / MS / RD plus the RDEX RX-PT-RP from T1.2 without enumeration). |
| \`core/hub_dispatch.lua\` | \`HQUI\` handler in \`_normal\` table calls \`user:client():close()\` and returns true. server.lua's read loop catches the EOF and routes through the existing \`disconnect()\` path - IQUI fanout + onLogout happen for free. |
| \`tests/smoke/run.py\` | \`test_hqui_from_client_honored\` asserts (a) hub closes socket within 2s and (b) no \`ISTA 125\` in the response buffer (which would indicate the previous unknown-command reject). Suite 36 -> 37 tests. |

## Spec note

ADC 6.3.10 lists QUI as permitted in any state. This PR only wires HQUI into \`_normal\` since pre-login QUI from a client has no realistic use case - clients that abort the handshake just close the socket. The parser now accepts the shape across all states, so adding HQUI to \`_identify\` / \`_verify\` later is a 4-line addition if a use case appears.

## Test plan

- [x] Lua syntax OK on both changed core files
- [x] Local smoke 37/37 PASS on Windows (new HQUI test passes; canary still green)
- [x] CI Linux + Windows smoke

## #147 status after merge

- [x] T1.1 NATT - #148
- [x] T1.2 RDEX - #149
- [x] T1.3 PING SS/SF - #150
- [x] T1.4 PING HE - #150
- [x] T1.5 STA codes - #151
- [x] T1.6 FRES routing - #152
- [x] **T1.7 QUI from client honor** - this PR
- [ ] T1.8 Minor extensions awareness (docs only)