### PR TITLE
docs: ADC-EXT passthrough extensions section (T1.8 of #147)

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -726,6 +726,47 @@ recommended for public-facing deployments.
 
 ---
 
+## ADC-EXT passthrough extensions
+
+ADC defines a number of optional extensions where the hub's role is
+purely transparent: clients negotiate the extension between
+themselves (typically via `INF.SU` advertisement) and the hub just
+relays the resulting commands like any other D-class / B-class
+message. luadch supports these by simply not blocking them - no
+SUP advertisement, no validation, no special parsing beyond the
+already-existing default-validator path on unknown named
+parameters (Phase 7d hardening).
+
+Extensions in this category that the audit catches as
+\"spec-defined, hub-passthrough\":
+
+| Ext | What it does | Hub-side |
+|---|---|---|
+| **TYPE** | Typing notifications (\"user X is composing...\"), like instant-messenger clients show | passthrough |
+| **ONID** | Per-user metadata about external services (email, ICQ, etc.); informational relay only | passthrough |
+| **DFAV** | Decentralised hub-list: clients exchange their public hub favourites via `GFA` / `RFA` to build a community hublist | passthrough |
+| **FEED** | RSS feed broadcasts inside the hub chat | passthrough |
+| **ASCH** | Extended search NPs (file/folder filter, depth limit, etc.) | passthrough |
+| **SEGA** | File-extension grouping in SCH | passthrough |
+| **SUDP** | Encrypted UDP search-result delivery (`KY` key NP) | passthrough |
+| **CCPM** | Client-to-client private messaging (`MSG.PM`) - hub detects support on login but stays out of the actual PM session | detect + passthrough |
+| **BZIP** | bzip2-compressed filelist transport (client-pair) | passthrough |
+
+luadch doesn't advertise any of these in its own ISUP because the
+hub itself doesn't speak them - the client signals support per-user
+in `INF.SU` and peers negotiate accordingly. If you write a plugin
+that wants to gate one of these (e.g. forbid TYPE for level-0
+unregistered users), it's a standard `onBroadcast` / `onPrivateMessage`
+listener on the relevant command 4cc.
+
+If a future ADC-EXT extension appears that the hub MUST validate
+or transform (rather than just relay), it gets a first-class entry
+in this doc and full \`core/hub_dispatch.lua\` plumbing - same way
+NATT (#147 T1.1) and FRES (#147 T1.6) landed. The four extensions
+above were filed as #147 T1.8 and explicitly do not need that.
+
+---
+
 ## Optional plugins (companion repo)
 
 The bundled tree above ships with luadch and is install-and-go. For


### PR DESCRIPTION
Last T1 item from the #147 ADC coverage tracker. Pure docs - the audit flagged TYPE / ONID / DFAV / FEED (plus ASCH / SEGA / SUDP / CCPM / BZIP) as \"missing\" when in fact they're spec-correct passthroughs that just weren't called out anywhere.

## What's added

New section **\"ADC-EXT passthrough extensions\"** in [\`docs/SCRIPTS.md\`](docs/SCRIPTS.md), inserted between the Rate-limit configuration and the companion-repo pointer.

Contents:

1. One-paragraph intro on what \"passthrough\" means for ADC - hub doesn't advertise, doesn't validate, just relays the commands.
2. Table of the nine extensions in this category with one-sentence summary:

   | Ext | What it does |
   |---|---|
   | **TYPE** | Typing notifications |
   | **ONID** | External-service metadata |
   | **DFAV** | Decentralised hub-list via GFA / RFA |
   | **FEED** | RSS broadcast inside hub chat |
   | **ASCH** | Extended search NPs |
   | **SEGA** | File-extension grouping in SCH |
   | **SUDP** | Encrypted UDP search-result delivery |
   | **CCPM** | Client-pair PMs (hub detects support, stays out of the session) |
   | **BZIP** | bzip2-compressed filelist transport |

3. Closing paragraph: why no ISUP advertisement (hub doesn't speak them, clients negotiate via INF.SU), how a plugin would gate one if needed (\`onBroadcast\` / \`onPrivateMessage\` listener on the 4cc), and contrast with NATT (#148) / FRES (#152) which DID need full dispatcher plumbing.

## Why this matters

Operators reading the audit (or grepping the source for ADC-EXT awareness) need to know that the absence of e.g. \"TYPE\" handling in \`hub_dispatch.lua\` is intentional, not a gap. Same for the other eight. Without this doc, the next ADC audit would re-flag them.

## What this PR does NOT do

- No code changes. luadch already passes these extensions through correctly via the parser's default-validator path (Phase 7d hardening).
- No ISUP changes. The spec wants advertising in INF.SU per-user, not in ISUP at hub level.
- No plugin changes. The bundled tree doesn't need to gate any of these by default.

## #147 status after merge

All T1 items closed:

- [x] T1.1 NATT - #148
- [x] T1.2 RDEX - #149
- [x] T1.3 PING SS/SF - #150
- [x] T1.4 PING HE - #150
- [x] T1.5 STA codes - #151
- [x] T1.6 FRES routing - #152
- [x] T1.7 QUI from client honor - #153
- [x] **T1.8 Minor extensions awareness** - this PR

T2 items (HUBI / BLOM / DHT-Reject) remain open in #147, T3 items (HBRI / ZLIF) deferred to 3.2.x per the established methodology.

After this merges, the hub is at the **~90% coverage milestone** projected in the #147 sequence-plan. Remaining gap is BLOM (Tier 2, demand-driven) + the two Tier 3 items in 3.2.x.