### PR TITLE
docs: release-line and support policy for v3.1.8+ (3.2.x split)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,3 +345,56 @@ open a fresh issue here that references the upstream one in its body.
 - **Comments:** explain *why*, not *what*. Don't add a comment that just restates code.
 - **No drive-by refactors.** If you spot something during an unrelated change, open
   an issue instead of fixing it inline.
+
+---
+
+## 8. Release lines and support policy
+
+Starting with **v3.1.8** (the "modernisation-complete" release that
+closed Phases 1-7 plus the ADC-coverage tracker #147 T1 line), the
+project follows a standard maintenance-branch model:
+
+| Line | Where | Status | What it gets |
+|---|---|---|---|
+| **3.2.x** | `master` | active development | All new features, Phase 8 work (#82 HTTP API, #83 Prometheus, #84 audit log, ...), refactors, plugin changes |
+| **3.1.x** | `release/3.1.x` | security fixes only | Critical CVE / severity-1 backports only. No features, no refactors, no Phase-8-anything |
+| ≤ v3.0.x | (untagged history) | end of life | No updates of any kind |
+
+### Workflow
+
+- **New work**: PR against `master`. Period. Don't think about 3.1.x.
+- **Security backport**: PR against master first, merge there, then
+  cherry-pick the merge commit to `release/3.1.x`, push, tag the
+  next v3.1.N patch. Don't open security PRs directly against
+  `release/3.1.x` - master is the canonical source of truth.
+- **3.2.x first release** will be tagged `v3.2.0` when Phase 8 has
+  enough content to merit a release. No fixed timeline.
+- **3.1.x EOL**: declared after v3.2.0 is released and has had 6-12
+  months in the wild without 3.2-regression complaints. From EOL
+  onward `release/3.1.x` gets no commits.
+
+### When to backport vs not
+
+| Issue severity | 3.2.x master | 3.1.x backport? |
+|---|---|---|
+| Critical CVE in hub-itself code | yes | **yes** |
+| Critical CVE in bundled C dep (luasocket / luasec / openssl) | yes | **yes** |
+| Hub-crash on adversarial input | yes | **yes** |
+| Plugin-state corruption | yes | maybe (judgement call - if data loss is the failure mode, yes) |
+| Spec-compliance bug, no security impact | yes | **no** |
+| New feature | yes | **no** |
+| UX / cosmetic | yes | **no** |
+| Documentation | yes | **no** |
+
+The bar for 3.1.x backport is high. When in doubt, don't.
+
+### Branch hygiene
+
+- `release/3.1.x` is the only long-lived maintenance branch. Do not
+  create `release/3.0.x` or similar for older lines (those are EOL).
+- Tags `v3.1.8`, `v3.1.9`, ... live on `release/3.1.x`. Tags
+  `v3.2.0`, `v3.2.1`, ... live on `master`.
+- Old `release/vX.Y.Z` prep branches (the per-release prep branches
+  we used through v3.1.7) can be deleted post-merge - their tags
+  preserve the history. The `release/3.1.x` maintenance branch is
+  the only one that stays around.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ A modernised fork of [luadch](https://github.com/luadch/luadch) by
 **blastbeat** and **pulsar**, hosted at [`luadch-ng`](https://github.com/luadch-ng).
 Maintained by [Aybo](https://github.com/Aybook), with help from Claude.
 
+## Release lines
+
+| Line | Status | What it gets |
+|---|---|---|
+| **3.2.x** | active development (`master`) | New features, Phase 8 work (HTTP API, audit log, etc.), refactors |
+| **3.1.x** | security fixes only (`release/3.1.x` branch) | Backports for critical CVEs / severity-1 bugs only; no new features |
+| ≤ 3.0.x | end of life | No updates of any kind |
+
+The 3.1.x line concludes the modernisation programme (Phases 1-7 +
+ADC-coverage closure). The active 3.2.x line picks up the Phase 8
+feature work. See [`CLAUDE.md`](CLAUDE.md#8-release-lines-and-support-policy)
+§8 for the full support policy.
+
 ## Original Features
 
 - TLS 1.3 with AES-128 / AES-256 cipher suites


### PR DESCRIPTION
Documentation companion to the upcoming v3.1.8 release - the \"modernisation-complete\" cutoff that concludes Phases 1-7 plus the #147 ADC-coverage T1 line. After v3.1.8 the project moves to a standard maintenance-branch model.

## What the new policy says

| Line | Where | Status | What it gets |
|---|---|---|---|
| **3.2.x** | \`master\` | active development | All new features, Phase 8 work, refactors |
| **3.1.x** | \`release/3.1.x\` | security fixes only | Critical CVE / severity-1 backports |
| ≤ v3.0.x | (untagged) | end of life | Nothing |

## Lands

### \`CLAUDE.md\` - new section 8

Full policy: which branch holds what, the cherry-pick workflow for security backports (master first, then 3.1.x), a \"when to backport\" decision table with a high bar (CVE-class only), and branch-hygiene notes. Future contributors + future-me have an anchor.

### \`README.md\` - compact \"Release lines\" table

Near the top so external users see at a glance which versions are active vs frozen without having to dig into CLAUDE.md. Cross-link to \`CLAUDE.md\` §8 for the full policy.

## What this PR explicitly does NOT do

- **No actual branching yet** - that happens after v3.1.8 ships. This PR just documents the policy that's about to take effect.
- **No CHANGELOG entry** - this is meta-docs, not a behaviour change.
- **No version bump** - happens in the v3.1.8 release PR.

## Test plan

- [x] Markdown render review
- [x] Cross-link \`README.md\` -> \`CLAUDE.md\` §8 anchor works (id-format check)

## After this merges

1. Cut v3.1.8 release (separate PR like v3.1.7 was) - master at the merge commit becomes v3.1.8.
2. Tag v3.1.8 on the merge.
3. Create \`release/3.1.x\` branch from the v3.1.8 tag.
4. Bump master \`core/const.lua\` VERSION to e.g. \`v3.2.0-dev\`.

This PR is the prerequisite step that makes (1)-(4) make sense to anyone reading the repo.