### PR TITLE
fix: T1 review followups - polish before v3.1.8 (closes review items #1-#8 + N1, N4)

### DIFF
--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -2073,6 +2073,15 @@ local defaults = {
     --   * federation / "anti-leech" hubs: min_reg_hubs = 1+ so regs
     --     must be present in other hubs too.
     --   * private hubs: leave at defaults.
+    --
+    -- Operator-side sanity: keep `min_*_hubs <= max_*_hubs` for each
+    -- role. The validators here are per-key (no cross-key check), so
+    -- a contradiction like `min_user_hubs = 50, max_user_hubs = 20`
+    -- loads without error but advertises nonsensical MU > XU in the
+    -- PING reply. usr_hubs.lua enforcement runs on both fields
+    -- independently so a user satisfying the max but not the min
+    -- still gets disconnected. Cross-validation is a future
+    -- candidate if the foot-gun ever bites in practice.
     max_user_hubs = { 20,
         function( value )
             return types_number( value, nil, true )

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -223,8 +223,11 @@ _protocol = {
                 min_share = min_share * 1024^3
                 max_share = max_share * 1024^4
                 -- T1.3 of #147: aggregate SS / SF over online users.
-                -- Bots have no INF and their share/files getters
-                -- return nil, so we skip them implicitly. Cost is
+                -- Bot user objects expose .share() returning 0 (not
+                -- nil) and may not expose .files() at all; the
+                -- short-circuit on `u.files and u:files()` plus the
+                -- nil-check before accumulation handles both shapes
+                -- and contributes 0 from bots either way. Cost is
                 -- O(N) once per PING handshake - not a hot path.
                 local total_ss, total_sf = 0, 0
                 for _, u in pairs( _normalstatesids ) do
@@ -287,7 +290,15 @@ _protocol = {
             user:kill( "ISTA 220 " .. _i18n_no_base_support .. "\n", "TL-1" )-----!
         end
         return true
-    end
+    end,
+    -- Pre-login QUI - client gave up mid-handshake. Spec allows QUI
+    -- in any state; we close cleanly so no ISTA 125 reaches the
+    -- client. The normal disconnect path will not broadcast IQUI to
+    -- others because state != "normal" (hub.lua:1325).
+    HQUI = function( user, adccmd )
+        user:client():close()
+        return true
+    end,
 
 }
 
@@ -396,6 +407,12 @@ _identify = {
         end
         return true
     end,
+    -- Same rationale as the protocol-state HQUI handler: spec allows
+    -- QUI in any state, clean-close instead of ISTA 125.
+    HQUI = function( user, adccmd )
+        user:client():close()
+        return true
+    end,
 
 }
 
@@ -464,6 +481,14 @@ _verify = {
         profile.lastseen = util_date( )
         profile.is_online = 1
         cfg_saveusers( _regusers )
+        return true
+    end,
+    -- Same rationale as the protocol-state / identify-state HQUI
+    -- handlers above. Reaching verify means BINF was accepted but
+    -- HPAS was either not sent or aborted; client-initiated QUI here
+    -- means the password prompt was abandoned.
+    HQUI = function( user, adccmd )
+        user:client():close()
         return true
     end,
 
@@ -586,7 +611,17 @@ _normal = {
     -- has to recognise the command. Fire the onSearchResult listener
     -- with nil targetuser so plugins can distinguish F-class
     -- (multi-target) from D-class (single-target) results.
-    FRES = function( user, adccmd )
+    FRES = function( user, adccmd, _targetuser )
+        -- F-class has no single targetuser by definition. Argument
+        -- kept in signature for visual symmetry with DRES so the
+        -- dispatcher table reads consistently top-to-bottom; the
+        -- onSearchResult listener still receives nil here so plugins
+        -- can branch on `if targetuser` to distinguish D-class from
+        -- F-class results. **Plugin contract note:** returning a
+        -- truthy value from an onSearchResult listener on a FRES path
+        -- suppresses the ENTIRE feature-filtered fan-out, not just a
+        -- single recipient as with DRES. See docs/SCRIPTS.md
+        -- "Passthrough extensions" for the implications.
         return scripts_firelistener( "onSearchResult", user, nil, adccmd )
     end,
     --URES = function( user, adccmd, targetuser ) -- new

--- a/core/hub_user_object.lua
+++ b/core/hub_user_object.lua
@@ -194,7 +194,13 @@ local function createuser( _client, _sid )
         -- docstring: flags is optional, must be a table when present.
         if type( flags ) == "table" then
             for flag, value in pairs( flags ) do
-                msg = msg .. " " .. escapeto( flag ) .. escapeto( value )
+                -- The NP name (e.g. "TL", "FC") is the on-wire field
+                -- key and must be emitted verbatim - escape-encoding
+                -- it would mangle non-alpha names that future spec
+                -- extensions may introduce. Today's NP names are all
+                -- alpha so this works by luck either way, but keep the
+                -- escape on the value where it actually matters.
+                msg = msg .. " " .. flag .. escapeto( value )
             end
         end
         msg =  msg .. "\n"
@@ -320,12 +326,15 @@ local function createuser( _client, _sid )
     -- driven from cfg. The legacy MS quitmsg stays as the trailing
     -- field. Cfg is looked up at call time so a +reload picks up new
     -- alternatives / permanent toggle without a hub restart.
+    -- Alternatives are iterated with ipairs so RX field order on the
+    -- wire matches the operator's cfg table order across reloads
+    -- (pairs() in Lua has implementation-defined iteration order).
     user.redirect = function( _, url, quitmsg )
         types_utf8( url )
         local parts = { "IQUI ", _sid, " RD", adclib_escape( url ) }
         local alts = cfg.get "hub_redirect_alternatives"
         if alts then
-            for _, alt in pairs( alts ) do
+            for _, alt in ipairs( alts ) do
                 types_utf8( alt )
                 parts[ #parts + 1 ] = " RX"
                 parts[ #parts + 1 ] = adclib_escape( alt )
@@ -337,7 +346,11 @@ local function createuser( _client, _sid )
         if quitmsg then
             types_utf8( quitmsg )
             parts[ #parts + 1 ] = " MS"
-            parts[ #parts + 1 ] = quitmsg
+            -- ADC requires whitespace / control-byte escaping in field
+            -- values. The legacy MS path emitted quitmsg raw, so any
+            -- caller passing a multi-word reason produced malformed
+            -- ADC on the wire. Now escaped same as RD / RX above.
+            parts[ #parts + 1 ] = adclib_escape( quitmsg )
         end
         parts[ #parts + 1 ] = "\n"
         user:kill( table_concat( parts ) )

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -356,6 +356,43 @@ If you write a plugin and need exact message accounting, do not
 rely on the dispatcher's listener fan-out alone - it is rate-
 limited at the hub boundary by design.
 
+### onSearchResult contract widening for F-class ([#147](https://github.com/luadch-ng/luadch/issues/147) T1.6)
+
+Before #147 the `onSearchResult` listener only fired on D-class
+(`DRES`) - single-recipient search results. Returning a truthy value
+(`return PROCESSED`) from the listener suppressed delivery to the
+**one** target SID.
+
+After #147 T1.6 the same listener also fires on F-class (`FRES`) -
+feature-filtered fan-out where the message is delivered to any
+client matching a feature mask. Returning truthy on the F-class
+path suppresses delivery to **the entire set** of matching
+recipients, not just one.
+
+Plugins differentiate the two cases by checking the `targetuser`
+arg: nil = F-class fan-out (wide impact), non-nil = D-class single
+recipient.
+
+```lua
+hub.setlistener( "onSearchResult", { },
+    function( user, targetuser, adccmd )
+        if not targetuser then
+            -- F-class. Returning PROCESSED here drops the whole
+            -- feature-filtered fan-out. Use with care.
+        else
+            -- D-class. Returning PROCESSED drops one delivery only.
+        end
+        return nil    -- let it through
+    end
+)
+```
+
+The bundled `hub_cmd_manager.lua` only reads `user:level()` and
+returns PROCESSED unconditionally on level mismatch; it tolerates
+the new arg shape but operators using it should be aware that
+unauthorised F-class results are now dropped for the whole
+recipient set instead of per-recipient.
+
 ---
 
 ## 6. TLS configuration

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -786,10 +786,15 @@ def test_neg_post_login_inf_burst():
 
 
 def test_neg_post_login_pm_burst():
-    """After a clean login, fire 50 DMSG private messages back-to-back at
-    a non-existent SID. Tests that the PM bucket (#80 split from msg)
-    rate-limits / absorbs without crashing the dispatcher. Independent of
-    the BMSG bucket exercised by other tests."""
+    """After a clean login, fire 50 DMSG private messages back-to-back
+    at our OWN sid (self-target). Self-target is accepted by incoming()
+    (mysid == usersid check passes, targetuser is non-nil) so the
+    dispatcher actually reaches the _normal.DMSG handler and the
+    rl_pm_drop rate-limit gate. Targeting a non-existent SID like ZZZZ
+    instead would short-circuit at hub.lua:1264 with ISTA 140 BEFORE
+    dispatch, defeating the test's purpose. Tests that the PM bucket
+    (#80 split from msg) rate-limits / absorbs without crashing the
+    dispatcher."""
     with socket.create_connection(
         (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
     ) as sock:
@@ -799,10 +804,8 @@ def test_neg_post_login_pm_burst():
             return
         for i in range(50):
             try:
-                # ZZZZ is a syntactically-valid SID slot with no logged-in
-                # client; the dispatcher rate-checks before target lookup.
                 sock.sendall(
-                    f"DMSG {sid} ZZZZ hello{i}\n".encode("utf-8")
+                    f"DMSG {sid} {sid} hello{i}\n".encode("utf-8")
                 )
             except (BrokenPipeError, ConnectionResetError, OSError):
                 return
@@ -810,10 +813,11 @@ def test_neg_post_login_pm_burst():
 
 
 def test_neg_post_login_ctm_burst():
-    """After a clean login, fire 50 DCTM commands at non-existent SIDs.
-    Confirms the #80 CTM bucket absorbs a connection-setup flood
-    without crashing the dispatcher. First ~burst go through to onCTM
-    listeners, the rest are silently dropped by rl_ctm_drop."""
+    """After a clean login, fire 50 DCTM commands at our own SID
+    (self-target). See PM burst test above for why we self-target
+    instead of using a non-existent SID. Confirms the #80 CTM bucket
+    absorbs a connection-setup flood without crashing the dispatcher
+    and actually reaches the rl_ctm_drop gate."""
     with socket.create_connection(
         (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
     ) as sock:
@@ -822,17 +826,15 @@ def test_neg_post_login_ctm_burst():
         except TestFailure:
             return
         for i in range(50):
-            # ZZZZ is a syntactically-valid SID slot that does not
-            # correspond to any logged-in client.
             try:
-                sock.sendall(f"DCTM {sid} ZZZZ ADC/1.0 12345\n".encode("utf-8"))
+                sock.sendall(f"DCTM {sid} {sid} ADC/1.0 12345 tok{i}\n".encode("utf-8"))
             except (BrokenPipeError, ConnectionResetError, OSError):
                 return
         _neg_drain_briefly(sock)
 
 
 def test_neg_post_login_rcm_burst():
-    """After a clean login, fire 50 DRCM commands at non-existent SIDs.
+    """After a clean login, fire 50 DRCM commands at our own SID.
     DRCM shares the CTM bucket since both are peer-connection
     initiation primitives. Tests the second code path through
     rl_ctm_drop."""
@@ -845,7 +847,7 @@ def test_neg_post_login_rcm_burst():
             return
         for i in range(50):
             try:
-                sock.sendall(f"DRCM {sid} ZZZZ ADC/1.0\n".encode("utf-8"))
+                sock.sendall(f"DRCM {sid} {sid} ADC/1.0\n".encode("utf-8"))
             except (BrokenPipeError, ConnectionResetError, OSError):
                 return
         _neg_drain_briefly(sock)
@@ -890,9 +892,10 @@ def test_hqui_from_client_honored():
 
 def test_neg_post_login_natt_burst():
     """After a clean login, fire 50 mixed DNAT / DRNT commands (ADC-EXT
-    NATT, T1.1 of #147) at non-existent SIDs. Both new dispatch routes
+    NATT, T1.1 of #147) at our own SID. Both new dispatch routes
     share the CTM bucket (peer-connection setup); confirms NATT relay
-    absorbs floods the same way DCTM / DRCM do without crashing."""
+    absorbs floods the same way DCTM / DRCM do without crashing and
+    actually reaches the rl_ctm_drop gate."""
     with socket.create_connection(
         (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
     ) as sock:
@@ -906,7 +909,7 @@ def test_neg_post_login_natt_burst():
             cmd = "DNAT" if i % 2 == 0 else "DRNT"
             try:
                 sock.sendall(
-                    f"{cmd} {sid} ZZZZ ADC/1.0 12345 tok{i}\n".encode("utf-8")
+                    f"{cmd} {sid} {sid} ADC/1.0 12345 tok{i}\n".encode("utf-8")
                 )
             except (BrokenPipeError, ConnectionResetError, OSError):
                 return


### PR DESCRIPTION
Last batch of polish before v3.1.8 ships. All 8 \"concerning\" items + 2 nits from the post-T1 review addressed.

## Lands (4 commits)

### 1. \`tests/smoke/run.py\` - burst tests reach the rate-limit gate (review #1)

PM / CTM / RCM / NATT burst tests were sending to \`ZZZZ\`. \`hub.lua:1264\` short-circuits with ISTA 140 BEFORE the dispatcher, so \`rl_pm_drop\` / \`rl_ctm_drop\` never fired. Tests passed for the wrong reason.

Switch to self-targeting (\`{sid} {sid}\`). The anti-spoof check at \`hub.lua:1266\` allows \`mysid == usersid\`, self-target gives a valid \`targetuser\`, dispatch proceeds into the rate-limit code path. Now the bucket is genuinely exercised.

### 2. \`core/hub_user_object.lua\` + \`core/hub_dispatch.lua\` - 6 polish items

- **user.sendsta NP key escape** (review #6) - the fixed branch from #151 was escape-encoding the 2-letter NP name alongside the value. Removed escape on the name (today's NPs are alpha so worked by luck; future-proofed).
- **user.redirect quitmsg escape** (review #7) - MS<quitmsg> was emitted raw; multi-word messages produced malformed ADC. Now adclib_escape'd same as RD / RX.
- **user.redirect alternatives use ipairs** (review #3) - deterministic RX field order on wire across +reload.
- **PING SS/SF aggregator comment** (review #2) - corrected. Bots' \`.share()\` returns 0, not nil; math worked but rationale was wrong.
- **HQUI in \`_protocol\` / \`_identify\` / \`_verify\`** (review #8) - ADC 6.3.10 says QUI permitted in any state. Pre-login clean-close instead of ISTA 125.
- **FRES signature + plugin contract** (review N1, #5) - unused \`_targetuser\` parameter back for visual symmetry, inline comment naming the wider onSearchResult fan-out semantic on F-class.

### 3. \`docs/SECURITY.md\` - onSearchResult contract widening note (review #5)

New sub-section in §5 \"Rate-limit and plugin contract\" documenting that returning PROCESSED from onSearchResult on a FRES path drops the entire feature-fanout (potentially N recipients), not just one. Worked example showing how to branch on \`targetuser\`.

### 4. \`core/cfg_defaults.lua\` - min/max_hubs cross-validation note (review N4)

Inline comment warning that \`min_*_hubs > max_*_hubs\` loads without validator error but advertises nonsense PING. Flagged as a future candidate. No code change for v3.1.8.

## What's deferred for the v3.1.8 release-prep PR

- **ERES no-longer-accepted note** (review #4) - belongs in the CHANGELOG entry for v3.1.8, not a code fix. Will land with the release-prep PR.

## Operator impact

**Zero behaviour change at defaults** for any of the changes. The two functional fixes (quitmsg escape, ipairs) affect only operators who:
- Pass multi-word quitmsg via cmd_disconnect / etc - they used to send malformed ADC, now they send valid ADC.
- Configure \`hub_redirect_alternatives\` with 2+ entries - they used to see arbitrary wire order, now they see cfg-table order.

Pre-login HQUI also has zero practical impact since no client today sends QUI before login (they just close the socket).

## Test plan

- [x] Lua syntax OK on all changed core files
- [x] Local smoke 37/37 PASS on Windows (burst tests now genuinely exercise rate-limit; canary still green)
- [x] CI Linux + Windows smoke

After this merges, the readiness target for v3.1.8 is hit. Release-prep PR follows.