### PR TITLE
release: prepare v3.1.8 (modernisation-complete + ADC coverage T1)

### DIFF
--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,10 +1,10 @@
-# Luadch v3.1.7
+# Luadch v3.1.8
 
-Plugin data-integrity patch release. `util.savearray` / `util.savetable` are now atomic-by-default across the bundled scripts tree, defensive `or {}` was swept onto `util.loadtable` consumers, the cross-month accounting bug in `usr_uptime` is fixed, and `cmd_gag` gains a shadowmute mode plus duration syntax.
+**Modernisation-complete patch release.** Closes the [#80](https://github.com/luadch-ng/luadch/issues/80) ratelimit v2 and [#147](https://github.com/luadch-ng/luadch/issues/147) ADC protocol coverage tracks. After this release the 3.1.x line is **stable, security-fixes-only**; new feature work moves to the 3.2.x line on `master`. See [`CLAUDE.md` §8](https://github.com/luadch-ng/luadch/blob/master/CLAUDE.md#8-release-lines-and-support-policy) for the full release-line policy.
 
 ## ⚠️ Before upgrading
 
-Back up your `cfg/`, `scripts/lang/`, `scripts/data/`, `scripts/cfg/`, `certs/`, and `secrets/` directories. This release modifies `scripts/lang/cmd_gag.lang.{en,de}` (5 new keys + 4 rewritten strings for shadowmute / duration support) and adds `encrypt_usertbl` to `examples/cfg/cfg.tbl`. If you have customised `cmd_gag` translations, see the **Lang file changes** section below before letting the autosync run.
+Back up your `cfg/`, `scripts/lang/`, `scripts/data/`, `scripts/cfg/`, `certs/`, and `secrets/` directories. This release adds new keys to several lang files (additive, see below) and introduces several new optional cfg keys for the ratelimit / RDEX / PING extensions.
 
 ```sh
 tar -czf "luadch-backup-$(date +%F).tar.gz" cfg scripts certs secrets
@@ -12,48 +12,108 @@ tar -czf "luadch-backup-$(date +%F).tar.gz" cfg scripts certs secrets
 
 ## Lang file changes
 
-Operators with stock bundled lang files get the new keys automatically via the Docker autosync from [#118](https://github.com/luadch-ng/luadch/pull/118), or via `cmake --install build` for source builds. Operators with **custom** `cmd_gag.lang.*` files have a small one-time merge:
+Operators with stock bundled lang files get the new keys automatically via the Docker autosync from [#118](https://github.com/luadch-ng/luadch/pull/118) or `cmake --install build` for source builds. Operators with **custom** translations have a small one-time additive merge:
 
-| File | What changed |
+| File | New key |
 |---|---|
-| `cmd_gag.lang.{en,de}` | New keys: `msg_invalid_duration`, `msg_add_user_with_duration`, `msg_expired`, `ucmd_duration`, `ucmd_menu_ct1b`. Rewritten: `msg_usage`, `help_usage`, `help_desc` (now reference shadowmute + `<DURATION>`), `msg_show_users` (adds the "Shadowmuted users" block). Missing keys fall back to the hardcoded English defaults; behaviour stays correct, the chat output just sits in mixed languages until the merge happens. |
+| `cmd_shutdown.lang.{en,de}` | `msg_hub_disabled` |
+| `cmd_restart.lang.{en,de}` | `msg_hub_disabled` |
 
-## Features
+Missing keys fall back to the hardcoded English string ("Hub is shutting down." / "Hub is restarting.") so the hub stays functional.
 
-- **`cmd_gag` shadowmute mode + duration** ([#85](https://github.com/luadch-ng/luadch/issues/85) / [#132](https://github.com/luadch-ng/luadch/pull/132)) - the gag bot gets a 4th mode where the target sees their own messages echo back as if everything works, but nobody else on the hub receives them. Combined with this, all three restriction modes (mute, kennylize, shadowmute) now take an optional duration: `30s`, `10m`, `2h`, `1d`, `1w` and combinations like `1h30m`. Empty duration = permanent. Restrictions auto-expire as the gag table is walked every 60s. Offline ungag works through `hub.getregusers()` so admins can lift restrictions even after the user disconnects. Right-click menu gets a "Shadowmute User" entry alongside the existing mute / kennylize ones.
-- **`encrypt_usertbl` opt-out toggle** ([#128](https://github.com/luadch-ng/luadch/issues/128) / [#129](https://github.com/luadch-ng/luadch/pull/129)) - the Phase-7f AES-256-GCM at-rest encryption of `cfg/user.tbl` is now optional. Default `true` preserves the v3.1.3+ behaviour. Setting `encrypt_usertbl = false` writes plaintext Lua for single-user / home-hub deployments where disk-level confidentiality isn't part of the threat model and operator tooling needs direct read access to the file. Auto-detected on read via the LDC1 magic prefix, so migration is transparent in both directions; `master.key` is loaded if present (legacy decrypt) but only auto-generated when encryption is on.
+## Cfg additions
+
+All new keys are additive with defaults that preserve v3.1.7 behaviour. No `cfg/cfg.tbl` migration is required.
+
+### Ratelimit v2 ([#80](https://github.com/luadch-ng/luadch/issues/80))
+
+```lua
+-- Per-bucket rate / burst, each independently tunable
+ratelimit_user_pm_rate  = 5,   ratelimit_user_pm_burst  = 10,
+ratelimit_user_inf_rate = 2,   ratelimit_user_inf_burst = 20,
+ratelimit_user_ctm_rate = 2,   ratelimit_user_ctm_burst = 30,
+
+-- Per-userlevel tier overlay - any subset of fields per tier,
+-- missing fields fall back to the global scalars above
+ratelimit_tiers = { },
+ratelimit_tier_for_level = { },
+```
+
+Worked example for the tier overlay is in [`docs/SCRIPTS.md`](https://github.com/luadch-ng/luadch/blob/master/docs/SCRIPTS.md#rate-limit-configuration). At defaults (empty tier tables) behaviour is identical to v3.1.7.
+
+### ADC protocol coverage ([#147](https://github.com/luadch-ng/luadch/issues/147))
+
+```lua
+-- ADC-EXT RDEX rich redirect
+hub_redirect_protocols = 3,         -- bitmask (ADC=1, ADCS=2, NEODC=4)
+hub_redirect_alternatives = { },    -- list of alternative URLs as RX fields
+hub_redirect_permanent = false,     -- PT1 flag on redirects
+
+-- ADC-EXT PING min-hubs federation policy (also from #146)
+min_user_hubs = 0,                  -- min OTHER hubs (federation requirement)
+min_reg_hubs = 0,
+min_op_hubs = 0,
+```
+
+## Highlights
+
+### Ratelimit v2 ([#80](https://github.com/luadch-ng/luadch/issues/80), 4 PRs + 2 review followups)
+
+The hub's per-user rate-limit machinery split BMSG / DMSG / EMSG / BINF / DCTM / DRCM into five independent buckets. Each bucket has its own rate + burst cfg keys, and **all five become optionally tier-mappable per user level** via the new `ratelimit_tiers` + `ratelimit_tier_for_level` overlay. Op-level bypass preserved. Worked tier-overlay example in [`docs/SCRIPTS.md`](https://github.com/luadch-ng/luadch/blob/master/docs/SCRIPTS.md#rate-limit-configuration).
+
+A strict-positive validator rejects `rate = 0` / `burst = -1` / NaN at cfg-load time, with a clear `out_error` log entry; the previous silent-mute failure mode under operator typo is gone.
+
+### ADC protocol coverage ([#147](https://github.com/luadch-ng/luadch/issues/147), 8 PRs)
+
+Eight protocol-completeness items shipped as small, additive PRs:
+
+- **NATT relay** (DNAT / DRNT, ADC-EXT 3.9) - hub-relay-only NAT-traversal for passive-passive transfers.
+- **RDEX rich redirect** - `IINF.RP` advertisement + `IQUI.RX` / `PT` NPs on every kick / redirect.
+- **PING completeness** - `SS` / `SF` aggregate share + file count, `HE` email, `MU` / `MR` / `MO` min-hubs federation policy now emitted in the ADPING reply. Hublist scrapers see the full spec-defined data.
+- **STA emission codes** - `cmd_shutdown` / `cmd_restart` emit `ISTA 212` ("Hub disabled") before close so clients distinguish a graceful shutdown from a network glitch. `cmd_ban` switches from incorrect 230 / 231 to spec-correct `ISTA 232` for finite-TL temporary bans.
+- **FRES routing** - feature-filtered search-result delivery (F-class) now dispatched.
+- **HQUI from client honored** - client-initiated quit triggers a clean close in any state instead of `ISTA 125` unknown-command.
+- **ECTM / ERCM dispatch** - modern E-class CTM / RCM variants accepted (was: silently dropped).
+- **Passthrough extensions documented** - `TYPE` / `ONID` / `DFAV` / `FEED` and friends are explicitly transparent passthrough (no SUP advertisement needed, hub relays the commands without inspection).
+
+Per the audit the hub is now at **~90% ADC + ADC-EXT coverage** for hub-relevant features. Remaining 10% is BLOM (Tier 2, demand-driven) and HBRI / ZLIF (Tier 3, deferred to 3.2.x).
+
+### Operator documentation
+
+- New [`docs/SCRIPTS.md`](https://github.com/luadch-ng/luadch/blob/master/docs/SCRIPTS.md) lists every bundled plugin (commands + cfg keys) with a full rate-limit configuration guide.
+- README cleaned up - dropped the "what's different in this fork" section now that the modernisation programme is done; added a release-line status table near the top.
+- [`CLAUDE.md` §8](https://github.com/luadch-ng/luadch/blob/master/CLAUDE.md#8-release-lines-and-support-policy) documents the post-3.1.8 maintenance-branch model.
 
 ## Bugfixes
 
-- **`usr_uptime` cross-month accounting** ([#127](https://github.com/luadch-ng/luadch/issues/127) / [#131](https://github.com/luadch-ng/luadch/pull/131)) - sessions that span month boundaries no longer accumulate as "years" of uptime. The pre-fix code bracketed sessions on `login` and credited the whole span to the login month on `logout`, so a session starting on the 31st and ending on the 1st saw the end-month-minus-start-month delta arithmetic wrap into multi-year totals. The fix walks the user list on a 60-second timer and credits each tick to the calendar month it falls into, so cross-month sessions land in both months correctly.
-- **Plugin save crash-safety - F-PLG-1** ([#133](https://github.com/luadch-ng/luadch/issues/133) / [#134](https://github.com/luadch-ng/luadch/pull/134)) - `util.savearray` and `util.savetable` previously opened the target file in `"w+"` (truncate) and wrote serialised content directly, so a hub crash mid-write left the `.tbl` partial. Both helpers now route through a new public `util.atomic_write(path, content)` helper that does tmp + rename (Windows fallback: remove then rename). 21 plugin save sites across the bundled tree get crash-safe writes with zero call-site changes; `core/cfg_users.lua` keeps its `chmod 600` for `user.tbl` separately via `util.chmod_secret`.
-- **Plugin load nil-handling - F-PLG-2** ([#133](https://github.com/luadch-ng/luadch/issues/133) / [#135](https://github.com/luadch-ng/luadch/pull/135)) - `util.loadtable` returns `nil` on missing / unreadable / parse-fail. Defensive `or {}` added at 22 consumer sites across 12 bundled plugins (`bot_session_chat`, `cmd_accinfo`, `cmd_delreg`, `cmd_nickchange`, `cmd_reg`, `cmd_usercleaner`, `etc_msgmanager`, `etc_trafficmanager`, `usr_hide_share`, plus field-read defence in `cmd_hubinfo`, `cmd_uptime`, `hub_runtime`). Sites with the existing init-pattern (`check_hci` style: type-check + savetable + opchat warning) intentionally left alone - they handle nil correctly and auto-create the file.
-- **F-PLG-3 audit** ([#133](https://github.com/luadch-ng/luadch/issues/133)) - silent no-op on incomplete `+cmd` audited across 24 bundled scripts and 53 `utf.match`-on-parameters sites. **No actionable bugs found.** Every command handler already has either an explicit pre-check guard or a final `msg_usage` fallback. Audit closeout on the tracker.
+- `user.sendsta` typo ([#151](https://github.com/luadch-ng/luadch/pull/151)) - `pairs(nil)` crash on callers that omitted the optional flags arg, present since the API was added.
+- `user.redirect` `MS<quitmsg>` was emitted raw; multi-word reasons produced malformed ADC. Now escaped.
+- Smoke battery's PM / CTM / RCM / NATT burst tests previously short-circuited at the target-lookup before reaching the rate-limit gate; they now self-target and exercise the actual code paths.
 
 ## Notes
 
-- New public helpers in `core/util.lua`: `util.atomic_write(path, content)` and `util.tabletostring(tbl, name)`. Plugins that roll their own save logic can route through them for crash-safe writes. The companion `luadch-ng/scripts` repo already uses them in `ptx_poll_bot`, `ptx_freshstuff`, `etc_requests`, and `etc_mainecho` (min hub version: **v3.1.7**).
-- Smoke harness: 31/31 PASS on Linux + Windows. No test count change in this release; the existing tests already cover the new behaviour (atomic-write path validated by `test_usertbl_bak_atomic_refresh` from v3.1.5).
-- Companion plugin updates landed in [`luadch-ng/scripts#24`](https://github.com/luadch-ng/scripts/issues/24) (closed) with two PRs adding atomic save + nil-handling to the curated plugin tree - operators running those plugins should also pull the latest from that repo.
+- **No breaking changes at defaults.** Every new cfg key has a default that preserves v3.1.7 behaviour. Operators upgrading without touching cfg get the new features behind unchanged knobs.
+- **ERES no longer accepted by the parser.** ADC 5.3.6 defines only D and F classes for RES; the parser context tightened to `[FD]` as part of FRES routing. No known client emits ERES; exotic NMDC bridges that did would now see parse-time rejection instead of forward-as-E-class.
+- **3.1.x maintenance from this release on.** New feature work goes to `master` (3.2.x line); security fixes for 3.1.x go to a `release/3.1.x` branch created from this tag. See [`CLAUDE.md` §8](https://github.com/luadch-ng/luadch/blob/master/CLAUDE.md#8-release-lines-and-support-policy).
 
 ## Downloads
 
 | File | Platform |
 |---|---|
-| `luadch-v3.1.7-linux-x86_64.tar.gz` | Linux glibc x86_64 |
-| `luadch-v3.1.7-windows-x86_64.zip`  | Windows x86_64 (MinGW UCRT64) |
-| `ghcr.io/luadch-ng/luadch:v3.1.7`   | Container, linux/amd64 + linux/arm64 |
+| `luadch-v3.1.8-linux-x86_64.tar.gz` | Linux glibc x86_64 |
+| `luadch-v3.1.8-windows-x86_64.zip`  | Windows x86_64 (MinGW UCRT64) |
+| `ghcr.io/luadch-ng/luadch:v3.1.8`   | Container, linux/amd64 + linux/arm64 |
 
-## Migration from v3.1.6
+## Migration from v3.1.7
 
 Drop the new install tree in place of the old one (or `git pull && cmake --build build && cmake --install build` from source). Container users get both the bundled `*.lua` sync and the lang add-only sync on the next `docker compose up -d` after `pull`.
 
-No `cfg.tbl` migration is needed. The new `encrypt_usertbl` key in `examples/cfg/cfg.tbl` is purely additive - existing `cfg/cfg.tbl` files without the key default to encrypted, which matches v3.1.6 behaviour. To opt out, add `encrypt_usertbl = false` and `+reload` (or restart the container).
+No `cfg/cfg.tbl` migration is needed - all new keys are additive with defaults. To opt into the tier-overlay rate-limit, see the worked example in [`docs/SCRIPTS.md` Rate-limit configuration](https://github.com/luadch-ng/luadch/blob/master/docs/SCRIPTS.md#rate-limit-configuration).
 
 ## Build from source
 
 ```sh
-git clone --branch v3.1.7 https://github.com/luadch-ng/luadch.git
+git clone --branch v3.1.8 https://github.com/luadch-ng/luadch.git
 cd luadch
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,121 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The upstream project (`luadch/luadch`) is a separate codebase; its release
 history is at https://github.com/luadch/luadch/releases.
 
+## [v3.1.8] - 2026-05-12
+
+Modernisation-complete patch release. Concludes the
+[#80](https://github.com/luadch-ng/luadch/issues/80) ratelimit v2 work
+(four buckets + per-userlevel tiers) and the
+[#147](https://github.com/luadch-ng/luadch/issues/147) ADC protocol
+coverage T1 line (eight items). After this release, `master` opens
+the 3.2.x line; security fixes for 3.1.x go to the
+`release/3.1.x` branch per [`CLAUDE.md`](CLAUDE.md#8-release-lines-and-support-policy)
+§8.
+
+Smoke 37/37 PASS on Linux + Windows.
+
+### Features
+
+- **Per-userlevel rate-limit tiers** ([#80](https://github.com/luadch-ng/luadch/issues/80), closed) -
+  the PM, BINF, and CTM/RCM dispatch paths each get their own
+  independent rate-limit bucket on top of the existing chat / search
+  buckets ([#138](https://github.com/luadch-ng/luadch/pull/138)
+  / [#139](https://github.com/luadch-ng/luadch/pull/139)
+  / [#140](https://github.com/luadch-ng/luadch/pull/140)). All five
+  buckets become optionally tier-mappable per user level via the new
+  `ratelimit_tiers` + `ratelimit_tier_for_level` cfg keys
+  ([#141](https://github.com/luadch-ng/luadch/pull/141)) - operators
+  can give unreg / guest strict tiers and bots headroom without
+  touching the global scalars. Strict-positive validators reject the
+  silent-mute failure modes
+  ([#142](https://github.com/luadch-ng/luadch/pull/142)
+  / [#143](https://github.com/luadch-ng/luadch/pull/143)).
+- **ADC protocol coverage** ([#147](https://github.com/luadch-ng/luadch/issues/147), T1 closed)
+  - eight protocol-completeness items:
+  - **NATT relay** ([#148](https://github.com/luadch-ng/luadch/pull/148)) -
+    DNAT / DRNT handlers, hub-relay-only NAT-traversal per ADC-EXT 3.9.
+  - **RDEX rich redirect** ([#149](https://github.com/luadch-ng/luadch/pull/149)) -
+    `IINF.RP` advertisement + `IQUI.RX` (alternative URLs) / `IQUI.PT`
+    (permanent flag) NPs, cfg-driven via `hub_redirect_protocols` /
+    `hub_redirect_alternatives` / `hub_redirect_permanent`.
+  - **PING completeness** ([#150](https://github.com/luadch-ng/luadch/pull/150)
+    / [#146](https://github.com/luadch-ng/luadch/pull/146)) - `SS` /
+    `SF` (total share / files), `HE` (email), `MU` / `MR` / `MO`
+    (min hubs) added to the `ADPING` reply. `MU/MR/MO` cfg-tunable
+    via new `min_user_hubs` / `min_reg_hubs` / `min_op_hubs` keys.
+  - **STA emission codes** ([#151](https://github.com/luadch-ng/luadch/pull/151)) -
+    `cmd_shutdown` / `cmd_restart` emit `ISTA 212` ("Hub disabled")
+    before close; `cmd_ban` switches from 230 / 231 to spec-correct
+    `ISTA 232` for finite-TL temporary bans.
+  - **FRES routing** ([#152](https://github.com/luadch-ng/luadch/pull/152)) -
+    feature-filtered search-result delivery (F-class RES) now
+    dispatches alongside DRES.
+  - **HQUI from client honored** ([#153](https://github.com/luadch-ng/luadch/pull/153)
+    + [#156](https://github.com/luadch-ng/luadch/pull/156)) - clean
+    close on client-initiated quit in any state, instead of `ISTA 125`
+    unknown-command.
+  - **ECTM / ERCM dispatch** ([#146](https://github.com/luadch-ng/luadch/pull/146)) -
+    modern E-class CTM / RCM variants now routed.
+- **Operator-facing docs** -
+  new [`docs/SCRIPTS.md`](docs/SCRIPTS.md)
+  ([#144](https://github.com/luadch-ng/luadch/pull/144)) lists every
+  bundled plugin with its commands and cfg keys plus the full
+  rate-limit configuration guide. README cleaned up
+  ([#145](https://github.com/luadch-ng/luadch/pull/145)). Passthrough
+  ADC-EXT extensions ([#154](https://github.com/luadch-ng/luadch/pull/154)),
+  release-line / support policy ([#155](https://github.com/luadch-ng/luadch/pull/155))
+  documented.
+
+### Bugfixes
+
+- **`user.sendsta` typo** ([#151](https://github.com/luadch-ng/luadch/pull/151)) -
+  the long-standing `type( flags == "table" )` typo made
+  `pairs(nil)` crash whenever a caller omitted the optional flags
+  arg. Now `type( flags ) == "table"` matches the docstring contract.
+- **`cmd_ban` STA code spec compliance** ([#151](https://github.com/luadch-ng/luadch/pull/151)) -
+  three call sites now use 232 (temporary ban with TL) instead of
+  231 (permanent ban, no TL) for finite-duration bans.
+- **`user.redirect` quitmsg escape**
+  ([#156](https://github.com/luadch-ng/luadch/pull/156)) -
+  `MS<quitmsg>` was emitted raw; multi-word reasons produced
+  malformed ADC. Now `adclib_escape`'d.
+- **Ratelimit cfg validator strict-positive**
+  ([#142](https://github.com/luadch-ng/luadch/pull/142)) - rate /
+  burst / period values must be > 0; pre-fix an operator typo like
+  `msg_burst = -1` would silent-mute every non-op user.
+- **Smoke battery exercises rate-limit gates correctly**
+  ([#156](https://github.com/luadch-ng/luadch/pull/156)) - the PM /
+  CTM / RCM / NATT burst tests were short-circuiting at the
+  target-lookup before reaching the dispatcher; now self-target so
+  the rate-limit code path is genuinely covered.
+
+### Notes
+
+- **No breaking changes at defaults.** All new cfg keys are
+  additive with conservative defaults that preserve v3.1.7
+  behaviour.
+- **ERES (Echo-class search result) is no longer parsed.** ADC 5.3.6
+  defines only `D` and `F` classes for RES; previously the parser
+  accepted ERES via the broader `[DE]` context and the hub forwarded
+  it as E-class. The parser context tightened to `[FD]` as part of
+  FRES routing ([#152](https://github.com/luadch-ng/luadch/pull/152)).
+  No known client emits ERES; if an exotic NMDC bridge does, it is
+  now rejected at parse instead of routed.
+- `scripts/lang/cmd_shutdown.lang.{en,de}` and
+  `scripts/lang/cmd_restart.lang.{en,de}` add a new `msg_hub_disabled`
+  key for the STA 212 message. Operators with custom translations
+  for these files need a one-time additive merge; missing keys fall
+  back to the hardcoded English string.
+- **Release-line model takes effect.** Starting after this release,
+  `master` is the 3.2.x active-development line; security-only
+  patches for 3.1.x land on `release/3.1.x`. See
+  [`CLAUDE.md` §8](CLAUDE.md#8-release-lines-and-support-policy) for
+  the full policy including the cherry-pick workflow and the
+  "when to backport" decision table.
+
+[v3.1.8]: https://github.com/luadch-ng/luadch/releases/tag/v3.1.8
+
+
 ## [v3.1.7] - 2026-05-11
 
 Plugin data-integrity patch release. `util.savearray` / `util.savetable` are atomic-by-default, defensive `or {}` swept across bundled plugins that load tables, cross-month uptime accounting bug fixed, and `cmd_gag` gains shadowmute mode + duration syntax. Smoke 31/31 PASS on Linux + Windows.

--- a/core/const.lua
+++ b/core/const.lua
@@ -11,7 +11,7 @@
 return {
 
     PROGRAM_NAME = "Luadch",
-    VERSION = "v3.1.7",
+    VERSION = "v3.1.8",
     COPYRIGHT = "by blastbeat and pulsar",
     FORK = "modernised fork by Aybo",
     CONFIG_PATH = "././cfg/",


### PR DESCRIPTION
## Summary

The **modernisation-complete cutoff release.** Closes both major in-flight tracks for the 3.1.x line:

- **#80 ratelimit v2** - per-bucket BMSG / PM / INF / CTM-RCM / search + per-userlevel tier overlay + strict-positive cfg validation. 4 PRs + 2 review followups merged.
- **#147 ADC protocol coverage T1** - 8 spec-completeness PRs covering NATT relay, RDEX rich redirect, PING SS/SF/HE/MU/MR/MO, STA 212/232 codes, FRES routing, HQUI honor, ECTM/ERCM dispatch, passthrough-extensions documentation.

Plus operator-facing documentation: new [`docs/SCRIPTS.md`](https://github.com/luadch-ng/luadch/blob/master/docs/SCRIPTS.md) with the full bundled-plugin reference + rate-limit configuration guide, README cleanup, and the release-line / support policy in [`CLAUDE.md` §8](https://github.com/luadch-ng/luadch/blob/master/CLAUDE.md#8-release-lines-and-support-policy).

After this merges, the 3.1.x line becomes maintenance-only (security fixes on \`release/3.1.x\`), and \`master\` opens the 3.2.x line for Phase 8 work.

## Lands

| File | Change |
|---|---|
| \`core/const.lua\` | VERSION \`v3.1.7\` -> \`v3.1.8\` |
| \`CHANGELOG.md\` | Full v3.1.8 entry with Features / Bugfixes / Notes sections + ERES behavioural note |
| \`.github/release-body.md\` | Rewritten retail-style with ⚠️ backup section, lang-file changes, cfg additions, highlights, migration |

## Notable behavioural change

**ERES (Echo-class search result) no longer parsed.** ADC 5.3.6 defines only D + F classes for RES; the parser context tightened from \`[DE]\` to \`[FD]\` as part of FRES routing (#152). No known client emits ERES; exotic NMDC bridges that did would now see parse-time rejection instead of forward-as-E-class. Flagged explicitly in both CHANGELOG and release-body.

## Test plan

- [x] Smoke harness 37/37 PASS on Windows (pre-PR)
- [x] CI Linux + Windows smoke green on this PR
- [x] Build clean (cmake --build build && cmake --install build)
- [x] After merge: see post-merge steps below

## Post-merge steps

1. **Tag** \`v3.1.8\` on the merge commit (annotated tag, same as v3.1.6 / v3.1.7)
2. **GitHub release** using \`.github/release-body.md\` as the body
3. **Create maintenance branch** \`release/3.1.x\` from the v3.1.8 tag
4. **Bump master** \`core/const.lua\` to \`v3.2.0-dev\` and open a CHANGELOG \`[Unreleased]\` section for 3.2.x work

CI will build and publish the binary artifacts + Docker images on the tag push - same workflow that ran for v3.1.7.

## #80 / #147 status after this

Both issues remain open until released; will close them as a final step after the GitHub release is live with the binary artifacts.