### PR TITLE
chore: bump master to v3.2.0-dev, open Unreleased CHANGELOG section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The upstream project (`luadch/luadch`) is a separate codebase; its release
 history is at https://github.com/luadch/luadch/releases.
 
+## [Unreleased] - 3.2.x line
+
+Phase-8 feature work in progress. See open issues for the planned
+scope: [#82](https://github.com/luadch-ng/luadch/issues/82) HTTP API,
+[#83](https://github.com/luadch-ng/luadch/issues/83) Prometheus
+metrics, [#84](https://github.com/luadch-ng/luadch/issues/84) audit
+log, [#100](https://github.com/luadch-ng/luadch/issues/100)
+self-registration, plus the deferred items in
+[#147](https://github.com/luadch-ng/luadch/issues/147) (T2 HUBI,
+T2 BLOM, T3 HBRI, T3 ZLIF). Security-fixes-only for the v3.1.x line
+land on `release/3.1.x` per
+[`CLAUDE.md` §8](CLAUDE.md#8-release-lines-and-support-policy).
+
+
 ## [v3.1.8] - 2026-05-12
 
 Modernisation-complete patch release. Concludes the

--- a/core/const.lua
+++ b/core/const.lua
@@ -11,7 +11,7 @@
 return {
 
     PROGRAM_NAME = "Luadch",
-    VERSION = "v3.1.8",
+    VERSION = "v3.2.0-dev",
     COPYRIGHT = "by blastbeat and pulsar",
     FORK = "modernised fork by Aybo",
     CONFIG_PATH = "././cfg/",


### PR DESCRIPTION
Last post-release step. v3.1.8 is tagged and live; \`release/3.1.x\` maintenance branch created. Master now opens the 3.2.x development line.

## Lands

| File | Change |
|---|---|
| \`core/const.lua\` | VERSION \`v3.1.8\` -> \`v3.2.0-dev\`. The \`-dev\` suffix makes \`git describe\` / boot banner clearly read as \"master in flight\". Will flip to \`v3.2.0\` at the actual 3.2.0 release-prep. |
| \`CHANGELOG.md\` | New \`## [Unreleased] - 3.2.x line\` section at the top with pointers to Phase-8 scope (#82 / #83 / #84 / #100) and the deferred ADC items from #147 (T2 HUBI / BLOM, T3 HBRI / ZLIF). Future PRs add their entries under this header. |

## After this merges

Master is open for 3.2.x feature work. Security fixes for 3.1.x go to \`release/3.1.x\` per [\`CLAUDE.md\` §8](https://github.com/luadch-ng/luadch/blob/master/CLAUDE.md#8-release-lines-and-support-policy), not under the \`[Unreleased]\` header here.