### PR TITLE
fix: import pairs into hub_dispatch sandbox locals (closes #162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ land on `release/3.1.x` per
 
 ### Bugfixes
 
-- [#162](https://github.com/luadch-ng/luadch/issues/162) - ADC PING HSUP handler crashed silently on public (`reg_only = false`) hubs because `pairs` was not imported into `core/hub_dispatch.lua`'s sandbox locals. Hublist pingers using the `ADPING` HSUP flag got zero frames and timed out. Regression introduced by T1.3 of [#147](https://github.com/luadch-ng/luadch/issues/147) in v3.1.8. Backport candidate for `release/3.1.x` as v3.1.9.
+- [#162](https://github.com/luadch-ng/luadch/issues/162) - ADC PING HSUP handler errored out (sandbox-undeclared `pairs`) on public (`reg_only = false`) hubs, returning zero frames to the pinger. Hublist scrapers timed out and dropped the hub from listings. Regression introduced by T1.3 of [#147](https://github.com/luadch-ng/luadch/issues/147) in v3.1.8. Backport target: `release/3.1.x` as v3.1.9 (self-introduced functional regression breaking the public-hub deployment mode - judgement call outside CLAUDE.md §8 table's listed categories).
+- Latent crash in `core/server.lua` `changesettings()`: `tonumber()` was called seven times without `local tonumber = use "tonumber"` import. Function is currently dead code (no caller in hub or plugins) so no production impact; surfaced by the #162 sandbox-locals audit. Fix is a one-line `use` declaration alongside the existing locals.
 
 
 ## [v3.1.8] - 2026-05-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ T2 BLOM, T3 HBRI, T3 ZLIF). Security-fixes-only for the v3.1.x line
 land on `release/3.1.x` per
 [`CLAUDE.md` §8](CLAUDE.md#8-release-lines-and-support-policy).
 
+### Bugfixes
+
+- [#162](https://github.com/luadch-ng/luadch/issues/162) - ADC PING HSUP handler crashed silently on public (`reg_only = false`) hubs because `pairs` was not imported into `core/hub_dispatch.lua`'s sandbox locals. Hublist pingers using the `ADPING` HSUP flag got zero frames and timed out. Regression introduced by T1.3 of [#147](https://github.com/luadch-ng/luadch/issues/147) in v3.1.8. Backport candidate for `release/3.1.x` as v3.1.9.
+
 
 ## [v3.1.8] - 2026-05-12
 

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -37,6 +37,7 @@
 
 local use = use
 
+local pairs = use "pairs"
 local tostring = use "tostring"
 local tablesize = use "tablesize"
 

--- a/core/server.lua
+++ b/core/server.lua
@@ -46,6 +46,7 @@ local type = use "type"
 local pairs = use "pairs"
 local ipairs = use "ipairs"
 local tostring = use "tostring"
+local tonumber = use "tonumber"
 local collectgarbage = use "collectgarbage"
 
 --// lua libs //--

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -1373,6 +1373,101 @@ def test_ratelimit_tier_msg_throttle(staging_dir: Path, proc=None):
             )
 
 
+def _switch_to_public_hub_mode(staging_dir: Path, current_proc, current_log_file):
+    """#162 setup: stop the hub, flip reg_only to false in cfg.tbl,
+    restart. Required so the next test exercises the
+    `(not _cfg_reg_only) and adccmd:hasparam "ADPING"` branch in
+    core/hub_dispatch.lua's HSUP handler - the branch that ADC pingers
+    (hublist scrapers) actually hit. Returns the new (proc, log_file)."""
+    stop_hub(current_proc, current_log_file)
+
+    cfg_path = staging_dir / "cfg" / "cfg.tbl"
+    text = cfg_path.read_text(encoding="utf-8")
+    text, n = re.subn(
+        r"^\s*reg_only\s*=\s*true\s*,",
+        "    reg_only = false,",
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if n != 1:
+        raise TestFailure(
+            "could not flip reg_only to false in cfg.tbl - the setting "
+            "line was not found in the staging tree"
+        )
+    cfg_path.write_text(text, encoding="utf-8")
+
+    time.sleep(1.0)
+    proc, log_file = start_hub(staging_dir)
+    return proc, log_file
+
+
+def test_ping_hsup_branch_emits_pingsup_response(staging_dir: Path, proc=None):
+    """#162 regression: an ADC pinger sending HSUP with the ADPING flag
+    against a public (reg_only=false) hub must receive the PING-IINF
+    response from core/hub_dispatch.lua's _protocol.HSUP. Pre-fix the
+    HSUP handler hit `pairs( _normalstatesids )` with `pairs` not
+    imported into the module locals, raising the sandbox guard and
+    silently failing the incoming() function - the pinger saw zero
+    frames and timed out.
+
+    Three assertions:
+    1. ISUP from the hub advertises ADPING (proves the pinger branch
+       at hub_dispatch.lua:220 fired, not the regular non-PING branch).
+    2. IINF carries the T1.3 aggregate fields (SS, SF) that are only
+       computed inside the buggy pairs() loop.
+    3. The hub's error.log gained no `attempt to read undeclared var`
+       entries during this connection (would catch the regression even
+       if some future change made the pingsup string format-tolerate
+       a missing field).
+    """
+    wait_for_port(HUB_HOST, TEST_PORT_PLAIN, START_TIMEOUT_SEC)
+
+    error_log = staging_dir / "log" / "error.log"
+    before = error_log.read_text(encoding="utf-8", errors="replace") if error_log.exists() else ""
+
+    with socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    ) as sock:
+        sock.sendall(b"HSUP ADBASE ADTIGR ADPING\n")
+        reader = _ADCReader(sock)
+        try:
+            isup = reader.recv_until(lambda f: f.startswith("ISUP "))
+            reader.recv_until(lambda f: f.startswith("ISID "))
+            iinf = reader.recv_until(lambda f: f.startswith("IINF "))
+        except TestFailure as e:
+            raise TestFailure(
+                f"public hub did not respond to HSUP ADPING (regression "
+                f"of #162 'pairs undeclared'); error: {e}"
+            ) from e
+
+    if "ADPING" not in isup:
+        raise TestFailure(
+            f"ISUP did not advertise ADPING - the pinger branch in "
+            f"hub_dispatch.lua:220 did not fire. Got: {isup!r}"
+        )
+
+    # T1.3 (#147) added SS / SF aggregate fields to the PING-IINF. The
+    # SS field on a freshly-started empty hub will be SS0; the
+    # regular non-PING IINF does not carry SS at all. Presence of SS
+    # is the smoking-gun signal that the aggregator loop ran.
+    if " SS" not in iinf:
+        raise TestFailure(
+            f"PING-IINF did not include the SS aggregate from T1.3 - the "
+            f"aggregator loop at hub_dispatch.lua:233 did not run. "
+            f"Got: {iinf!r}"
+        )
+
+    after = error_log.read_text(encoding="utf-8", errors="replace") if error_log.exists() else ""
+    new_lines = after[len(before):]
+    if "attempt to read undeclared var" in new_lines:
+        raise TestFailure(
+            f"hub emitted a sandbox-undeclared-var error during the "
+            f"PING handshake (regression of #162). New error.log "
+            f"content: {new_lines!r}"
+        )
+
+
 def test_canonical_socket_layout(staging_dir: Path):
     """Closes #88: LuaSocket and LuaSec install in the canonical layout
     so plugins can `require "socket.http"` / `require "ssl.https"` per
@@ -1625,6 +1720,23 @@ def main():
             failed.append("ratelimit tier overlay throttles BMSG")
         else:
             log("PASS  ratelimit tier overlay throttles BMSG")
+
+        # #162 regression test: switch to a public (reg_only=false) hub
+        # and verify the ADC PING HSUP branch in hub_dispatch.lua emits
+        # ISUP+ADPING and the T1.3 PING-IINF without sandbox errors.
+        # Pre-fix, `pairs` was not imported into the dispatcher module
+        # so the aggregator loop crashed and pingers saw silent
+        # timeouts.
+        try:
+            proc, log_file = _switch_to_public_hub_mode(
+                staging_dir, proc, log_file
+            )
+            test_ping_hsup_branch_emits_pingsup_response(staging_dir, proc=proc)
+        except Exception as e:
+            log(f"FAIL  ADC PING HSUP emits pingsup response (#162): {e}")
+            failed.append("ADC PING HSUP emits pingsup response (#162)")
+        else:
+            log("PASS  ADC PING HSUP emits pingsup response (#162)")
     finally:
         if proc is not None:
             stop_hub(proc, log_file)


### PR DESCRIPTION
Closes #162.

## Summary

- One-line import `local pairs = use "pairs"` in [`core/hub_dispatch.lua`](core/hub_dispatch.lua) fixes the T1.3 regression that prevented the HSUP handler from running on public (`reg_only = false`) hubs since v3.1.8. The dispatcher errored out per-connection (caught by hub.lua's `pcall` wrapper, logged to `error.log`) and the pinger saw zero frames.
- New smoke regression test `test_ping_hsup_branch_emits_pingsup_response` + helper `_switch_to_public_hub_mode` in [`tests/smoke/run.py`](tests/smoke/run.py) - asserts ISUP advertises `ADPING`, PING-IINF carries `SS` from the T1.3 aggregator loop, and no sandbox-undeclared-var errors in `log/error.log`.
- CHANGELOG entry under Unreleased / Bugfixes for both bugs in this PR.
- **Review-followup commit:** `core/server.lua:49` adds `local tonumber = use "tonumber"`. Surfaced by the cross-module builtin audit during PR review. The `changesettings()` function called `tonumber()` seven times without declaring it - currently dead code (no caller in hub or plugins), so the bug was latent, but cleaning it up while we're auditing the same class of bug.

## Verified

- `python tests/smoke/run.py build/install/luadch` -> all 50+ tests PASS
- Without the `pairs` fix the new regression test FAILS with a clear diagnostic: `public hub did not respond to HSUP ADPING (regression of #162 'pairs undeclared')`
- Standalone repro at `d:/tmp/repro_pinger_no_ip.py` (documented in #161 comment) confirms scenario C goes from "zero frames" to "full PING-IINF with `SS0 SF0 MU0 MR0 MO0 XU20 XR20 XO20 ...`" after the fix
- Cross-file sandbox-builtin audit: every `core/*.lua` that calls `pairs / ipairs / type / pcall / tonumber / select / setmetatable / next` declares it via `use "X"` after this PR

## Test plan

- [x] Smoke harness green on Windows / Linux CI
- [ ] Reviewer can verify the regression diagnostic by reverting just the one-line `pairs` import in `core/hub_dispatch.lua` and running smoke - expected: new test FAILS, all other tests PASS

## Backport

Self-introduced regression from T1.3 of #147 in v3.1.8. Breaks the public-hub deployment mode for all hublist visibility - operator-facing impact comparable to a release-blocker. Does not fit any single category in [`CLAUDE.md` §8](CLAUDE.md) backport table (the table covers crashes, plugin-state corruption, CVEs, and spec-compliance bugs; this is none of those exactly). Treating as a judgement-call backport: cherry-pick to `release/3.1.x` as **v3.1.9** is the right call because the alternative is "v3.1.8 stays the latest 3.1.x and is unusable as a public hub".

The §8 table may want a "self-introduced functional regression for a documented deployment mode" row added before the v3.1.9 tag so future similar cases have a clear category - flagged as follow-up.

## Related

- Issue #162 (this PR closes it)
- Issue #161 (BINF I4/I6 spec-compliance, the *other* half of the pinger-disconnect symptom complex - still open, separate scope, different root cause and code path; planned for the same v3.1.9 backport line)
- Origin: [#147](https://github.com/luadch-ng/luadch/issues/147) T1.3 (the SS/SF aggregator that introduced the `pairs` call)
