### PR TITLE
feat(ci): linux-aarch64 release artifact for Raspberry Pi (closes #159)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,67 @@ jobs:
           path: luadch-*-linux-x86_64.tar.gz
           if-no-files-found: error
 
+  build-linux-aarch64:
+    name: Build Linux aarch64 (native arm64 runner)
+    # GitHub-hosted native aarch64 runner (Cobalt 100, available on
+    # public repos since 2025). No cross-compile, no qemu - same
+    # three-step cmake pipeline as the x86_64 build, just on a
+    # different ISA. Closes #159 (Pi pre-compiled). Covers Pi 3+ / 4
+    # / 5 / Zero 2W with a 64-bit OS, which is >95% of the installed
+    # base in 2026.
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake libssl-dev
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build -j"$(nproc)"
+
+      - name: Install into staging tree
+        run: cmake --install build
+
+      - name: Verify install tree
+        run: |
+          test -f build/install/luadch/luadch
+          test -f build/install/luadch/liblua.so
+          test -d build/install/luadch/scripts
+          test -d build/install/luadch/cfg
+          test -d build/install/luadch/certs
+
+      - name: Verify binary is aarch64
+        run: |
+          file build/install/luadch/luadch | grep -q "ARM aarch64"
+
+      - name: Determine version tag
+        id: tag
+        run: |
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            TAG="${GITHUB_REF_NAME}"
+          elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag_name }}"
+          else
+            # Branch push: derive "vX.Y.Z-dev" from a "release/vX.Y.Z" branch.
+            BRANCH="${GITHUB_REF_NAME}"
+            TAG="${BRANCH#release/}-dev"
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Package
+        run: tar czf "luadch-${{ steps.tag.outputs.tag }}-linux-aarch64.tar.gz" -C build/install luadch
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: luadch-linux-aarch64
+          path: luadch-*-linux-aarch64.tar.gz
+          if-no-files-found: error
+
   build-windows:
     name: Build Windows x86_64 (MinGW UCRT64)
     runs-on: windows-latest
@@ -145,7 +206,7 @@ jobs:
 
   release:
     name: Create GitHub release
-    needs: [build-linux, build-windows]
+    needs: [build-linux, build-linux-aarch64, build-windows]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ land on `release/3.1.x` per
 - Latent crash in `core/server.lua` `changesettings()`: `tonumber()` was called seven times without `local tonumber = use "tonumber"` import. Function is currently dead code (no caller in hub or plugins) so no production impact; surfaced by the #162 sandbox-locals audit. Fix is a one-line `use` declaration alongside the existing locals.
 - [#160](https://github.com/luadch-ng/luadch/issues/160) (Sopor) - defense-in-depth for `etc_trafficmanager.lua` search blocking. The `onSearch` listener already swallows searches in both directions for blocked users, so they normally have no search to reply to. The new `onSearchResult` listener catches the protocol-violating edge case where a blocked user sends an unsolicited DRES / FRES (or a DRES targets a blocked user). Plugin bumped to v2.2.
 
+### Features
+
+- [#159](https://github.com/luadch-ng/luadch/issues/159) (Sopor) - pre-compiled `linux-aarch64` release artifact. The `release.yml` workflow gains a `build-linux-aarch64` job on GitHub's native `ubuntu-24.04-arm` runner (Cobalt 100, public-repo-free since 2025). Produces `luadch-vX.Y.Z-linux-aarch64.tar.gz` alongside the existing x86_64 / Windows artifacts on every tag push. Covers Raspberry Pi 3+ / 4 / 5 / Zero 2W with a 64-bit OS (>95% of the installed Pi base in 2026). Release-body Downloads table needs the new line added at release-prep time. Backport target: `release/3.1.x` as v3.1.9 - the workflow lives in `.github/`, which is mirrored from master for every backport release, so the cherry-pick is purely the workflow file.
+
 
 ## [v3.1.8] - 2026-05-12
 


### PR DESCRIPTION
Closes #159.

## Summary

Sopor in #159 asked for a pre-compiled Raspberry Pi binary. Today the release pipeline ships `linux-x86_64` and `windows-x86_64` only; the multi-arch Docker container covers `linux/arm64` but no standalone binary exists.

This PR adds a `build-linux-aarch64` job to `release.yml` using GitHub's native `ubuntu-24.04-arm` runner. Produces `luadch-vX.Y.Z-linux-aarch64.tar.gz` on every tag push and every `release/**` branch push, alongside the existing x86_64 / Windows artifacts.

## Coverage

| Pi model | OS bitness | Covered? |
|---|---|---|
| Pi 5 | 64-bit only | yes |
| Pi 4 | 64-bit default | yes |
| Pi 3 B/B+ | 64-bit default for new installs | yes |
| Pi Zero 2W | 64-bit | yes |
| Pi 2 / Zero (v1) | 32-bit (armv6/v7) | no (deferred, no demand) |
| Pi 1 | armv6 32-bit | no (EOL hardware) |

aarch64 covers >95% of the active Pi installed base in 2026.

## What it does

- Adds `build-linux-aarch64` job: native arm64 runner (no cross-compile), same three-step cmake pipeline as `build-linux`
- Verifies the binary is actually aarch64 via `file ... | grep "ARM aarch64"` (defensive against future runner-config reshuffles)
- Packages as `.tar.gz`, uploads as artifact
- Release job's `needs:` extended to include the new build

## What it does NOT do

- Modify `release-body.md` Downloads table - that file is rewritten per release; the v3.1.9 prep will add the new line
- Add a smoke test on arm64 - the [`smoke.yml`](.github/workflows/smoke.yml) workflow stays x86_64. Adding cross-arch smoke is an enhancement candidate but not gating for the artifact ship
- Cover 32-bit ARM (Pi 1 / Zero / Pi 2): would need a separate cross-compile job, deferred unless asked

## Verified

- YAML syntax valid (`python -c "import yaml; yaml.safe_load(...)"`)
- New job mirrors `build-linux` structure exactly except for runner + filename, so behaviour is well-understood
- `needs:` chain extends correctly (release fires only after all three builds complete)

## Test plan

- [x] Reviewer merges this PR
- [ ] CI dry-run via workflow_dispatch with `tag_name: v0.0.0-test` to verify the aarch64 job produces an artifact end-to-end before tagging real v3.1.9

## Backport

`release/3.1.x` as part of v3.1.9. The workflow file mirrors from master per release; the cherry-pick is the single workflow change.

## Related

- Issue #159 (this PR closes it)
- Existing multi-arch Docker container ([`docker.yml`](.github/workflows/docker.yml))
- Existing ARM cross-compile recipe in [`docs/BUILDING.md`](docs/BUILDING.md) (still valid for armv7 / armv6 users who want to self-build)
