### PR TITLE
feat(scripts): catch literal '[+!#]command' typo (closes #137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,13 @@ T2 BLOM, T3 HBRI, T3 ZLIF). Security-fixes-only for the v3.1.x line
 land on `release/3.1.x` per
 [`CLAUDE.md` §8](CLAUDE.md#8-release-lines-and-support-policy).
 
-> **Note:** All entries in the **Bugfixes** and **Features** sections
-> below were also cherry-picked to `release/3.1.x` and shipped as
-> **[v3.1.9](https://github.com/luadch-ng/luadch/releases/tag/v3.1.9)**
+> **Note:** All **Bugfixes** entries below and the `#159` aarch64 entry
+> under **Features** were cherry-picked to `release/3.1.x` and shipped
+> as **[v3.1.9](https://github.com/luadch-ng/luadch/releases/tag/v3.1.9)**
 > (2026-05-13). They stay listed here because they are part of the
 > 3.2.x line as well - merged on master first per the §8 workflow.
-> Entries in **Refactors** and **Documentation** are 3.2.x-only and not part of v3.1.9.
+> The `#137` literal-bracket hint under **Features**, the entries in
+> **Refactors**, and **Documentation** are 3.2.x-only and not part of v3.1.9.
 
 ### Bugfixes
 
@@ -40,6 +41,7 @@ land on `release/3.1.x` per
 ### Features
 
 - [#159](https://github.com/luadch-ng/luadch/issues/159) (Sopor) - pre-compiled `linux-aarch64` release artifact. The `release.yml` workflow gains a `build-linux-aarch64` job on GitHub's native `ubuntu-24.04-arm` runner (Cobalt 100, public-repo-free since 2025). Produces `luadch-vX.Y.Z-linux-aarch64.tar.gz` alongside the existing x86_64 / Windows artifacts on every tag push. Covers Raspberry Pi 3+ / 4 / 5 / Zero 2W with a 64-bit OS (>95% of the installed Pi base in 2026). Backported to `release/3.1.x` as v3.1.9 - the workflow lives in `.github/`, which is mirrored from master for every backport release, so the cherry-pick is purely the workflow file.
+- [#137](https://github.com/luadch-ng/luadch/issues/137) (Sopor) - `etc_hubcommands.lua` now catches the literal-bracket mistake. Users who type `[+!#]command` (with the square brackets, reading the doc notation as if it were the actual syntax) get a hint and the broadcast is swallowed - same swallow-and-hint mechanism as the bare-word case (#223). Critical: the hint never echoes the input args, because the args can carry a password when the user typed e.g. `[+!#]reg <user> <pw>`. Matches the literal-bracket form with one or more of `+`, `!`, `#` inside the brackets. Plugin bumped to v0.05. 3.2.x only, not backported.
 
 ### Refactors
 

--- a/scripts/etc_hubcommands.lua
+++ b/scripts/etc_hubcommands.lua
@@ -2,8 +2,21 @@
 
         etc_hubcommands.lua v0.03 by blastbeat
 
+        v0.05: by Aybo
+            - catch users who type the literal `[+!#]command` form
+              with the doc-notation brackets included
+                - closes luadch-ng/luadch#137 (Sopor)
+                - same swallow-and-hint mechanism as the bare-word
+                  case; the hint never echoes the input args because
+                  the args can carry a password (e.g. `[+!#]reg
+                  <user> <pw>`)
+
+        v0.04: by Aybo
+            - upstream #223: catch the bare-word "forgot the prefix"
+              case for known commands and reply with a hint
+
         v0.03: by blastbeat
-            - improve error handling   
+            - improve error handling
 
         v0.02: by pulsar
             - add support for multiple commands, usage: hubcmd.add( { cmd1, cmd2, cmd3 ... }, onbmsg )
@@ -18,7 +31,7 @@
 --// settings end //--
 
 local scriptname = "etc_hubcommands"
-local scriptversion = "0.04"
+local scriptversion = "0.05"
 
 local utf_match = utf.match
 local hub_getbot = hub.getbot
@@ -70,6 +83,27 @@ hub.setlistener( "onBroadcast", { },
             user:reply(
                 "Did you mean +" .. first_word ..
                 "? Hub commands need the [+!#] prefix; your message was NOT sent to main chat.",
+                hub_getbot( )
+            )
+            return PROCESSED
+        end
+        -- Closes luadch-ng/luadch#137 (Sopor): catch the "literal
+        -- bracket" mistake. Users who are not familiar with the
+        -- documentation notation type the form `[+!#]command` (or
+        -- partial forms like `[+]command`, `[!#]command`) as if
+        -- the brackets were part of the syntax. The literal-bracket
+        -- message currently broadcasts as main-chat text, which can
+        -- leak credentials when the user typed e.g.
+        -- `[+!#]reg <user> <password>`. Swallow the broadcast and
+        -- hint at the correct form. The hint does NOT echo the
+        -- input args - only the command-name capture (`%a+`), which
+        -- is never a password.
+        local lit_cmd = utf_match( txt, "^%[[%+!#]+%](%a+)" )
+        if lit_cmd and commands[ lit_cmd ] then
+            user:reply(
+                "The `[+!#]` in the docs is notation for 'pick one " ..
+                "of +, !, or #', not literal brackets. Try `+" ..
+                lit_cmd .. "` (your message was NOT sent to main chat).",
                 hub_getbot( )
             )
             return PROCESSED

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -398,26 +398,48 @@ def test_literal_bracket_command_hint():
         # ADC escape: spaces become \s. So `[+!#]help foo bar` ->
         # `[+!#]help\sfoo\sbar`.
         sock.sendall(f"BMSG {sid} [+!#]help\\sfoo\\sbar\n".encode("utf-8"))
-        # The hint is delivered via `user:reply(msg, hub_getbot())`
-        # (2-arg form) which writes a BMSG back to the user only
-        # (`client_write`, not a broadcast). Match on a BMSG frame
-        # containing the unique hint phrase. The wire format escapes
-        # spaces as `\s`, so the predicate looks for `pick\sone\sof`.
-        response = reader.recv_until(
-            lambda f: f.startswith("BMSG ") and "pick\\sone\\sof" in f,
-            timeout=PROTOCOL_TIMEOUT_SEC,
-        )
-        if "help" not in response:
+        # Drain all frames the hub sends back within 3 seconds and
+        # collect them ALL. Two independent assertions:
+        #   1. the hint BMSG (with "pick one of") arrived
+        #   2. NO BMSG frame contains the input args "foo"/"bar"
+        # Matching only the hint frame and checking it for leakage
+        # would miss a regression where the broadcast escapes the
+        # PROCESSED swallow and is echoed back from the user's own
+        # SID before the hint - that BMSG would contain foo/bar
+        # and the privacy claim would silently regress (the hint
+        # itself never echoes input, but the un-swallowed broadcast
+        # would).
+        all_frames = []
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline:
+            try:
+                f = reader.recv_until(lambda x: True, timeout=0.5)
+                all_frames.append(f)
+            except TestFailure:
+                break
+        bmsg_frames = [f for f in all_frames if f.startswith("BMSG ")]
+        hint_frames = [f for f in bmsg_frames if "pick\\sone\\sof" in f]
+        if not hint_frames:
             raise TestFailure(
-                f"hint did not mention the command name 'help': {response!r}"
+                f"did not receive the literal-bracket hint BMSG; "
+                f"BMSG frames seen: {bmsg_frames!r}"
             )
-        # Privacy assertion: the bot must not echo the supplied args.
-        # `foo` / `bar` are the standin for hypothetical password
-        # tokens. If either appears in the reply, the hint is leaking.
-        if "foo" in response or "bar" in response:
+        hint = hint_frames[0]
+        if "help" not in hint:
             raise TestFailure(
-                f"hint leaked input args (privacy regression of #137): {response!r}"
+                f"hint did not mention the command name 'help': {hint!r}"
             )
+        # Privacy assertion across ALL BMSG frames (hint plus any
+        # leaked broadcast). `foo` / `bar` are stand-ins for
+        # hypothetical password tokens; either appearing in any
+        # BMSG returned by the hub means the swallow regressed.
+        for frame in bmsg_frames:
+            if "foo" in frame or "bar" in frame:
+                raise TestFailure(
+                    f"hub leaked input args (privacy regression of "
+                    f"#137 - either hint echoed them or the broadcast "
+                    f"was not swallowed): {frame!r}"
+                )
 
 
 def test_csprng_salt_uniqueness():

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -378,6 +378,48 @@ def test_command_routing():
             raise TestFailure(f"+help response unexpectedly short: {response!r}")
 
 
+def test_literal_bracket_command_hint():
+    """#137 regression: a user who types `[+!#]<cmd>` (with literal
+    square brackets, copying the doc-notation as if it were the
+    actual syntax) gets a hint and the broadcast is swallowed.
+
+    The hint MUST:
+      - mention the correct prefix form (e.g. `+help`)
+      - NOT echo the input args - args may contain a password
+        (e.g. `[+!#]reg <user> <pw>` would leak credentials if
+        the bot replied with the original line)
+
+    The test sends `[+!#]help foo bar` where `foo bar` stands in
+    for arbitrary "secret" args, then asserts the bot's EMSG/DMSG
+    reply does NOT contain `foo` or `bar`.
+    """
+    with socket.create_connection((HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC) as sock:
+        sid, reader = _adc_login(sock, "dummy", "test")
+        # ADC escape: spaces become \s. So `[+!#]help foo bar` ->
+        # `[+!#]help\sfoo\sbar`.
+        sock.sendall(f"BMSG {sid} [+!#]help\\sfoo\\sbar\n".encode("utf-8"))
+        # The hint is delivered via `user:reply(msg, hub_getbot())`
+        # (2-arg form) which writes a BMSG back to the user only
+        # (`client_write`, not a broadcast). Match on a BMSG frame
+        # containing the unique hint phrase. The wire format escapes
+        # spaces as `\s`, so the predicate looks for `pick\sone\sof`.
+        response = reader.recv_until(
+            lambda f: f.startswith("BMSG ") and "pick\\sone\\sof" in f,
+            timeout=PROTOCOL_TIMEOUT_SEC,
+        )
+        if "help" not in response:
+            raise TestFailure(
+                f"hint did not mention the command name 'help': {response!r}"
+            )
+        # Privacy assertion: the bot must not echo the supplied args.
+        # `foo` / `bar` are the standin for hypothetical password
+        # tokens. If either appears in the reply, the hint is leaking.
+        if "foo" in response or "bar" in response:
+            raise TestFailure(
+                f"hint leaked input args (privacy regression of #137): {response!r}"
+            )
+
+
 def test_csprng_salt_uniqueness():
     """Open N sequential connections to a registered nick, drive each through
     SUP/BINF until the hub answers IGPA <salt>, capture the salt and disconnect
@@ -1670,6 +1712,7 @@ TESTS = [
     ("plain ADC full login (dummy/test)", test_full_login_plain),
     ("TLS ADC full login (dummy/test)", test_full_login_tls),
     ("+cmd routing (post-login +help)", test_command_routing),
+    ("literal [+!#] bracket hint + no-arg-echo (#137)", test_literal_bracket_command_hint),
     ("BINF without I4/I6 accepted (#161)", test_binf_without_i4_or_i6_accepted),
     ("CSPRNG salts are unique across connections", test_csprng_salt_uniqueness),
     ("per-IP connection cap refuses overflow", test_perip_connection_cap),


### PR DESCRIPTION
Closes #137 (confirmed via comment exchange with Sopor).

## Summary

Users unfamiliar with the documentation notation type the form `[+!#]command` (with literal square brackets) as if the brackets were part of the syntax. Pre-fix the message broadcasts as main-chat text - a privacy risk when the user typed e.g. `[+!#]reg <user> <password>`.

This PR adds a third match path to `etc_hubcommands.lua` onBroadcast next to the existing legitimate-command path and the bare-word hint (#223): match `^%[[%+!#]+%](%a+)`, swallow the broadcast, reply with a hint pointing at the correct form.

## Privacy-critical detail

The hint NEVER echoes the input args. Only the captured command-name word (`%a+`, e.g. `help`) is reflected. The args after the command (which can contain a password) stay out of the reply entirely.

The smoke regression test `test_literal_bracket_command_hint` verifies BOTH halves:
1. The BMSG reply contains the unique hint phrase `pick one of`
2. The input args `foo`/`bar` (standins for hypothetical password tokens) do NOT appear in the reply

## Verified

- Smoke 50+ PASS on Windows
- Pattern matches `[+!#]command`, `[+!]command`, `[+]command`, `[!#]command` etc - one or more of `+`/`!`/`#` inside the brackets
- Reply mirrors the #223 bare-word path: `user:reply(msg, hub_getbot())` 2-arg form writes a BMSG via `client_write` to the sender's connection only
- Plugin scriptversion 0.04 -> 0.05 with header changelog entry

## Pattern semantics

| User input | Lua pattern | Action |
|---|---|---|
| `+help foo` | matches existing first check | route to registered handler |
| `help foo` | matches bare-word #223 | swallow + bare-word hint |
| `[+!#]help foo` | matches new #137 | swallow + literal-bracket hint |
| `[+]help foo` | matches new #137 | swallow + literal-bracket hint |
| `hello world` | matches none | regular main-chat broadcast |

## Not backported

3.2.x-only. The behaviour change is additive and harmless, but the privacy fix only helps users who typo the bracket form - not a v3.1.x security backport candidate per CLAUDE.md §8.

## Related

- Issue #137 (this PR closes it, confirmed by Sopor)
- Sibling existing path: #223 (bare-word hint, already in etc_hubcommands.lua)
- Plugin: `scripts/etc_hubcommands.lua` v0.04 -> v0.05