### PR TITLE
fix: replace anti-rebrand util.decode for Luadch-NG identity

### DIFF
--- a/core/hub.lua
+++ b/core/hub.lua
@@ -677,10 +677,10 @@ login = function( user, bot )
             return "NO"
         end
         local TLS = "[TLS: " .. get_tls_mode() .. "]"
-        local msg = utf_format( _i18n_login_message, 
-            util.decode( '8129587ede4c' ), 
-            VERSION, 
-            TLS, 
+        local msg = utf_format( _i18n_login_message,
+            NAME,
+            VERSION,
+            TLS,
             util_formatseconds( os_difftime( os_time( ), signal_get "start" ), true )
         )
         user:reply( msg, _hubbot )

--- a/core/init.lua
+++ b/core/init.lua
@@ -184,10 +184,9 @@ init = function( )    -- this function is the start point
         .. const.PROGRAM_NAME
         .. " "
         .. const.VERSION
-        .. " "
-        --.. const.COPYRIGHT .. " (2007-" .. os.date( "%Y" ) .. ")"
-        .. util.decode( 'c75d3b4cc292dbf99f02507e0b3e5f58bb939d19fae422' ) .. " (2007-" .. os.date( "%Y" ) .. ")"
-        .. ", " .. const.FORK
+        .. " by Aybo (fork of Luadch "
+        .. const.COPYRIGHT
+        .. ") (2007-" .. os.date( "%Y" ) .. ")"
         .. "\n\n"
     )
     signal.set( "start", os.time( ) )


### PR DESCRIPTION
## Summary

Follow-up to #173. Two `Luadch` strings were still visible in user-facing output after that PR merged because they came from `util.decode(<hex>)` calls (anti-rebrand obfuscation by the original author) instead of the `PROGRAM_NAME` / `COPYRIGHT` constants. Plain `grep "Luadch"` did not catch them, so the #173 review missed them. Reported by maintainer at runtime - the post-login welcome message still read `This server is running Luadch v3.2.0-dev ...` despite the IINF wire identifier already being `APLUADCH-NG`.

## Changes

**`core/hub.lua` login message**
- `util.decode('8129587ede4c')` -> `NAME` (= `const.PROGRAM_NAME`, the existing module-local at line 414).
- Result: `This server is running Luadch-NG v3.2.0-dev [TLS: ...] (Uptime: ...)`.

**`core/init.lua` boot banner restructure**
- `util.decode('c75d3b4cc292...')` -> `const.COPYRIGHT` (same string, no longer obfuscated).
- Reordered so the current maintainer is prominent, original-author credit moves into a parenthetical:
  - Before: `Luadch-NG v3.2.0-dev by blastbeat and pulsar (2007-Y), fork by Aybo`
  - After: `Luadch-NG v3.2.0-dev by Aybo (fork of Luadch by blastbeat and pulsar) (2007-Y)`
- `const.FORK` is no longer referenced in the banner (the banner now hardcodes `by Aybo` inline because the surrounding text reads more naturally that way). `FORK = "fork by Aybo"` stays unchanged and is still consumed by `scripts/cmd_hubinfo.lua`.

## Why util.decode was used

The original author wrapped two brand strings in `util.decode(<hex>)` so that even forks that change `PROGRAM_NAME` would still display `Luadch` at runtime - a classic anti-rebrand pattern. For an officially-renamed fork the pattern works against the intent, so the obfuscation comes out.

## Out of scope

The `util.encode` / `util.decode` API itself is left intact - it is referenced in API docs and may be used by plugins for legitimate purposes (config secrets, etc.). Only the two known brand-string call sites are unwrapped.

## Backport

3.2.x only. Same rationale as #173 (UX / branding follow-up).

## Test plan

- [x] Local smoke test: **41/41 PASS**, includes the plain and TLS full-login tests that exercise the post-login welcome message and the boot banner.
- [x] Pre-merge two-pass review (independent agent + self spot-check):
  - Verified `NAME` scope at hub.lua:681 (declared at line 414, same shape as adjacent `VERSION`)
  - Verified format-string arity unchanged (3 `%s` + 4 `%d` matched by `NAME, VERSION, TLS` + 4-return `formatseconds`)
  - Verified `examples/lang/en.tbl` / `de.tbl` `hub_login_message` contains only `%s` placeholders - no operator i18n templates bake `Luadch` in literally, so no behaviour change for translated hubs
  - Verified `scripts/cmd_hubinfo.lua` still renders `FORK` as `... by blastbeat and pulsar (2007-Y), fork by Aybo` - `FORK` constant is not orphaned
  - Verified `grep "util.decode\s*\(\s*['\"][0-9a-fA-F]{6,}"` returns no matches anywhere in the tree - no other obfuscated brand strings remain
- [ ] CI smoke job (Linux + Windows)