### PR TITLE
docs: drop HUBI references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ scope: [#82](https://github.com/luadch-ng/luadch/issues/82) HTTP API,
 metrics, [#84](https://github.com/luadch-ng/luadch/issues/84) audit
 log, [#100](https://github.com/luadch-ng/luadch/issues/100)
 self-registration, plus the deferred items in
-[#147](https://github.com/luadch-ng/luadch/issues/147) (T2 HUBI,
-T2 BLOM, T3 HBRI, T3 ZLIF). Security-fixes-only for the v3.1.x line
+[#147](https://github.com/luadch-ng/luadch/issues/147) (T2 BLOM,
+T3 ZLIF). Security-fixes-only for the v3.1.x line
 land on `release/3.1.x` per
 [`CLAUDE.md` §8](CLAUDE.md#8-release-lines-and-support-policy).
 

--- a/docs/phases/PHASE_8B_DUAL_STACK.md
+++ b/docs/phases/PHASE_8B_DUAL_STACK.md
@@ -14,10 +14,6 @@
 
 ## Items deferred from the original sweep
 
-**T2.1 HUBI (Hub Identification)** - originally planned as the warm-up PR for this phase. Investigation on 2026-05-14 found that **HUBI is not in the ADC-EXT 1.0.9 spec** (33 documented extensions, no HUBI) and **not in the ADCH++ source** (verified via `gh search code "HUBI" --repo adricu/adchpp`). The plan-doc's earlier citation of "ADC-EXT 3.10" and "ADCH++ ships HUBI behind a build flag" turned out to be speculation; neither claim survives verification. Implementing HUBI would mean inventing wire format with zero client uptake.
-
-The persistent-hub-identifier use case (clients verifying "same hub as before" beyond KEYP keyprint pinning) is still legitimate, but it needs either (a) a standardisation effort with the ADC working group, or (b) a luadch-specific extension with clear "non-standard" documentation. Either way the work no longer fits "low-risk warm-up PR". **Deferred to a separate phase or quietly dropped** depending on operator demand.
-
 **T2.2 BLOM (Bloom Filter SCH)** - still demand-driven, only worth it for hubs with 100+ users. Out of scope.
 
 **T3.2 ZLIF (full-stream zlib)** - architectural, depends on a Phase 8 IO refactor for HTTP API (#82) / Prometheus (#83). Stays in Phase 8 backlog.


### PR DESCRIPTION
## Summary

Remove HUBI references from CHANGELOG and PHASE_8B docs. Issue [#147](https://github.com/luadch-ng/luadch/issues/147) body edited separately.

## Changes

| File | What |
|---|---|
| `CHANGELOG.md` | Deferred-scope list under `[Unreleased] - 3.2.x line` no longer mentions HUBI (also drops the already-closed HBRI). |
| `docs/phases/PHASE_8B_DUAL_STACK.md` | "Items deferred from the original sweep" no longer carries the HUBI subsection. |
| Issue #147 (out-of-tree) | T2.1 HUBI bullet + sequence line removed; T3.1 HBRI marked closed via #177. |

## Backport

3.2.x only. Docs cleanup.

## Test plan

- [x] `grep -nE "HUBI" -- CHANGELOG.md docs/phases/` returns no matches.
- [x] Remaining `HUBI` matches in the repo are only the `HUBINFO` ASCII banner substring in `scripts/cmd_hubinfo.lua` / its lang files (unrelated to the dropped item).