### PR TITLE
fix(ci): build aarch64 on Bullseye container with bundled OpenSSL (#159)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,11 +113,17 @@ jobs:
       OPENSSL_PREFIX: /opt/openssl3
     steps:
       - name: Install build dependencies
+        # Bullseye's stock cmake is 3.18 but luadch needs >= 3.20.
+        # Enable bullseye-backports which ships a modern cmake (>= 3.25).
         run: |
           apt-get update
           apt-get install -y --no-install-recommends \
-            build-essential cmake perl wget ca-certificates \
+            build-essential perl wget ca-certificates \
             patchelf file git
+          echo "deb http://deb.debian.org/debian bullseye-backports main" \
+            > /etc/apt/sources.list.d/backports.list
+          apt-get update
+          apt-get install -y --no-install-recommends -t bullseye-backports cmake
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,24 +80,69 @@ jobs:
           if-no-files-found: error
 
   build-linux-aarch64:
-    name: Build Linux aarch64 (native arm64 runner)
+    name: Build Linux aarch64 (Bullseye container, glibc 2.31)
     # GitHub-hosted native aarch64 runner (Cobalt 100, available on
-    # public repos since 2025). No cross-compile, no qemu - same
-    # three-step cmake pipeline as the x86_64 build, just on a
-    # different ISA. Closes #159 (Pi pre-compiled). Covers Pi 3+ / 4
-    # / 5 / Zero 2W with a 64-bit OS, which is >95% of the installed
-    # base in 2026.
+    # public repos since 2025). Closes #159 (Pi pre-compiled). Covers
+    # Pi 3+ / 4 / 5 / Zero 2W with a 64-bit OS.
+    #
+    # Build runs inside a Debian Bullseye container (glibc 2.31)
+    # because Sopor's report on #159 showed v3.1.9 broke on Pi systems
+    # with glibc < 2.34. Even fresh Pi OS Bookworm (glibc 2.36) failed
+    # because our liblua.so referenced GLIBC_2.38 (built on
+    # ubuntu-24.04 = glibc 2.39). Bullseye gives the broadest Pi-base
+    # coverage: it works on Pi OS Bullseye / DietPi v9.x (glibc 2.31)
+    # AND forward-compatibly on Bookworm (2.36) and any newer system.
+    #
+    # OpenSSL 3.x is required (CMakeLists.txt enforces >= 3.0; F-DEP-4
+    # of Phase 7). Bullseye only ships OpenSSL 1.1.1, so we build 3.x
+    # from source inside the container and bundle libssl.so.3 +
+    # libcrypto.so.3 alongside the binary in the tarball (same pattern
+    # as the Windows build's libssl-3-x64.dll). rpath is patched to
+    # `$ORIGIN` for the binary and `$ORIGIN/../../..` for luasec's
+    # ssl.so so they find the bundled libs.
     runs-on: ubuntu-24.04-arm
+    container:
+      image: debian:bullseye-slim
+    env:
+      # Pinned OpenSSL 3.0.x LTS (security-maintained until 2026-09-07).
+      # Bump on advisory. Source integrity is verified against the
+      # SHA256 sum that openssl.org publishes alongside the tarball;
+      # both files travel over HTTPS so the trust chain is the
+      # openssl.org cert.
+      OPENSSL_VERSION: 3.0.16
+      OPENSSL_PREFIX: /opt/openssl3
     steps:
-      - uses: actions/checkout@v4
-
       - name: Install build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential cmake libssl-dev
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential cmake perl wget ca-certificates \
+            patchelf file git
 
-      - name: Configure
-        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+      - uses: actions/checkout@v4
+
+      - name: Build OpenSSL 3.x from source
+        # Bullseye ships OpenSSL 1.1.1 (EOL 2023-09-11); we need 3.0+.
+        # Built shared at /opt/openssl3 and bundled below.
+        run: |
+          cd /tmp
+          BASE_URL="https://www.openssl.org/source"
+          wget -q "${BASE_URL}/openssl-${OPENSSL_VERSION}.tar.gz"
+          wget -q "${BASE_URL}/openssl-${OPENSSL_VERSION}.tar.gz.sha256"
+          # The .sha256 file is just the hex digest, no filename - prepend.
+          DIGEST=$(cat "openssl-${OPENSSL_VERSION}.tar.gz.sha256" | tr -d '[:space:]')
+          echo "${DIGEST}  openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c -
+          tar xzf "openssl-${OPENSSL_VERSION}.tar.gz"
+          cd "openssl-${OPENSSL_VERSION}"
+          ./Configure linux-aarch64 \
+            --prefix="${OPENSSL_PREFIX}" \
+            --openssldir="${OPENSSL_PREFIX}/ssl" \
+            shared no-tests
+          make -j"$(nproc)"
+          make install_sw
+
+      - name: Configure luadch
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR="${OPENSSL_PREFIX}"
 
       - name: Build
         run: cmake --build build -j"$(nproc)"
@@ -112,10 +157,44 @@ jobs:
           test -d build/install/luadch/scripts
           test -d build/install/luadch/cfg
           test -d build/install/luadch/certs
+          test -f build/install/luadch/lib/luasec/ssl/ssl.so
 
       - name: Verify binary is aarch64
         run: |
           file build/install/luadch/luadch | grep -q "ARM aarch64"
+
+      - name: Bundle OpenSSL libs alongside binary
+        # Same pattern as the Windows build's libssl-3-x64.dll /
+        # libcrypto-3-x64.dll: ship the .so.3 files at the tarball
+        # root so the binary and luasec's ssl.so find them via rpath
+        # without depending on the user's system OpenSSL version
+        # (Bullseye-based Pi systems ship libssl1.1, not libssl3).
+        run: |
+          cp -L "${OPENSSL_PREFIX}/lib/libssl.so.3" build/install/luadch/
+          cp -L "${OPENSSL_PREFIX}/lib/libcrypto.so.3" build/install/luadch/
+          chmod 644 build/install/luadch/libssl.so.3 build/install/luadch/libcrypto.so.3
+
+      - name: Patch rpath for bundled OpenSSL
+        # The main binary lives at <root>/luadch, so $ORIGIN finds the
+        # bundled libssl/libcrypto at the same level. luasec's ssl.so
+        # lives at <root>/lib/luasec/ssl/ssl.so, so it needs to walk
+        # three levels up to reach the bundled libs.
+        run: |
+          patchelf --set-rpath '$ORIGIN' build/install/luadch/luadch
+          patchelf --set-rpath '$ORIGIN/../../..' build/install/luadch/lib/luasec/ssl/ssl.so
+
+      - name: Verify glibc baseline (must be <= 2.31)
+        # Catches a regression where someone bumps the container away
+        # from Bullseye without thinking. Fails the build if the
+        # binary or liblua.so requires a glibc symbol newer than 2.31.
+        run: |
+          MAX_GLIBC=$(objdump -T build/install/luadch/luadch build/install/luadch/liblua.so build/install/luadch/lib/luasec/ssl/ssl.so 2>/dev/null \
+            | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -uV | tail -1)
+          echo "highest GLIBC symbol required across binary + liblua + luasec: ${MAX_GLIBC}"
+          if [ "$(printf '%s\nGLIBC_2.31\n' "${MAX_GLIBC}" | sort -V | tail -1)" != "GLIBC_2.31" ]; then
+            echo "ERROR: binary requires ${MAX_GLIBC} > GLIBC_2.31 (Bullseye baseline)" >&2
+            exit 1
+          fi
 
       - name: Determine version tag
         id: tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,8 +129,10 @@ jobs:
           BASE_URL="https://www.openssl.org/source"
           wget -q "${BASE_URL}/openssl-${OPENSSL_VERSION}.tar.gz"
           wget -q "${BASE_URL}/openssl-${OPENSSL_VERSION}.tar.gz.sha256"
-          # The .sha256 file is just the hex digest, no filename - prepend.
-          DIGEST=$(cat "openssl-${OPENSSL_VERSION}.tar.gz.sha256" | tr -d '[:space:]')
+          # openssl.org publishes hashes in OpenSSL dgst format:
+          # `SHA256(openssl-X.Y.Z.tar.gz)= <hex>` - extract the hash
+          # (last whitespace-delimited field) and feed to sha256sum.
+          DIGEST=$(awk '{print $NF}' "openssl-${OPENSSL_VERSION}.tar.gz.sha256")
           echo "${DIGEST}  openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c -
           tar xzf "openssl-${OPENSSL_VERSION}.tar.gz"
           cd "openssl-${OPENSSL_VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,11 +129,9 @@ jobs:
           BASE_URL="https://www.openssl.org/source"
           wget -q "${BASE_URL}/openssl-${OPENSSL_VERSION}.tar.gz"
           wget -q "${BASE_URL}/openssl-${OPENSSL_VERSION}.tar.gz.sha256"
-          # openssl.org publishes hashes in OpenSSL dgst format:
-          # `SHA256(openssl-X.Y.Z.tar.gz)= <hex>` - extract the hash
-          # (last whitespace-delimited field) and feed to sha256sum.
-          DIGEST=$(awk '{print $NF}' "openssl-${OPENSSL_VERSION}.tar.gz.sha256")
-          echo "${DIGEST}  openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c -
+          # openssl.org publishes hashes in the standard sha256sum
+          # format: `<hex>  <filename>` - feed directly to `sha256sum -c`.
+          sha256sum -c "openssl-${OPENSSL_VERSION}.tar.gz.sha256"
           tar xzf "openssl-${OPENSSL_VERSION}.tar.gz"
           cd "openssl-${OPENSSL_VERSION}"
           ./Configure linux-aarch64 \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,19 +111,27 @@ jobs:
       # openssl.org cert.
       OPENSSL_VERSION: 3.0.16
       OPENSSL_PREFIX: /opt/openssl3
+      # Bullseye ships cmake 3.18 but luadch needs >= 3.20.
+      # bullseye-backports is no longer served (archived after Bullseye
+      # went oldoldstable in 2024), so pull Kitware's official aarch64
+      # binary tarball instead.
+      CMAKE_VERSION: 3.30.5
     steps:
       - name: Install build dependencies
-        # Bullseye's stock cmake is 3.18 but luadch needs >= 3.20.
-        # Enable bullseye-backports which ships a modern cmake (>= 3.25).
         run: |
           apt-get update
           apt-get install -y --no-install-recommends \
             build-essential perl wget ca-certificates \
             patchelf file git
-          echo "deb http://deb.debian.org/debian bullseye-backports main" \
-            > /etc/apt/sources.list.d/backports.list
-          apt-get update
-          apt-get install -y --no-install-recommends -t bullseye-backports cmake
+
+      - name: Install CMake ${{ env.CMAKE_VERSION }} (Kitware aarch64 binary)
+        # Bullseye's stock cmake (3.18) is too old for cmake_minimum_required(3.20).
+        run: |
+          cd /tmp
+          wget -q "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-aarch64.tar.gz"
+          tar xzf "cmake-${CMAKE_VERSION}-linux-aarch64.tar.gz" -C /opt
+          ln -s "/opt/cmake-${CMAKE_VERSION}-linux-aarch64/bin/cmake" /usr/local/bin/cmake
+          cmake --version
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,17 +118,32 @@ jobs:
       CMAKE_VERSION: 3.30.5
     steps:
       - name: Install build dependencies
+        # Retry apt-get update to absorb a transient deb.debian.org
+        # outage - the release pipeline should not break on one
+        # network blip.
         run: |
-          apt-get update
+          for i in 1 2 3; do
+            apt-get update && break
+            echo "apt-get update failed, retrying in 5s..."
+            sleep 5
+          done
           apt-get install -y --no-install-recommends \
             build-essential perl wget ca-certificates \
             patchelf file git
 
       - name: Install CMake ${{ env.CMAKE_VERSION }} (Kitware aarch64 binary)
         # Bullseye's stock cmake (3.18) is too old for cmake_minimum_required(3.20).
+        # Integrity is verified against the SHA-256 sums file Kitware
+        # publishes alongside the tarball on the GitHub release.
         run: |
           cd /tmp
-          wget -q "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-aarch64.tar.gz"
+          BASE_URL="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}"
+          wget -q "${BASE_URL}/cmake-${CMAKE_VERSION}-linux-aarch64.tar.gz"
+          wget -q "${BASE_URL}/cmake-${CMAKE_VERSION}-SHA-256.txt"
+          # The SHA-256 file lists hashes for every platform's tarball;
+          # --ignore-missing skips the entries for files we did not
+          # download (x86_64, macOS, etc.), so we only check our own.
+          sha256sum --ignore-missing -c "cmake-${CMAKE_VERSION}-SHA-256.txt"
           tar xzf "cmake-${CMAKE_VERSION}-linux-aarch64.tar.gz" -C /opt
           ln -s "/opt/cmake-${CMAKE_VERSION}-linux-aarch64/bin/cmake" /usr/local/bin/cmake
           cmake --version
@@ -151,6 +166,7 @@ jobs:
           ./Configure linux-aarch64 \
             --prefix="${OPENSSL_PREFIX}" \
             --openssldir="${OPENSSL_PREFIX}/ssl" \
+            --libdir=lib \
             shared no-tests
           make -j"$(nproc)"
           make install_sw
@@ -171,6 +187,7 @@ jobs:
           test -d build/install/luadch/scripts
           test -d build/install/luadch/cfg
           test -d build/install/luadch/certs
+          test -f build/install/luadch/lib/adclib/adclib.so
           test -f build/install/luadch/lib/luasec/ssl/ssl.so
 
       - name: Verify binary is aarch64
@@ -211,12 +228,23 @@ jobs:
 
       - name: Verify glibc baseline (must be <= 2.31)
         # Catches a regression where someone bumps the container away
-        # from Bullseye without thinking. Fails the build if the
-        # binary or liblua.so requires a glibc symbol newer than 2.31.
+        # from Bullseye without thinking. Fails the build if any of
+        # the native binaries we ship requires a glibc symbol newer
+        # than 2.31. Covers the main binary + every shipped .so that
+        # links against libc (liblua, adclib, luasec ssl). The
+        # bundled libssl.so.3 / libcrypto.so.3 also link libc but
+        # they were built in the same container, so they share the
+        # same glibc baseline by construction - re-checking them
+        # here would only catch a corrupt bundle, which is unlikely.
         run: |
-          MAX_GLIBC=$(objdump -T build/install/luadch/luadch build/install/luadch/liblua.so build/install/luadch/lib/luasec/ssl/ssl.so 2>/dev/null \
+          MAX_GLIBC=$(objdump -T \
+              build/install/luadch/luadch \
+              build/install/luadch/liblua.so \
+              build/install/luadch/lib/adclib/adclib.so \
+              build/install/luadch/lib/luasec/ssl/ssl.so \
+              2>/dev/null \
             | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -uV | tail -1)
-          echo "highest GLIBC symbol required across binary + liblua + luasec: ${MAX_GLIBC}"
+          echo "highest GLIBC symbol required across binary + liblua + adclib + luasec: ${MAX_GLIBC}"
           if [ "$(printf '%s\nGLIBC_2.31\n' "${MAX_GLIBC}" | sort -V | tail -1)" != "GLIBC_2.31" ]; then
             echo "ERROR: binary requires ${MAX_GLIBC} > GLIBC_2.31 (Bullseye baseline)" >&2
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,13 +188,25 @@ jobs:
           cp -L "${OPENSSL_PREFIX}/lib/libcrypto.so.3" build/install/luadch/
           chmod 644 build/install/luadch/libssl.so.3 build/install/luadch/libcrypto.so.3
 
-      - name: Patch rpath for bundled OpenSSL
-        # The main binary lives at <root>/luadch, so $ORIGIN finds the
-        # bundled libssl/libcrypto at the same level. luasec's ssl.so
-        # lives at <root>/lib/luasec/ssl/ssl.so, so it needs to walk
-        # three levels up to reach the bundled libs.
+      - name: Patch rpath on all SSL-linked artifacts
+        # The bundled libssl.so.3 / libcrypto.so.3 live at the tarball
+        # root, alongside the luadch binary and liblua.so. Every ELF
+        # object that has libssl or libcrypto in its NEEDED list needs
+        # an rpath / RUNPATH set so the dynamic loader finds the
+        # bundled libs at runtime (DT_RUNPATH is NOT inherited from
+        # the caller, so each consumer must declare its own search
+        # path).
+        #
+        # Linked-against-OpenSSL artifacts and their level relative
+        # to <root>:
+        #   <root>/luadch                       -> $ORIGIN
+        #   <root>/libssl.so.3                  -> $ORIGIN (needs libcrypto)
+        #   <root>/lib/adclib/adclib.so         -> $ORIGIN/../..
+        #   <root>/lib/luasec/ssl/ssl.so        -> $ORIGIN/../../..
         run: |
-          patchelf --set-rpath '$ORIGIN' build/install/luadch/luadch
+          patchelf --set-rpath '$ORIGIN'           build/install/luadch/luadch
+          patchelf --set-rpath '$ORIGIN'           build/install/luadch/libssl.so.3
+          patchelf --set-rpath '$ORIGIN/../..'     build/install/luadch/lib/adclib/adclib.so
           patchelf --set-rpath '$ORIGIN/../../..' build/install/luadch/lib/luasec/ssl/ssl.so
 
       - name: Verify glibc baseline (must be <= 2.31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,19 +23,24 @@ T3 ZLIF). Security-fixes-only for the v3.1.x line
 land on `release/3.1.x` per
 [`CLAUDE.md` §8](CLAUDE.md#8-release-lines-and-support-policy).
 
-> **Note:** All **Bugfixes** entries below and the `#159` aarch64 entry
-> under **Features** were cherry-picked to `release/3.1.x` and shipped
-> as **[v3.1.9](https://github.com/luadch-ng/luadch/releases/tag/v3.1.9)**
+> **Note:** The **Bugfixes** entries for `#161`, `#162`, the latent
+> `server.lua tonumber` crash, and `#160`, plus the `#159` aarch64
+> entry under **Features**, were cherry-picked to `release/3.1.x`
+> and shipped as **[v3.1.9](https://github.com/luadch-ng/luadch/releases/tag/v3.1.9)**
 > (2026-05-13). They stay listed here because they are part of the
 > 3.2.x line as well - merged on master first per the §8 workflow.
-> The `#137` literal-bracket hint under **Features**, the entries in
-> **Refactors**, and **Documentation** are 3.2.x-only and not part of v3.1.9.
+> The `#159` aarch64 follow-up under **Bugfixes** is a v3.1.10
+> backport candidate (regression-fix on a v3.1.9 feature). The
+> `#137` literal-bracket hint and the **Luadch-NG identifier
+> rename** under **Features**, the entries in **Refactors**, and
+> **Documentation** are 3.2.x-only and not part of v3.1.9.
 
 ### Bugfixes
 
 - [#161](https://github.com/luadch-ng/luadch/issues/161) - BINF without `I4` / `I6` fields was rejected with `ISTA 220 No CID/PID/NICK/IP found in your INF.` Per ADC 4.3.x the `I4` / `I6` fields are *conditionally* required (only when the client advertises TCP4 / UDP4 / TCP6 / UDP6 in `SU`); hublist pingers and any IP-agnostic probe legitimately omit them. The hub now treats a missing `I4` / `I6` like the spec-defined `0.0.0.0` placeholder - fills in the TCP-source IP under the connection's address family, no special-case "no-IP user" shape downstream. `kill_wrong_ips` spoof-detection is unchanged for actually-mismatched claims. Mirrors upstream [luadch/luadch#176](https://github.com/luadch/luadch/issues/176). Backported to `release/3.1.x` as v3.1.9.
 - [#162](https://github.com/luadch-ng/luadch/issues/162) - ADC PING HSUP handler errored out (sandbox-undeclared `pairs`) on public (`reg_only = false`) hubs, returning zero frames to the pinger. Hublist scrapers timed out and dropped the hub from listings. Regression introduced by T1.3 of [#147](https://github.com/luadch-ng/luadch/issues/147) in v3.1.8. Backported to `release/3.1.x` as v3.1.9 (self-introduced functional regression breaking the public-hub deployment mode - judgement call outside CLAUDE.md §8 table's listed categories).
 - Latent crash in `core/server.lua` `changesettings()`: `tonumber()` was called seven times without `local tonumber = use "tonumber"` import. Function is currently dead code (no caller in hub or plugins) so no production impact; surfaced by the #162 sandbox-locals audit. Fix is a one-line `use` declaration alongside the existing locals. Backported to v3.1.9 alongside #162.
+- [#159](https://github.com/luadch-ng/luadch/issues/159) follow-up (Sopor / Boro) - the v3.1.9 `linux-aarch64` artifact was unusable on Bullseye-based Pi systems (DietPi v9.x, glibc 2.31) AND on fresh Pi OS Bookworm (glibc 2.36) because it was built on `ubuntu-24.04-arm` (glibc 2.39) and inherited `GLIBC_2.34` / `GLIBC_2.38` symbol requirements. The aarch64 build now runs inside a Debian Bullseye container on the same native-arm runner, with OpenSSL 3.x built from source and bundled (`libssl.so.3` + `libcrypto.so.3` alongside the binary, same pattern as the Windows `libssl-3-x64.dll`). `rpath` is patched to `$ORIGIN` on the main binary and `$ORIGIN/../../..` on `luasec/ssl.so` so the bundled libs resolve without depending on the system OpenSSL version. The workflow has an explicit `objdump -T | grep GLIBC` step that fails the build if any required symbol exceeds GLIBC_2.31 (Bullseye baseline) - catches a future regression where someone bumps the container away from Bullseye without thinking. Backport candidate for v3.1.10.
 - [#160](https://github.com/luadch-ng/luadch/issues/160) (Sopor) - defense-in-depth for `etc_trafficmanager.lua` search blocking. The `onSearch` listener already swallows searches in both directions for blocked users, so they normally have no search to reply to. The new `onSearchResult` listener catches the protocol-violating edge case where a blocked user sends an unsolicited DRES / FRES (or a DRES targets a blocked user). Plugin bumped to v2.2. Backported to `release/3.1.x` as v3.1.9.
 
 ### Features


### PR DESCRIPTION
## Summary

The v3.1.9 `linux-aarch64` release artifact was unusable on most Raspberry Pi systems - it was built on `ubuntu-24.04-arm` (glibc 2.39) and inherited `GLIBC_2.34` / `GLIBC_2.38` symbol requirements that DietPi v9.x (glibc 2.31) and even fresh Pi OS Bookworm (glibc 2.36) cannot satisfy. Reported by Sopor on [#159](https://github.com/luadch-ng/luadch/issues/159).

The aarch64 build now runs inside a Debian Bullseye container (glibc 2.31) on the same native-arm runner, with OpenSSL 3.x built from source and bundled (`libssl.so.3` + `libcrypto.so.3` alongside the binary, same pattern as the Windows `libssl-3-x64.dll`).

## Validated on real hardware

Sopor tested the build artifact on his DietPi v9.x Pi ([comment](https://github.com/luadch-ng/luadch/issues/159#issuecomment-4449842072) thread):

```
[26-05-15] *** Connected
[26-05-15] *** Stored password sent...
[26-05-15] <[BOT]HubSecurity> This server is running Luadch-NG v3.2.0-dev [TLS: v1.3] (Uptime: ...)
```

Clean connect, TLS v1.3 handshake, password auth, hub running. 👍

## What changed

`.github/workflows/release.yml` `build-linux-aarch64` job:

- `container: debian:bullseye-slim` (glibc 2.31 - broadest Pi-base coverage; works on Bullseye/DietPi v9 AND forward-compat on Bookworm and newer)
- OpenSSL 3.0.16 LTS built from source (Bullseye only ships 1.1.1; CMakeLists enforces >= 3.0 per Phase 7 F-DEP-4). SHA256-verified against the openssl.org-published digest.
- CMake 3.30.5 from Kitware's official aarch64 binary (Bullseye ships 3.18 < required 3.20; bullseye-backports is 404 since Bullseye went oldoldstable). SHA256-verified.
- `libssl.so.3` + `libcrypto.so.3` bundled at the tarball root
- `patchelf` rpath: `$ORIGIN` on the binary + `libssl.so.3`, `$ORIGIN/../..` on `adclib.so`, `$ORIGIN/../../..` on `luasec/ssl.so`
- Regression guard: `objdump -T | grep GLIBC` step fails the build if any required symbol across binary / liblua / adclib / luasec exceeds GLIBC_2.31
- apt-get retry loop for transient deb.debian.org outages

`CHANGELOG.md`: Bugfixes entry for the #159 follow-up.

## Backport

Hybrid release per [`CLAUDE.md` §8](https://github.com/luadch-ng/luadch/blob/master/CLAUDE.md#8-release-lines-and-support-policy) judgement call: merge here, cherry-pick `.github/workflows/release.yml` to `release/3.1.x`, rebuild the v3.1.9 aarch64 artifact in place via `workflow_dispatch tag_name=v3.1.9`, `gh release upload --clobber`, and annotate the v3.1.9 release notes. No new v3.1.10 tag - the original v3.1.9 aarch64 artifact was simply broken; an in-place swap fixes it retroactively for operators who already downloaded.

## Test plan

- [x] **Validated on real Pi hardware** (Sopor, DietPi v9.x glibc 2.31) - clean connect + TLS + auth
- [x] Local end-to-end: artifact runs in fresh `debian:bullseye-slim --platform linux/arm64` container, hub boots all modules, GLIBC_2.29 max symbol (below the 2.31 baseline)
- [x] Pre-merge two-pass review completed yesterday (independent agent + spot-check): findings on `--libdir`, adclib glibc-coverage, cmake SHA verification, apt-retry all addressed in the `review followups` commit. Branch was rebased onto current master today; `git diff` confirms `release.yml` is **byte-identical** to the Sopor-validated commit (rebase replayed cleanly, only added master commits underneath) - the prior review fully applies.
- [ ] CI workflow_dispatch green on the rebased branch (re-run optional - release.yml unchanged, build deterministic)