### PR TITLE
fix: exclude bots from hublist PING UC (closes #179)

### DIFF
--- a/core/hub.lua
+++ b/core/hub.lua
@@ -1323,7 +1323,16 @@ disconnect = function( client, err, user, quitstring )
         if user:isregged() then _regusercids[userhash][usercid] = nil end
 
         if userstate == "normal" then
-	    _user_count = _user_count - 1
+            -- _user_count is humans-only: it is incremented only in
+            -- login()'s non-bot branch. Bots reach this block via
+            -- bot.kill() -> disconnect() (state() hard-returns
+            -- "normal"), notably during killscripts() on every
+            -- +reload. Without this symmetry guard each reload
+            -- underflows _user_count by the bot count - a skew #179
+            -- now also surfaces in the external hublist UC field.
+            if not user:isbot( ) then
+                _user_count = _user_count - 1
+            end
             if user:isregged( ) then
                 local profile = user:profile( )
                 profile.lastlogout = util_date( )

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -39,7 +39,6 @@ local use = use
 
 local pairs = use "pairs"
 local tostring = use "tostring"
-local tablesize = use "tablesize"
 
 local adclib = use "adclib"
 local cfg = use "cfg"
@@ -248,7 +247,14 @@ _protocol = {
                     _cfg_hub_owner,
                     adclib_escape( _cfg_hub_email or "" ),
                     _cfg_hub_redirect_protocols,
-                    tablesize( _normalstatesids ),
+                    -- UC = humans online only. _get_user_count() is the
+                    -- humans-only counter (incremented solely in login()'s
+                    -- non-bot branch); _normalstatesids is the
+                    -- humans+bots union, so tablesize() over it inflated
+                    -- hublist UC by the bot count (#179). This now also
+                    -- matches the max_users capacity gate below, which
+                    -- already uses _get_user_count().
+                    _get_user_count(),
                     total_ss,
                     total_sf,
                     min_share,

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -1843,8 +1843,9 @@ def _ping_uc(host: str, port: int) -> int:
     Requires the hub to be in public mode (reg_only=false) - the PING
     branch in hub_dispatch.lua's HSUP handler only fires there. The
     _pingsup template (core/hub.lua) is `... UC%s SS%s SF%s ...`, so UC
-    is a space-delimited, digits-only named param: \\bUC(\\d+)\\b is a
-    safe extraction."""
+    is a space-delimited named param. Capture an optional leading
+    minus too, so a #179-style _user_count underflow surfaces as a
+    clear "UC=-N" assertion failure rather than a no-match error."""
     with socket.create_connection(
         (host, port), timeout=PROTOCOL_TIMEOUT_SEC
     ) as sock:
@@ -1853,7 +1854,7 @@ def _ping_uc(host: str, port: int) -> int:
         reader.recv_until(lambda f: f.startswith("ISUP "))
         reader.recv_until(lambda f: f.startswith("ISID "))
         iinf = reader.recv_until(lambda f: f.startswith("IINF "))
-    m = re.search(r"\bUC(\d+)\b", iinf)
+    m = re.search(r"\bUC(-?\d+)\b", iinf)
     if not m:
         raise TestFailure(
             f"PING-IINF carried no UC field; got: {iinf!r}"
@@ -1900,6 +1901,46 @@ def test_ping_uc_excludes_bots_one_human(staging_dir: Path, proc=None):
         raise TestFailure(
             f"one human + bots online but PING UC={uc}; expected exactly "
             f"1. Bots are still inflating the hublist user count (#179)."
+        )
+
+
+def test_ping_uc_survives_reload(staging_dir: Path, proc=None):
+    """#179 tier 3: PING UC must stay correct across a +reload.
+
+    +reload -> hub.restartscripts() -> killscripts(), which bot.kill()s
+    every bot. Each bot.kill() reaches disconnect()'s
+    `if userstate == "normal"` block (bot.state() hard-returns
+    "normal") and, without the symmetry guard in core/hub.lua, runs
+    `_user_count = _user_count - 1` for an entity that never
+    incremented it. Re-created bots take login()'s if-bot branch and
+    never re-increment. So pre-guard, one +reload underflows
+    _user_count by the bot count and the externally advertised UC goes
+    negative/garbage.
+
+    One human (dummy, level 100) stays connected across the reload, so
+    the correct post-reload UC is exactly 1."""
+    wait_for_port(HUB_HOST, TEST_PORT_PLAIN, START_TIMEOUT_SEC)
+    with socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    ) as human:
+        sid, reader = _adc_login(human, "dummy", "test")
+        if not sid:
+            raise TestFailure("setup login failed; cannot assert UC")
+        human.sendall(f"BMSG {sid} +reload\n".encode("utf-8"))
+        # cmd_reload sends its "Configuration reloaded." confirmation
+        # only AFTER hub.restartscripts() has run, so receiving any
+        # private reply means killscripts() (the underflow path) is
+        # already done.
+        reader.recv_until(
+            lambda f: f.startswith("EMSG ") or f.startswith("DMSG "),
+            timeout=PROTOCOL_TIMEOUT_SEC,
+        )
+        uc = _ping_uc(HUB_HOST, TEST_PORT_PLAIN)
+    if uc != 1:
+        raise TestFailure(
+            f"after +reload with one human online PING UC={uc}; "
+            f"expected exactly 1. _user_count underflowed on bot "
+            f"teardown during killscripts() (#179)."
         )
 
 
@@ -2196,6 +2237,14 @@ def main():
             failed.append("PING UC excludes bots, one human (#179)")
         else:
             log("PASS  PING UC excludes bots, one human (#179)")
+
+        try:
+            test_ping_uc_survives_reload(staging_dir, proc=proc)
+        except Exception as e:
+            log(f"FAIL  PING UC survives +reload (#179): {e}")
+            failed.append("PING UC survives +reload (#179)")
+        else:
+            log("PASS  PING UC survives +reload (#179)")
 
         # #107 dual-stack same-port: flip the v6 ports in cfg.tbl to
         # the same number as the v4 ports and confirm both listeners

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -1836,6 +1836,73 @@ def test_ping_hsup_branch_emits_pingsup_response(staging_dir: Path, proc=None):
         )
 
 
+def _ping_uc(host: str, port: int) -> int:
+    """Open a fresh connection, run the hublist-pinger HSUP handshake
+    (ADPING flag), read the PING-IINF and return its UC field as an int.
+
+    Requires the hub to be in public mode (reg_only=false) - the PING
+    branch in hub_dispatch.lua's HSUP handler only fires there. The
+    _pingsup template (core/hub.lua) is `... UC%s SS%s SF%s ...`, so UC
+    is a space-delimited, digits-only named param: \\bUC(\\d+)\\b is a
+    safe extraction."""
+    with socket.create_connection(
+        (host, port), timeout=PROTOCOL_TIMEOUT_SEC
+    ) as sock:
+        sock.sendall(b"HSUP ADBASE ADTIGR ADPING\n")
+        reader = _ADCReader(sock)
+        reader.recv_until(lambda f: f.startswith("ISUP "))
+        reader.recv_until(lambda f: f.startswith("ISID "))
+        iinf = reader.recv_until(lambda f: f.startswith("IINF "))
+    m = re.search(r"\bUC(\d+)\b", iinf)
+    if not m:
+        raise TestFailure(
+            f"PING-IINF carried no UC field; got: {iinf!r}"
+        )
+    return int(m.group(1))
+
+
+def test_ping_uc_excludes_bots_empty_hub(staging_dir: Path, proc=None):
+    """#179 tier 1: on a freshly-started public hub with zero humans
+    connected, PING UC must be 0.
+
+    The hub always runs at least the mandatory hubbot (created via
+    regbot -> _normalstatesids) plus the example-cfg RegChat/OpChat
+    bots. Pre-fix UC = tablesize(_normalstatesids) counted those bots,
+    so an empty hub advertised UC>=1 to hublist scrapers. Post-fix UC =
+    _get_user_count() (humans-only) = 0."""
+    wait_for_port(HUB_HOST, TEST_PORT_PLAIN, START_TIMEOUT_SEC)
+    uc = _ping_uc(HUB_HOST, TEST_PORT_PLAIN)
+    if uc != 0:
+        raise TestFailure(
+            f"empty hub advertised UC={uc} to a hublist pinger; expected "
+            f"0. Bots are leaking into the PING user count (#179)."
+        )
+
+
+def test_ping_uc_excludes_bots_one_human(staging_dir: Path, proc=None):
+    """#179 tier 2 (the strong one): with exactly one human logged in
+    and N bots online, PING UC must be 1, not 1+N.
+
+    Differentiates all three wrong behaviours at once: counts bots
+    (UC=1+N), is hard-wired 0 (UC=0), or counts everything. Only the
+    correct humans-only counter yields exactly 1."""
+    wait_for_port(HUB_HOST, TEST_PORT_PLAIN, START_TIMEOUT_SEC)
+    with socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    ) as human:
+        sid, _reader = _adc_login(human, "dummy", "test")
+        if not sid:
+            raise TestFailure("setup login failed; cannot assert UC")
+        # Second, independent connection performs the pinger handshake
+        # while the human above stays in NORMAL state.
+        uc = _ping_uc(HUB_HOST, TEST_PORT_PLAIN)
+    if uc != 1:
+        raise TestFailure(
+            f"one human + bots online but PING UC={uc}; expected exactly "
+            f"1. Bots are still inflating the hublist user count (#179)."
+        )
+
+
 def test_canonical_socket_layout(staging_dir: Path):
     """Closes #88: LuaSocket and LuaSec install in the canonical layout
     so plugins can `require "socket.http"` / `require "ssl.https"` per
@@ -2109,6 +2176,26 @@ def main():
             failed.append("ADC PING HSUP emits pingsup response (#162)")
         else:
             log("PASS  ADC PING HSUP emits pingsup response (#162)")
+
+        # #179: hublist PING UC must exclude bots. Reuses the public-hub
+        # mode left active by the #162 test (no extra restart). Tier 1
+        # MUST run first - it asserts an empty hub (no humans connected
+        # yet) advertises UC0.
+        try:
+            test_ping_uc_excludes_bots_empty_hub(staging_dir, proc=proc)
+        except Exception as e:
+            log(f"FAIL  PING UC excludes bots, empty hub (#179): {e}")
+            failed.append("PING UC excludes bots, empty hub (#179)")
+        else:
+            log("PASS  PING UC excludes bots, empty hub (#179)")
+
+        try:
+            test_ping_uc_excludes_bots_one_human(staging_dir, proc=proc)
+        except Exception as e:
+            log(f"FAIL  PING UC excludes bots, one human (#179): {e}")
+            failed.append("PING UC excludes bots, one human (#179)")
+        else:
+            log("PASS  PING UC excludes bots, one human (#179)")
 
         # #107 dual-stack same-port: flip the v6 ports in cfg.tbl to
         # the same number as the v4 ports and confirm both listeners


### PR DESCRIPTION
Closes #179.

## What

PING-IINF `UC` (the user count hublist scrapers like dchublist.org read) counted plugin bots. Now humans-only.

- `core/hub_dispatch.lua`: `UC` sources `_get_user_count()` (humans-only) instead of `tablesize( _normalstatesids )` (humans+bots union). Now consistent with the `max_users` capacity gate, which already used it. Dropped the now-dead `use "tablesize"` import.
- `core/hub.lua`: pre-merge review surfaced a latent bug this change would make externally visible - `_user_count`'s decrement in `disconnect()` was not bot-symmetric, so every `+reload` (killscripts -> bot.kill) underflowed the counter by the bot count. Guarded the decrement with `not user:isbot()` to mirror the humans-only increment. Sole decrement site.

The issue's original split-table redesign was based on an incorrect root cause (`_nobot_normalstatesids` is already humans-only; bots never reach the `login()` SET). Issue body corrected. No SID table mutated, no broadcast/`getusers()` path touched - zero plugin-visible behaviour change.

## Tests

3 smoke tests added, each verified to FAIL pre-fix and PASS post-fix:
1. empty public hub -> `UC0` (pre-fix `UC4`)
2. 1 human + bots -> `UC1` (pre-fix `UC5`)
3. 1 human, `+reload`, re-ping -> `UC1` (pre-guard `UC-3`)

Full smoke suite green on Windows (MinGW UCRT).

## Review

Two-pass pre-merge review done: independent agent review (caught the `+reload` underflow) + maintainer spot-check (verified the path, fixed it in-scope rather than deferring per CLAUDE.md s1.1).