### PR TITLE
Phase 8 S1: raw-byte read + ADC-line framer (core/iostream.lua)

### DIFF
--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -3215,7 +3215,16 @@ local defaults = {
         key = "certs/serverkey.pem",  -- your ssl key
         certificate = "certs/servercert.pem",  -- your cert
         cafile = "certs/cacert.pem",  -- your ca file
-        options = { "no_sslv2", "no_sslv3" },  -- do not touch this
+        -- TLS-1.3-only by design: protocol = "tlsv1_3" pins the
+        -- SSL_CTX min == max == TLS1_3_VERSION (verified in luasec
+        -- src/context.c), so nothing can negotiate down to <= 1.2.
+        -- "no_renegotiation" is defense-in-depth for the case an
+        -- operator manually downgrades protocol to "tlsv1_2"
+        -- (unsupported - see examples/cfg/cfg.tbl); TLS 1.3 has no
+        -- renegotiation anyway (RFC 8446). Requires OpenSSL >= 1.1.0h
+        -- (project bundles 3.x; luasec raises "invalid option" on a
+        -- flag the linked OpenSSL does not define).
+        options = { "no_sslv2", "no_sslv3", "no_tlsv1", "no_tlsv1_1", "no_renegotiation" },  -- do not touch this
         curve = "prime256v1",  -- do not touch this
 
         protocol = "tlsv1_3",

--- a/core/iostream.lua
+++ b/core/iostream.lua
@@ -14,11 +14,14 @@
         identical to the previous `receive( socket, "*l" )` path:
 
           - a frame is the bytes up to (not including) a "\n";
-          - a single trailing "\r" before the "\n" is stripped, mirroring
-            LuaSocket "*l"'s CRLF tolerance (ADC itself is "\n"-only and
-            the Phase-7 parser rejects CR, so without this an injected
-            CRLF would flip from lenient to a hard reject - that would be
-            a behaviour change, so S1 keeps the old leniency);
+          - EVERY "\r" in the frame is dropped, exactly as LuaSocket
+            "*l" does (luasocket/src/buffer.c:231-234 recvline: "we
+            ignore all \r's" - it strips every CR in the line, not just
+            a trailing one). ADC is "\n"-only and the Phase-7 parser
+            rejects embedded CR, so stripping only a trailing CR would
+            flip a previously-accepted "a\rb" line into a hard parser
+            reject - a real behaviour change. S1 must be neutral, so it
+            reproduces "*l"'s strip-all-CR behaviour verbatim;
           - an empty line yields "" (hub.lua's incoming() already skips
             data == "", unchanged);
           - the unterminated remainder is kept for the next feed();
@@ -41,7 +44,7 @@ local setmetatable = use "setmetatable"
 
 local string_find = string.find
 local string_sub = string.sub
-local string_byte = string.byte
+local string_gsub = string.gsub
 local string_len = string.len
 
 local newframer
@@ -86,12 +89,10 @@ newframer = function( maxlen )
             if not nlpos then
                 break
             end
-            local endpos = nlpos - 1
-            -- mirror LuaSocket "*l": drop one trailing "\r" before "\n"
-            if endpos >= startpos and string_byte( buf, endpos ) == 13 then
-                endpos = endpos - 1
-            end
-            local frame = string_sub( buf, startpos, endpos )
+            -- mirror LuaSocket "*l" exactly: take bytes up to (not
+            -- including) "\n", then drop EVERY "\r" (recvline ignores
+            -- all CRs in the line, not just a trailing one).
+            local frame = ( string_gsub( string_sub( buf, startpos, nlpos - 1 ), "\r", "" ) )
             if string_len( frame ) > maxlen then
                 overflow = true
             end

--- a/core/iostream.lua
+++ b/core/iostream.lua
@@ -1,0 +1,124 @@
+--[[
+
+        iostream.lua - Phase 8 IO layer, step 1
+
+        Per-connection inbound framing, extracted out of server.lua so the
+        server loop no longer relies on LuaSocket's "*l" line pattern to
+        cut ADC frames for it. server.lua now reads raw bytes and hands
+        them here; this module reassembles them into newline-delimited
+        ADC frames across reads (the buffer LuaSocket used to own
+        internally now lives in our process, which is what later steps -
+        HTTP framing, ZLIF inflate, BLOM counted-binary - need).
+
+        S1 scope: ADC-line framer ONLY. Behaviour is intentionally
+        identical to the previous `receive( socket, "*l" )` path:
+
+          - a frame is the bytes up to (not including) a "\n";
+          - a single trailing "\r" before the "\n" is stripped, mirroring
+            LuaSocket "*l"'s CRLF tolerance (ADC itself is "\n"-only and
+            the Phase-7 parser rejects CR, so without this an injected
+            CRLF would flip from lenient to a hard reject - that would be
+            a behaviour change, so S1 keeps the old leniency);
+          - an empty line yields "" (hub.lua's incoming() already skips
+            data == "", unchanged);
+          - the unterminated remainder is kept for the next feed();
+          - if the pending unterminated buffer, or any single extracted
+            frame, exceeds maxlen, overflow is signalled so the caller
+            can close the connection exactly like the old
+            `len > maxreadlen` guard did (Phase-7 oversize protection).
+
+        No sockets, no IO, no globals here - pure byte -> frame logic so
+        it is unit-testable and reusable by every later pipeline stage.
+
+]]--
+
+----------------------------------// DECLARATION //--
+
+local use = use
+
+local string = use "string"
+local setmetatable = use "setmetatable"
+
+local string_find = string.find
+local string_sub = string.sub
+local string_byte = string.byte
+local string_len = string.len
+
+local newframer
+
+----------------------------------// DEFINITION //--
+
+-- newframer( maxlen ) -> framer object with one method:
+--
+--   framer:feed( chunk ) -> frames, overflow
+--
+--     frames   : array (possibly empty) of complete ADC frames, in
+--                order, each WITHOUT the terminating "\n" (and without a
+--                single trailing "\r" if one was present), exactly the
+--                strings the old "*l" path produced.
+--     overflow : true if the pending unterminated buffer or any single
+--                returned frame exceeded maxlen. The caller must then
+--                close the connection (mirrors server.lua's old
+--                "receive buffer exceeded" path). Frames decoded before
+--                the offending oversize one are still returned so the
+--                caller can dispatch them first, matching how the old
+--                multi-call "*l" path dispatched earlier valid lines
+--                before hitting the oversize one.
+--
+-- The framer holds the cross-read remainder in a closure; one framer
+-- per connection, created in server.lua's wrapconnection().
+
+newframer = function( maxlen )
+
+    local buf = ""
+
+    local feed = function( _, chunk )
+        local frames, n = { }, 0
+        local overflow = false
+
+        if chunk and chunk ~= "" then
+            buf = buf .. chunk
+        end
+
+        local startpos = 1
+        while true do
+            local nlpos = string_find( buf, "\n", startpos, true )    -- plain find, no patterns
+            if not nlpos then
+                break
+            end
+            local endpos = nlpos - 1
+            -- mirror LuaSocket "*l": drop one trailing "\r" before "\n"
+            if endpos >= startpos and string_byte( buf, endpos ) == 13 then
+                endpos = endpos - 1
+            end
+            local frame = string_sub( buf, startpos, endpos )
+            if string_len( frame ) > maxlen then
+                overflow = true
+            end
+            n = n + 1
+            frames[ n ] = frame
+            startpos = nlpos + 1
+        end
+
+        -- keep only the unterminated remainder
+        if startpos > 1 then
+            buf = string_sub( buf, startpos )
+        end
+        if string_len( buf ) > maxlen then
+            overflow = true
+        end
+
+        return frames, overflow
+    end
+
+    return setmetatable( { }, { __index = { feed = feed } } )
+
+end    -- newframer
+
+----------------------------------// PUBLIC INTERFACE //--
+
+return {
+
+    newframer = newframer,
+
+}

--- a/core/server.lua
+++ b/core/server.lua
@@ -623,10 +623,13 @@ wrapconnection = function( server, listeners, socket, serverip, clientip, server
                     return false
                 end
                 dispatch( handler, frame, err )
-                -- If processing this frame closed/killed the connection
-                -- (e.g. invalid-SID kill), stop: do not process further
-                -- pipelined frames on a dead handler. Under the old
-                -- one-frame-per-call "*l" path this was implicit.
+                -- If processing this frame closed the connection (e.g.
+                -- invalid-SID kill -> handler.close), stop: do not
+                -- process further pipelined frames on a closing handler.
+                -- handler.close() sets handler.readbuffer = return_false
+                -- synchronously, so that is the live guard. The
+                -- `not handler` check is purely defensive (the actual
+                -- handler = nil teardown happens later in tick()).
                 if not handler then
                     return false
                 end

--- a/core/server.lua
+++ b/core/server.lua
@@ -91,6 +91,7 @@ local out = use "out"
 local mem = use "mem"
 local signal = use "signal"
 local ratelimit = use "ratelimit"
+local iostream = use "iostream"
 
 --// core methods //--
 
@@ -105,6 +106,7 @@ local ratelimit_release_ip = ratelimit.release_ip
 local ratelimit_handshake_started = ratelimit.handshake_started
 local ratelimit_handshake_finished = ratelimit.handshake_finished
 local ratelimit_expired_handshakes = ratelimit.expired_handshakes
+local iostream_newframer = iostream.newframer
 local ratelimit_tick = ratelimit.tick
 
 --// functions //--
@@ -437,6 +439,11 @@ wrapconnection = function( server, listeners, socket, serverip, clientip, server
     local bufferqueue = { }    -- buffer array
     local bufferqueuelen = 0    -- end of buffer array
 
+    -- Phase 8 S1: inbound ADC-line framer. Replaces LuaSocket's
+    -- internal "*l" line buffer; reassembles raw reads into frames
+    -- across select() iterations. One per connection.
+    local inframer = iostream_newframer( _maxreadlen )
+
     local toclose
     local fatalerror
     local needtls
@@ -562,23 +569,41 @@ wrapconnection = function( server, listeners, socket, serverip, clientip, server
     local _readbuffer
 
     _readbuffer = function( )    -- this function reads data
-        local buffer, err, part = receive( socket, pattern )    -- receive buffer with "pattern"
+        -- Phase 8 S1: raw byte read instead of LuaSocket "*l". We no
+        -- longer let LuaSocket cut lines for us; raw bytes go to the
+        -- per-connection framer (inframer) which reassembles ADC frames
+        -- across reads. receive( socket, n ) with settimeout(0):
+        -- IO_DONE returns up to n bytes; otherwise returns
+        -- nil, errstr, <partial>, where errstr is "timeout" for
+        -- plain-TCP nonblocking, "wantread"/"wantwrite" for the luasec
+        -- TLS want-dance, or "closed"/other for a real failure
+        -- (verified vs luasocket/src/buffer.c buffer_meth_receive).
+        local buffer, err, part = receive( socket, maxreadlen )
         _activitytimes[ handler ] = _currenttime
-        if ( not err ) or ( part and ( ( err == "wantread" ) or ( err == "wantwrite" ) ) ) then    -- received something; "timeout" is considered as fatal error, as luadch uses the *l pattern in receive
-            local buffer = buffer or part
-            local len = string_len( buffer )
-            if len > maxreadlen then
-                handler.close( "receive buffer exceeded" )
-                return false
-            end
-            local count = len * STAT_UNIT
+        local data = buffer or part or ""
+        local got = string_len( data )
+        -- "benign" = the read did not fail terminally. "timeout" with no
+        -- bytes is the normal nonblocking "nothing this tick" case and,
+        -- unlike the old "*l" guard, must NOT close the connection (the
+        -- old behaviour dropped any plain-TCP frame split across TCP
+        -- segments - the latent "unwanted disconnects in big hubs" bug).
+        local benign = ( err == nil ) or ( err == "timeout" ) or ( err == "wantread" ) or ( err == "wantwrite" )
+
+        -- Process any bytes regardless of err. A final TCP segment can
+        -- carry data AND the FIN, in which case LuaSocket returns
+        -- nil,"closed",<final-bytes>. The old "*l" path never hit this
+        -- (one line per call; the close arrived as a separate empty
+        -- read) but with raw reads the data and the close coalesce -
+        -- discarding the bytes here loses the last command (e.g. a
+        -- +setpass sent immediately before the client closes).
+        if got > 0 then
+            local count = got * STAT_UNIT
             readtraffic = readtraffic + count
             _readtraffic = _readtraffic + count
 
             try_reading_on_write = do_nothing
             try_reading_on_read = _readbuffer
-
-            if ( err == "wantwrite" ) then
+            if ( err == "wantwrite" ) then    -- TLS want-dance, preserved verbatim
               try_reading_on_write = _readbuffer
               try_reading_on_read = do_nothing
               if not _sendlist[ socket ] then   -- add socket to writelist
@@ -587,9 +612,42 @@ wrapconnection = function( server, listeners, socket, serverip, clientip, server
                 _sendlist[ socket ] = _sendlistlen
               end
             end
-            out_put( "server.lua: function 'wrapconnection': read data '", buffer, "', error: ", err )
-            return dispatch( handler, buffer, err )
-        else    -- connections was closed or fatal error
+
+            out_put( "server.lua: function 'wrapconnection': read data '", data, "', error: ", err )
+
+            local frames, overflow = inframer:feed( data )
+            for i = 1, #frames do
+                local frame = frames[ i ]
+                if string_len( frame ) > maxreadlen then    -- mirror old per-line cap: drop, don't dispatch
+                    handler.close( "receive buffer exceeded" )
+                    return false
+                end
+                dispatch( handler, frame, err )
+                -- If processing this frame closed/killed the connection
+                -- (e.g. invalid-SID kill), stop: do not process further
+                -- pipelined frames on a dead handler. Under the old
+                -- one-frame-per-call "*l" path this was implicit.
+                if not handler then
+                    return false
+                end
+                if handler.readbuffer == return_false then
+                    return true
+                end
+            end
+            if overflow then    -- unterminated remainder exceeded the cap
+                handler.close( "receive buffer exceeded" )
+                return false
+            end
+        elseif benign then
+            -- No bytes and no terminal error: keep the read wiring sane
+            -- and wait for the next tick.
+            try_reading_on_write = do_nothing
+            try_reading_on_read = _readbuffer
+        end
+
+        if benign then
+            return true
+        else    -- terminal error / close: any final data dispatched above
             out_put( "server.lua: function 'wrapconnection': client ", clientip, ":", clientport, " error: ", err )
             fatalerror = err or "fatal error"
             handler.close( fatalerror )

--- a/docs/phases/PHASE_8_IO.md
+++ b/docs/phases/PHASE_8_IO.md
@@ -186,12 +186,29 @@ the handshake coroutine is untouched (the framer is only installed
 *after* handshake), and both reviews judged the path logically
 equivalent (or better - S1 also keeps the partial on `wantread`).
 
-**OPEN GATE (before `phase8-io` -> `master`, not before the S1
-sub-PR):** the smoke suite proves TLS handshake/login/throughput but
-does NOT exercise a real mid-stream TLS renegotiation under traffic.
-That synthetic gap is the riskiest residual. A live `adcs://`
-renegotiation-under-load test must pass before the integration branch
-merges to master. Tracked here so it is not forgotten at phase close.
+**GATE RESOLVED 2026-05-15 (not by a test - by removing the cause).**
+Re-derived from source instead of building a synthetic reneg test:
+`protocol = "tlsv1_3"` makes luasec pin the SSL context to
+`min == max == TLS1_3_VERSION` (`luasec/src/context.c:107-111` +
+`SSL_CTX_set_min/max_proto_version` at `:337-338`). TLS 1.3 has **no
+renegotiation** (RFC 8446). So under the shipped default the
+mid-stream `wantread`/`wantwrite` reneg inversion is impossible *by
+protocol*, not by luck - the "SSL nightmare" comments predate the
+TLS-1.3 default. The only path back to renegotiation was a manual
+operator downgrade to `protocol = "tlsv1_2"`. That opt-out is now
+removed: the commented `tlsv1_2` blocks are deleted from
+`examples/cfg/cfg.tbl` (replaced with an explicit "TLS 1.2 is
+UNSUPPORTED" note), and `"no_renegotiation"` (OpenSSL
+`SSL_OP_NO_RENEGOTIATION`, luasec `options.c:113-114`) is added to the
+default `ssl_params.options` in both `core/cfg_defaults.lua` and
+`examples/cfg/cfg.tbl` as defense-in-depth. Dependency constraint:
+`no_renegotiation` needs OpenSSL >= 1.1.0h (project bundles 3.x
+everywhere; luasec raises "invalid option" on an undefined flag, so a
+future OpenSSL downgrade would fail TLS startup loudly, not silently).
+Residual want-dance can now only originate from the normal handshake
+(framer installed only *after* handshake - untouched) and benign
+partial-record reads (handled). Folded into PR #184 as the direct
+resolution of this IO-stack review finding.
 
 ## Log
 
@@ -204,6 +221,10 @@ merges to master. Tracked here so it is not forgotten at phase close.
   (CR-strip scope, false neutrality claim) - fixed (strip all CR, true
   `*l` parity). C1/C2/N1/N2 carried as documented notes above. Smoke
   green 3x on Windows incl. the +setpass test that exposed the FIN bug;
-  framer unit-tested incl. embedded-CR. Next: re-verify post-B1-fix,
-  then sub-PR into phase8-io. TLS-reneg-under-load remains an open gate
-  before phase8-io -> master.
+  framer unit-tested incl. embedded-CR. Sub-PR #184 -> phase8-io.
+- 2026-05-15: TLS-reneg gate RESOLVED by removing the cause (not a
+  test): default is TLS-1.3-only (min==max pin verified in luasec
+  context.c; RFC 8446 = no reneg), tlsv1_2 opt-out removed from
+  examples/cfg, "no_renegotiation" added to default ssl_params.options
+  in cfg_defaults.lua + examples/cfg.tbl as defense-in-depth. Folded
+  into PR #184 (direct resolution of the IO-stack review finding).

--- a/docs/phases/PHASE_8_IO.md
+++ b/docs/phases/PHASE_8_IO.md
@@ -71,18 +71,67 @@ phase passes the review gate.
 | **S4** | ZLIF inflate/deflate stage + `ZON`/`ZOF` + zlib build dep | opt-in via SUP |
 | **S5** | BLOM counted-binary capture stage + H-class GET/SND | opt-in via SUP |
 
+### Finding 2026-05-15: the old `*l` path has a latent fragmented-frame disconnect bug
+
+Verified against bundled LuaSocket `luasocket/src/buffer.c:105-152`
+(`buffer_meth_receive`) + `recvline`:
+
+- `sock:receive("*l")` on an incomplete line returns `nil, errstr,
+  <partial>`. errstr is `"timeout"` for plain-TCP nonblocking, or
+  `"wantread"`/`"wantwrite"` for the luasec TLS want-dance.
+- The old `_readbuffer` guard was
+  `if (not err) or (part and (err=="wantread" or err=="wantwrite"))`.
+  For a **plain-TCP** frame split across TCP segments, `err=="timeout"`
+  -> falls to the `else` branch -> `handler.close` -> **the connection
+  is dropped**. TLS partials (`wantread`/`wantwrite`) were tolerated;
+  plain-TCP partials were fatal. Asymmetric and fragile.
+
+So the old behaviour for a fragmented frame on plain TCP is "disconnect
+the client", almost certainly the root of the historical "Kungen
+disconnect bug" / "occasional unwanted disconnects in big hubs"
+(server.lua changelog). It rarely bites because small ADC control
+frames usually arrive in one TCP segment.
+
+Consequence: "behaviour-neutral" for S1 means neutral w.r.t. the
+*intended* behaviour (each complete ADC frame processed exactly once),
+**not** bug-for-bug compatible. S1's raw-read + framer **fixes** this
+latent disconnect bug. This also upgrades the fragmentation smoke test
+from a no-regression check to a genuine pre/post regression test
+(fails on old code = connection drops; passes on S1).
+
+### Finding 2026-05-15 (during S1 impl): data + FIN coalescing
+
+The first S1 implementation processed received bytes only on the
+benign branch and treated `err == "closed"` as purely fatal (discard,
+close). The `+setpass` smoke test failed deterministically. Root cause
+(found via instrumented `_readbuffer`): a final TCP segment can carry
+both data and the FIN, so `receive( socket, n )` returns
+`nil, "closed", <final-bytes>` in a single call. The old `*l` path
+never hit this (one line per call; the close arrived as a separate
+empty read), so discarding the bytes on "closed" lost the last
+command - here a `+setpass` sent immediately before the client closed.
+`+help`-style tests masked it (they matched an unrelated login
+broadcast frame and passed spuriously); `+setpass`'s strict re-login
+assertion exposed it.
+
+Fix: `_readbuffer` now feeds the framer and dispatches complete frames
+whenever `got > 0`, **regardless of err**, then performs the close if
+the error was terminal. This is the correct read-returns-data-then-EOF
+handling and is another strict correctness improvement over the old
+path (which could also lose a last command on a fast client close;
+rarely bit because clients usually waited for a reply first).
+
 ### S1 acceptance (the load-bearing step)
 
-S1 changes zero observable behaviour. Proof:
-
-1. Full smoke suite (plain + TLS handshake / login / +cmd routing / burst /
-   negative battery) stays green unchanged.
+1. Full smoke suite (plain + TLS handshake / login / +cmd routing /
+   burst / negative battery) stays green unchanged.
 2. New smoke test: an ADC frame delivered split across multiple TCP
    segments (write half a frame, flush, write the rest) is reassembled
-   into exactly one frame - `*l` did this implicitly via LuaSocket's
-   internal buffer; our explicit reassembler must be proven to match.
-3. New smoke test: two ADC frames in a single TCP segment are split into
-   exactly two frames (no over-merge).
+   into exactly one processed frame. **This FAILS on pre-S1 code**
+   (plain-TCP partial -> "timeout" -> connection dropped) and PASSES on
+   S1 - a true pre/post differentiator per CLAUDE.md s1a.7.
+3. New smoke test: two ADC frames in a single TCP segment are processed
+   as exactly two frames (no over-merge, no drop of the second).
 4. error.log gains no new entries during the suite.
 
 S1 is NOT done until 1-4 hold on both Linux (CI) and Windows (local).

--- a/docs/phases/PHASE_8_IO.md
+++ b/docs/phases/PHASE_8_IO.md
@@ -121,6 +121,46 @@ handling and is another strict correctness improvement over the old
 path (which could also lose a last command on a fast client close;
 rarely bit because clients usually waited for a reply first).
 
+### Finding 2026-05-15 (two-pass review, BLOCKER B1): CR-strip scope
+
+The first framer stripped only a single trailing `\r` before `\n`. The
+independent reviewer caught (and the maintainer spot-check confirmed
+against `luasocket/src/buffer.c:231-234` recvline, "we ignore all
+\r's") that LuaSocket `*l` strips **every** `\r` anywhere in the line.
+So `BMSG <sid> a\rb\n` was accepted pre-S1 (`*l` -> `BMSG <sid> ab`)
+but rejected post-S1 (embedded CR -> Phase-7 `%c` parser reject ->
+silently dropped). The "behaviour-neutral" claim was false - exactly
+the §1a.5 "verify every assumption against current source" trap. Fix:
+the framer now drops every `\r` in the frame (`gsub`), true `*l`
+parity, verified by an embedded-CR framer unit test. This is why the
+mandatory two-pass review exists.
+
+### Review findings carried as documented notes (not blocking)
+
+- **C1 - per-tick read pacing changed (acknowledged, not a regression).**
+  Pre-S1, `*l` returned one line per `_readbuffer` call; pipelined
+  frames sat in LuaSocket's 8 KiB userspace buffer so a flood was
+  implicitly throttled to ~1 frame / select-tick / connection. S1
+  dispatches all complete frames in the segment in one synchronous
+  loop (bounded by `_maxreadlen` = 1 MiB worth, then overflow-close).
+  Net: a latency improvement (also fixes a latent pipelined-2nd-frame
+  stall) but worst-case synchronous work per tick per connection grew
+  from 1 to N frames. There is no per-message ratelimit in the read
+  path (ratelimit.lua is per-IP-accept / handshake-deadline only). S2+
+  adds heavier per-frame stages (HTTP, ZLIF inflate) and MUST account
+  for this - consider a per-tick frame budget when the pipeline lands.
+- **C2 - `maxreadlen` cap split.** The framer is constructed once with
+  the module-global `_maxreadlen`; the per-frame cap in `_readbuffer`
+  uses the per-handler local `maxreadlen`. Equal unless
+  `handler.bufferlen()` mutates it - no in-tree caller does (dead
+  today). Resolve (pass the live cap into the framer) when S2+ makes
+  per-connection caps live.
+- **N2 - two-frames smoke test kept as-is.** Reviewer rated it
+  adequate; a "two distinct replies" assertion against `+help`'s
+  multi-frame reply would add flakiness (worse than the current
+  over-merge-caught-via-timeout + desync-caught-via-followup proof).
+  Deliberate.
+
 ### S1 acceptance (the load-bearing step)
 
 1. Full smoke suite (plain + TLS handshake / login / +cmd routing /
@@ -141,12 +181,29 @@ S1 is NOT done until 1-4 hold on both Linux (CI) and Windows (local).
 The luasec TLS path: raw-byte reads over TLS have their own
 `wantread`/`wantwrite` semantics during renegotiation, which the current
 `*l` code already wrestles with ("SSL nightmare" comments in server.lua
-history). S1 must preserve this exactly; prototype/verify the TLS partial
-read before S1 is considered complete - a regression here breaks every
-adcs:// connection.
+history). S1 preserves the `wantwrite` cross-wiring byte-for-byte and
+the handshake coroutine is untouched (the framer is only installed
+*after* handshake), and both reviews judged the path logically
+equivalent (or better - S1 also keeps the partial on `wantread`).
+
+**OPEN GATE (before `phase8-io` -> `master`, not before the S1
+sub-PR):** the smoke suite proves TLS handshake/login/throughput but
+does NOT exercise a real mid-stream TLS renegotiation under traffic.
+That synthetic gap is the riskiest residual. A live `adcs://`
+renegotiation-under-load test must pass before the integration branch
+merges to master. Tracked here so it is not forgotten at phase close.
 
 ## Log
 
 - 2026-05-15: phase opened, integration branch `phase8-io` created, design
   + S1 spec recorded (this doc). IO contract verified against source.
-  Next: S1 design checkpoint, then implement.
+- 2026-05-15: S1 implemented (core/iostream.lua + server.lua _readbuffer),
+  commit 36d932c. Two latent bugs found+fixed during impl (plain-TCP
+  fragmentation disconnect; data+FIN coalescing). Mandatory two-pass
+  review run: independent agent + maintainer spot-check found BLOCKER B1
+  (CR-strip scope, false neutrality claim) - fixed (strip all CR, true
+  `*l` parity). C1/C2/N1/N2 carried as documented notes above. Smoke
+  green 3x on Windows incl. the +setpass test that exposed the FIN bug;
+  framer unit-tested incl. embedded-CR. Next: re-verify post-B1-fix,
+  then sub-PR into phase8-io. TLS-reneg-under-load remains an open gate
+  before phase8-io -> master.

--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -1372,29 +1372,28 @@ return { -- the settings are a lua table, do not tough this!
         key = "certs/serverkey.pem",  -- your ssl key
         certificate = "certs/servercert.pem",  -- your cert
         cafile = "certs/cacert.pem",  -- your ca file
-        options = { "no_sslv2", "no_sslv3", "no_tlsv1", "no_tlsv1_1" },  -- do not touch this!
+        options = { "no_sslv2", "no_sslv3", "no_tlsv1", "no_tlsv1_1", "no_renegotiation" },  -- do not touch this!
         curve = "prime256v1",  -- do not touch this!
 
-        --// IMPORTANT:
-        --// there are four TLS configs to your choice, but you can only use one of the
-        --// following configs at the same time, you have to comment out the other ones!
-        --// "comment out" means "--" at the beginning of the line
+        --// TLS 1.3 ONLY. protocol = "tlsv1_3" pins the SSL context to
+        --// min == max == TLS 1.3 (luasec src/context.c), so a client
+        --// that cannot do TLS 1.3 simply cannot connect - there is no
+        --// downgrade to 1.2. This is intentional: every current ADC
+        --// client (DC++, AirDC++, EiskaltDC++, ncdc, ...) speaks
+        --// TLS 1.3, and pinning 1.3 also makes TLS renegotiation
+        --// impossible by protocol (RFC 8446) - which the IO layer
+        --// relies on (see docs/phases/PHASE_8_IO.md). TLS 1.2 is
+        --// UNSUPPORTED; do not re-introduce a "tlsv1_2" protocol here.
+        --// "no_renegotiation" above is belt-and-suspenders for that
+        --// case and requires OpenSSL >= 1.1.0h (project bundles 3.x).
 
-            --// use this config for:  TLSv1.2 with AES128 + AES256
-                --protocol = "tlsv1_2",
-                --ciphers = "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256",
-
-
-            --// use this config for:  TLSv1.2 with AES256 only
-                --protocol = "tlsv1_2",
-                --ciphers = "ECDHE-ECDSA-AES256-GCM-SHA384",
-
-            --// use this config for:  TLSv1.3 with AES256 + CHACHA20 + AES128 (default); requires OpenSSL 1.1.1 or higher
+            --// default:  TLSv1.3 with AES256 + CHACHA20 + AES128
                 protocol = "tlsv1_3",
                 ciphers = "HIGH",
                 ciphersuites = "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256",
 
-            --// use this config for:  TLSv1.3 with a forced cipher; requires OpenSSL 1.1.1 or higher
+            --// alternative:  TLSv1.3 with a single forced cipher
+            --// (comment out the block above, uncomment this one)
                 --protocol = "tlsv1_3",
                 --ciphers = "HIGH",
                 --ciphersuites = "TLS_AES_256_GCM_SHA384", -- force

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -378,6 +378,68 @@ def test_command_routing():
             raise TestFailure(f"+help response unexpectedly short: {response!r}")
 
 
+def test_s1_fragmented_frame_reassembled():
+    """Phase 8 S1: an ADC frame split across two TCP segments must be
+    reassembled and processed as one frame.
+
+    Pre-S1 (`receive(socket, "*l")`) a plain-TCP partial line returned
+    nil,"timeout",<partial>, which the old _readbuffer guard treated as
+    fatal -> the hub dropped the connection. This test therefore FAILS
+    on pre-S1 code (connection closed / no reply) and PASSES on S1 - a
+    true pre/post differentiator (CLAUDE.md s1a.7), and it directly
+    exercises the latent "unwanted disconnects in big hubs" bug the S1
+    journal documents.
+    """
+    with socket.create_connection((HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC) as sock:
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        sid, reader = _adc_login(sock, "dummy", "test")
+        # Send "+help" as two TCP segments with the frame boundary (\n)
+        # only in the second write.
+        sock.sendall(f"BMSG {sid} +he".encode("utf-8"))
+        time.sleep(0.25)  # force a separate read event on the hub side
+        sock.sendall(b"lp\n")
+        response = reader.recv_until(
+            lambda f: f.startswith("EMSG ") or f.startswith("DMSG "),
+            timeout=PROTOCOL_TIMEOUT_SEC,
+        )
+        if len(response) < 20:
+            raise TestFailure(
+                f"fragmented +help reply unexpectedly short: {response!r}"
+            )
+
+
+def test_s1_two_frames_one_segment():
+    """Phase 8 S1: two ADC frames delivered in a single TCP segment must
+    be processed as two independent frames (no over-merge into one
+    unparseable blob, no desync of the trailing-byte buffer).
+
+    Over-merge would make adc_parse choke on an embedded \\n and produce
+    no reply at all; a desynced remainder buffer would break the next
+    command. The test asserts a reply to the doubled send AND that a
+    subsequent independent command still works."""
+    with socket.create_connection((HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC) as sock:
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        sid, reader = _adc_login(sock, "dummy", "test")
+        # Two complete frames, one write / one segment.
+        sock.sendall(f"BMSG {sid} +help\nBMSG {sid} +help\n".encode("utf-8"))
+        reader.recv_until(
+            lambda f: f.startswith("EMSG ") or f.startswith("DMSG "),
+            timeout=PROTOCOL_TIMEOUT_SEC,
+        )
+        # Stream must not be desynced by the framer's remainder handling:
+        # an independent follow-up command still gets answered.
+        sock.sendall(f"BMSG {sid} +help\n".encode("utf-8"))
+        followup = reader.recv_until(
+            lambda f: f.startswith("EMSG ") or f.startswith("DMSG "),
+            timeout=PROTOCOL_TIMEOUT_SEC,
+        )
+        if len(followup) < 20:
+            raise TestFailure(
+                f"stream desynced after pipelined frames; follow-up "
+                f"reply too short: {followup!r}"
+            )
+
+
 def test_literal_bracket_command_hint():
     """#137 regression: a user who types `[+!#]<cmd>` (with literal
     square brackets, copying the doc-notation as if it were the
@@ -2029,6 +2091,8 @@ TESTS = [
     ("plain ADC full login (dummy/test)", test_full_login_plain),
     ("TLS ADC full login (dummy/test)", test_full_login_tls),
     ("+cmd routing (post-login +help)", test_command_routing),
+    ("S1: fragmented frame reassembled (phase8-io)", test_s1_fragmented_frame_reassembled),
+    ("S1: two frames in one segment (phase8-io)", test_s1_two_frames_one_segment),
     ("literal [+!#] bracket hint + no-arg-echo (#137)", test_literal_bracket_command_hint),
     ("BINF without I4/I6 accepted (#161)", test_binf_without_i4_or_i6_accepted),
     ("BINF with both I4 and I6 accepted (#147 T3.1 HBRI)", test_binf_with_both_i4_and_i6_accepted),


### PR DESCRIPTION
**Sub-PR into the `phase8-io` integration branch** (not master). Part of Phase 8 IO rework. Drivers: #82, #83, #147 T2.2/T3.2.

## What

server.lua no longer relies on LuaSocket `*l` to cut ADC frames. New `core/iostream.lua` owns per-connection inbound framing (pure byte->frame, unit-testable, no IO/globals); `_readbuffer` reads raw bytes and reassembles frames across reads. This is the substrate later stages (HTTP #82, ZLIF inflate, BLOM counted-binary) need.

## Behaviour

Neutral for the common case (whole frame per segment), verified against bundled `luasocket/src/buffer.c`. Additionally **fixes two latent bugs** the old `*l` path had (both documented in `docs/phases/PHASE_8_IO.md`):

1. **Plain-TCP fragmented-frame disconnect** - old guard treated the `*l` partial `timeout` as fatal and dropped the connection (the historical "unwanted disconnects in big hubs"). S1 reassembles across reads.
2. **data+FIN coalescing** - a final TCP segment carrying data AND the close made `receive()` return `nil,"closed",<bytes>`; the old path never hit this (one line/call, close as a separate empty read). S1 dispatches any bytes regardless of err, then closes, so a last command before client close (e.g. `+setpass`) is no longer lost.

Deliberate documented deviation: a bare `timeout`/`wantread`/`wantwrite` with no bytes is no longer fatal. TLS `wantwrite` cross-wiring preserved verbatim; handshake coroutine untouched.

## Review (mandatory two-pass, CLAUDE.md §1a.6)

Independent agent + maintainer spot-check. Found **BLOCKER B1**: framer stripped only a trailing CR while `*l` recvline drops *every* `\r` (`buffer.c:231-234`) - false neutrality. **Fixed** (strip all CR, true parity, embedded-CR unit test). C1 (per-tick pacing change), C2 (maxreadlen cap split, dead today), N2 (two-frames test rationale) carried as documented journal notes. **Open gate before `phase8-io` -> master:** live TLS-renegotiation-under-load test (smoke does not exercise it).

## Tests

2 new smoke tests. The fragmentation test FAILS on pre-S1 code (connection dropped, WinError 10053) and PASSES on S1 - a true pre/post differentiator (§1a.7). Framer unit-tested incl. embedded-CR parity. Full suite green 3x + 2x post-B1-fix on Windows (MinGW UCRT), incl. the +setpass test that exposed bug #2.