### PR TITLE
Phase 8 S2: composable stage pipeline (behaviour-neutral)

### DIFF
--- a/core/iostream.lua
+++ b/core/iostream.lua
@@ -1,37 +1,58 @@
 --[[
 
-        iostream.lua - Phase 8 IO layer, step 1
+        iostream.lua - Phase 8 IO layer, steps S1 + S2
 
-        Per-connection inbound framing, extracted out of server.lua so the
-        server loop no longer relies on LuaSocket's "*l" line pattern to
-        cut ADC frames for it. server.lua now reads raw bytes and hands
-        them here; this module reassembles them into newline-delimited
-        ADC frames across reads (the buffer LuaSocket used to own
-        internally now lives in our process, which is what later steps -
-        HTTP framing, ZLIF inflate, BLOM counted-binary - need).
+        Per-connection inbound framing, extracted out of server.lua so
+        the server loop no longer relies on LuaSocket's "*l" line
+        pattern. server.lua reads raw bytes and feeds them to a
+        per-connection PIPELINE; the pipeline reassembles them into
+        newline-delimited ADC frames across reads (the buffer LuaSocket
+        used to own internally now lives here).
 
-        S1 scope: ADC-line framer ONLY. Behaviour is intentionally
-        identical to the previous `receive( socket, "*l" )` path:
+        S2 generalises the S1 fixed framer into a composable pipeline of
+        STAGES. This is a behaviour-neutral proof step: the default
+        pipeline is exactly one stage (the ADC-line framer carrying the
+        S1 logic verbatim), so a 1-stage pipeline is byte-for-byte
+        identical to the old framer. The seam exists so later steps slot
+        in as stages without touching server.lua again:
 
-          - a frame is the bytes up to (not including) a "\n";
-          - EVERY "\r" in the frame is dropped, exactly as LuaSocket
-            "*l" does (luasocket/src/buffer.c:231-234 recvline: "we
-            ignore all \r's" - it strips every CR in the line, not just
-            a trailing one). ADC is "\n"-only and the Phase-7 parser
-            rejects embedded CR, so stripping only a trailing CR would
-            flip a previously-accepted "a\rb" line into a hard parser
-            reject - a real behaviour change. S1 must be neutral, so it
-            reproduces "*l"'s strip-all-CR behaviour verbatim;
-          - an empty line yields "" (hub.lua's incoming() already skips
-            data == "", unchanged);
-          - the unterminated remainder is kept for the next feed();
-          - if the pending unterminated buffer, or any single extracted
-            frame, exceeds maxlen, overflow is signalled so the caller
-            can close the connection exactly like the old
-            `len > maxreadlen` guard did (Phase-7 oversize protection).
+          - S3 HTTP: an HTTP framer stage (bytes -> request units)
+          - S4 ZLIF: an inflate stage prepended ahead of the ADC-line
+            stage on ZON (bytes -> decompressed bytes)
+          - S5 BLOM: a counted-binary capture stage
 
-        No sockets, no IO, no globals here - pure byte -> frame logic so
-        it is unit-testable and reusable by every later pipeline stage.
+        Stage contract:
+
+            stage:push( chunk ) -> units, overflow
+
+          - `chunk`    : a byte string from the previous stage (raw
+                         socket bytes for stage 1).
+          - `units`    : ordered array of whatever this stage emits.
+                         The ADC-line stage emits complete frame
+                         strings (each WITHOUT the terminating "\n" and
+                         with every "\r" dropped, exactly as LuaSocket
+                         "*l" recvline does - see below). A passthrough
+                         stage re-emits its input as a single unit.
+          - `overflow` : bool; only a framing/terminal stage sets it
+                         (size-cap breach -> caller closes the
+                         connection, mirroring the old
+                         `len > maxreadlen` guard).
+
+        Pipeline contract (unchanged from S1's framer so server.lua is
+        a ~2-line change):
+
+            pipeline:feed( bytes ) -> frames, overflow
+
+        ADC-line stage CR handling: LuaSocket "*l" recvline
+        (luasocket/src/buffer.c:231-234, "we ignore all \r's") strips
+        EVERY "\r" in the line, not just a trailing one. ADC is
+        "\n"-only and the Phase-7 parser rejects embedded CR, so
+        stripping only a trailing CR would flip a previously-accepted
+        "a\rb" line into a hard parser reject - a real behaviour
+        change. S1/S2 reproduce "*l"'s strip-all-CR verbatim.
+
+        No sockets, no IO, no globals here - pure byte -> unit logic so
+        every stage is unit-testable in isolation.
 
 ]]--
 
@@ -47,36 +68,21 @@ local string_sub = string.sub
 local string_gsub = string.gsub
 local string_len = string.len
 
-local newframer
+local newadclinestage
+local newpassthroughstage
+local newpipeline
 
 ----------------------------------// DEFINITION //--
 
--- newframer( maxlen ) -> framer object with one method:
---
---   framer:feed( chunk ) -> frames, overflow
---
---     frames   : array (possibly empty) of complete ADC frames, in
---                order, each WITHOUT the terminating "\n" (and without a
---                single trailing "\r" if one was present), exactly the
---                strings the old "*l" path produced.
---     overflow : true if the pending unterminated buffer or any single
---                returned frame exceeded maxlen. The caller must then
---                close the connection (mirrors server.lua's old
---                "receive buffer exceeded" path). Frames decoded before
---                the offending oversize one are still returned so the
---                caller can dispatch them first, matching how the old
---                multi-call "*l" path dispatched earlier valid lines
---                before hitting the oversize one.
---
--- The framer holds the cross-read remainder in a closure; one framer
--- per connection, created in server.lua's wrapconnection().
-
-newframer = function( maxlen )
+-- ADC-line framer stage. Holds the cross-push unterminated remainder
+-- in a closure. Logic is the S1 framer verbatim (so the default
+-- 1-stage pipeline is byte-identical to S1).
+newadclinestage = function( maxlen )
 
     local buf = ""
 
-    local feed = function( _, chunk )
-        local frames, n = { }, 0
+    local push = function( _, chunk )
+        local units, n = { }, 0
         local overflow = false
 
         if chunk and chunk ~= "" then
@@ -89,19 +95,17 @@ newframer = function( maxlen )
             if not nlpos then
                 break
             end
-            -- mirror LuaSocket "*l" exactly: take bytes up to (not
-            -- including) "\n", then drop EVERY "\r" (recvline ignores
-            -- all CRs in the line, not just a trailing one).
+            -- take bytes up to (not including) "\n", then drop EVERY
+            -- "\r" (recvline ignores all CRs in the line).
             local frame = ( string_gsub( string_sub( buf, startpos, nlpos - 1 ), "\r", "" ) )
             if string_len( frame ) > maxlen then
                 overflow = true
             end
             n = n + 1
-            frames[ n ] = frame
+            units[ n ] = frame
             startpos = nlpos + 1
         end
 
-        -- keep only the unterminated remainder
         if startpos > 1 then
             buf = string_sub( buf, startpos )
         end
@@ -109,17 +113,84 @@ newframer = function( maxlen )
             overflow = true
         end
 
-        return frames, overflow
+        return units, overflow
     end
 
-    return setmetatable( { }, { __index = { feed = feed } } )
+    return setmetatable( { }, { __index = { push = push } } )
 
-end    -- newframer
+end    -- newadclinestage
+
+-- Passthrough stage: re-emits its input chunk as a single unit,
+-- stateless, never overflows. Identity element for pipeline
+-- composition; `[passthrough, adcline]` behaves exactly like
+-- `[adcline]`.
+newpassthroughstage = function( )
+
+    local push = function( _, chunk )
+        return { chunk }, false
+    end
+
+    return setmetatable( { }, { __index = { push = push } } )
+
+end    -- newpassthroughstage
+
+-- newpipeline( maxlen ) -> pipeline object.
+--
+--   pipeline:feed( bytes ) -> frames, overflow
+--       runs bytes through stage 1, its units through stage 2, ... ;
+--       the terminal stage's units are the dispatchable ADC frames.
+--       `overflow` is the OR of every stage's overflow signal.
+--
+--   pipeline:prepend( stage )
+--       insert a stage at the FRONT (the rebuild seam: S4's ZON
+--       handler splices an inflate stage ahead of the ADC-line stage
+--       mid-stream). Defined here, first exercised in S4.
+--
+-- The default pipeline is a single ADC-line stage, so feed() is
+-- byte-for-byte identical to S1's framer (one consumer: server.lua).
+newpipeline = function( maxlen )
+
+    local stages = { newadclinestage( maxlen ) }
+
+    local feed = function( _, bytes )
+        local units = { bytes or "" }
+        local overflow = false
+        for s = 1, #stages do
+            local stage = stages[ s ]
+            local out, m = { }, 0
+            for u = 1, #units do
+                local produced, ov = stage:push( units[ u ] )
+                if ov then
+                    overflow = true
+                end
+                for i = 1, #produced do
+                    m = m + 1
+                    out[ m ] = produced[ i ]
+                end
+            end
+            units = out
+        end
+        return units, overflow
+    end
+
+    local prepend = function( _, stage )
+        local shifted = { stage }
+        for i = 1, #stages do
+            shifted[ i + 1 ] = stages[ i ]
+        end
+        stages = shifted
+    end
+
+    return setmetatable( { }, { __index = { feed = feed, prepend = prepend } } )
+
+end    -- newpipeline
 
 ----------------------------------// PUBLIC INTERFACE //--
 
 return {
 
-    newframer = newframer,
+    newpipeline         = newpipeline,
+    newadclinestage     = newadclinestage,
+    newpassthroughstage = newpassthroughstage,
 
 }

--- a/core/server.lua
+++ b/core/server.lua
@@ -106,7 +106,7 @@ local ratelimit_release_ip = ratelimit.release_ip
 local ratelimit_handshake_started = ratelimit.handshake_started
 local ratelimit_handshake_finished = ratelimit.handshake_finished
 local ratelimit_expired_handshakes = ratelimit.expired_handshakes
-local iostream_newframer = iostream.newframer
+local iostream_newpipeline = iostream.newpipeline
 local ratelimit_tick = ratelimit.tick
 
 --// functions //--
@@ -439,10 +439,13 @@ wrapconnection = function( server, listeners, socket, serverip, clientip, server
     local bufferqueue = { }    -- buffer array
     local bufferqueuelen = 0    -- end of buffer array
 
-    -- Phase 8 S1: inbound ADC-line framer. Replaces LuaSocket's
-    -- internal "*l" line buffer; reassembles raw reads into frames
-    -- across select() iterations. One per connection.
-    local inframer = iostream_newframer( _maxreadlen )
+    -- Phase 8 S1/S2: inbound framing pipeline. Replaces LuaSocket's
+    -- internal "*l" line buffer; reassembles raw reads into ADC frames
+    -- across select() iterations. One per connection. The default
+    -- pipeline is a single ADC-line stage, so :feed() is byte-for-byte
+    -- identical to the S1 framer; later steps (S3 HTTP, S4 ZLIF, S5
+    -- BLOM) add/splice stages without touching this call site.
+    local inframer = iostream_newpipeline( _maxreadlen )
 
     local toclose
     local fatalerror

--- a/core/server.lua
+++ b/core/server.lua
@@ -572,10 +572,11 @@ wrapconnection = function( server, listeners, socket, serverip, clientip, server
     local _readbuffer
 
     _readbuffer = function( )    -- this function reads data
-        -- Phase 8 S1: raw byte read instead of LuaSocket "*l". We no
-        -- longer let LuaSocket cut lines for us; raw bytes go to the
-        -- per-connection framer (inframer) which reassembles ADC frames
-        -- across reads. receive( socket, n ) with settimeout(0):
+        -- Phase 8 S1/S2: raw byte read instead of LuaSocket "*l". We
+        -- no longer let LuaSocket cut lines for us; raw bytes go to
+        -- the per-connection pipeline (inframer) whose terminal stage
+        -- reassembles ADC frames across reads. receive( socket, n )
+        -- with settimeout(0):
         -- IO_DONE returns up to n bytes; otherwise returns
         -- nil, errstr, <partial>, where errstr is "timeout" for
         -- plain-TCP nonblocking, "wantread"/"wantwrite" for the luasec

--- a/docs/phases/PHASE_8_IO.md
+++ b/docs/phases/PHASE_8_IO.md
@@ -270,3 +270,16 @@ restructures the byte/frame flow already in our hands.
 - 2026-05-15: S1 PR #184 merged into phase8-io (squash 42e2393), all
   CI green (Linux + Windows smoke, image build). S2 spec locked
   (above); branch phase8-io-s2 opened.
+- 2026-05-15: S2 implemented (stage pipeline, commit 8336c01),
+  behaviour-neutral, full smoke green. Two-pass review: independent
+  agent verdict SOUND (no BLOCKER/CONCERN), confirmed by maintainer
+  spot-check. Two cosmetic NITs fixed (server.lua phase tag /
+  framer->pipeline wording). TEST-DEBT closed in-step rather than
+  deferred: added committed `tests/unit/iostream_test.lua` (15
+  checks: S1 framer parity + passthrough + composition + prepend
+  ordering) - S1/S2 had only throwaway scripts before, which prove
+  nothing per s1a.7. **Open gate (S4):** wire
+  `tests/unit/iostream_test.lua` into CI before S4 - S4 already
+  touches the build/CI for the zlib dependency, so the lua-unit
+  runner is in-scope there; the pipeline `prepend` seam gets its
+  first production caller in S4 and must be CI-guarded by then.

--- a/docs/phases/PHASE_8_IO.md
+++ b/docs/phases/PHASE_8_IO.md
@@ -210,6 +210,45 @@ Residual want-dance can now only originate from the normal handshake
 partial-record reads (handled). Folded into PR #184 as the direct
 resolution of this IO-stack review finding.
 
+## S2 spec (locked 2026-05-15, maintainer-approved)
+
+Generalise `core/iostream.lua` from one fixed framer into a
+composable per-connection **pipeline of stages**. Behaviour-neutral
+proof step (no new functional stage; the S1 ADC-line logic becomes
+*a* stage). Decisions:
+
+- **Stage interface (Q1, chosen):** a stage is an object with
+  `stage:push( chunk ) -> units, overflow`. `units` is an ordered
+  array of whatever this stage emits (the ADC-line stage emits
+  complete frame strings; a passthrough stage re-emits its input
+  byte chunk as a single unit; future inflate emits decompressed
+  byte chunks; future HTTP emits request units). `overflow` is a
+  bool only the terminal/framing stage sets (size-cap breach).
+- **Pipeline:** `iostream.newpipeline( maxlen )` builds the default
+  inbound pipeline = `{ adcline(maxlen) }` and returns an object
+  with the **same `:feed( bytes ) -> frames, overflow` contract as
+  S1's framer** (so server.lua is a ~2-line change and behaviour is
+  provably identical: a 1-stage pipeline == the old framer). `feed`
+  runs bytes through stage 1, its units through stage 2, ... ; the
+  terminal stage's units are the dispatchable frames.
+- **Rebuild seam:** the pipeline exposes an internal `:prepend(stage)`
+  so a future stage (S4 ZON -> splice inflate ahead of the framer)
+  can rebuild mid-stream. Defined in S2, exercised first in S4 - no
+  server.lua hook is added now (YAGNI; the existing unused
+  `handler.pattern()` is left as-is, not repurposed).
+- **Scope (Q2):** inbound only. The outbound seam is deferred to S4
+  (ZLIF deflate); an outbound passthrough now would be speculative.
+- Public surface becomes `newpipeline`, `newadclinestage`,
+  `newpassthroughstage`; `newframer` is dropped (server.lua is its
+  only consumer, verified by grep).
+
+S2 acceptance: the S1 framer unit-test cases pass byte-identically
+through the pipeline; a passthrough stage and a `[passthrough,
+adcline]` composition behave exactly like `[adcline]`; full smoke
+stays green unchanged (neutrality proof). Risk is well below S1 -
+the dangerous `*l` -> raw socket change is already shipped; S2 only
+restructures the byte/frame flow already in our hands.
+
 ## Log
 
 - 2026-05-15: phase opened, integration branch `phase8-io` created, design
@@ -228,3 +267,6 @@ resolution of this IO-stack review finding.
   examples/cfg, "no_renegotiation" added to default ssl_params.options
   in cfg_defaults.lua + examples/cfg.tbl as defense-in-depth. Folded
   into PR #184 (direct resolution of the IO-stack review finding).
+- 2026-05-15: S1 PR #184 merged into phase8-io (squash 42e2393), all
+  CI green (Linux + Windows smoke, image build). S2 spec locked
+  (above); branch phase8-io-s2 opened.

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,6 +20,11 @@ tests/
     tiger.py      Vendored pure-Python Tiger-192 hash. Used to compute
                   CIDs and password challenge responses for the login
                   flow tests. Self-tests on import.
+  unit/
+    iostream_test.lua  Pure-Lua unit test for core/iostream.lua
+                  (Phase 8 framing pipeline). Stubs the `use` sandbox
+                  shim, loads the module standalone, asserts the
+                  stage/pipeline contract. Exit 0/1.
   README.md       (this file)
 ```
 
@@ -90,13 +95,36 @@ upstream defaults (5000-5003) so a developer running the suite locally
 does not collide with their real hub. CI is isolated so the offset
 does not matter there.
 
+## Unit tests (`tests/unit/`)
+
+Pure-byte core modules with no socket/global dependencies can be
+loaded standalone by stubbing the `use "X"` sandbox shim. Currently:
+
+```sh
+# any Lua 5.4 interpreter, from repo root:
+lua tests/unit/iostream_test.lua
+```
+
+Exit `0` = all pass, `1` = a failure. `iostream_test.lua` is the
+durable regression for the Phase 8 framing pipeline (S1 framer parity
++ S2 passthrough / composition / `prepend` ordering).
+
+**Not yet wired into CI:** `.github/workflows/smoke.yml` is Python and
+the CMake build does not emit a standalone `lua` interpreter. The
+*neutral* path is already CI-guarded transitively (a 1-stage pipeline
+is byte-identical to the S1 framer, so the S1 protocol smoke tests
+would break on a framing regression). Wiring this file into CI is an
+explicit gate before Phase 8 S4 - see
+[`docs/phases/PHASE_8_IO.md`](../docs/phases/PHASE_8_IO.md).
+
 ## Limitations
 
-- **No internal unit tests.** `core/adc.lua` could be exercised
-  directly with parser fixtures, but the `use "X"` sandbox in
-  `core/init.lua` makes loading core modules standalone clunky. We
-  test the parser via the running hub instead, which is more accurate
-  but slower per assertion.
+- **Sandboxed core modules.** `core/adc.lua` and similar could be
+  exercised with fixtures, but the `use "X"` sandbox in
+  `core/init.lua` makes loading most core modules standalone clunky
+  (the `iostream` shim works because that module is pure byte logic
+  with no hub deps). We test the parser via the running hub instead,
+  which is more accurate but slower per assertion.
 - **Tiger hash is vendored.** ADC's CID and password-challenge use
   Tiger-192, which has been removed from `hashlib`, `pycryptodome`
   and other modern Python crypto libraries. `tiger.py` is a

--- a/tests/unit/iostream_test.lua
+++ b/tests/unit/iostream_test.lua
@@ -1,0 +1,120 @@
+--[[
+
+    tests/unit/iostream_test.lua
+
+    Committed unit test for core/iostream.lua (Phase 8 S1 + S2). Pure
+    Lua, no hub, no sockets: stubs the `use` sandbox shim, loads the
+    module, asserts the stage/pipeline contract.
+
+    Why this exists: S1/S2 were verified with throwaway scripts, which
+    prove nothing for the next person (CLAUDE.md s1a.7). The S2
+    pre-merge review flagged the new abstraction surface (passthrough,
+    multi-stage fan-in, prepend ordering) as having no committed
+    regression - that surface is what S4 (ZLIF inflate spliced ahead of
+    the framer via pipeline:prepend) will rely on. This file is the
+    durable regression for it.
+
+    Run: lua tests/unit/iostream_test.lua   (any Lua 5.4)
+    Exit code 0 = all pass, 1 = a failure (CI-friendly).
+
+    CI wiring: not run by .github/workflows/smoke.yml yet (that harness
+    is Python and the build does not emit a standalone lua interpreter).
+    The neutral path is already CI-guarded transitively by the S1
+    protocol smoke tests (a 1-stage pipeline is byte-identical to the
+    S1 framer, so test_s1_fragmented_frame_reassembled /
+    test_s1_two_frames_one_segment would break if framing regressed).
+    Wiring this file into CI is an explicit gate before S4 lands (see
+    docs/phases/PHASE_8_IO.md) - S4 already touches the build for the
+    zlib dependency, so the lua-unit runner is in-scope there.
+
+]]--
+
+-- minimal sandbox shim: core/iostream.lua does `local x = use "x"`
+local _real = { string = string, table = table, setmetatable = setmetatable }
+_G.use = function( name ) return _real[ name ] end
+
+local iostream = assert( loadfile( "core/iostream.lua" ) )( )
+
+local NL, CR, BS = string.char( 10 ), string.char( 13 ), string.char( 92 )
+
+local failures, checks = 0, 0
+local function eq( label, got, want )
+    checks = checks + 1
+    if got ~= want then
+        failures = failures + 1
+        io.write( string.format( "FAIL %-34s got=%q want=%q\n", label, tostring( got ), tostring( want ) ) )
+    else
+        io.write( string.format( "ok   %s\n", label ) )
+    end
+end
+-- frames array -> single comparable string
+local function j( t ) return "[" .. table.concat( t, "|" ) .. "]" end
+
+----------------------------------------------------------------------
+-- S1 parity: default 1-stage pipeline must be byte-identical to the
+-- old newframer for every input class.
+----------------------------------------------------------------------
+
+local p = iostream.newpipeline( 1048576 )
+eq( "single frame, escaped body",
+    j( ( p:feed( "BMSG AAAA +setpass" .. BS .. "snick" .. BS .. "smyself" .. BS .. "ssmoketestnew" .. NL ) ) ),
+    "[BMSG AAAA +setpass\\snick\\smyself\\ssmoketestnew]" )
+
+p = iostream.newpipeline( 1048576 )
+eq( "fragmented part 1 -> no frame", j( ( p:feed( "BMSG AAAA +he" ) ) ), "[]" )
+eq( "fragmented part 2 -> reassembled", j( ( p:feed( "lp" .. NL ) ) ), "[BMSG AAAA +help]" )
+
+p = iostream.newpipeline( 1048576 )
+eq( "two frames one feed",
+    j( ( p:feed( "BMSG AAAA +help" .. NL .. "BMSG AAAA +help" .. NL ) ) ),
+    "[BMSG AAAA +help|BMSG AAAA +help]" )
+
+p = iostream.newpipeline( 1048576 )
+local fr, ov = p:feed( "ABC" .. CR .. NL .. "DEF" .. NL .. "GHI" )
+eq( "CRLF stripped + two frames", j( fr ), "[ABC|DEF]" )
+eq( "no overflow on normal input", ov, false )
+eq( "remainder kept then completed", j( ( p:feed( NL ) ) ), "[GHI]" )
+
+p = iostream.newpipeline( 1048576 )
+eq( "embedded CR all stripped (*l recvline parity)",
+    j( ( p:feed( "BMSG x he" .. CR .. "ll" .. CR .. "o" .. CR .. NL ) ) ),
+    "[BMSG x hello]" )
+
+p = iostream.newpipeline( 8 )
+local g, gov = p:feed( "ABCDEFGHIJKL" )    -- 12 byte unterminated > maxlen 8
+eq( "oversize unterminated -> overflow", gov, true )
+eq( "oversize unterminated -> no frame yet", j( g ), "[]" )
+
+----------------------------------------------------------------------
+-- S2 new surface: passthrough, composition, prepend ordering.
+----------------------------------------------------------------------
+
+local pt = iostream.newpassthroughstage( )
+local u, o = pt:push( "raw" .. NL .. "bytes" )
+eq( "passthrough re-emits input as one unit", j( u ), "[raw\nbytes]" )
+eq( "passthrough never overflows", o, false )
+
+-- [passthrough, adcline] must behave exactly like [adcline], incl.
+-- unterminated-remainder reassembly across feeds.
+p = iostream.newpipeline( 1048576 )
+p:prepend( iostream.newpassthroughstage( ) )
+eq( "compose: frame split, 2nd held",
+    j( ( p:feed( "BMSG Z +help" .. NL .. "BMSG Z +x" ) ) ), "[BMSG Z +help]" )
+eq( "compose: remainder completes across feed",
+    j( ( p:feed( "yz" .. NL ) ) ), "[BMSG Z +xyz]" )
+
+-- prepend must run the new stage BEFORE the framer (the S4
+-- inflate-before-framing ordering). A stage that turns 'X' into CR,
+-- prepended, must let the framer then strip those CRs.
+p = iostream.newpipeline( 1048576 )
+local crstage = setmetatable( { }, { __index = { push = function( _, c )
+    return { ( c:gsub( "X", CR ) ) }, false
+end } } )
+p:prepend( crstage )
+eq( "prepend ordering: stage runs before framer",
+    j( ( p:feed( "aXbXc" .. NL ) ) ), "[abc]" )
+
+----------------------------------------------------------------------
+
+io.write( string.format( "\n%d checks, %d failures\n", checks, failures ) )
+os.exit( failures == 0 and 0 or 1 )


### PR DESCRIPTION
**Sub-PR into `phase8-io`** (not master). Part of Phase 8 IO rework.

## What

Generalises the single S1 `newframer` into a per-connection **pipeline of stages** (`core/iostream.lua`): `newpipeline`, `newadclinestage`, `newpassthroughstage`, with `pipeline:feed` and `pipeline:prepend`. The default pipeline is exactly one ADC-line stage carrying the S1 logic verbatim, so it is **byte-for-byte identical** to the old framer. `core/server.lua` is a 2-line change (`newframer` -> `newpipeline`, same `:feed` contract); the `_readbuffer` data+FIN / dispatch logic from S1 is untouched. `newframer` dropped (server.lua was its only consumer).

This is the seam so S3 (HTTP framer), S4 (ZLIF inflate prepended ahead of the framer on ZON), S5 (BLOM counted-binary) slot in as stages without touching server.lua again.

Scope per locked S2 spec: inbound only (no speculative outbound passthrough - S4); no server.lua handler hook (rebuild is an internal pipeline method until S4).

## Review (mandatory two-pass, CLAUDE.md §1a.6)

Independent agent verdict **SOUND** - no BLOCKER, no CONCERN; confirmed by maintainer spot-check. Addressed in-step:

- **TEST-DEBT (the one substantive finding):** S1/S2 had only throwaway verification scripts. Added committed `tests/unit/iostream_test.lua` (15 checks: S1 framer parity incl. embedded-CR `*l` recvline parity + overflow + remainder reassembly; S2 passthrough; `[passthrough, adcline]` composition; `prepend` ordering). Documented in `tests/README.md`.
- 2 cosmetic NITs (server.lua phase tag / framer->pipeline wording) fixed.
- **Explicit S4 gate** recorded in `PHASE_8_IO.md`: wire `iostream_test.lua` into CI before S4 (S4 already touches the build for the zlib dep; S4 is `prepend`'s first production caller). The neutral path is already CI-guarded transitively today (1-stage pipeline == S1 framer -> the S1 protocol smoke tests break on any framing regression).

## Verification

`iostream_test.lua` 15/15 pass; full smoke green on Windows incl. TLS + the `+setpass` FIN-bug regression. Behaviour-neutral (all S1/TLS/setpass smoke tests unchanged through the pipeline).