### PR TITLE
Phase 8 S3: hardened HTTP framer stage + /health (#82)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -30,7 +30,16 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake libssl-dev
+          sudo apt-get install -y build-essential cmake libssl-dev lua5.4
+
+      # Pure-Lua unit test for the Phase 8 framing pipeline
+      # (core/iostream.lua). Byte/string logic only, no OS specifics,
+      # so the canonical Linux job is sufficient - it does not need the
+      # built hub. Run before the build so a framing-logic regression
+      # fails fast. The CMake build deliberately ships Lua as a library
+      # only (no standalone interpreter), hence the system lua5.4.
+      - name: Run iostream unit test
+        run: lua5.4 tests/unit/iostream_test.lua
 
       - name: Configure
         run: cmake -B build -DCMAKE_BUILD_TYPE=Release

--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -221,7 +221,16 @@ local defaults = {
     -- #82 follow-up PR.
     http_port = { false,
         function( value )
-            return value == false or types_number( value, nil, true )
+            if value == false then
+                return true
+            end
+            -- integer in the valid TCP port range only: types_number
+            -- has no range/integer check, so 0 (OS-assigned ephemeral
+            -- on all interfaces) and floats would otherwise slip
+            -- through.
+            return types_number( value, nil, true )
+                and value % 1 == 0
+                and value >= 1 and value <= 65535
         end
     },
     hub_website = { "http://yourwebsite.org",

--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -213,6 +213,17 @@ local defaults = {
             return true
         end
     },
+    -- Phase 8 S3 (#82): local read-only HTTP API port. `false` (the
+    -- default) = no HTTP listener bound at all. A number = bind the
+    -- hardened HTTP framer on 127.0.0.1:<n> only (loopback; #82
+    -- assumes a reverse proxy for any non-loopback exposure). S3
+    -- serves only /health; auth + data endpoints land in a separate
+    -- #82 follow-up PR.
+    http_port = { false,
+        function( value )
+            return value == false or types_number( value, nil, true )
+        end
+    },
     hub_website = { "http://yourwebsite.org",
         function( value )
             return types_utf8( value, nil, true )

--- a/core/http.lua
+++ b/core/http.lua
@@ -1,0 +1,137 @@
+--[[
+
+        http.lua - Phase 8 S3 HTTP request router (drives #82)
+
+        Maps a parsed/rejected HTTP request unit (produced by the
+        hardened iostream.newhttpstage framer) to a minimal HTTP
+        response, writes it, and closes the connection (one request
+        per connection - no keep-alive; see docs/phases/PHASE_8_IO.md).
+
+        S3 ships ONLY /health (static 200 "ok", no auth, no data). The
+        #82 read endpoints (/users /stats /version, token auth, JSON)
+        are a separate follow-up PR with its own security review - this
+        module is deliberately tiny and exposes nothing sensitive.
+
+        Security notes:
+          - no `Server` header (no version fingerprint pre-auth)
+          - fixed minimal headers, explicit Content-Length, always
+            Connection: close
+          - transport hardening already happened in the framer; a
+            { reject = <status> } unit is answered with a canned body
+          - log lines sanitise the path (control bytes already
+            rejected upstream - defence in depth, no log injection)
+
+]]--
+
+----------------------------------// DECLARATION //--
+
+local use = use
+
+local out = use "out"
+local string = use "string"
+local iostream = use "iostream"
+
+local out_put = out.put
+local string_sub = string.sub
+local string_gsub = string.gsub
+local tostring = use "tostring"
+
+local _status
+local response
+local logsafe
+local handle
+local http_incoming
+local http_disconnect
+
+----------------------------------// DEFINITION //--
+
+_status = {
+    [ 200 ] = "200 OK",
+    [ 400 ] = "400 Bad Request",
+    [ 404 ] = "404 Not Found",
+    [ 405 ] = "405 Method Not Allowed",
+    [ 414 ] = "414 URI Too Long",
+    [ 431 ] = "431 Request Header Fields Too Large",
+    [ 505 ] = "505 HTTP Version Not Supported",
+}
+
+response = function( status, body, headonly )
+    local line = _status[ status ] or "500 Internal Server Error"
+    body = body or ""
+    local head = "HTTP/1.1 " .. line .. "\r\n"
+        .. "Content-Type: text/plain; charset=utf-8\r\n"
+        .. "Content-Length: " .. #body .. "\r\n"
+        .. "Connection: close\r\n"
+        .. "\r\n"
+    if headonly then
+        return head
+    end
+    return head .. body
+end
+
+-- defence in depth: the framer already rejects any control byte in
+-- the target, but never interpolate request data into a log line
+-- without neutralising CR/LF and capping length.
+logsafe = function( s )
+    s = string_gsub( tostring( s or "" ), "%c", "?" )
+    if #s > 80 then
+        s = string_sub( s, 1, 80 ) .. "..."
+    end
+    return s
+end
+
+handle = function( handler, req )
+    local status, body, headonly
+
+    if req.reject then
+        status = req.reject
+        body = ( _status[ status ] or "error" ) .. "\n"
+        out_put( "http.lua: rejected request, status ", status )
+    elseif req.method ~= "GET" and req.method ~= "HEAD" then
+        status, body = 405, "405 Method Not Allowed\n"
+        out_put( "http.lua: 405 method ", logsafe( req.method ) )
+    else
+        headonly = ( req.method == "HEAD" )
+        if req.target == "/health" then
+            status, body = 200, "ok\n"
+        else
+            status, body = 404, "404 Not Found\n"
+            out_put( "http.lua: 404 ", logsafe( req.target ) )
+        end
+    end
+
+    handler.write( response( status, body, headonly ) )
+    handler.close( )    -- graceful: flush the response, then close
+    return true
+end
+
+-- server.lua calls the listener's `incoming` once at accept with no
+-- data (we ignore that), then once per framed unit with the parsed
+-- request. No hub user object is created for an HTTP connection.
+http_incoming = function( handler, req )
+    if not req then
+        return true
+    end
+    return handle( handler, req )
+end
+
+http_disconnect = function( )
+    -- no per-connection state to tear down
+end
+
+----------------------------------// PUBLIC INTERFACE //--
+
+return {
+
+    -- listener spec for server.addserver: the `pipeline` field makes
+    -- server.lua build the hardened HTTP framer pipeline for these
+    -- connections instead of the default ADC-line one.
+    listeners = function( )
+        return {
+            incoming   = http_incoming,
+            disconnect = http_disconnect,
+            pipeline   = iostream.newhttppipeline,
+        }
+    end,
+
+}

--- a/core/hub.lua
+++ b/core/hub.lua
@@ -1504,9 +1504,29 @@ init = function( )
     -- HTTP framer pipeline (http.listeners().pipeline), never the ADC
     -- one, and no hub user object is created for it. No TLS here:
     -- #82 assumes a reverse proxy for any non-loopback exposure.
+    --
+    -- server.addserver binds p.addr (NOT p.ip - p.ip is dead; the ADC
+    -- listeners' `ip = ip` has always been silently ignored, tracked
+    -- as a separate pre-existing bug). Loopback-only is the entire
+    -- security premise for shipping this without TLS/auth, so it MUST
+    -- be `addr`. A non-loopback bind here is a network-exposed
+    -- unauthenticated socket.
     local http_port = cfg_get "http_port"
     if type( http_port ) == "number" then
-        add_server_handler{ listeners = http.listeners( ), port = http_port, ip = "127.0.0.1" }
+        -- Refuse to share a port with an ADC listener: addserver would
+        -- reject the second registration and the API would silently
+        -- never come up. Fail loud instead.
+        local clash = false
+        for _, list in ipairs( { "tcp_ports", "ssl_ports", "tcp_ports_ipv6", "ssl_ports_ipv6" } ) do
+            for _, p in pairs( cfg_get( list ) ) do
+                if p == http_port then clash = true end
+            end
+        end
+        if clash then
+            out_error( "hub.lua: http_port ", http_port, " collides with an ADC port; HTTP API not started" )
+        else
+            add_server_handler{ listeners = http.listeners( ), port = http_port, addr = "127.0.0.1" }
+        end
     end
     server.addtimer(
         function( )

--- a/core/hub.lua
+++ b/core/hub.lua
@@ -229,6 +229,7 @@ local const = use "const"
 local server = use "server"
 local signal = use "signal"
 local scripts = use "scripts"
+local http = use "http"
 
 -- User / bot factories and the ADC command dispatcher each live in
 -- their own module since Phase 6d. All three use the bind_late()
@@ -1495,6 +1496,17 @@ init = function( )
         for j, ip in pairs( cfg_get "hub_listen" ) do
             add_server_handler{ listeners = { incoming = newuser, disconnect = disconnect }, port = port, ip  = ip, sslctx = cfg_get "ssl_params", maxconnections = 10000, startssl = true, family = "ipv6" }
         end
+    end
+    -- Phase 8 S3 (#82): optional local HTTP listener. Bound to
+    -- 127.0.0.1 ONLY and only when cfg http_port is a number; unset
+    -- (the default) means no HTTP socket exists at all, so existing
+    -- hubs are byte-unaffected. The connection runs the hardened
+    -- HTTP framer pipeline (http.listeners().pipeline), never the ADC
+    -- one, and no hub user object is created for it. No TLS here:
+    -- #82 assumes a reverse proxy for any non-loopback exposure.
+    local http_port = cfg_get "http_port"
+    if type( http_port ) == "number" then
+        add_server_handler{ listeners = http.listeners( ), port = http_port, ip = "127.0.0.1" }
     end
     server.addtimer(
         function( )

--- a/core/iostream.lua
+++ b/core/iostream.lua
@@ -286,7 +286,13 @@ newhttpstage = function( )
                     if string_len( line ) > MAXHDRLINE then
                         return emit{ reject = 431 }
                     end
-                    local name, value = string_match( line, "^([^:%c]+):[ \t]*(.-)[ \t]*$" )
+                    -- name = token with NO whitespace and no control
+                    -- (RFC 7230 forbids OWS before the colon; allowing
+                    -- it - e.g. "Content-Length : 5" - would let a
+                    -- spaced name dodge the CL/TE smuggling classifier
+                    -- below, which compares the lowercased name to the
+                    -- exact strings).
+                    local name, value = string_match( line, "^([^:%c ]+):[ \t]*(.-)[ \t]*$" )
                     if not name then
                         return emit{ reject = 400 }
                     end

--- a/core/iostream.lua
+++ b/core/iostream.lua
@@ -61,16 +61,22 @@
 local use = use
 
 local string = use "string"
+local tonumber = use "tonumber"
 local setmetatable = use "setmetatable"
 
 local string_find = string.find
 local string_sub = string.sub
 local string_gsub = string.gsub
 local string_len = string.len
+local string_lower = string.lower
+local string_match = string.match
+local string_gmatch = string.gmatch
 
 local newadclinestage
 local newpassthroughstage
 local newpipeline
+local newhttpstage
+local newhttppipeline
 
 ----------------------------------// DEFINITION //--
 
@@ -185,6 +191,177 @@ newpipeline = function( maxlen )
 
 end    -- newpipeline
 
+-- Hardened HTTP/1.x request-framer stage (Phase 8 S3, drives #82).
+--
+-- Emits exactly ONE unit then goes inert (one request per connection;
+-- the caller responds with Connection: close and closes - this kills
+-- keep-alive request smuggling and slowloris-via-many-requests). The
+-- unit is either a parsed request
+--   { method=, target=, version=, headers={lowercased name -> value} }
+-- or a transport-level rejection { reject = <http status int> }. The
+-- router (core/http.lua) maps a reject status to a canned response and
+-- otherwise decides path/method semantics (404/405). This stage does
+-- ONLY transport hardening; it never reads a body (read-only S3:
+-- GET/HEAD only, any body/Content-Length>0/Transfer-Encoding -> 400).
+--
+-- Every limit lives here so it is unit-testable in isolation.
+newhttpstage = function( )
+
+    local MAXREQ      = 16384    -- total request-line + headers cap
+    local MAXLINE     = 8192     -- request-line cap
+    local MAXTARGET   = 2048     -- request-target cap
+    local MAXHDRS     = 100      -- header count cap
+    local MAXHDRLINE  = 8192     -- single header line cap
+
+    local buf = ""
+    local done = false
+
+    local emit = function( unit )
+        done = true
+        return { unit }, false
+    end
+
+    local push = function( _, chunk )
+        if done then
+            return { }, false    -- single request already produced; ignore trailing bytes
+        end
+        if chunk and chunk ~= "" then
+            buf = buf .. chunk
+        end
+
+        local hdrend = string_find( buf, "\r\n\r\n", 1, true )
+        if not hdrend then
+            -- headers not complete yet; bound the wait (slowloris /
+            -- unbounded buffer): oversize before terminator -> 431.
+            if string_len( buf ) > MAXREQ then
+                return emit{ reject = 431 }
+            end
+            return { }, false
+        end
+        if hdrend > MAXREQ then
+            return emit{ reject = 431 }
+        end
+
+        local head = string_sub( buf, 1, hdrend - 1 )    -- request-line + header lines, no trailing CRLFCRLF
+
+        -- request-line
+        local rlend = string_find( head, "\r\n", 1, true )
+        local requestline = ( rlend and string_sub( head, 1, rlend - 1 ) ) or head
+        if string_len( requestline ) > MAXLINE then
+            return emit{ reject = 414 }
+        end
+        if string_find( requestline, "%c" ) then    -- no NUL / control (CR/LF already split out)
+            return emit{ reject = 400 }
+        end
+        local method, target, version = string_match( requestline, "^(%u+) (%S+) (HTTP/%d%.%d)$" )
+        if not method then
+            return emit{ reject = 400 }
+        end
+        if version ~= "HTTP/1.0" and version ~= "HTTP/1.1" then
+            return emit{ reject = 505 }
+        end
+        if string_len( target ) > MAXTARGET then
+            return emit{ reject = 414 }
+        end
+        if string_sub( target, 1, 1 ) ~= "/" then
+            return emit{ reject = 400 }
+        end
+        if string_find( target, "..", 1, true ) then    -- path traversal
+            return emit{ reject = 400 }
+        end
+
+        -- header lines
+        local headers = { }
+        local count = 0
+        local cl_count = 0
+        local te_seen = false
+        local rest = ( rlend and string_sub( head, rlend + 2 ) ) or ""
+        if rest ~= "" then
+            for line in string_gmatch( rest .. "\r\n", "(.-)\r\n" ) do
+                if line ~= "" then
+                    count = count + 1
+                    if count > MAXHDRS then
+                        return emit{ reject = 431 }
+                    end
+                    if string_len( line ) > MAXHDRLINE then
+                        return emit{ reject = 431 }
+                    end
+                    local name, value = string_match( line, "^([^:%c]+):[ \t]*(.-)[ \t]*$" )
+                    if not name then
+                        return emit{ reject = 400 }
+                    end
+                    if string_find( value, "%c" ) then    -- no NUL / control in value
+                        return emit{ reject = 400 }
+                    end
+                    name = string_lower( name )
+                    if name == "content-length" then
+                        cl_count = cl_count + 1
+                    elseif name == "transfer-encoding" then
+                        te_seen = true
+                    end
+                    headers[ name ] = value
+                end
+            end
+        end
+
+        -- body / request-smuggling rules (read-only S3: no body at all)
+        if te_seen then
+            return emit{ reject = 400 }    -- any Transfer-Encoding (incl. chunked) rejected outright
+        end
+        if cl_count > 1 then
+            return emit{ reject = 400 }    -- multiple Content-Length
+        end
+        local cl = headers[ "content-length" ]
+        if cl then
+            if not string_match( cl, "^%d+$" ) then
+                return emit{ reject = 400 }
+            end
+            if tonumber( cl ) ~= 0 then
+                return emit{ reject = 400 }    -- non-zero body not allowed
+            end
+        end
+
+        return emit{ method = method, target = target, version = version, headers = headers }
+    end
+
+    return setmetatable( { }, { __index = { push = push } } )
+
+end    -- newhttpstage
+
+-- newhttppipeline( maxlen ) -> pipeline whose single stage is the
+-- hardened HTTP request framer. Same object shape / :feed contract as
+-- newpipeline so server.lua selects it via `listeners.pipeline`
+-- without any other change. `maxlen` is accepted for call-site
+-- symmetry; the HTTP stage enforces its own (tighter) caps.
+newhttppipeline = function( maxlen )
+
+    local stages = { newhttpstage( ) }
+
+    local feed = function( _, bytes )
+        local units = { bytes or "" }
+        local overflow = false
+        for s = 1, #stages do
+            local stage = stages[ s ]
+            local out, m = { }, 0
+            for u = 1, #units do
+                local produced, ov = stage:push( units[ u ] )
+                if ov then
+                    overflow = true
+                end
+                for i = 1, #produced do
+                    m = m + 1
+                    out[ m ] = produced[ i ]
+                end
+            end
+            units = out
+        end
+        return units, overflow
+    end
+
+    return setmetatable( { }, { __index = { feed = feed } } )
+
+end    -- newhttppipeline
+
 ----------------------------------// PUBLIC INTERFACE //--
 
 return {
@@ -192,5 +369,7 @@ return {
     newpipeline         = newpipeline,
     newadclinestage     = newadclinestage,
     newpassthroughstage = newpassthroughstage,
+    newhttpstage        = newhttpstage,
+    newhttppipeline     = newhttppipeline,
 
 }

--- a/core/server.lua
+++ b/core/server.lua
@@ -852,6 +852,15 @@ wrapconnection = function( server, listeners, socket, serverip, clientip, server
     _readlist[ _readlistlen ] = socket
     _readlist[ socket ] = _readlistlen
 
+    -- Arm the idle sweep at accept. Previously _activitytimes[handler]
+    -- was set only on the first read with bytes (_readbuffer, got>0),
+    -- so a connection that completes TCP accept and then sends NOTHING
+    -- was never swept (held until the client closes - a slowloris /
+    -- fd-exhaustion vector, especially on the no-handshake HTTP
+    -- listener). Initialising here bounds every connection by the
+    -- standard _max_idle_time regardless of listener type.
+    _activitytimes[ handler ] = _currenttime
+
     return handler, socket
 end
 

--- a/core/server.lua
+++ b/core/server.lua
@@ -440,12 +440,15 @@ wrapconnection = function( server, listeners, socket, serverip, clientip, server
     local bufferqueuelen = 0    -- end of buffer array
 
     -- Phase 8 S1/S2: inbound framing pipeline. Replaces LuaSocket's
-    -- internal "*l" line buffer; reassembles raw reads into ADC frames
+    -- internal "*l" line buffer; reassembles raw reads into frames
     -- across select() iterations. One per connection. The default
     -- pipeline is a single ADC-line stage, so :feed() is byte-for-byte
-    -- identical to the S1 framer; later steps (S3 HTTP, S4 ZLIF, S5
-    -- BLOM) add/splice stages without touching this call site.
-    local inframer = iostream_newpipeline( _maxreadlen )
+    -- identical to the S1 framer. S3: a listener may supply its own
+    -- pipeline factory (e.g. the hardened HTTP framer for the #82 API
+    -- listener) via listeners.pipeline; ADC listeners set none and get
+    -- the default. Same :feed( bytes ) -> units, overflow contract
+    -- either way, so this is the only server.lua seam.
+    local inframer = ( listeners.pipeline or iostream_newpipeline )( _maxreadlen )
 
     local toclose
     local fatalerror
@@ -622,7 +625,12 @@ wrapconnection = function( server, listeners, socket, serverip, clientip, server
             local frames, overflow = inframer:feed( data )
             for i = 1, #frames do
                 local frame = frames[ i ]
-                if string_len( frame ) > maxreadlen then    -- mirror old per-line cap: drop, don't dispatch
+                -- The per-unit oversize cap is an ADC-line transport
+                -- concern: that stage emits string frames. Non-string
+                -- units (e.g. the HTTP framer's parsed-request /
+                -- { reject } tables) carry their own hardening inside
+                -- the stage and must not be string-length-checked here.
+                if type( frame ) == "string" and string_len( frame ) > maxreadlen then    -- mirror old per-line cap: drop, don't dispatch
                     handler.close( "receive buffer exceeded" )
                     return false
                 end

--- a/docs/phases/PHASE_8_IO.md
+++ b/docs/phases/PHASE_8_IO.md
@@ -333,6 +333,47 @@ binds the HTTP listener (pipeline = `[httpstage]`, dispatch ->
   §1a.6 + §1.1): the new network listener is the highest-risk
   surface added since the modernisation.
 
+
+### Finding 2026-05-15 (S3 security review, BLOCKER B1 + C1-C5)
+
+The mandatory security-focused two-pass review (independent agent +
+maintainer spot-check vs source) found, and S3 fixed in-branch:
+
+- **B1 (BLOCKER) - HTTP listener bound 0.0.0.0, not 127.0.0.1.**
+  `server.addserver` binds `p.addr` (default `"*"`); it never reads
+  `p.ip`. hub.lua passed `ip = "127.0.0.1"` -> silently ignored ->
+  the unauthenticated, no-TLS HTTP socket was exposed on ALL
+  interfaces, nullifying the entire loopback-only security premise.
+  Fix: pass `addr = "127.0.0.1"` (the param addserver actually
+  reads). Smoke now asserts the listener is unreachable on a
+  non-loopback address. The pre-existing ADC-side `hub_listen`
+  ignored / `addserver` dead range-clause are tracked separately as
+  #186 (CLAUDE.md §7, no drive-by).
+- **C1 - zero-byte connection slowloris.** `_activitytimes[handler]`
+  was armed only on first read with bytes, so a connect-and-send-
+  nothing was never idle-swept. Fixed: armed at accept in
+  wrapconnection (bounds every connection by the standard
+  `_max_idle_time`, all listener types).
+- **C2 - http_port validator had no range/integer check** (0 / floats
+  slipped through). Now: false, or integer 1..65535.
+- **C3 - http_port colliding with an ADC port** silently failed to
+  bind. Now: explicit `out_error` and the HTTP API is not started
+  (fail loud).
+- **C4 - header name whitespace bypass.** `Content-Length : 0`
+  matched the old name pattern, dodging the CL/TE smuggling
+  classifier. Pattern tightened to reject any whitespace in the
+  header name (-> 400). Unit-tested.
+- **C5 - the loopback property was untested** (smoke connected to
+  127.0.0.1, which a 0.0.0.0 bind also accepts, so it was green with
+  B1 live). Added the non-loopback-unreachable smoke assertion.
+
+Everything else in the hardening contract held: the reviewer could
+not smuggle, DoS the framer, leak info, or escape the sandbox; the
+type-guard does not weaken S1/S2; HTTP never enters hub user
+machinery. This is exactly the §1a.5 "verify every assumption
+against current source" miss the security two-pass gate exists to
+catch.
+
 ## Log
 
 - 2026-05-15: phase opened, integration branch `phase8-io` created, design
@@ -384,3 +425,8 @@ binds the HTTP listener (pipeline = `[httpstage]`, dispatch ->
   units carry their own in-stage hardening). Full smoke green on
   Windows; iostream_test 35/35. Next: security-focused two-pass review
   -> sub-PR into phase8-io.
+- 2026-05-15: S3 security two-pass review found BLOCKER B1 (HTTP
+  listener bound 0.0.0.0 not 127.0.0.1 - addserver reads p.addr,
+  not p.ip) + C1-C5; all fixed in-branch (see finding above). N4
+  pre-existing hub_listen/addserver bugs tracked as #186. Re-run
+  security review on the fixes before sub-PR.

--- a/docs/phases/PHASE_8_IO.md
+++ b/docs/phases/PHASE_8_IO.md
@@ -249,6 +249,90 @@ stays green unchanged (neutrality proof). Risk is well below S1 -
 the dangerous `*l` -> raw socket change is already shipped; S2 only
 restructures the byte/frame flow already in our hands.
 
+## S3 spec (locked 2026-05-15, maintainer-approved - SECURITY-CRITICAL)
+
+First *additive* step: an HTTP request-framer stage so the pipeline
+can also carry an HTTP listener (drives #82). **Scope split decision:**
+S3 ships ONLY the hardened framing + listener substrate + a trivial
+`/health` endpoint (no auth, no data). #82 phase-1 proper (token
+auth, `/users` `/stats` `/version`, JSON) is a SEPARATE follow-up PR
+with its own security-focused review - the sensitive auth / data
+exposure work must not be bundled with IO plumbing.
+
+Default behaviour change: **none**. No `http_port` in cfg -> no HTTP
+listener bound -> existing hubs byte-unaffected. Purely additive.
+
+**JSON:** deferred to the endpoints PR (S3 `/health` needs none).
+Decision criteria recorded now so it is not relitigated: prefer
+`dkjson` (pure-Lua, no new C dep / build change / supply-chain
+surface; the read-only API only *serialises* trusted hub state and
+never *parses* untrusted JSON input). Final call in the endpoints PR.
+
+### Hardening contract (S3 MUST enforce all of these)
+
+Module split (CLAUDE.md §2): the hardened parser is
+`iostream.newhttpstage` (pure bytes -> request-unit, unit-testable in
+isolation - this is where every limit lives); `core/http.lua` (new)
+is the request router (parsed request -> response); `server.lua` only
+binds the HTTP listener (pipeline = `[httpstage]`, dispatch ->
+`http.handle`).
+
+- **Listener:** bind `127.0.0.1` only; bind nothing unless cfg
+  `http_port` is set (default unset). No HTTPS on the API port (#82:
+  reverse-proxy assumed for non-loopback; out of scope here). The new
+  listener still goes through `ratelimit.accept_ip` (per-IP accept
+  cap) and the existing handshake-deadline / idle-timeout in
+  server.lua.
+- **One request per connection.** No keep-alive: parse one request,
+  respond, `Connection: close`, close. Eliminates keep-alive request
+  smuggling and slowloris-via-many-requests in one stroke; read-only
+  health/stat probes do not need pipelining.
+- **Request-line:** length cap; method in {GET, HEAD} only (else
+  405); HTTP version in {HTTP/1.0, HTTP/1.1} only (else 505);
+  request-target must start with `/`, length cap, reject NUL / CR /
+  LF / control bytes / `..` traversal.
+- **Headers:** cap total header bytes, header count, single-line
+  length; reject NUL/control in names/values; case-insensitive field
+  names.
+- **Body / smuggling:** GET/HEAD carry no body - any `Content-Length`
+  > 0 or any `Transfer-Encoding` -> 400. `Content-Length` AND
+  `Transfer-Encoding` both present -> 400. Multiple `Content-Length`
+  -> 400. `Transfer-Encoding: chunked` is rejected outright (the
+  classic smuggling vector; never needed for read-only GET).
+- **Oversize / slowloris:** an unterminated request that exceeds the
+  cap trips the pipeline overflow (S1/S2 mechanism) -> connection
+  closed. The per-connection idle timeout already bounds a stalled
+  request.
+- **Response:** minimal fixed headers (`Content-Type: text/plain`,
+  `Content-Length`, `Connection: close`); **no `Server` header** (no
+  version fingerprint pre-auth). Body for `/health` is a tiny static
+  `ok\n` (200). Everything else: 400 (malformed) / 404 (unknown
+  path) / 405 (method) / 505 (version). HEAD = same status/headers,
+  empty body.
+- **Logging:** malformed/oversize/rejected requests logged at low
+  verbosity via `out`; never log the body; sanitise the path in log
+  lines (no log injection via CR/LF - already rejected, defence in
+  depth).
+
+### S3 acceptance
+
+- `iostream_test.lua` extended with httpstage hardening cases, each
+  asserting the reject: oversize request-line/header, header-count
+  cap, `CL`+`TE` together, multiple `CL`, `chunked` rejected,
+  body-on-GET, bad method (405), bad version (505), NUL/CRLF in
+  path, `..` traversal, partial-request reassembly across feeds,
+  the happy `GET /health` and `HEAD /health` paths.
+- Smoke: HTTP roundtrip test (staging cfg enables `http_port`):
+  `GET /health` -> 200 `ok`; malformed -> 400; unknown path -> 404;
+  bad method -> 405. Existing ADC smoke unaffected (no http_port in
+  the default path = no listener).
+- `tests/unit/iostream_test.lua` wired into CI (smoke.yml) in S3
+  (closes the S2 deferred gate early - S3 adds a second testable
+  stage that needs the same net).
+- Mandatory two-pass review is **security-focused** (CLAUDE.md
+  §1a.6 + §1.1): the new network listener is the highest-risk
+  surface added since the modernisation.
+
 ## Log
 
 - 2026-05-15: phase opened, integration branch `phase8-io` created, design
@@ -283,3 +367,20 @@ restructures the byte/frame flow already in our hands.
   touches the build/CI for the zlib dependency, so the lua-unit
   runner is in-scope there; the pipeline `prepend` seam gets its
   first production caller in S4 and must be CI-guarded by then.
+- 2026-05-15: S3 implemented on branch phase8-io-s3 - hardened HTTP
+  request framer (iostream.newhttpstage + newhttppipeline), core/http.lua
+  /health router, server.lua per-listener pipeline seam
+  (listeners.pipeline), hub.lua 127.0.0.1-only HTTP listener gated on
+  cfg http_port (default false), http_port added to cfg_defaults +
+  examples/cfg. iostream_test.lua extended to 35 checks (HTTP hardening:
+  TE/CL smuggling, oversize 414/431, bad version 505, traversal,
+  control bytes, obs-fold, partial reassembly, one-req-per-conn) and
+  WIRED INTO CI (smoke.yml lua5.4 step, Linux job) - closes the S2
+  deferred gate early. Smoke gained an HTTP /health roundtrip +
+  hardening + ADC-still-works test. Integration bug found+fixed during
+  smoke: _readbuffer's per-unit oversize cap did `string_len(frame)`
+  assuming string frames (true for S1/S2 ADC-line) but S3 emits table
+  units -> type-guarded the cap (ADC behaviour identical; non-string
+  units carry their own in-stage hardening). Full smoke green on
+  Windows; iostream_test 35/35. Next: security-focused two-pass review
+  -> sub-PR into phase8-io.

--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -31,6 +31,8 @@ return { -- the settings are a lua table, do not tough this!
     tcp_ports_ipv6 = { },  -- listen on these ports for normal tcp IPv6 connections (e.g.: adc://<address>:<port>) (integer array); empty {} = TLS-only
     ssl_ports_ipv6 = { 5003 },  -- listen on these ports for ssl tcp IPv6 connections (e.g.: adcs://<address>:<port>) (integer array); to use more than one port use: { port, port, port },
 
+    http_port = false,  -- local read-only HTTP API (#82): false = OFF (default, no socket bound); a number = bind hardened HTTP framer on 127.0.0.1:<n> ONLY (loopback; use a reverse proxy for non-loopback). S3 serves only /health; auth + data endpoints come in a later release
+
     use_ssl = true,  -- use ssl (boolean); you have to make a cert for adcs!; use "certs/make_cert.bat/.sh" or "Luadch-NG Certmanager"
 
     hub_website = "https://yourwebsite.org",  -- your website (string)

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -1904,6 +1904,37 @@ def test_http_health_roundtrip(staging_dir: Path, proc=None):
                 f"HTTP {label}: expected {want}, got {status(r)!r}"
             )
 
+    # SECURITY: the HTTP listener MUST be loopback-only (no TLS / no
+    # auth is only acceptable because it is 127.0.0.1-bound). Prove it
+    # is NOT reachable on this host's non-loopback address. Skipped
+    # only if the environment has no usable non-loopback IPv4 (some
+    # locked-down CI net namespaces) - never failed spuriously.
+    nonloop = None
+    try:
+        probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            probe.connect(("8.8.8.8", 80))  # no packets sent; just resolves the local addr
+            cand = probe.getsockname()[0]
+        finally:
+            probe.close()
+        if cand and not cand.startswith("127.") and cand != "0.0.0.0":
+            nonloop = cand
+    except OSError:
+        nonloop = None
+    if nonloop:
+        try:
+            c = socket.create_connection((nonloop, TEST_PORT_HTTP), timeout=2)
+            c.close()
+            raise TestFailure(
+                f"SECURITY: HTTP listener reachable on non-loopback "
+                f"{nonloop}:{TEST_PORT_HTTP} - it must bind 127.0.0.1 "
+                f"only (regression of B1: addr vs ip)."
+            )
+        except (ConnectionRefusedError, socket.timeout, OSError):
+            pass  # expected: refused/unreachable off-loopback
+    else:
+        log("  (skip non-loopback bind check: no non-loopback IPv4)")
+
     # ADC path still works alongside the HTTP listener
     with socket.create_connection(
         (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -49,6 +49,7 @@ TEST_PORT_PLAIN = 15500
 TEST_PORT_TLS = 15501
 TEST_PORT_PLAIN_V6 = 15502
 TEST_PORT_TLS_V6 = 15503
+TEST_PORT_HTTP = 15510    # Phase 8 S3: local HTTP API listener (#82)
 
 HUB_HOST = "127.0.0.1"
 
@@ -1803,6 +1804,115 @@ def test_dual_stack_same_port_binds(staging_dir: Path, proc=None):
             )
 
 
+def _switch_to_http_mode(staging_dir: Path, current_proc, current_log_file):
+    """Phase 8 S3 (#82) setup: stop the hub, flip `http_port = false`
+    to a test port so the next test can exercise the local HTTP API
+    listener. ADC ports are left as-is - the test also re-checks an
+    ADC handshake to prove the per-listener pipeline selection did not
+    disturb the ADC path. Returns the new (proc, log_file)."""
+    stop_hub(current_proc, current_log_file)
+
+    cfg_path = staging_dir / "cfg" / "cfg.tbl"
+    text = cfg_path.read_text(encoding="utf-8")
+    new_text, n = re.subn(
+        r"http_port\s*=\s*false",
+        f"http_port = {TEST_PORT_HTTP}",
+        text,
+        count=1,
+    )
+    if n != 1:
+        raise TestFailure(
+            "could not flip http_port = false to a test port in cfg.tbl "
+            "(is the http_port key present in examples/cfg/cfg.tbl?)"
+        )
+    cfg_path.write_text(new_text, encoding="utf-8")
+
+    time.sleep(1.0)
+    proc, log_file = start_hub(staging_dir)
+    return proc, log_file
+
+
+def _http_roundtrip(raw_request: bytes) -> str:
+    """Open a fresh connection to the HTTP listener, send a raw
+    request, read until the server closes (the hub always answers
+    Connection: close - one request per connection), return the
+    decoded response."""
+    with socket.create_connection(
+        (HUB_HOST, TEST_PORT_HTTP), timeout=PROTOCOL_TIMEOUT_SEC
+    ) as s:
+        s.sendall(raw_request)
+        chunks = []
+        s.settimeout(PROTOCOL_TIMEOUT_SEC)
+        while True:
+            try:
+                c = s.recv(4096)
+            except socket.timeout:
+                break
+            if not c:
+                break
+            chunks.append(c)
+    return b"".join(chunks).decode("latin-1", errors="replace")
+
+
+def test_http_health_roundtrip(staging_dir: Path, proc=None):
+    """Phase 8 S3: the hardened HTTP framer + /health router answer
+    correctly and the security posture holds.
+
+    - GET /health -> 200, body "ok", Connection: close, NO Server header
+    - HEAD /health -> 200, same headers, empty body
+    - unknown path -> 404; non-GET/HEAD -> 405
+    - malformed request-line -> 400; bad HTTP version -> 505
+    - Transfer-Encoding (smuggling vector) -> 400
+    - the ADC listener still handshakes (per-listener pipeline
+      selection did not regress the ADC path)
+    """
+    wait_for_port(HUB_HOST, TEST_PORT_HTTP, START_TIMEOUT_SEC)
+
+    def status(resp):
+        return resp.split("\r\n", 1)[0]
+
+    # 1. happy path
+    r = _http_roundtrip(b"GET /health HTTP/1.1\r\nHost: x\r\n\r\n")
+    if "200 OK" not in status(r):
+        raise TestFailure(f"GET /health: expected 200, got {status(r)!r}")
+    if "\r\n\r\nok" not in r:
+        raise TestFailure(f"GET /health: body 'ok' missing; resp={r!r}")
+    if "Connection: close" not in r:
+        raise TestFailure("GET /health: missing Connection: close")
+    if "server:" in r.lower():
+        raise TestFailure(f"Server header leaked (fingerprint): {r!r}")
+
+    # 2. HEAD: same status, empty body
+    r = _http_roundtrip(b"HEAD /health HTTP/1.1\r\n\r\n")
+    if "200 OK" not in status(r):
+        raise TestFailure(f"HEAD /health: expected 200, got {status(r)!r}")
+    if r.split("\r\n\r\n", 1)[1] != "":
+        raise TestFailure(f"HEAD /health: body must be empty; resp={r!r}")
+
+    # 3. unknown path / 4. bad method / 5. malformed / 6. bad version /
+    #    7. smuggling - each must get the right hard status
+    for label, req, want in [
+        ("unknown path", b"GET /nope HTTP/1.1\r\n\r\n", "404"),
+        ("bad method", b"DELETE /health HTTP/1.1\r\n\r\n", "405"),
+        ("malformed reqline", b"GET/health HTTP/1.1\r\n\r\n", "400"),
+        ("bad version", b"GET /health HTTP/2.0\r\n\r\n", "505"),
+        ("TE smuggling", b"GET /health HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n", "400"),
+    ]:
+        r = _http_roundtrip(req)
+        if want not in status(r):
+            raise TestFailure(
+                f"HTTP {label}: expected {want}, got {status(r)!r}"
+            )
+
+    # ADC path still works alongside the HTTP listener
+    with socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    ) as s:
+        s.sendall(b"HSUP ADBASE ADTIGR\n")
+        reader = _ADCReader(s)
+        reader.recv_until(lambda f: f.startswith("ISUP "))
+
+
 def _switch_to_public_hub_mode(staging_dir: Path, current_proc, current_log_file):
     """#162 setup: stop the hub, flip reg_only to false in cfg.tbl,
     restart. Required so the next test exercises the
@@ -2325,6 +2435,20 @@ def main():
             failed.append("dual-stack same-port binding (#107)")
         else:
             log("PASS  dual-stack same-port binding (#107)")
+
+        # Phase 8 S3 (#82): enable the local HTTP API and exercise the
+        # hardened framer + /health router (last test - mutates
+        # http_port; no later test depends on it).
+        try:
+            proc, log_file = _switch_to_http_mode(
+                staging_dir, proc, log_file
+            )
+            test_http_health_roundtrip(staging_dir, proc=proc)
+        except Exception as e:
+            log(f"FAIL  HTTP /health roundtrip + hardening (#82 S3): {e}")
+            failed.append("HTTP /health roundtrip + hardening (#82 S3)")
+        else:
+            log("PASS  HTTP /health roundtrip + hardening (#82 S3)")
     finally:
         if proc is not None:
             stop_hub(proc, log_file)

--- a/tests/unit/iostream_test.lua
+++ b/tests/unit/iostream_test.lua
@@ -176,6 +176,8 @@ eq( "http: non-numeric Content-Length -> 400",
     du( httpreq( "GET /health HTTP/1.1" .. CRLF .. "Content-Length: ab" .. CRLF .. CRLF ) ), "reject=400" )
 eq( "http: obs-fold continuation rejected -> 400",
     du( httpreq( "GET /health HTTP/1.1" .. CRLF .. "X: a" .. CRLF .. " cont" .. CRLF .. CRLF ) ), "reject=400" )
+eq( "http: whitespace in header name rejected -> 400 (CL/TE classifier bypass)",
+    du( httpreq( "GET /health HTTP/1.1" .. CRLF .. "Content-Length : 0" .. CRLF .. CRLF ) ), "reject=400" )
 eq( "http: oversize request-line -> 414",
     du( httpreq( "GET /" .. string.rep( "a", 9000 ) .. " HTTP/1.1" .. CRLF .. CRLF ) ), "reject=414" )
 

--- a/tests/unit/iostream_test.lua
+++ b/tests/unit/iostream_test.lua
@@ -29,9 +29,17 @@
 
 ]]--
 
--- minimal sandbox shim: core/iostream.lua does `local x = use "x"`
-local _real = { string = string, table = table, setmetatable = setmetatable }
-_G.use = function( name ) return _real[ name ] end
+-- minimal sandbox shim: core/iostream.lua does `local x = use "x"`.
+-- Keep this in lockstep with iostream.lua's `use` imports.
+local _real = {
+    string = string, table = table,
+    setmetatable = setmetatable, tonumber = tonumber,
+}
+_G.use = function( name )
+    local v = _real[ name ]
+    assert( v ~= nil, "iostream_test shim missing dep: use \"" .. name .. "\"" )
+    return v
+end
 
 local iostream = assert( loadfile( "core/iostream.lua" ) )( )
 
@@ -113,6 +121,86 @@ end } } )
 p:prepend( crstage )
 eq( "prepend ordering: stage runs before framer",
     j( ( p:feed( "aXbXc" .. NL ) ) ), "[abc]" )
+
+----------------------------------------------------------------------
+-- S3: hardened HTTP request-framer stage. Each reject case asserts the
+-- transport-level rejection status; the happy cases assert the parsed
+-- request. (Method policy 404/405 is the router's job, not the
+-- framer's - see core/http.lua - so DELETE frames OK here.)
+----------------------------------------------------------------------
+
+local CRLF = CR .. NL
+-- single-feed helper: returns the one emitted unit (or nil)
+local function httpreq( s )
+    local st = iostream.newhttpstage( )
+    local u = st:push( s )
+    return u[ 1 ]
+end
+-- describe a unit as a stable comparable string
+local function du( u )
+    if not u then return "NONE" end
+    if u.reject then return "reject=" .. u.reject end
+    return u.method .. " " .. u.target .. " " .. u.version
+end
+
+eq( "http: GET /health",
+    du( httpreq( "GET /health HTTP/1.1" .. CRLF .. "Host: x" .. CRLF .. CRLF ) ),
+    "GET /health HTTP/1.1" )
+eq( "http: HEAD /health 1.0",
+    du( httpreq( "HEAD /health HTTP/1.0" .. CRLF .. CRLF ) ),
+    "HEAD /health HTTP/1.0" )
+eq( "http: framer passes non-GET/HEAD (router 405s)",
+    du( httpreq( "DELETE /health HTTP/1.1" .. CRLF .. CRLF ) ),
+    "DELETE /health HTTP/1.1" )
+eq( "http: Content-Length: 0 accepted",
+    du( httpreq( "GET /health HTTP/1.1" .. CRLF .. "Content-Length: 0" .. CRLF .. CRLF ) ),
+    "GET /health HTTP/1.1" )
+
+eq( "http: bad version -> 505",
+    du( httpreq( "GET /health HTTP/2.0" .. CRLF .. CRLF ) ), "reject=505" )
+eq( "http: no space in request-line -> 400",
+    du( httpreq( "GET/health HTTP/1.1" .. CRLF .. CRLF ) ), "reject=400" )
+eq( "http: target not /-rooted -> 400",
+    du( httpreq( "GET health HTTP/1.1" .. CRLF .. CRLF ) ), "reject=400" )
+eq( "http: path traversal -> 400",
+    du( httpreq( "GET /../etc HTTP/1.1" .. CRLF .. CRLF ) ), "reject=400" )
+eq( "http: control byte in request-line -> 400",
+    du( httpreq( "GET /h" .. string.char( 1 ) .. " HTTP/1.1" .. CRLF .. CRLF ) ), "reject=400" )
+eq( "http: Transfer-Encoding rejected outright -> 400",
+    du( httpreq( "GET /health HTTP/1.1" .. CRLF .. "Transfer-Encoding: chunked" .. CRLF .. CRLF ) ), "reject=400" )
+eq( "http: multiple Content-Length -> 400",
+    du( httpreq( "GET /health HTTP/1.1" .. CRLF .. "Content-Length: 0" .. CRLF .. "Content-Length: 0" .. CRLF .. CRLF ) ), "reject=400" )
+eq( "http: non-zero body (Content-Length) -> 400",
+    du( httpreq( "GET /health HTTP/1.1" .. CRLF .. "Content-Length: 5" .. CRLF .. CRLF ) ), "reject=400" )
+eq( "http: non-numeric Content-Length -> 400",
+    du( httpreq( "GET /health HTTP/1.1" .. CRLF .. "Content-Length: ab" .. CRLF .. CRLF ) ), "reject=400" )
+eq( "http: obs-fold continuation rejected -> 400",
+    du( httpreq( "GET /health HTTP/1.1" .. CRLF .. "X: a" .. CRLF .. " cont" .. CRLF .. CRLF ) ), "reject=400" )
+eq( "http: oversize request-line -> 414",
+    du( httpreq( "GET /" .. string.rep( "a", 9000 ) .. " HTTP/1.1" .. CRLF .. CRLF ) ), "reject=414" )
+
+-- header-count cap -> 431
+local manyhdrs = "GET /health HTTP/1.1" .. CRLF
+for i = 1, 150 do manyhdrs = manyhdrs .. "X-h" .. i .. ": v" .. CRLF end
+eq( "http: >100 headers -> 431", du( httpreq( manyhdrs .. CRLF ) ), "reject=431" )
+
+-- oversize total before terminator -> 431 (slowloris / unbounded buf)
+local big = iostream.newhttpstage( )
+eq( "http: oversize pre-terminator -> 431",
+    du( ( big:push( "GET /health HTTP/1.1" .. CRLF .. "X: " .. string.rep( "a", 17000 ) ) )[ 1 ] ),
+    "reject=431" )
+
+-- partial request reassembled across feeds
+local hp = iostream.newhttpstage( )
+eq( "http: partial feed 1 -> no unit", j( ( hp:push( "GET /heal" ) ) ), "[]" )
+local hp2 = ( hp:push( "th HTTP/1.1" .. CRLF .. CRLF ) )[ 1 ]
+eq( "http: partial feed 2 -> request", du( hp2 ), "GET /health HTTP/1.1" )
+
+-- one request per connection: stage goes inert after the first
+local hi = iostream.newhttpstage( )
+hi:push( "GET /health HTTP/1.1" .. CRLF .. CRLF )
+eq( "http: inert after first request",
+    j( ( hi:push( "GET /again HTTP/1.1" .. CRLF .. CRLF ) ) ), "[]" )
 
 ----------------------------------------------------------------------
 


### PR DESCRIPTION
**Sub-PR into `phase8-io`** (not master). First *additive* IO step. Scope split: S3 ships ONLY the hardened framing/listener substrate + `/health` (no auth, no data). #82's token-auth + `/users` `/stats` `/version` + JSON is a separate security-reviewed follow-up.

Default behaviour unchanged: no `http_port` in cfg => no HTTP socket => existing hubs byte-unaffected.

## What

- `iostream.newhttpstage` + `newhttppipeline`: hardened HTTP/1.x request framer (one request/connection then inert). All limits in-stage, unit-testable: request-line/header/target/count caps; rejects any body / `Content-Length`>0 / `Transfer-Encoding` (chunked smuggling) / dup CL / obs-fold / control bytes / traversal / bad version (505) / oversize (414/431) / whitespace-in-header-name.
- `core/http.lua`: `/health` router. No `Server` header, fixed minimal headers, `Connection: close`, sanitised logs.
- `core/server.lua`: per-listener pipeline seam (`listeners.pipeline`); type-guarded the per-unit oversize cap (HTTP units are tables); arm idle-sweep at accept.
- `core/hub.lua`: HTTP listener on **127.0.0.1 only**, gated on cfg `http_port` (default false), with an ADC-port-collision fail-loud guard.
- cfg `http_port` (false-or-int-1..65535); examples/cfg documented.
- `tests/unit/iostream_test.lua`: 36 checks, **wired into CI** (smoke.yml lua5.4 step) - closes the S2-deferred gate early. Smoke: HTTP roundtrip + hardening + non-loopback-unreachable + ADC-still-works.

## Security review (mandatory two-pass, §1a.6 + §1.1)

Independent agent + maintainer spot-check. Found **BLOCKER B1**: the listener bound `0.0.0.0` not `127.0.0.1` (`addserver` binds `p.addr`, not `p.ip`) - nullified the loopback-only premise. **Fixed** (`addr = "127.0.0.1"`) + 5 concerns (C1 zero-byte slowloris, C2 port-range validator, C3 ADC-port-collision, C4 header-name-whitespace classifier bypass, C5 the loopback property was untested). **Re-reviewed: all RESOLVED, no new defect, SAFE TO MERGE.**

Pre-existing `hub_listen`-ignored / `addserver` dead-clause bugs found during review are out of scope (§7) - tracked as #186.

## Verification

iostream_test 36/36; full smoke green on Windows incl. HTTP + non-loopback assertion + TLS + +setpass. Journal `docs/phases/PHASE_8_IO.md` has the full S3 spec + security finding + resolutions.