### PR TITLE
fix(server): honor hub_listen bind address (closes #186)

### DIFF
--- a/core/server.lua
+++ b/core/server.lua
@@ -821,7 +821,11 @@ addclient = function( address, port, listeners, pattern, sslctx, startssl )
     if type( listeners ) ~= "table" then
         err = "invalid listener table"
     end
-    if not type( port ) == "number" or not ( port >= 0 and port <= 65535 ) then
+    -- #186: same dead-guard parse bug as addserver (see comment
+    -- there). Fixed here too per CLAUDE.md s1a.1 (fix the pattern
+    -- everywhere) even though addclient currently has no in-tree
+    -- caller - a divergent broken copy is a defect.
+    if type( port ) ~= "number" or port % 1 ~= 0 or not ( port >= 1 and port <= 65535 ) then
         err = "invalid port"
     --elseif _server[ port ] then
     --    err =  "listeners on port '" .. port .. "' already exist"
@@ -856,7 +860,12 @@ addserver = function( p ) -- listeners, port, addr, pattern, sslctx, maxconnecti
     if type( p.listeners ) ~= "table" then
         err = "invalid listener table"
     end
-    if not type( p.port ) == "number" or not ( p.port >= 0 and p.port <= 65535 ) then
+    -- #186: the first clause was `not type( p.port ) == "number"`,
+    -- which parses as `(not type(p.port)) == "number"` -> always
+    -- false, so the type check was dead and only the range check ran
+    -- (and it accepted port 0 = OS-assigned ephemeral). Fixed to a
+    -- real integer-in-1..65535 check.
+    if type( p.port ) ~= "number" or p.port % 1 ~= 0 or not ( p.port >= 1 and p.port <= 65535 ) then
         err = "invalid port"
     elseif _server[ _serverkey( p.port, p.family ) ] then
         err =  "listeners on port '" .. p.port .. "' (" .. ( p.family or "ipv4" ) .. ") already exist"
@@ -867,7 +876,15 @@ addserver = function( p ) -- listeners, port, addr, pattern, sslctx, maxconnecti
         out_error( "server.lua: function 'addserver': ", err )
         return nil, err
     end
-    p.addr = p.addr or "*"
+    -- #186: addserver binds p.addr and never read p.ip, but every
+    -- ADC listener in hub.lua passes the hub_listen address as `ip`.
+    -- Result: hub_listen was silently ignored and the hub ALWAYS
+    -- bound 0.0.0.0 / in6addr_any regardless of an operator's
+    -- explicit bind restriction (exposure). Honour `ip` as the bind
+    -- address; explicit `addr` still wins (e.g. the loopback-pinned
+    -- HTTP listener); default "*" (bind-all) is unchanged so the
+    -- default hub_listen = { "*" } config behaves exactly as before.
+    p.addr = p.addr or p.ip or "*"
     local server, err
     -- The IPv6 socket here is created via luasocket.tcp6(), which in
     -- the bundled luasocket (see luasocket/src/inet.c inet_trycreate)

--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -31,6 +31,8 @@ return { -- the settings are a lua table, do not tough this!
     tcp_ports_ipv6 = { },  -- listen on these ports for normal tcp IPv6 connections (e.g.: adc://<address>:<port>) (integer array); empty {} = TLS-only
     ssl_ports_ipv6 = { 5003 },  -- listen on these ports for ssl tcp IPv6 connections (e.g.: adcs://<address>:<port>) (integer array); to use more than one port use: { port, port, port },
 
+    hub_listen = { "*" },  -- ADC listener bind address(es): "*" = all interfaces (default); e.g. { "127.0.0.1" } = loopback only. Applies to BOTH IPv4 + IPv6 listeners (a v4-only address yields no IPv6 listener)
+
     use_ssl = true,  -- use ssl (boolean); you have to make a cert for adcs!; use "certs/make_cert.bat/.sh" or "Luadch-NG Certmanager"
 
     hub_website = "https://yourwebsite.org",  -- your website (string)

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -1741,6 +1741,85 @@ def test_dual_stack_same_port_binds(staging_dir: Path, proc=None):
             )
 
 
+def _switch_to_hub_listen_loopback_mode(staging_dir: Path, current_proc, current_log_file):
+    """#186 setup: stop the hub, set hub_listen to loopback-only and
+    blank the IPv6 port arrays (a v4-only bind address yields no IPv6
+    listener by design - blanking them keeps the test about the v4
+    bind-restriction and avoids a noisy expected v6 bind failure).
+    Returns the new (proc, log_file)."""
+    stop_hub(current_proc, current_log_file)
+
+    cfg_path = staging_dir / "cfg" / "cfg.tbl"
+    text = cfg_path.read_text(encoding="utf-8")
+    rewrites = [
+        (r'hub_listen\s*=\s*\{[^}]*\}', 'hub_listen = { "127.0.0.1" }'),
+        (r"tcp_ports_ipv6\s*=\s*\{[^}]*\}", "tcp_ports_ipv6 = { }"),
+        (r"ssl_ports_ipv6\s*=\s*\{[^}]*\}", "ssl_ports_ipv6 = { }"),
+    ]
+    for pattern, replacement in rewrites:
+        new_text, n = re.subn(pattern, replacement, text, count=1)
+        if n != 1:
+            raise TestFailure(
+                f"could not apply {pattern!r} in cfg.tbl (is hub_listen "
+                f"present in examples/cfg/cfg.tbl?)"
+            )
+        text = new_text
+    cfg_path.write_text(text, encoding="utf-8")
+
+    time.sleep(1.0)
+    proc, log_file = start_hub(staging_dir)
+    return proc, log_file
+
+
+def test_hub_listen_honored(staging_dir: Path, proc=None):
+    """#186 regression: with hub_listen = { "127.0.0.1" } the ADC
+    listener MUST bind loopback only. Pre-fix, server.addserver bound
+    p.addr (never p.ip) so hub_listen was silently ignored and the hub
+    bound 0.0.0.0 regardless - an exposure for any operator who set a
+    bind restriction. This test FAILS pre-fix (reachable off-loopback)
+    and PASSES post-fix.
+
+    1. ADC handshake on 127.0.0.1:<plain> still works.
+    2. The same port is NOT reachable on this host's non-loopback
+       IPv4 (skipped only if the env has no routable non-loopback
+       address - never failed spuriously).
+    """
+    wait_for_port(HUB_HOST, TEST_PORT_PLAIN, START_TIMEOUT_SEC)
+
+    with socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    ) as s:
+        s.sendall(b"HSUP ADBASE ADTIGR\n")
+        reader = _ADCReader(s)
+        reader.recv_until(lambda f: f.startswith("ISUP "))
+
+    nonloop = None
+    try:
+        probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            probe.connect(("8.8.8.8", 80))  # no packets; resolves local addr
+            cand = probe.getsockname()[0]
+        finally:
+            probe.close()
+        if cand and not cand.startswith("127.") and cand != "0.0.0.0":
+            nonloop = cand
+    except OSError:
+        nonloop = None
+    if nonloop:
+        try:
+            c = socket.create_connection((nonloop, TEST_PORT_PLAIN), timeout=2)
+            c.close()
+            raise TestFailure(
+                f"SECURITY: ADC listener reachable on non-loopback "
+                f"{nonloop}:{TEST_PORT_PLAIN} despite hub_listen = "
+                f'{{ "127.0.0.1" }} (#186: hub_listen ignored).'
+            )
+        except (ConnectionRefusedError, socket.timeout, OSError):
+            pass  # expected: refused/unreachable off-loopback
+    else:
+        log("  (skip non-loopback check: no non-loopback IPv4)")
+
+
 def _switch_to_public_hub_mode(staging_dir: Path, current_proc, current_log_file):
     """#162 setup: stop the hub, flip reg_only to false in cfg.tbl,
     restart. Required so the next test exercises the
@@ -2261,6 +2340,19 @@ def main():
             failed.append("dual-stack same-port binding (#107)")
         else:
             log("PASS  dual-stack same-port binding (#107)")
+
+        # #186: hub_listen must actually restrict the bind address
+        # (last test - mutates hub_listen + blanks v6; nothing after).
+        try:
+            proc, log_file = _switch_to_hub_listen_loopback_mode(
+                staging_dir, proc, log_file
+            )
+            test_hub_listen_honored(staging_dir, proc=proc)
+        except Exception as e:
+            log(f"FAIL  hub_listen honored / loopback-only (#186): {e}")
+            failed.append("hub_listen honored / loopback-only (#186)")
+        else:
+            log("PASS  hub_listen honored / loopback-only (#186)")
     finally:
         if proc is not None:
             stop_hub(proc, log_file)


### PR DESCRIPTION
Closes #186. Pre-existing exposure found during the Phase 8 S3 HTTP-listener security review.

## Problem

`server.addserver` binds `p.addr` (default `"*"`) and **never reads `p.ip`**, but every ADC listener in `hub.lua` passes the `hub_listen` address as `ip=`. So `hub_listen` has never been honored - the hub always bound `0.0.0.0`/`in6addr_any`. An operator who set `hub_listen = { "127.0.0.1" }` (loopback-only behind a reverse proxy) was silently exposed on all interfaces.

## Fix

- `addserver`: `p.addr = p.addr or p.ip or "*"` - explicit `addr` still wins; default `hub_listen = { "*" }` stays bind-all (no default behaviour change).
- `addserver` **and** `addclient`: corrected the dead port guard (`(not type(x)) == "number"` was always false; port 0 slipped through) to a real integer-1..65535 check. Both copies fixed per CLAUDE.md §1a.1 (addclient has no in-tree caller but a divergent broken twin is a defect).
- `examples/cfg/cfg.tbl`: documents `hub_listen` + the v4/v6-shared footgun.
- Smoke: regression test (`hub_listen={"127.0.0.1"}` -> ADC unreachable off-loopback). **Verified FAILS pre-fix** (bound 0.0.0.0, reachable on the LAN IP `192.168.x`) and **PASSES post-fix** - a true §1a.7 differentiator.

## Review

Two-pass (independent agent + maintainer spot-check): no BLOCKER. The agent's CONCERN (the identical dead guard in `addclient`) was fixed in this PR per §1a.1 rather than deferred. Full smoke green on Windows.

## Backport (CLAUDE.md §8): master / 3.2.x only - do NOT backport to release/3.1.x

Operator-cfg-gated and fail-safe-by-default: the default `hub_listen = { "*" }` is bind-all on every release, so no operator on defaults is affected and this is **not a regression**. Impact is limited to operators who set a restricted `hub_listen` expecting it to work - which it never did in any released version (years-old, upstream-inherited). Not an attacker-triggerable CVE/crash. Per §8's high bar ("when in doubt, don't") this is master-only; the v3.2.0 release notes should call it out so operators who tried `hub_listen` know it now works (and the v4/v6 footgun). Maintainer's call.