### PR TITLE
Phase 8 S4a: iterator pipeline + outbound passthrough seam

### DIFF
--- a/core/iostream.lua
+++ b/core/iostream.lua
@@ -1,47 +1,115 @@
 --[[
 
-        iostream.lua - Phase 8 IO layer, steps S1 + S2
+        iostream.lua - Phase 8 IO layer, steps S1 + S2 + S3 + S4a
 
-        Per-connection inbound framing, extracted out of server.lua so
-        the server loop no longer relies on LuaSocket's "*l" line
-        pattern. server.lua reads raw bytes and feeds them to a
-        per-connection PIPELINE; the pipeline reassembles them into
-        newline-delimited ADC frames across reads (the buffer LuaSocket
-        used to own internally now lives here).
+        Per-connection inbound + outbound transform pipelines, extracted
+        out of server.lua so the server loop no longer relies on
+        LuaSocket's "*l" line pattern. server.lua reads raw bytes and
+        feeds them to a per-connection INBOUND pipeline; its terminal
+        stage reassembles them into newline-delimited ADC frames (or
+        hardened HTTP request units, on the HTTP listener) across
+        reads. Writes go through a per-connection OUTBOUND pipeline
+        before they hit the socket. The buffer LuaSocket used to own
+        internally now lives in our stages.
 
-        S2 generalises the S1 fixed framer into a composable pipeline of
-        STAGES. This is a behaviour-neutral proof step: the default
-        pipeline is exactly one stage (the ADC-line framer carrying the
-        S1 logic verbatim), so a 1-stage pipeline is byte-for-byte
-        identical to the old framer. The seam exists so later steps slot
-        in as stages without touching server.lua again:
+        S2 generalised S1's fixed framer into a composable pipeline of
+        stages. S3 added the hardened HTTP request-framer stage.
 
-          - S3 HTTP: an HTTP framer stage (bytes -> request units)
-          - S4 ZLIF: an inflate stage prepended ahead of the ADC-line
-            stage on ZON (bytes -> decompressed bytes)
-          - S5 BLOM: a counted-binary capture stage
+        S4a (this step) is again behaviour-neutral: it changes the
+        pipeline CONTRACT from "feed bytes -> get all frames" to a
+        lazy one-frame-at-a-time iterator, and adds an OUTBOUND
+        pipeline mirror (default = passthrough = byte-identical). The
+        old contract returned every frame an input chunk could
+        produce, which is wrong the moment a mid-stream stage swap is
+        possible: an input chunk "ZON\n<compressed bytes>" would have
+        the ADC-line stage read past the "\n" and emit garbage
+        "frames" out of the compressed suffix BEFORE the ZON
+        dispatcher gets a chance to splice in an inflate stage. S4b
+        will rely on this: the ZON handler calls
+        `pipeline:prepend( inflate_stage )` immediately after
+        dispatching the ZON frame, the residual suffix the ADC-line
+        stage had buffered gets re-fed through the new front stage,
+        and no garbage was emitted because the outer loop only asks
+        for the next frame AFTER each dispatch returns.
 
-        Stage contract:
+        Inbound stage contract (S4a):
 
-            stage:push( chunk ) -> units, overflow
+            stage:push( chunk ) -> unit, overflow
 
-          - `chunk`    : a byte string from the previous stage (raw
-                         socket bytes for stage 1).
-          - `units`    : ordered array of whatever this stage emits.
+          - `chunk`    : bytes from the previous stage (raw socket
+                         bytes for stage 1). Empty string means
+                         "drain: do not consume new input, but emit a
+                         unit from current state if possible".
+          - `unit`     : the single unit this stage produces this
+                         call, or nil if nothing is available yet.
                          The ADC-line stage emits complete frame
-                         strings (each WITHOUT the terminating "\n" and
-                         with every "\r" dropped, exactly as LuaSocket
-                         "*l" recvline does - see below). A passthrough
-                         stage re-emits its input as a single unit.
-          - `overflow` : bool; only a framing/terminal stage sets it
-                         (size-cap breach -> caller closes the
-                         connection, mirroring the old
-                         `len > maxreadlen` guard).
+                         strings (without the terminating "\n" and
+                         with every "\r" dropped, matching LuaSocket
+                         "*l" recvline - see CR note below). The HTTP
+                         stage emits a parsed-request table or a
+                         { reject = <status> } table.
+          - `overflow` : bool; set by framing / terminal stages when a
+                         size cap is breached. The caller closes the
+                         connection.
 
-        Pipeline contract (unchanged from S1's framer so server.lua is
-        a ~2-line change):
+            stage:residual( ) -> bytes
 
-            pipeline:feed( bytes ) -> frames, overflow
+          - Returns this stage's unprocessed input bytes and clears
+                         that internal buffer. Used by
+                         pipeline:prepend to re-route a residual
+                         suffix through a newly inserted upstream
+                         stage. Stateless stages (passthrough) return
+                         "".
+
+        Outbound stage contract (S4a, mirrors inbound):
+
+            stage:write( bytes ) -> bytes
+
+          - Transforms outgoing bytes synchronously (passthrough = same
+                         bytes; S4b deflate_stream = Z_SYNC_FLUSH'd
+                         zlib output). No internal buffering across
+                         calls is required for the passthrough
+                         default; stateful outbound stages (deflate)
+                         own their own state.
+
+        Inbound pipeline contract:
+
+            pipeline:feed( bytes )
+                Append bytes to the head of the pipeline. No return.
+
+            pipeline:next( ) -> frame, overflow
+                Lazy pull: returns the next dispatchable frame from
+                the terminal stage, or nil if nothing is available
+                yet. `overflow` is true at most once per overflow
+                event - the caller MUST close the connection.
+
+            pipeline:drain( ) -> frames, overflow
+                Convenience: calls :next() until it yields nil and
+                collects the frames. The S1/S2/S3 contract was
+                effectively "feed + drain" combined - keeping this
+                helper preserves byte-identical behaviour for unit
+                tests and lets dispatcher code stay an explicit while-
+                next loop (which is required for mid-stream reshape).
+
+            pipeline:prepend( stage )
+                Insert a stage at the FRONT. The current front
+                stage's residual unprocessed bytes are routed back
+                through the new stage. The rebuild seam for S4b's
+                ZON-prepends-inflate; first defined in S2.
+
+        Outbound pipeline contract:
+
+            outpipeline:write( bytes ) -> bytes
+                Runs bytes through every outbound stage left-to-right
+                and returns the transformed bytes. Empty pipeline
+                (current default) is identity. Order matches a write
+                that travels stage[1] -> stage[2] -> ... -> socket.
+
+            outpipeline:prepend( stage )
+                Insert a stage at the FRONT (closest to the writer);
+                the existing stages then transform the new stage's
+                output. S4b prepends a deflate_stream stage on
+                outbound ZON.
 
         ADC-line stage CR handling: LuaSocket "*l" recvline
         (luasocket/src/buffer.c:231-234, "we ignore all \r's") strips
@@ -49,7 +117,7 @@
         "\n"-only and the Phase-7 parser rejects embedded CR, so
         stripping only a trailing CR would flip a previously-accepted
         "a\rb" line into a hard parser reject - a real behaviour
-        change. S1/S2 reproduce "*l"'s strip-all-CR verbatim.
+        change. S1+ reproduce "*l"'s strip-all-CR verbatim.
 
         No sockets, no IO, no globals here - pure byte -> unit logic so
         every stage is unit-testable in isolation.
@@ -74,122 +142,196 @@ local string_gmatch = string.gmatch
 
 local newadclinestage
 local newpassthroughstage
-local newpipeline
 local newhttpstage
+
+local newpipeline
 local newhttppipeline
+
+local newoutpassthroughstage
+local newoutpipeline
 
 ----------------------------------// DEFINITION //--
 
--- ADC-line framer stage. Holds the cross-push unterminated remainder
--- in a closure. Logic is the S1 framer verbatim (so the default
--- 1-stage pipeline is byte-identical to S1).
+-- ADC-line framer stage (S1 logic carried through S4a; emits AT MOST
+-- ONE frame per push() call so the lazy pipeline can reshape between
+-- frames).
 newadclinestage = function( maxlen )
 
     local buf = ""
 
     local push = function( _, chunk )
-        local units, n = { }, 0
-        local overflow = false
-
         if chunk and chunk ~= "" then
             buf = buf .. chunk
         end
-
-        local startpos = 1
-        while true do
-            local nlpos = string_find( buf, "\n", startpos, true )    -- plain find, no patterns
-            if not nlpos then
-                break
+        local nlpos = string_find( buf, "\n", 1, true )    -- plain find, no patterns
+        if not nlpos then
+            -- No frame yet; signal overflow if the unterminated
+            -- remainder exceeded the cap so the caller closes the
+            -- connection (mirrors the S1 `_maxreadlen` guard).
+            if string_len( buf ) > maxlen then
+                return nil, true
             end
-            -- take bytes up to (not including) "\n", then drop EVERY
-            -- "\r" (recvline ignores all CRs in the line).
-            local frame = ( string_gsub( string_sub( buf, startpos, nlpos - 1 ), "\r", "" ) )
-            if string_len( frame ) > maxlen then
-                overflow = true
-            end
-            n = n + 1
-            units[ n ] = frame
-            startpos = nlpos + 1
+            return nil, false
         end
-
-        if startpos > 1 then
-            buf = string_sub( buf, startpos )
+        -- Take bytes up to (not including) "\n", then drop EVERY
+        -- "\r" (recvline ignores all CRs in the line).
+        local frame = ( string_gsub( string_sub( buf, 1, nlpos - 1 ), "\r", "" ) )
+        buf = string_sub( buf, nlpos + 1 )
+        if string_len( frame ) > maxlen then
+            return frame, true    -- emit so the caller sees what was rejected, then close
         end
-        if string_len( buf ) > maxlen then
-            overflow = true
-        end
-
-        return units, overflow
+        return frame, false
     end
 
-    return setmetatable( { }, { __index = { push = push } } )
+    local residual = function( )
+        local r = buf
+        buf = ""
+        return r
+    end
+
+    return setmetatable( { }, { __index = { push = push, residual = residual } } )
 
 end    -- newadclinestage
 
--- Passthrough stage: re-emits its input chunk as a single unit,
--- stateless, never overflows. Identity element for pipeline
--- composition; `[passthrough, adcline]` behaves exactly like
--- `[adcline]`.
+-- Inbound passthrough stage: re-emits its input chunk as a single
+-- unit, no internal buffering, stateless. Identity element for
+-- pipeline composition (a passthrough before an ADC-line stage is
+-- byte-equivalent to the ADC-line stage alone).
 newpassthroughstage = function( )
 
+    local pending = nil
+
     local push = function( _, chunk )
-        return { chunk }, false
+        if chunk and chunk ~= "" then
+            pending = chunk
+        end
+        local u = pending
+        pending = nil
+        return u, false
     end
 
-    return setmetatable( { }, { __index = { push = push } } )
+    local residual = function( )
+        local r = pending or ""
+        pending = nil
+        return r
+    end
+
+    return setmetatable( { }, { __index = { push = push, residual = residual } } )
 
 end    -- newpassthroughstage
 
--- newpipeline( maxlen ) -> pipeline object.
---
---   pipeline:feed( bytes ) -> frames, overflow
---       runs bytes through stage 1, its units through stage 2, ... ;
---       the terminal stage's units are the dispatchable ADC frames.
---       `overflow` is the OR of every stage's overflow signal.
---
---   pipeline:prepend( stage )
---       insert a stage at the FRONT (the rebuild seam: S4's ZON
---       handler splices an inflate stage ahead of the ADC-line stage
---       mid-stream). Defined here, first exercised in S4.
---
--- The default pipeline is a single ADC-line stage, so feed() is
--- byte-for-byte identical to S1's framer (one consumer: server.lua).
-newpipeline = function( maxlen )
+-- Build a pipeline shared between newpipeline (terminal = ADC-line)
+-- and newhttppipeline (terminal = HTTP). The terminal stage is
+-- passed in; the input buffer + lazy pull machinery + reshape seam
+-- are common.
+local _newpipeline = function( terminalstage )
 
-    local stages = { newadclinestage( maxlen ) }
+    local stages = { terminalstage }
+    local input_buf = ""
+    local sticky_overflow = false
+
+    -- Drive one unit out of stage i, top-down lazy: stage i first
+    -- tries to emit from its own buffered state; if that fails, ask
+    -- stage i-1 for a unit and feed it. Stage 1 reads from
+    -- input_buf. Returns (unit, overflow); unit may be nil.
+    local _pull
+    _pull = function( i )
+        if i == 1 then
+            local input
+            if input_buf ~= "" then
+                input = input_buf
+                input_buf = ""
+            else
+                input = ""
+            end
+            local unit, ov = stages[ 1 ]:push( input )
+            return unit, ov
+        end
+        local prev_unit, prev_ov = _pull( i - 1 )
+        if prev_ov then
+            -- Latch overflow so the caller still sees the unit (so
+            -- e.g. the oversized frame can be logged) AND the
+            -- overflow flag on the next next() call. Single flag is
+            -- enough because the caller is contractually required to
+            -- close on overflow.
+            sticky_overflow = true
+        end
+        local input = prev_unit or ""
+        if input == "" and prev_unit == nil then
+            -- Upstream dry: drain pending state of this stage with
+            -- empty push, but don't claim more input than we have.
+            local unit, ov = stages[ i ]:push( "" )
+            return unit, ov
+        end
+        local unit, ov = stages[ i ]:push( input )
+        return unit, ov
+    end
 
     local feed = function( _, bytes )
-        local units = { bytes or "" }
-        local overflow = false
-        for s = 1, #stages do
-            local stage = stages[ s ]
-            local out, m = { }, 0
-            for u = 1, #units do
-                local produced, ov = stage:push( units[ u ] )
-                if ov then
-                    overflow = true
-                end
-                for i = 1, #produced do
-                    m = m + 1
-                    out[ m ] = produced[ i ]
-                end
-            end
-            units = out
+        if bytes and bytes ~= "" then
+            input_buf = input_buf .. bytes
         end
-        return units, overflow
+    end
+
+    local next_frame = function( _ )
+        local unit, ov = _pull( #stages )
+        if sticky_overflow then
+            ov = true
+            sticky_overflow = false
+        end
+        return unit, ov
+    end
+
+    local drain = function( self )
+        local frames, n = { }, 0
+        local overflow = false
+        while true do
+            local frame, ov = next_frame( self )
+            if ov then overflow = true end
+            if frame == nil then
+                return frames, overflow
+            end
+            n = n + 1
+            frames[ n ] = frame
+        end
     end
 
     local prepend = function( _, stage )
+        -- 1. The CURRENT front stage may have buffered unprocessed
+        --    bytes (e.g. the ADC-line stage's `buf` containing the
+        --    bytes that arrived after a `ZON\n` and were not yet
+        --    drained because the dispatcher loop exited after the
+        --    ZON frame). Pull them out before inserting the new
+        --    stage so they go through the new front instead.
+        local residual = stages[ 1 ].residual and stages[ 1 ]:residual( ) or ""
         local shifted = { stage }
         for i = 1, #stages do
             shifted[ i + 1 ] = stages[ i ]
         end
         stages = shifted
+        if residual ~= "" then
+            input_buf = residual .. input_buf
+        end
     end
 
-    return setmetatable( { }, { __index = { feed = feed, prepend = prepend } } )
+    return setmetatable( { }, {
+        __index = {
+            feed    = feed,
+            next    = next_frame,
+            drain   = drain,
+            prepend = prepend,
+        }
+    } )
 
-end    -- newpipeline
+end
+
+-- newpipeline( maxlen ) -> pipeline whose single (terminal) stage is
+-- the ADC-line framer. Default for ADC listeners. The 1-stage default
+-- + lazy pull is byte-for-byte equivalent to S1/S2/S3 inbound
+-- behaviour, asserted by the unit-test parity suite.
+newpipeline = function( maxlen )
+    return _newpipeline( newadclinestage( maxlen ) )
+end
 
 -- Hardened HTTP/1.x request-framer stage (Phase 8 S3, drives #82).
 --
@@ -218,12 +360,12 @@ newhttpstage = function( )
 
     local emit = function( unit )
         done = true
-        return { unit }, false
+        return unit, false
     end
 
     local push = function( _, chunk )
         if done then
-            return { }, false    -- single request already produced; ignore trailing bytes
+            return nil, false    -- single request already produced; ignore trailing bytes
         end
         if chunk and chunk ~= "" then
             buf = buf .. chunk
@@ -236,7 +378,7 @@ newhttpstage = function( )
             if string_len( buf ) > MAXREQ then
                 return emit{ reject = 431 }
             end
-            return { }, false
+            return nil, false
         end
         if hdrend > MAXREQ then
             return emit{ reject = 431 }
@@ -330,52 +472,86 @@ newhttpstage = function( )
         return emit{ method = method, target = target, version = version, headers = headers }
     end
 
-    return setmetatable( { }, { __index = { push = push } } )
+    local residual = function( )
+        -- HTTP stage never carries unprocessed bytes across a
+        -- pipeline reshape - one request per connection, the only
+        -- caller (http.lua) closes immediately after dispatch.
+        return ""
+    end
+
+    return setmetatable( { }, { __index = { push = push, residual = residual } } )
 
 end    -- newhttpstage
 
--- newhttppipeline( maxlen ) -> pipeline whose single stage is the
--- hardened HTTP request framer. Same object shape / :feed contract as
+-- newhttppipeline( maxlen ) -> pipeline whose single (terminal) stage
+-- is the hardened HTTP request framer. Same object shape as
 -- newpipeline so server.lua selects it via `listeners.pipeline`
 -- without any other change. `maxlen` is accepted for call-site
 -- symmetry; the HTTP stage enforces its own (tighter) caps.
-newhttppipeline = function( maxlen )
+newhttppipeline = function( maxlen )    -- luacheck: ignore (maxlen unused; symmetry)
+    return _newpipeline( newhttpstage( ) )
+end
 
-    local stages = { newhttpstage( ) }
+-- Outbound passthrough stage: identity transform. Stateless. The
+-- default outbound pipeline is exactly one of these so writes are
+-- byte-for-byte unchanged from the legacy / S3 path.
+newoutpassthroughstage = function( )
 
-    local feed = function( _, bytes )
-        local units = { bytes or "" }
-        local overflow = false
-        for s = 1, #stages do
-            local stage = stages[ s ]
-            local out, m = { }, 0
-            for u = 1, #units do
-                local produced, ov = stage:push( units[ u ] )
-                if ov then
-                    overflow = true
-                end
-                for i = 1, #produced do
-                    m = m + 1
-                    out[ m ] = produced[ i ]
-                end
-            end
-            units = out
-        end
-        return units, overflow
+    local write = function( _, bytes )
+        return bytes
     end
 
-    return setmetatable( { }, { __index = { feed = feed } } )
+    return setmetatable( { }, { __index = { write = write } } )
 
-end    -- newhttppipeline
+end    -- newoutpassthroughstage
+
+-- newoutpipeline( ) -> outbound pipeline. Default = one passthrough
+-- stage = identity. S4b prepends a deflate_stream stage on outbound
+-- ZON. Stage order: stage[1] is closest to the writer, stage[#] is
+-- closest to the socket - the order data travels.
+newoutpipeline = function( )
+
+    local stages = { newoutpassthroughstage( ) }
+
+    local write = function( _, bytes )
+        local out = bytes or ""
+        for i = 1, #stages do
+            out = stages[ i ]:write( out )
+            if out == "" then
+                return ""
+            end
+        end
+        return out
+    end
+
+    local prepend = function( _, stage )
+        local shifted = { stage }
+        for i = 1, #stages do
+            shifted[ i + 1 ] = stages[ i ]
+        end
+        stages = shifted
+    end
+
+    return setmetatable( { }, {
+        __index = {
+            write   = write,
+            prepend = prepend,
+        }
+    } )
+
+end    -- newoutpipeline
 
 ----------------------------------// PUBLIC INTERFACE //--
 
 return {
 
-    newpipeline         = newpipeline,
-    newadclinestage     = newadclinestage,
-    newpassthroughstage = newpassthroughstage,
-    newhttpstage        = newhttpstage,
-    newhttppipeline     = newhttppipeline,
+    newpipeline            = newpipeline,
+    newadclinestage        = newadclinestage,
+    newpassthroughstage    = newpassthroughstage,
+    newhttpstage           = newhttpstage,
+    newhttppipeline        = newhttppipeline,
+
+    newoutpipeline         = newoutpipeline,
+    newoutpassthroughstage = newoutpassthroughstage,
 
 }

--- a/core/iostream.lua
+++ b/core/iostream.lua
@@ -249,20 +249,16 @@ local _newpipeline = function( terminalstage )
         end
         local prev_unit, prev_ov = _pull( i - 1 )
         if prev_ov then
-            -- Latch overflow so the caller still sees the unit (so
-            -- e.g. the oversized frame can be logged) AND the
-            -- overflow flag on the next next() call. Single flag is
-            -- enough because the caller is contractually required to
-            -- close on overflow.
+            -- Latch an upstream overflow so it survives until the next
+            -- :next() call surfaces it. The caller is contractually
+            -- required to close on overflow, so it is correct that any
+            -- unit we still bubble up gets dropped server-side; this
+            -- flag is the close signal, not a "ignore the unit too"
+            -- signal. Single flag is enough because one overflow event
+            -- per connection is fatal anyway.
             sticky_overflow = true
         end
         local input = prev_unit or ""
-        if input == "" and prev_unit == nil then
-            -- Upstream dry: drain pending state of this stage with
-            -- empty push, but don't claim more input than we have.
-            local unit, ov = stages[ i ]:push( "" )
-            return unit, ov
-        end
         local unit, ov = stages[ i ]:push( input )
         return unit, ov
     end

--- a/core/server.lua
+++ b/core/server.lua
@@ -107,6 +107,7 @@ local ratelimit_handshake_started = ratelimit.handshake_started
 local ratelimit_handshake_finished = ratelimit.handshake_finished
 local ratelimit_expired_handshakes = ratelimit.expired_handshakes
 local iostream_newpipeline = iostream.newpipeline
+local iostream_newoutpipeline = iostream.newoutpipeline
 local ratelimit_tick = ratelimit.tick
 
 --// functions //--
@@ -439,16 +440,26 @@ wrapconnection = function( server, listeners, socket, serverip, clientip, server
     local bufferqueue = { }    -- buffer array
     local bufferqueuelen = 0    -- end of buffer array
 
-    -- Phase 8 S1/S2: inbound framing pipeline. Replaces LuaSocket's
-    -- internal "*l" line buffer; reassembles raw reads into frames
-    -- across select() iterations. One per connection. The default
-    -- pipeline is a single ADC-line stage, so :feed() is byte-for-byte
-    -- identical to the S1 framer. S3: a listener may supply its own
-    -- pipeline factory (e.g. the hardened HTTP framer for the #82 API
-    -- listener) via listeners.pipeline; ADC listeners set none and get
-    -- the default. Same :feed( bytes ) -> units, overflow contract
-    -- either way, so this is the only server.lua seam.
+    -- Phase 8 S1/S2/S3/S4a: inbound + outbound transform pipelines.
+    -- Replace LuaSocket's internal "*l" line buffer (inbound) and add
+    -- a per-connection write-time transform seam (outbound). One pair
+    -- per connection.
+    --
+    -- Inbound default = a single ADC-line stage; ADC listeners get
+    -- that. HTTP listener supplies its own factory via
+    -- listeners.pipeline (the hardened HTTP framer for #82). S4a
+    -- changed the contract to lazy / iterator-style: server.lua does
+    -- feed() + while next() loop instead of "give me all frames",
+    -- because S4b will prepend an inflate stage mid-chunk on ZON and
+    -- the loop MUST stop feeding the framer after the ZON frame so
+    -- the post-ZON compressed suffix is not mis-parsed as ADC frames.
+    --
+    -- Outbound default = a single passthrough = identity transform,
+    -- byte-for-byte equivalent to pre-S4a write behaviour. A listener
+    -- may supply listeners.pipeline_out for a custom factory; S4b
+    -- prepends a deflate_stream stage on outbound ZON.
     local inframer = ( listeners.pipeline or iostream_newpipeline )( _maxreadlen )
+    local outframer = ( listeners.pipeline_out or iostream_newoutpipeline )( )
 
     local toclose
     local fatalerror
@@ -542,7 +553,20 @@ wrapconnection = function( server, listeners, socket, serverip, clientip, server
         return serverport
     end
     local write = function( data )
-        bufferlen = bufferlen + string_len( data )
+        -- Phase 8 S4a: outbound transform pipeline runs at write
+        -- time, not at send time. Once a stage has produced output
+        -- bytes (e.g. zlib's deflate(Z_SYNC_FLUSH) for S4b) those
+        -- bytes are committed - the partial-send retry path operates
+        -- on the already-transformed wire bytes, which is the only
+        -- way to keep stateful transforms (deflate) correct under
+        -- partial sends. Default = passthrough = identity, so this is
+        -- byte-for-byte equivalent to the legacy path.
+        local wire = outframer:write( data )
+        local n = string_len( wire )
+        if n == 0 then
+            return true
+        end
+        bufferlen = bufferlen + n
         if bufferlen > maxsendlen then
             handler.close( "send buffer exceeded" )
             return false
@@ -552,7 +576,7 @@ wrapconnection = function( server, listeners, socket, serverip, clientip, server
             _sendlist[ socket ] = _sendlistlen
         end
         bufferqueuelen = bufferqueuelen + 1
-        bufferqueue[ bufferqueuelen ] = data
+        bufferqueue[ bufferqueuelen ] = wire
         _writetimes[ handler ] = _writetimes[ handler ] or _currenttime
         return true
     end
@@ -622,9 +646,22 @@ wrapconnection = function( server, listeners, socket, serverip, clientip, server
 
             out_put( "server.lua: function 'wrapconnection': read data '", data, "', error: ", err )
 
-            local frames, overflow = inframer:feed( data )
-            for i = 1, #frames do
-                local frame = frames[ i ]
+            -- Phase 8 S4a: feed + lazy iterator. We pull frames one
+            -- at a time so the ZON dispatcher (S4b) can call
+            -- inframer:prepend( inflate_stage ) BEFORE the loop asks
+            -- for the next frame. If we pulled all frames up front,
+            -- the ADC-line stage would have already mis-parsed the
+            -- post-ZON compressed suffix as plain ADC frames.
+            inframer:feed( data )
+            while true do
+                local frame, overflow = inframer:next( )
+                if overflow then
+                    handler.close( "receive buffer exceeded" )
+                    return false
+                end
+                if frame == nil then
+                    break
+                end
                 -- The per-unit oversize cap is an ADC-line transport
                 -- concern: that stage emits string frames. Non-string
                 -- units (e.g. the HTTP framer's parsed-request /
@@ -648,10 +685,6 @@ wrapconnection = function( server, listeners, socket, serverip, clientip, server
                 if handler.readbuffer == return_false then
                     return true
                 end
-            end
-            if overflow then    -- unterminated remainder exceeded the cap
-                handler.close( "receive buffer exceeded" )
-                return false
             end
         elseif benign then
             -- No bytes and no terminal error: keep the read wiring sane

--- a/docs/phases/PHASE_8_IO.md
+++ b/docs/phases/PHASE_8_IO.md
@@ -374,6 +374,150 @@ machinery. This is exactly the §1a.5 "verify every assumption
 against current source" miss the security two-pass gate exists to
 catch.
 
+## S4 spec (locked 2026-05-20, maintainer-approved)
+
+ZLIF = ADC-EXT zlib stream compression per connection. Hub <-> client
+agree on `ZLIF` in SUP, then either side can flip its outbound stream
+to a zlib stream with `ZON` (peer decompresses inbound after this
+line) and back with `ZOF` (in the compressed stream). `Z_SYNC_FLUSH`
+after each chunk. Spec is silent on error handling, TLS interaction,
+decompression-bomb caps -> all hardened by us.
+
+### S4 splits into two sub-PRs
+
+S4 is the biggest single step (pipeline contract change + outbound
+seam + new C dep + Lua binding + dispatch + cfg + smoke). Per CLAUDE.md
+§1a.8 (small reviewable PRs), it splits cleanly along the
+behaviour-neutral / additive boundary already used in S1->S2->S3:
+
+- **S4a - iterator pipeline + outbound passthrough seam
+  (behaviour-neutral).** Refactors the pipeline contract to lazy /
+  one-frame-at-a-time, adds an outbound pipeline seam to server.lua
+  (default = passthrough = byte-identical send path). No new
+  dependency, no protocol change. The clean review base for S4b.
+- **S4b - ZLIF feature.** zlib_stream C module + inflate/deflate
+  stages + ZON/ZOF dispatch + cfg gates + smoke. Built on the S4a
+  seams; this PR ONLY adds the compression layer, never restructures
+  IO. Maintains the S3 split-by-risk-surface pattern.
+
+### Locked design decisions (Q1-Q3, maintainer-approved)
+
+- **Q1 - zlib binding: own minimal C module.** New
+  `zlib_stream/zlib_stream.c` (`require "zlib_stream"`), exposes only
+  `deflate_stream` and `inflate_stream` objects with `:push(bytes) ->
+  bytes` (Z_SYNC_FLUSH). Mirrors the project pattern of `adclib` /
+  `slnunicode` shim - minimum surface, hub-specific. Build:
+  `find_package(ZLIB REQUIRED)` (system zlib on Linux + MinGW, CI
+  installs `zlib1g-dev`). Vendored `lua-zlib` rejected: 4x larger,
+  features we don't need, extra supply-chain surface.
+- **Q2 - default policy: opt-in.** New cfg key `zlif_enabled` (default
+  `false`). Hub advertises `ADZLIF` only when enabled. Matches the
+  S3 default-off pattern (`http_port = false`) - new IO surface is
+  opt-in by operator, not bundled into the default behaviour set.
+- **Q3 - TLS + ZLIF: default-off on TLS connections.** Independent
+  cfg flag `zlif_over_tls` (default `false`). CRIME-class chosen-
+  plaintext-length leak is theoretically possible on the hub's TLS
+  outbound (attacker PMs victim, hub forwards mixed with victim's
+  other traffic, observer infers length deltas). Mitigation:
+  opt-in only, document in SECURITY.md. Plain ADC connections see
+  ZLIF when `zlif_enabled = true` and the client advertises `ADZLIF`.
+
+### Pipeline contract change (S4a, load-bearing correctness)
+
+The pipeline's `:feed(bytes) -> frames, overflow` contract returns
+ALL frames in one shot. With S4b's mid-stream `ZON` arrival, an input
+chunk can carry `"ZON\nXXX..."` where `XXX` is compressed - the
+ADC-line stage cannot know `ZON` is the last plain frame and will
+happily parse compressed bytes as ADC frames before the dispatcher
+gets a chance to splice in the inflate stage. Result: dispatched
+garbage frames. This is the load-bearing correctness issue.
+
+Fix (S4a, behaviour-neutral): pipeline switches to **lazy / iterator**
+contract:
+
+    pipeline:feed( bytes )         -- inputs bytes, no return
+    pipeline:next( ) -> frame, overflow    -- pulls ONE frame; nil = drained
+    pipeline:drain( ) -> frames, overflow  -- convenience: loop next() to nil
+
+Internal model: top-down lazy pull. `_pull(i)` asks stage `i` for a
+unit; if stage `i` has none, ask stage `i-1` and feed its output to
+stage `i`. The stage contract is tightened: `stage:push(chunk) ->
+unit, overflow` returns AT MOST ONE unit (with `chunk = ""` meaning
+"drain pending state"). Stages also expose `:residual() -> bytes` so
+the pipeline can extract the front stage's unprocessed suffix on
+reshape.
+
+Reshape semantic:
+
+    pipeline:prepend( newstage )
+        residual = stages[1]:residual()         -- empty, or unprocessed suffix
+        stages = { newstage } ++ stages
+        input_buffer = residual ++ input_buffer  -- new front sees residual first
+
+So when the ZON dispatch handler (S4b) calls
+`pipeline:prepend(inflate_stage)` immediately after dispatching the
+ZON frame, the compressed bytes the ADC-line stage had buffered post-
+ZON get re-fed through the new inflate stage. By construction, the
+dispatcher's outer loop has not yet asked for the next frame, so no
+garbage was emitted. Verified by the new "ZON-mid-chunk" unit test
+(`tests/unit/iostream_test.lua`).
+
+Outbound seam (S4a): mirrors the inbound seam. `server.lua` gains a
+per-connection `outframer` constructed from `listeners.pipeline_out`
+(default = passthrough = current behaviour, byte-identical). Stage
+contract for outbound: `stage:write(bytes) -> bytes`. Pipeline:
+`outpipeline:write(bytes) -> bytes`, `outpipeline:prepend(stage)`.
+`handler.write(data)` becomes `bufferqueue ++= outframer:write(data)`.
+S4b adds a `deflate_stream` stage prepended on `IZON`-out.
+
+### S4a acceptance
+
+1. `tests/unit/iostream_test.lua` extends to cover the iterator API
+   (next/drain), ZON-mid-chunk reshape (a "ZON" line in a chunk with
+   compressed-looking suffix bytes is dispatched alone; subsequent
+   bytes are re-fed through a prepended stage and not mis-framed),
+   outbound pipeline composition (passthrough x passthrough is
+   byte-identical to the input).
+2. Full smoke green unchanged (no protocol behaviour change).
+3. S1/S2 behaviour-equivalence checks: `pipeline:drain(bytes)` on
+   the default pipeline returns the exact same `(frames, overflow)`
+   tuple S1/S2's feed did, for every existing test case.
+
+### S4b acceptance
+
+- Unit tests: deflate-stream / inflate-stream basic roundtrip
+  (Z_SYNC_FLUSH partial flush correctness); ZON activates inflate
+  mid-chunk in the pipeline; ZOF removes inflate stage; size-cap on
+  inflate output (decompression-bomb guard, hard byte cap per push
+  + ADC `_maxreadlen` enforced post-inflate as today); malformed
+  compressed input -> handler.close (no silent garbage frames).
+- Smoke: a "ZLIF roundtrip" test on a plain-ADC test client that
+  speaks ZON, login completes, +help routes correctly, ZOF reverts
+  cleanly. Default `zlif_enabled = false` path: existing smoke
+  unchanged (the ZLIF SUP token MUST NOT appear in the default
+  `_normalsup` advertise string, lest non-ZLIF clients try and we
+  fail).
+- Hardening: inflate output cap per `:push` call = 4 MiB (well above
+  any realistic ADC frame burst, well below memory-pressure); ratio
+  guard not needed (the byte cap already bounds decompression). Cfg
+  validator on `zlif_enabled` / `zlif_over_tls` = boolean only.
+- Two-pass review focus: decompression-bomb path, TLS interaction
+  (assert plain default; cfg gate works), correct reshape on edge
+  cases (ZON immediately followed by ZOF; multiple ZON/ZOF cycles;
+  client-initiated ZON before hub-initiated; only-one-side-ZON).
+
+### Build / CI (S4b)
+
+- Top-level `CMakeLists.txt`: `find_package(ZLIB REQUIRED)` next to
+  the OpenSSL find. Log the version (matches OpenSSL pattern).
+- New module dir `zlib_stream/` with `CMakeLists.txt` + `zlib_stream.c`.
+  Links `ZLIB::ZLIB` + `lua`. Builds to `lib/zlib_stream/zlib_stream.{so,dll}`
+  identical to `adclib` layout.
+- `.github/workflows/smoke.yml` Linux job: add `zlib1g-dev` to the
+  apt-get install line. Windows MinGW already ships zlib via the
+  default mingw distribution (verify in S4b CI run, bundle if not).
+- aarch64 Bullseye container build: zlib is base-system, no change.
+
 ## Log
 
 - 2026-05-15: phase opened, integration branch `phase8-io` created, design

--- a/tests/unit/iostream_test.lua
+++ b/tests/unit/iostream_test.lua
@@ -2,30 +2,23 @@
 
     tests/unit/iostream_test.lua
 
-    Committed unit test for core/iostream.lua (Phase 8 S1 + S2). Pure
-    Lua, no hub, no sockets: stubs the `use` sandbox shim, loads the
-    module, asserts the stage/pipeline contract.
+    Committed unit test for core/iostream.lua (Phase 8 S1 + S2 + S3 +
+    S4a). Pure Lua, no hub, no sockets: stubs the `use` sandbox shim,
+    loads the module, asserts the stage/pipeline contract.
 
-    Why this exists: S1/S2 were verified with throwaway scripts, which
-    prove nothing for the next person (CLAUDE.md s1a.7). The S2
-    pre-merge review flagged the new abstraction surface (passthrough,
-    multi-stage fan-in, prepend ordering) as having no committed
-    regression - that surface is what S4 (ZLIF inflate spliced ahead of
-    the framer via pipeline:prepend) will rely on. This file is the
-    durable regression for it.
+    S4a changed the pipeline contract from "feed -> get all frames" to
+    a lazy iterator (`feed(bytes)`, `next() -> frame | nil`,
+    `drain() -> frames` convenience). The tests use `drain()` for the
+    S1/S2/S3 parity cases (one-line equivalent of the old `feed`
+    shape) plus add explicit `next()` cases for the iterator
+    behaviour and a ZON-style mid-chunk reshape case that exercises
+    the load-bearing correctness fix S4b will rely on.
 
     Run: lua tests/unit/iostream_test.lua   (any Lua 5.4)
     Exit code 0 = all pass, 1 = a failure (CI-friendly).
 
-    CI wiring: not run by .github/workflows/smoke.yml yet (that harness
-    is Python and the build does not emit a standalone lua interpreter).
-    The neutral path is already CI-guarded transitively by the S1
-    protocol smoke tests (a 1-stage pipeline is byte-identical to the
-    S1 framer, so test_s1_fragmented_frame_reassembled /
-    test_s1_two_frames_one_segment would break if framing regressed).
-    Wiring this file into CI is an explicit gate before S4 lands (see
-    docs/phases/PHASE_8_IO.md) - S4 already touches the build for the
-    zlib dependency, so the lua-unit runner is in-scope there.
+    CI: wired into .github/workflows/smoke.yml's Linux job since S3
+    (lua5.4 step ahead of the build).
 
 ]]--
 
@@ -58,6 +51,15 @@ end
 -- frames array -> single comparable string
 local function j( t ) return "[" .. table.concat( t, "|" ) .. "]" end
 
+-- S1/S2/S3 parity helper: behaviour-equivalent of the pre-S4a
+-- "feed(bytes) -> frames, overflow" shape. The lazy iterator makes
+-- this two calls; the helper hides that so the parity assertions
+-- below read like the pre-S4a tests.
+local function feed_drain( p, bytes )
+    p:feed( bytes )
+    return p:drain( )
+end
+
 ----------------------------------------------------------------------
 -- S1 parity: default 1-stage pipeline must be byte-identical to the
 -- old newframer for every input class.
@@ -65,41 +67,43 @@ local function j( t ) return "[" .. table.concat( t, "|" ) .. "]" end
 
 local p = iostream.newpipeline( 1048576 )
 eq( "single frame, escaped body",
-    j( ( p:feed( "BMSG AAAA +setpass" .. BS .. "snick" .. BS .. "smyself" .. BS .. "ssmoketestnew" .. NL ) ) ),
+    j( ( feed_drain( p, "BMSG AAAA +setpass" .. BS .. "snick" .. BS .. "smyself" .. BS .. "ssmoketestnew" .. NL ) ) ),
     "[BMSG AAAA +setpass\\snick\\smyself\\ssmoketestnew]" )
 
 p = iostream.newpipeline( 1048576 )
-eq( "fragmented part 1 -> no frame", j( ( p:feed( "BMSG AAAA +he" ) ) ), "[]" )
-eq( "fragmented part 2 -> reassembled", j( ( p:feed( "lp" .. NL ) ) ), "[BMSG AAAA +help]" )
+eq( "fragmented part 1 -> no frame", j( ( feed_drain( p, "BMSG AAAA +he" ) ) ), "[]" )
+eq( "fragmented part 2 -> reassembled", j( ( feed_drain( p, "lp" .. NL ) ) ), "[BMSG AAAA +help]" )
 
 p = iostream.newpipeline( 1048576 )
 eq( "two frames one feed",
-    j( ( p:feed( "BMSG AAAA +help" .. NL .. "BMSG AAAA +help" .. NL ) ) ),
+    j( ( feed_drain( p, "BMSG AAAA +help" .. NL .. "BMSG AAAA +help" .. NL ) ) ),
     "[BMSG AAAA +help|BMSG AAAA +help]" )
 
 p = iostream.newpipeline( 1048576 )
-local fr, ov = p:feed( "ABC" .. CR .. NL .. "DEF" .. NL .. "GHI" )
+local fr, ov = feed_drain( p, "ABC" .. CR .. NL .. "DEF" .. NL .. "GHI" )
 eq( "CRLF stripped + two frames", j( fr ), "[ABC|DEF]" )
 eq( "no overflow on normal input", ov, false )
-eq( "remainder kept then completed", j( ( p:feed( NL ) ) ), "[GHI]" )
+eq( "remainder kept then completed", j( ( feed_drain( p, NL ) ) ), "[GHI]" )
 
 p = iostream.newpipeline( 1048576 )
 eq( "embedded CR all stripped (*l recvline parity)",
-    j( ( p:feed( "BMSG x he" .. CR .. "ll" .. CR .. "o" .. CR .. NL ) ) ),
+    j( ( feed_drain( p, "BMSG x he" .. CR .. "ll" .. CR .. "o" .. CR .. NL ) ) ),
     "[BMSG x hello]" )
 
 p = iostream.newpipeline( 8 )
-local g, gov = p:feed( "ABCDEFGHIJKL" )    -- 12 byte unterminated > maxlen 8
+local g, gov = feed_drain( p, "ABCDEFGHIJKL" )    -- 12 byte unterminated > maxlen 8
 eq( "oversize unterminated -> overflow", gov, true )
 eq( "oversize unterminated -> no frame yet", j( g ), "[]" )
 
 ----------------------------------------------------------------------
--- S2 new surface: passthrough, composition, prepend ordering.
+-- S2 surface: passthrough, composition, prepend ordering. The stage
+-- contract changed in S4a (push -> single unit, not list); rebuilt
+-- here against the new shape.
 ----------------------------------------------------------------------
 
 local pt = iostream.newpassthroughstage( )
 local u, o = pt:push( "raw" .. NL .. "bytes" )
-eq( "passthrough re-emits input as one unit", j( u ), "[raw\nbytes]" )
+eq( "passthrough re-emits input as one unit", u, "raw" .. NL .. "bytes" )
 eq( "passthrough never overflows", o, false )
 
 -- [passthrough, adcline] must behave exactly like [adcline], incl.
@@ -107,20 +111,69 @@ eq( "passthrough never overflows", o, false )
 p = iostream.newpipeline( 1048576 )
 p:prepend( iostream.newpassthroughstage( ) )
 eq( "compose: frame split, 2nd held",
-    j( ( p:feed( "BMSG Z +help" .. NL .. "BMSG Z +x" ) ) ), "[BMSG Z +help]" )
+    j( ( feed_drain( p, "BMSG Z +help" .. NL .. "BMSG Z +x" ) ) ), "[BMSG Z +help]" )
 eq( "compose: remainder completes across feed",
-    j( ( p:feed( "yz" .. NL ) ) ), "[BMSG Z +xyz]" )
+    j( ( feed_drain( p, "yz" .. NL ) ) ), "[BMSG Z +xyz]" )
 
 -- prepend must run the new stage BEFORE the framer (the S4
 -- inflate-before-framing ordering). A stage that turns 'X' into CR,
 -- prepended, must let the framer then strip those CRs.
 p = iostream.newpipeline( 1048576 )
-local crstage = setmetatable( { }, { __index = { push = function( _, c )
-    return { ( c:gsub( "X", CR ) ) }, false
-end } } )
+local crstage = setmetatable( { }, { __index = {
+    push = function( self, c )
+        if c and c ~= "" then return ( c:gsub( "X", CR ) ), false end
+        return nil, false
+    end,
+    residual = function( ) return "" end,
+} } )
 p:prepend( crstage )
 eq( "prepend ordering: stage runs before framer",
-    j( ( p:feed( "aXbXc" .. NL ) ) ), "[abc]" )
+    j( ( feed_drain( p, "aXbXc" .. NL ) ) ), "[abc]" )
+
+----------------------------------------------------------------------
+-- S4a iterator API: next() returns one frame at a time; drain()
+-- collects to convenience array. Asserts the contract directly.
+----------------------------------------------------------------------
+
+p = iostream.newpipeline( 1048576 )
+p:feed( "AAA" .. NL .. "BBB" .. NL .. "CCC" )
+local f1 = p:next( ); local f2 = p:next( ); local f3 = p:next( )
+eq( "next: frame 1", f1, "AAA" )
+eq( "next: frame 2", f2, "BBB" )
+eq( "next: only complete frames emitted", f3, nil )
+p:feed( NL )
+eq( "next: completes remainder on more bytes", p:next( ), "CCC" )
+eq( "next: drained returns nil", p:next( ), nil )
+
+----------------------------------------------------------------------
+-- S4a load-bearing fix: mid-chunk reshape. A "ZON\nXX\nYY\n" pattern
+-- where the post-ZON suffix is opaque-to-framer bytes (here ASCII
+-- standing in for compressed bytes for the unit test - the test does
+-- not depend on actual zlib) must NOT have "XX" / "YY" dispatched
+-- before the ZON-handler reshape. Modelled as: pull ZON, prepend a
+-- byte-rewriting stage that maps the suffix bytes into something
+-- the framer must see, assert the rewritten output emerges.
+----------------------------------------------------------------------
+
+p = iostream.newpipeline( 1048576 )
+p:feed( "ZON" .. NL .. "XX" .. NL .. "YY" .. NL )
+local first = p:next( )
+eq( "reshape: first frame is ZON", first, "ZON" )
+-- Splice in a stage that uppercases each byte chunk (stands in for
+-- inflate). The post-ZON residual ("XX\nYY\n") was buffered in the
+-- ADC-line stage's `buf`; prepend MUST route it through the new
+-- stage so the resulting frames reflect the transform.
+local upperstage = setmetatable( { }, { __index = {
+    push = function( self, c )
+        if c and c ~= "" then return ( c:lower( ) ), false end
+        return nil, false
+    end,
+    residual = function( ) return "" end,
+} } )
+p:prepend( upperstage )
+eq( "reshape: post-ZON suffix re-fed via new stage", p:next( ), "xx" )
+eq( "reshape: continued through new stage", p:next( ), "yy" )
+eq( "reshape: pipeline drains cleanly", p:next( ), nil )
 
 ----------------------------------------------------------------------
 -- S3: hardened HTTP request-framer stage. Each reject case asserts the
@@ -130,11 +183,11 @@ eq( "prepend ordering: stage runs before framer",
 ----------------------------------------------------------------------
 
 local CRLF = CR .. NL
--- single-feed helper: returns the one emitted unit (or nil)
+-- single-feed helper: returns the one emitted unit (or nil). S4a:
+-- the stage emits a single unit, not a list.
 local function httpreq( s )
     local st = iostream.newhttpstage( )
-    local u = st:push( s )
-    return u[ 1 ]
+    return ( st:push( s ) )
 end
 -- describe a unit as a stable comparable string
 local function du( u )
@@ -189,20 +242,47 @@ eq( "http: >100 headers -> 431", du( httpreq( manyhdrs .. CRLF ) ), "reject=431"
 -- oversize total before terminator -> 431 (slowloris / unbounded buf)
 local big = iostream.newhttpstage( )
 eq( "http: oversize pre-terminator -> 431",
-    du( ( big:push( "GET /health HTTP/1.1" .. CRLF .. "X: " .. string.rep( "a", 17000 ) ) )[ 1 ] ),
+    du( big:push( "GET /health HTTP/1.1" .. CRLF .. "X: " .. string.rep( "a", 17000 ) ) ),
     "reject=431" )
 
 -- partial request reassembled across feeds
 local hp = iostream.newhttpstage( )
-eq( "http: partial feed 1 -> no unit", j( ( hp:push( "GET /heal" ) ) ), "[]" )
-local hp2 = ( hp:push( "th HTTP/1.1" .. CRLF .. CRLF ) )[ 1 ]
+eq( "http: partial feed 1 -> no unit", tostring( hp:push( "GET /heal" ) ), "nil" )
+local hp2 = hp:push( "th HTTP/1.1" .. CRLF .. CRLF )
 eq( "http: partial feed 2 -> request", du( hp2 ), "GET /health HTTP/1.1" )
 
 -- one request per connection: stage goes inert after the first
 local hi = iostream.newhttpstage( )
 hi:push( "GET /health HTTP/1.1" .. CRLF .. CRLF )
 eq( "http: inert after first request",
-    j( ( hi:push( "GET /again HTTP/1.1" .. CRLF .. CRLF ) ) ), "[]" )
+    tostring( hi:push( "GET /again HTTP/1.1" .. CRLF .. CRLF ) ), "nil" )
+
+----------------------------------------------------------------------
+-- S4a outbound passthrough pipeline: identity transform, default.
+-- Prepending more passthrough stages must stay identity.
+----------------------------------------------------------------------
+
+local op = iostream.newoutpipeline( )
+eq( "out: passthrough is identity", op:write( "BMSG x +help" .. NL ), "BMSG x +help" .. NL )
+eq( "out: empty input -> empty output", op:write( "" ), "" )
+
+-- A test stage that uppercases its input - asserts stage ordering:
+-- stage[1] (prepended) runs first, then stage[2] (the existing
+-- passthrough) - so the final output is uppercased.
+local upper_out = setmetatable( { }, { __index = {
+    write = function( _, b ) return ( b:upper( ) ) end,
+} } )
+op:prepend( upper_out )
+eq( "out: prepended stage runs first", op:write( "hello" ), "HELLO" )
+
+-- Two prepended stages: stage1 (added 2nd, ends up at front) -> stage2
+-- (added 1st, now stage 2) -> passthrough. So the input runs front-to-back.
+local op2 = iostream.newoutpipeline( )
+local add_x = setmetatable( { }, { __index = { write = function( _, b ) return b .. "X" end } } )
+local add_y = setmetatable( { }, { __index = { write = function( _, b ) return b .. "Y" end } } )
+op2:prepend( add_y )    -- stages = { add_y, passthrough }
+op2:prepend( add_x )    -- stages = { add_x, add_y, passthrough }
+eq( "out: prepend ordering (front-to-back)", op2:write( "a" ), "aXY" )
 
 ----------------------------------------------------------------------
 

--- a/tests/unit/iostream_test.lua
+++ b/tests/unit/iostream_test.lua
@@ -146,6 +146,34 @@ eq( "next: completes remainder on more bytes", p:next( ), "CCC" )
 eq( "next: drained returns nil", p:next( ), nil )
 
 ----------------------------------------------------------------------
+-- S4a multi-stage overflow propagation (sticky_overflow path). The
+-- 1-stage default pipeline never exercises this - the upstream stage
+-- in a 2-stage pipeline (e.g. S4b's inflate) signals overflow, and
+-- next() must surface it on its return tuple regardless of which
+-- iteration the upstream stage decided to overflow on. Reviewer N2
+-- gate before S4b uses this in production.
+----------------------------------------------------------------------
+
+p = iostream.newpipeline( 1048576 )
+local overflow_stage_fired = false
+local overflow_stage = setmetatable( { }, { __index = {
+    push = function( _, c )
+        if overflow_stage_fired then return nil, false end
+        if c and c ~= "" then
+            overflow_stage_fired = true
+            return c, true    -- emit unit AND signal overflow on same call
+        end
+        return nil, false
+    end,
+    residual = function( ) return "" end,
+} } )
+p:prepend( overflow_stage )
+p:feed( "AAA" .. NL )
+local mu, mov = p:next( )
+eq( "multi-stage: upstream-stage overflow surfaces", mov, true )
+eq( "multi-stage: unit still threaded through downstream", mu, "AAA" )
+
+----------------------------------------------------------------------
 -- S4a load-bearing fix: mid-chunk reshape. A "ZON\nXX\nYY\n" pattern
 -- where the post-ZON suffix is opaque-to-framer bytes (here ASCII
 -- standing in for compressed bytes for the unit test - the test does


### PR DESCRIPTION
First half of S4 (split per CLAUDE.md §1a.8 because S4 is large enough to warrant two focused review surfaces). **Behaviour-neutral**: no new dependency, no protocol change, no functional change. This is the refactor S4b ZLIF needs to land cleanly.

## Summary

- Pipeline contract changes from "feed(bytes) -> all frames" to lazy iterator (`feed`, `next`, `drain` convenience). Stage contract tightens to one-unit-per-push so the dispatcher can splice a stage between frames.
- Adds outbound transform pipeline mirror (default = single passthrough = identity, byte-for-byte equivalent to the legacy send path).
- server.lua: `_readbuffer` becomes feed + while-next loop. `write` runs through outframer at write-time (not send-time), so stateful transforms commit before the partial-send retry path operates on the wire bytes.

## Why now

S4b (ZON/ZOF) needs to splice an inflate stage in front of the ADC-line stage mid-stream. With the old "feed returns all frames" contract, the ADC-line stage would have already mis-parsed the post-ZON compressed suffix as plain frames before the dispatcher could splice. The iterator API stops the framer between frames; reshape happens cleanly.

## Test plan

- [x] `tests/unit/iostream_test.lua` 51/51 (S1/S2/S3 byte-parity via `drain()`, explicit `next()` cases, mid-chunk reshape, multi-stage sticky_overflow, outbound passthrough + prepend ordering)
- [x] Full smoke green on Windows (plain + TLS handshake/login, +cmd, burst battery, encryption at rest, dual-stack, HTTP /health hardening, etc — all 60+ checks)
- [x] Independent review (CLAUDE.md §1a.6): 0 BLOCKER, 2 CONCERN, 5 NIT; review-fixes applied (C1 misleading-comment, C2 dead branch in `_pull`, N2 missing multi-stage sticky test)

## Spec

`docs/phases/PHASE_8_IO.md` S4 spec section (locked 2026-05-20).

Part of Phase 8 IO rework. Sub-PR into the `phase8-io` integration branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)