### PR TITLE
Phase 8 S4b: ADC-EXT ZLIF stream compression (#147 T3.2)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake libssl-dev lua5.4
+          sudo apt-get install -y build-essential cmake libssl-dev zlib1g-dev lua5.4
 
       # Pure-Lua unit test for the Phase 8 framing pipeline
       # (core/iostream.lua). Byte/string logic only, no OS specifics,
@@ -72,6 +72,7 @@ jobs:
             mingw-w64-ucrt-x86_64-cmake
             mingw-w64-ucrt-x86_64-make
             mingw-w64-ucrt-x86_64-openssl
+            mingw-w64-ucrt-x86_64-zlib
 
       - name: Configure
         shell: msys2 {0}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,12 +60,23 @@ find_package(OpenSSL 3.0 REQUIRED)
 message(STATUS "luadch: OpenSSL ${OPENSSL_VERSION} at ${OPENSSL_INCLUDE_DIR}")
 
 # -----------------------------------------------------------------------------
+# zlib: Phase 8 S4b (ADC-EXT ZLIF stream compression). Used by the
+# zlib_stream C module that wraps deflate / inflate streams with the
+# Z_SYNC_FLUSH semantic ADC mandates. System zlib on Linux + MinGW
+# (Ubuntu CI installs zlib1g-dev). aarch64 Bullseye container has zlib
+# as a base-system package - no change needed.
+# -----------------------------------------------------------------------------
+find_package(ZLIB REQUIRED)
+message(STATUS "luadch: ZLIB ${ZLIB_VERSION_STRING} at ${ZLIB_INCLUDE_DIRS}")
+
+# -----------------------------------------------------------------------------
 # Modules (each builds the artefacts listed in docs/phases/PHASE_1.md §3)
 # -----------------------------------------------------------------------------
 add_subdirectory(lua/src)
 add_subdirectory(adclib)
 add_subdirectory(luasocket)
 add_subdirectory(luasec)
+add_subdirectory(zlib_stream)
 add_subdirectory(hub)
 
 # -----------------------------------------------------------------------------

--- a/core/adc.lua
+++ b/core/adc.lua
@@ -239,6 +239,11 @@ _regex = {
         direct = "[DE]",
         hubdirect = "[HDE]",
         result = "[FD]",        -- ADC 5.3.6 RES: D (direct) + F (feature-filtered)
+        streamctl = "[BIH]",    -- Phase 8 S4b ADC-EXT ZLIF ZON / ZOF; spec is
+                                -- ambiguous on the fourcc class, real clients
+                                -- vary (BZON / IZON / HZON have all been seen),
+                                -- so accept any of them in the framer and let
+                                -- hub.lua's incoming intercept decide.
 
     },
 
@@ -534,6 +539,26 @@ _protocol = {
             nonpclones = false,
 
         },
+        -- Phase 8 S4b ADC-EXT ZLIF stream-on / stream-off. The fourcc
+        -- class can be B / I / H (per the streamctl context above);
+        -- there are no positional or named parameters in the spec.
+        -- Empty pp/np shape so adc_parse accepts the message; the
+        -- actual transport-level handling (install inflate / close
+        -- connection) lives in hub.lua's incoming intercept.
+        ZON = {
+
+            pp = { len = 0, },
+            np = { },
+            nonpclones = false,
+
+        },
+        ZOF = {
+
+            pp = { len = 0, },
+            np = { },
+            nonpclones = false,
+
+        },
 
     },
     contexts = {
@@ -555,6 +580,8 @@ _protocol = {
         GET = _regex.context.hub,
         GFI = _regex.context.hub,
         SND = _regex.context.hub,
+        ZON = _regex.context.streamctl,    -- Phase 8 S4b ADC-EXT ZLIF stream-on
+        ZOF = _regex.context.streamctl,    -- Phase 8 S4b ADC-EXT ZLIF stream-off
 
     }
 

--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -233,6 +233,32 @@ local defaults = {
                 and value >= 1 and value <= 65535
         end
     },
+    -- Phase 8 S4b: ADC-EXT ZLIF (zlib stream compression). Off by
+    -- default - operator opt-in, matches the S3 http_port pattern.
+    -- When enabled and the client also advertises ADZLIF in HSUP, the
+    -- hub initiates compression (sends IZON, installs an outbound
+    -- deflate stage) and decompresses inbound after the client's own
+    -- ZON. Spec is per-direction; the hub advertises only when
+    -- enabled. See docs/SECURITY.md for the CRIME-class chosen-
+    -- plaintext-length leak discussion that gates ZLIF over TLS
+    -- behind the separate zlif_over_tls flag below.
+    zlif_enabled = { false,
+        function( value )
+            return value == false or value == true
+        end
+    },
+    -- TLS+ZLIF is theoretically vulnerable to CRIME-class length-leak
+    -- attacks (chosen-plaintext PM mixed with victim's other traffic
+    -- on the same TLS-then-compressed wire). Practical exploitability
+    -- is low (eavesdropper needed, broadcast noise masks length
+    -- deltas) but the mitigation cost is one cfg flag. Plain-ADC
+    -- connections see ZLIF when `zlif_enabled` is true regardless of
+    -- this flag.
+    zlif_over_tls = { false,
+        function( value )
+            return value == false or value == true
+        end
+    },
     hub_website = { "http://yourwebsite.org",
         function( value )
             return types_utf8( value, nil, true )

--- a/core/hub.lua
+++ b/core/hub.lua
@@ -1288,17 +1288,40 @@ incoming = function( client, data, err )
         -- (we did stop decompressing) and matches real-world client
         -- behaviour (DC++ clients send ZON once and never ZOF
         -- during a session).
-        if cmd == "ZON" then
-            if _cfg_zlif.enabled then
-                user:client().inframer_prepend( ( use "iostream" ).newinflatestage( ) )
-                out_put( "hub.lua: function 'incoming': ZLIF activated inbound for user ", usersid )
-            else
-                user.write( "ISTA 144 FCZON\n" )
+        if cmd == "ZON" or cmd == "ZOF" then
+            -- Spec sequence: ZON / ZOF only after the HSUP exchange
+            -- has completed, i.e. only in identify / verify / normal
+            -- state. A pre-HSUP `BZON` from a hostile client would
+            -- otherwise install the inflate stage before any peer
+            -- identity is established and let the client send a
+            -- compressed HSUP - protocol violation we close on
+            -- defence-in-depth, not because we know an exploitable
+            -- consequence beyond connection self-DoS.
+            local userstate = user.state( )
+            if userstate == "protocol" then
+                -- write + graceful close. user:kill( ) here goes
+                -- through disconnect() which calls user.destroy() -
+                -- still works pre-HSUP but is heavier than needed
+                -- for a transport-level reject. The graceful close
+                -- (no `forced` arg) defers the socket close until
+                -- _sendbuffer drains, so the ISTA reaches the wire
+                -- before the FIN.
+                user.write( "ISTA 240 FCZON ZLIF before HSUP\n" )
+                user:client().close( )
+                return true
             end
-            return true
-        elseif cmd == "ZOF" then
-            user:kill( "ISTA 200 ZLIF ZOF unsupported, closing connection\n", "TL-1" )
-            return true
+            if cmd == "ZON" then
+                if _cfg_zlif.enabled then
+                    user:client().inframer_prepend( ( use "iostream" ).newinflatestage( ) )
+                    out_put( "hub.lua: function 'incoming': ZLIF activated inbound for user ", usersid )
+                else
+                    user.write( "ISTA 144 FCZON\n" )
+                end
+                return true
+            else
+                user:kill( "ISTA 200 ZLIF ZOF unsupported, closing connection\n", "TL-1" )
+                return true
+            end
         end
         local mysid = adccmd:mysid( )
         local userstate = user.state( )

--- a/core/hub.lua
+++ b/core/hub.lua
@@ -257,6 +257,11 @@ local scripts_import = scripts.import
 local scripts_firelistener = scripts.firelistener
 local mem_free = mem.free
 local adc_parse = adc.parse
+-- Phase 8 S4b: ZLIF stage constructors are looked up via `use` at
+-- ZON dispatch time rather than aliased into a local. hub.lua sits
+-- at Lua 5.4's 200-locals-per-chunk ceiling; adding a `local
+-- iostream = use "iostream"` here puts us over and the file fails
+-- to compile. Per-connect lookup cost is negligible.
 local types_check = types.check
 local util_formatseconds = util.formatseconds
 local util_date = util.date
@@ -394,6 +399,11 @@ local _cfg_hub_hostaddress
 local _cfg_hub_website
 local _cfg_hub_network
 local _cfg_hub_owner
+-- Phase 8 S4b ZLIF cfg cache, packed into a table so we stay below
+-- Lua 5.4's 200-local-per-chunk compile-time limit (hub.lua sits at
+-- the upper-100s of locals). Read via _cfg_zlif.enabled /
+-- _cfg_zlif.over_tls; values are rebuilt by loadsettings().
+local _cfg_zlif = { enabled = false, over_tls = false }
 local _cfg_min_share
 local _cfg_max_share
 local _cfg_min_slots
@@ -457,6 +467,8 @@ local function _bind_dispatch_module( )
         _cfg_hub_website     = _cfg_hub_website,
         _cfg_hub_network     = _cfg_hub_network,
         _cfg_hub_owner       = _cfg_hub_owner,
+        _cfg_zlif_enabled    = _cfg_zlif.enabled,
+        _cfg_zlif_over_tls   = _cfg_zlif.over_tls,
         _i18n_unknown            = _i18n_unknown,
         _i18n_cid_taken          = _i18n_cid_taken,
         _i18n_hub_is_full        = _i18n_hub_is_full,
@@ -1254,6 +1266,40 @@ incoming = function( client, data, err )
     if adccmd then    -- adc command, try to process
         local type = adccmd:type( )
         local cmd =  adccmd:cmd( )
+        -- Phase 8 S4b: transport-level ZLIF intercept. ZON / ZOF are
+        -- stream-control messages, not application commands. They
+        -- never reach plugins or the state-machine dispatcher.
+        --
+        -- ZON: client signals "my outbound from the next byte is
+        -- zlib-compressed". Splice an inflate stage ahead of the
+        -- ADC-line stage on this connection's inbound pipeline; the
+        -- post-ZON residual buf (any compressed bytes that arrived
+        -- in the same TCP chunk) gets re-routed through the new
+        -- stage by S4a's pipeline:prepend semantic. Spurious ZON
+        -- when ZLIF is disabled gets ISTA 144 (feature not
+        -- supported, FCZON identifier per ADC 5.4.2).
+        --
+        -- ZOF: hub MVP closes the connection. The spec's "stop
+        -- decompressing" semantic requires us to splice the inflate
+        -- stage out, which is not a simple operation while the
+        -- zlib stream is mid-sync-flush + the post-ZOF wire is
+        -- plain (no way to safely re-feed input_buf if it
+        -- straddles the boundary). Closing on ZOF is spec-permitted
+        -- (we did stop decompressing) and matches real-world client
+        -- behaviour (DC++ clients send ZON once and never ZOF
+        -- during a session).
+        if cmd == "ZON" then
+            if _cfg_zlif.enabled then
+                user:client().inframer_prepend( ( use "iostream" ).newinflatestage( ) )
+                out_put( "hub.lua: function 'incoming': ZLIF activated inbound for user ", usersid )
+            else
+                user.write( "ISTA 144 FCZON\n" )
+            end
+            return true
+        elseif cmd == "ZOF" then
+            user:kill( "ISTA 200 ZLIF ZOF unsupported, closing connection\n", "TL-1" )
+            return true
+        end
         local mysid = adccmd:mysid( )
         local userstate = user.state( )
         local targetsid = adccmd:targetsid( )
@@ -1407,6 +1453,18 @@ loadsettings = function( )    -- caching table lookups...
     _cfg_max_bad_password = cfg_get "max_bad_password"
     _cfg_bad_pass_timeout = cfg_get "bad_pass_timeout"
     _cfg_kill_wrong_ips = cfg_get "kill_wrong_ips" -- not in cfg.tbl
+    -- Phase 8 S4b: ZLIF gates. `zlif_enabled` toggles SUP advertise +
+    -- post-HSUP IZON initiation. `zlif_over_tls` separately gates the
+    -- TLS path (CRIME-class chosen-plaintext-length leak mitigation,
+    -- see docs/SECURITY.md). Defensive: refuse to enable ZLIF if the
+    -- zlib_stream C module failed to load (optional dependency
+    -- pattern in core/init.lua).
+    _cfg_zlif.enabled = cfg_get "zlif_enabled" and true or false
+    _cfg_zlif.over_tls = cfg_get "zlif_over_tls" and true or false
+    if _cfg_zlif.enabled and ( use "zlib_stream" == false ) then
+        out_error( "hub.lua: zlif_enabled = true but the zlib_stream C module did not load; disabling ZLIF for this run" )
+        _cfg_zlif.enabled = false
+    end
     _bind_dispatch_module()
 end
 

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -42,6 +42,7 @@ local tostring = use "tostring"
 
 local adclib = use "adclib"
 local cfg = use "cfg"
+local iostream = use "iostream"
 local ratelimit = use "ratelimit"
 local scripts = use "scripts"
 local signal = use "signal"
@@ -54,6 +55,8 @@ local adclib_createsalt = adclib.createsalt
 local adclib_escape = adclib.escape
 local adclib_hash = adclib.hash
 local adclib_hashpas = adclib.hashpas
+local iostream_newinflatestage = iostream.newinflatestage
+local iostream_newdeflatestage = iostream.newdeflatestage
 local adclib_hasholdpas = adclib.hasholdpas
 local escapeto = adclib_escape
 local escapefrom = adclib.unescape
@@ -139,6 +142,8 @@ local _cfg_hub_hostaddress
 local _cfg_hub_website
 local _cfg_hub_network
 local _cfg_hub_owner
+local _cfg_zlif_enabled
+local _cfg_zlif_over_tls
 
 -- i18n strings (rebuilt on +reload via loadlanguage).
 local _i18n_unknown
@@ -193,6 +198,8 @@ local function bind( deps )
     _cfg_hub_website     = deps._cfg_hub_website
     _cfg_hub_network     = deps._cfg_hub_network
     _cfg_hub_owner       = deps._cfg_hub_owner
+    _cfg_zlif_enabled    = deps._cfg_zlif_enabled
+    _cfg_zlif_over_tls   = deps._cfg_zlif_over_tls
     -- i18n
     _i18n_unknown            = deps._i18n_unknown
     _i18n_cid_taken          = deps._i18n_cid_taken
@@ -271,7 +278,11 @@ _protocol = {
                     os_difftime( os_time( ), signal_get( "start" ) )
                 )
             elseif not _cfg_reg_only then
-                response = utf_format( _normalsup,
+                local tpl = _normalsup
+                if _cfg_zlif_enabled then
+                    tpl = tpl:gsub( "ADUCMD\n", "ADUCMD ADZLIF\n", 1 )
+                end
+                response = utf_format( tpl,
                     user.sid( ),
                     _cfg_hub_name,
                     adclib_escape( VERSION ),
@@ -279,13 +290,37 @@ _protocol = {
                     _cfg_hub_redirect_protocols
                 )
             elseif _cfg_reg_only then
-                response = utf_format( _normalsup_regonly,
+                local tpl = _normalsup_regonly
+                if _cfg_zlif_enabled then
+                    tpl = tpl:gsub( "ADUCMD\n", "ADUCMD ADZLIF\n", 1 )
+                end
+                response = utf_format( tpl,
                     user.sid( ),
                     adclib_escape( VERSION ),
                     _cfg_hub_redirect_protocols
                 )
             end
             user.write( response )
+            -- Phase 8 S4b: ZLIF activation. Decision is made by the
+            -- hub on every connect; the client's `ADZLIF` token in
+            -- HSUP signals it CAN do compression. Hub-initiated:
+            -- write the IZON marker UNCOMPRESSED (it is the last
+            -- plain frame, per ADC-EXT) then install the outbound
+            -- deflate stage so subsequent writes are deflated. The
+            -- client decides separately whether to compress its own
+            -- outbound (and signals via its own ZON; we install
+            -- inbound inflate on receipt in hub.lua's incoming
+            -- intercept). zlif_over_tls separately gates the TLS
+            -- path - see SECURITY.md for the CRIME discussion.
+            if _cfg_zlif_enabled and adccmd:hasparam "ADZLIF" then
+                local client = user:client()
+                local is_tls = client.ssl and client.ssl( )
+                if ( not is_tls ) or _cfg_zlif_over_tls then
+                    user.write( "IZON\n" )
+                    client.outframer_prepend( iostream_newdeflatestage( ) )
+                    user._zlif_out = true    -- annotation for logs / introspection
+                end
+            end
             if _cfg_max_users <= _get_user_count() then
                 user:kill( "ISTA 211 " .. _i18n_hub_is_full .. "\n" )-----!
                 return true

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -280,6 +280,16 @@ _protocol = {
             elseif not _cfg_reg_only then
                 local tpl = _normalsup
                 if _cfg_zlif_enabled then
+                    -- Insert ADZLIF into the SUP token list. Anchor:
+                    -- "ADUCMD\n" - the last token in the SUP segment.
+                    -- DO NOT remove or rename ADUCMD in _normalsup
+                    -- without updating this gsub anchor (and the
+                    -- _normalsup_regonly branch below). The S4b ZLIF
+                    -- smoke test asserts ADZLIF appears in the
+                    -- advertise, so a dropped anchor fails CI - the
+                    -- runtime check that used to live here was a
+                    -- sandbox-violating `assert` (no `assert` in the
+                    -- core env).
                     tpl = tpl:gsub( "ADUCMD\n", "ADUCMD ADZLIF\n", 1 )
                 end
                 response = utf_format( tpl,
@@ -292,6 +302,8 @@ _protocol = {
             elseif _cfg_reg_only then
                 local tpl = _normalsup_regonly
                 if _cfg_zlif_enabled then
+                    -- Same anchor + smoke-test gate as the
+                    -- non-regonly branch above.
                     tpl = tpl:gsub( "ADUCMD\n", "ADUCMD ADZLIF\n", 1 )
                 end
                 response = utf_format( tpl,
@@ -311,14 +323,20 @@ _protocol = {
             -- outbound (and signals via its own ZON; we install
             -- inbound inflate on receipt in hub.lua's incoming
             -- intercept). zlif_over_tls separately gates the TLS
-            -- path - see SECURITY.md for the CRIME discussion.
-            if _cfg_zlif_enabled and adccmd:hasparam "ADZLIF" then
+            -- path - see SECURITY.md for the CRIME discussion. PING
+            -- (hublist) handshakes are excluded - pingers disconnect
+            -- immediately after the response, and dispatching them a
+            -- deflate stage would compress nothing useful and only
+            -- complicate the scraper's debug output.
+            if _cfg_zlif_enabled
+                and adccmd:hasparam "ADZLIF"
+                and ( not adccmd:hasparam "ADPING" )
+            then
                 local client = user:client()
                 local is_tls = client.ssl and client.ssl( )
                 if ( not is_tls ) or _cfg_zlif_over_tls then
                     user.write( "IZON\n" )
                     client.outframer_prepend( iostream_newdeflatestage( ) )
-                    user._zlif_out = true    -- annotation for logs / introspection
                 end
             end
             if _cfg_max_users <= _get_user_count() then

--- a/core/init.lua
+++ b/core/init.lua
@@ -109,6 +109,12 @@ _optional = {    -- optional extern libs
 
     "ssl",
     "basexx",
+    -- Phase 8 S4b: zlib stream binding for ADC-EXT ZLIF (stream
+    -- compression). Optional so the hub still runs if the binary
+    -- failed to build / is missing; cfg validates `zlif_enabled =
+    -- true` against load success and refuses to advertise ZLIF if
+    -- the binding is not available.
+    "zlib_stream",
 
 }
 

--- a/core/iostream.lua
+++ b/core/iostream.lua
@@ -150,6 +150,10 @@ local newhttppipeline
 local newoutpassthroughstage
 local newoutpipeline
 
+-- S4b ADC-EXT ZLIF.
+local newinflatestage
+local newdeflatestage
+
 ----------------------------------// DEFINITION //--
 
 -- ADC-line framer stage (S1 logic carried through S4a; emits AT MOST
@@ -537,6 +541,76 @@ newoutpipeline = function( )
 
 end    -- newoutpipeline
 
+-- Inbound inflate stage (Phase 8 S4b, ADC-EXT ZLIF).
+--
+-- Holds an inflate_stream userdata across calls; decompresses each
+-- input chunk with Z_SYNC_FLUSH. The C binding caps decompressed
+-- output per push at 4 MiB (decompression-bomb guard) and raises a
+-- Lua error on malformed input. We pcall around it so a hostile or
+-- corrupt compressed stream surfaces as the pipeline's overflow
+-- signal -> server.lua closes the connection (no half-decompressed
+-- garbage ever reaches the ADC parser).
+--
+-- :residual() returns "" because inflate has no notion of
+-- "unprocessed bytes that can be moved": Z_SYNC_FLUSH consumes every
+-- input byte per push, the internal history buffer is zlib state not
+-- byte content. The pipeline reshape seam is only ever used to
+-- INSERT this stage ahead of the ADC-line stage on ZON; ZOF closes
+-- the connection (see hub_dispatch.lua), so no removal-side
+-- reshape is needed.
+newinflatestage = function( )
+    local zlib_stream = use "zlib_stream"
+    if not zlib_stream then
+        error( "iostream.newinflatestage: zlib_stream module not loaded" )
+    end
+    local strm = zlib_stream.inflate( )
+
+    local push = function( _, chunk )
+        if chunk and chunk ~= "" then
+            local ok, out = pcall( strm.push, strm, chunk )
+            if not ok then
+                return nil, true    -- malformed input / bomb guard -> close
+            end
+            if out and out ~= "" then
+                return out, false
+            end
+        end
+        return nil, false
+    end
+
+    local residual = function( ) return "" end
+
+    return setmetatable( { }, { __index = { push = push, residual = residual } } )
+end
+
+-- Outbound deflate stage (Phase 8 S4b, ADC-EXT ZLIF).
+--
+-- Symmetric to the inbound inflate stage: compresses each chunk of
+-- outbound bytes with Z_SYNC_FLUSH so the peer can decompress
+-- promptly (spec mandates partial flush per chunk). `level` defaults
+-- to the C module's Z_DEFAULT_COMPRESSION; callers may pass 1-9 for
+-- speed / size tradeoff (out of scope for S4b - cfg knob is binary
+-- enable/disable, level is hardcoded default).
+--
+-- No :residual() on outbound stages by contract - the outbound
+-- pipeline only prepends, never strips.
+newdeflatestage = function( level )
+    local zlib_stream = use "zlib_stream"
+    if not zlib_stream then
+        error( "iostream.newdeflatestage: zlib_stream module not loaded" )
+    end
+    local strm = zlib_stream.deflate( level )
+
+    local write = function( _, bytes )
+        if bytes and bytes ~= "" then
+            return strm:push( bytes )
+        end
+        return ""
+    end
+
+    return setmetatable( { }, { __index = { write = write } } )
+end
+
 ----------------------------------// PUBLIC INTERFACE //--
 
 return {
@@ -549,5 +623,9 @@ return {
 
     newoutpipeline         = newoutpipeline,
     newoutpassthroughstage = newoutpassthroughstage,
+
+    -- S4b ADC-EXT ZLIF (zlib stream compression).
+    newinflatestage        = newinflatestage,
+    newdeflatestage        = newdeflatestage,
 
 }

--- a/core/iostream.lua
+++ b/core/iostream.lua
@@ -131,6 +131,12 @@ local use = use
 local string = use "string"
 local tonumber = use "tonumber"
 local setmetatable = use "setmetatable"
+-- Phase 8 S4b: the inflate stage pcalls the C binding so that the
+-- 4 MiB bomb cap or a malformed compressed stream surfaces as the
+-- pipeline overflow signal instead of crashing the hub. Core scripts
+-- run in a sandboxed env (see core/init.lua setenv) where global
+-- pcall is not in scope - must `use` it explicitly.
+local pcall = use "pcall"
 
 local string_find = string.find
 local string_sub = string.sub

--- a/core/server.lua
+++ b/core/server.lua
@@ -590,6 +590,20 @@ wrapconnection = function( server, listeners, socket, serverip, clientip, server
         maxreadlen = readlen or maxreadlen
         return maxreadlen, maxsendlen
     end
+    -- Phase 8 S4b: per-connection pipeline reshape accessors so the
+    -- ADC dispatcher (hub_dispatch.lua) can splice an inflate stage
+    -- ahead of the ADC-line stage on inbound ZON, and prepend a
+    -- deflate stage on the outbound pipeline on outbound ZON. The
+    -- inframer:prepend() reshape is the load-bearing semantic that
+    -- S4a's iterator API was designed for - residual bytes the
+    -- ADC-line stage had buffered after the ZON `\n` get re-fed
+    -- through the new front (inflate) stage; see core/iostream.lua.
+    handler.inframer_prepend = function( stage )
+        return inframer:prepend( stage )
+    end
+    handler.outframer_prepend = function( stage )
+        return outframer:prepend( stage )
+    end
 
     local try_sending_on_write
     local try_reading_on_write

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@
 # ---------------------------------------------------------------------------
 FROM alpine:3.20 AS build
 
-RUN apk add --no-cache build-base cmake openssl-dev linux-headers
+RUN apk add --no-cache build-base cmake openssl-dev zlib-dev linux-headers
 
 WORKDIR /src
 COPY . .
@@ -36,7 +36,11 @@ FROM alpine:3.20
 #                 it so we have to pull it in explicitly
 #   coreutils     busybox lacks `base32`, which we need for the
 #                 SHA256 keyprint -> adcs:// URL form
-RUN apk add --no-cache openssl ca-certificates tini libstdc++ coreutils
+#   zlib          dynamic dep of zlib_stream.so (Phase 8 S4b ADC-EXT
+#                 ZLIF binding); only matters at runtime when
+#                 cfg.zlif_enabled = true, but the shared object's
+#                 dependency on libz.so.1 is resolved at hub start
+RUN apk add --no-cache openssl zlib ca-certificates tini libstdc++ coreutils
 
 # Fixed image UID/GID. Operators who want their host bind-mount files
 # owned by their own UID override this at run time with `--user $(id

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -20,17 +20,20 @@ Output lands in `build/install/luadch/`. Run the hub from there.
 
 ```sh
 # Debian / Ubuntu
-sudo apt-get install -y build-essential cmake libssl-dev git
+sudo apt-get install -y build-essential cmake libssl-dev zlib1g-dev git
 
 # Fedora / RHEL
-sudo dnf install gcc gcc-c++ make cmake openssl-devel git
+sudo dnf install gcc gcc-c++ make cmake openssl-devel zlib-devel git
 
 # FreeBSD / OpenBSD
-pkg install cmake gcc git    # OpenSSL is in base
+pkg install cmake gcc git    # OpenSSL + zlib are in base
 ```
 
 Required: gcc or clang (any version supporting C99 / C++17), CMake ≥ 3.20,
-OpenSSL 3.x development headers.
+OpenSSL 3.x development headers, zlib development headers (used by the
+Phase 8 S4b ADC-EXT ZLIF stream-compression binding;
+`find_package(ZLIB REQUIRED)` is unconditional even when `zlif_enabled =
+false` at runtime).
 
 ### Build & install
 
@@ -61,10 +64,12 @@ cd build/install/luadch
 | MinGW-w64 | https://winlibs.com/ | x86_64, POSIX threads, SEH, UCRT — extract so `C:\MinGW\bin\gcc.exe` exists |
 | CMake ≥ 3.20 | https://cmake.org/download/ or `choco install cmake` | must be on PATH |
 | OpenSSL 3.x | `C:\OpenSSL\` | see "OpenSSL on Windows" below |
+| zlib 1.3+ | `C:\MinGW\include\zlib.h` + `C:\MinGW\lib\libz.a` | see "zlib on Windows" below |
 
 For non-default install paths, point CMake at them at configure time, e.g.
-`-DOPENSSL_ROOT_DIR=D:/path/to/openssl`. MinGW is picked up from `PATH`
-(make sure `gcc.exe` is reachable, or pass `-DCMAKE_C_COMPILER=...`).
+`-DOPENSSL_ROOT_DIR=D:/path/to/openssl` or `-DZLIB_ROOT=D:/path/to/zlib`.
+MinGW is picked up from `PATH` (make sure `gcc.exe` is reachable, or pass
+`-DCMAKE_C_COMPILER=...`).
 
 ### OpenSSL on Windows
 
@@ -88,6 +93,37 @@ C:\OpenSSL\libcrypto-3-x64.dll
 C:\OpenSSL\libssl.dll.a
 C:\OpenSSL\libcrypto.dll.a
 ```
+
+### zlib on Windows
+
+Vanilla MinGW-w64 distributions do not ship zlib development files (only
+the `zlib1.dll` runtime, embedded in projects like Git for Windows).
+`find_package(ZLIB REQUIRED)` in our top-level CMakeLists therefore
+needs a manual one-time install. Easiest path: build from upstream
+source against the same MinGW you use for luadch.
+
+```sh
+# In any unix-y shell with the MinGW gcc on PATH:
+curl -fsSL -o zlib-1.3.2.tar.gz https://www.zlib.net/zlib-1.3.2.tar.gz
+# Optional but recommended: verify the SHA-256
+# (bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16
+#  at the time of writing; check https://www.zlib.net/ for the current
+#  release / hash).
+tar -xzf zlib-1.3.2.tar.gz
+cd zlib-1.3.2
+mingw32-make -f win32/Makefile.gcc \
+    CC=C:/MinGW/bin/gcc.exe AR=C:/MinGW/bin/ar.exe
+# The DLL build step needs gcc on PATH for windres - we only need the
+# static lib (libz.a) and the headers, so a Makefile.gcc partial
+# failure on the windres step is OK.
+cp zlib.h zconf.h C:/MinGW/include/
+cp libz.a            C:/MinGW/lib/
+```
+
+luadch's `zlib_stream.dll` then statically links `libz.a`, so the
+runtime install tree does NOT need a separate `zlib1.dll`. Pass
+`-DZLIB_ROOT=C:/MinGW` to CMake if zlib lives anywhere other than the
+default search path.
 
 ### Build & install
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -447,6 +447,52 @@ fingerprint; operators can publish their fingerprint via the
 `+hubinfo` command and clients that support `KEYP` will reject
 mismatching certs.
 
+### TLS + ZLIF (`zlif_over_tls`) - CRIME-class length leak
+
+Phase 8 S4b adds optional ADC-EXT ZLIF stream compression. ZLIF is
+off by default (`zlif_enabled = false`); when an operator enables
+it, a separate flag (`zlif_over_tls`, also default `false`) gates
+whether ZLIF activates on TLS-wrapped connections in addition to
+plain ADC.
+
+The rationale for the second flag is the CRIME-class
+chosen-plaintext-length leak that applies to **any** scheme of
+"compress then encrypt". In the luadch + ZLIF + TLS deployment the
+shape is:
+
+- An attacker on the same hub PMs a victim chosen plaintext.
+- The hub forwards the PM on the victim's TLS-wrapped connection,
+  mixed with whatever else that connection carries (broadcast chat,
+  user lists, PMs from other peers).
+- The hub deflates the per-connection stream BEFORE TLS encrypts
+  it, so the ciphertext **length** depends on the compressed length,
+  which depends on the dictionary similarity between the attacker's
+  chosen plaintext and the victim's other contents.
+- A wire-level eavesdropper (LAN/ISP) observing length deltas can
+  in principle infer whether the chosen plaintext matched something
+  else in the victim's stream.
+
+In practice the exploit is weak: broadcast traffic adds noise, the
+attacker needs eavesdropper access on the victim's network, and
+distinguishing 1-bit length deltas in a busy hub is hard. But the
+mitigation cost is one cfg flag, so the safe default is `false` -
+operators who want the bandwidth saving and accept the residual
+risk set `zlif_over_tls = true`. Plain-ADC connections see ZLIF
+unconditionally when `zlif_enabled = true`; only TLS is gated.
+
+ZLIF also has two transport-level hardening properties enforced by
+the binding ([`zlib_stream/zlib_stream.c`](../zlib_stream/zlib_stream.c)):
+
+- **Decompression-bomb cap.** Each inflate call caps decompressed
+  output at 4 MiB. Exceeding the cap raises a Lua error which the
+  inbound inflate stage propagates as the pipeline's overflow
+  signal, and `core/server.lua`'s read loop closes the connection.
+  A 1 KB compressed payload that expands to GiB on the wire cannot
+  drive runaway memory usage on the hub.
+- **Malformed-input close.** zlib `Z_DATA_ERROR` / `Z_NEED_DICT` on
+  a corrupted compressed stream is also surfaced as overflow; the
+  hub closes rather than continuing on poisoned state.
+
 ---
 
 ## 7. CVE / dependency tracking
@@ -461,6 +507,10 @@ subscribe to upstream releases:
   v0.4.1, upstream essentially abandoned
 - [OpenSSL](https://github.com/openssl/openssl) - linked dynamically;
   `find_package(OpenSSL 3.0 REQUIRED)` enforces the floor
+- [zlib](https://www.zlib.net/) - linked dynamically;
+  `find_package(ZLIB REQUIRED)`. Used by the
+  [`zlib_stream`](../zlib_stream/zlib_stream.c) ADC-EXT ZLIF binding
+  (Phase 8 S4b); only matters at runtime when `zlif_enabled = true`
 
 Quarterly checklist: query
 [osv.dev](https://osv.dev) and the GitHub Advisory Database for each

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -449,6 +449,12 @@ mismatching certs.
 
 ### TLS + ZLIF (`zlif_over_tls`) - CRIME-class length leak
 
+**Recommendation: leave `zlif_over_tls = false` on production hubs.**
+The bandwidth saving stacking compression UNDER TLS is usually not
+worth the residual CRIME-class risk. Plain-ADC connections see
+ZLIF unconditionally when `zlif_enabled = true`; the flag below
+only matters for ADCS / TLS connections.
+
 Phase 8 S4b adds optional ADC-EXT ZLIF stream compression. ZLIF is
 off by default (`zlif_enabled = false`); when an operator enables
 it, a separate flag (`zlif_over_tls`, also default `false`) gates

--- a/docs/phases/PHASE_8_IO.md
+++ b/docs/phases/PHASE_8_IO.md
@@ -574,3 +574,75 @@ S4b adds a `deflate_stream` stage prepended on `IZON`-out.
   not p.ip) + C1-C5; all fixed in-branch (see finding above). N4
   pre-existing hub_listen/addserver bugs tracked as #186. Re-run
   security review on the fixes before sub-PR.
+- 2026-05-20: S4 split into S4a (behaviour-neutral pipeline
+  iterator + outbound passthrough seam) and S4b (ZLIF feature) per
+  CLAUDE.md §1a.8. S4a (#189) merged into phase8-io (squash f56dd44),
+  CI green: pipeline contract switched from "feed -> all frames" to
+  lazy iterator (feed + next + drain), stage contract tightened to
+  one-unit-per-push, outbound pipeline added (default passthrough =
+  byte-identical), 51/51 unit tests including mid-chunk reshape +
+  multi-stage sticky_overflow + outbound prepend-ordering. Two-pass
+  review: 0 BLOCKER / 2 CONCERN (C1 misleading sticky-overflow
+  comment, C2 dead branch in `_pull`) / 5 NIT - C1/C2/N2 fixed
+  in-branch before merge.
+- 2026-05-20: S4b implemented on branch phase8-io-s4b. New zlib
+  build dep (`find_package(ZLIB REQUIRED)`); new C module
+  `zlib_stream/zlib_stream.c` (~250 LoC: deflate_stream +
+  inflate_stream userdata, Z_SYNC_FLUSH semantic, 4 MiB
+  decompression-bomb cap per inflate push). New Lua stages
+  `iostream.newinflatestage` / `newdeflatestage` wrapping the C
+  module; pcall around inflate so a corrupt / bomb-cap stream
+  surfaces as the pipeline overflow signal -> server.lua closes
+  the connection. Handler accessors
+  `inframer_prepend` / `outframer_prepend` added to server.lua so
+  the dispatcher can splice stages mid-stream. `cfg.zlif_enabled`
+  + `cfg.zlif_over_tls` validators added (boolean only). hub.lua's
+  HSUP handler gsubs `ADZLIF` into the SUP advertise template when
+  `zlif_enabled`, sends `IZON\n` after the SUP response (last
+  plain frame) and prepends the outbound deflate stage so all
+  subsequent writes are compressed. Inbound `ZON` intercepted in
+  `hub.lua's incoming()` before plugins / state dispatch see it,
+  routes to `inframer_prepend(newinflatestage())`; the post-ZON
+  residual buf the ADC-line stage had buffered re-feeds through
+  the new inflate stage by S4a's reshape semantic. Inbound `ZOF`
+  closes the connection politely (spec-permitted; clean strip-
+  inflate-mid-stream is deferred until a real client actually
+  exercises the path).
+
+  **Lua 5.4 200-locals-per-chunk ceiling encountered.** hub.lua
+  already sat near the limit; adding two new cfg cache locals +
+  the iostream binding tripped it. Resolved by packing the ZLIF
+  cfg cache into a single table (`local _cfg_zlif = { enabled,
+  over_tls }`) and looking up `iostream` via `use` at ZON dispatch
+  time instead of aliasing it into a top-level local. Per-connect
+  cost is negligible; the comment in hub.lua documents the
+  constraint so future refactors do not re-grow the local count
+  without noticing.
+
+  **zlib_stream is loaded as `_optional` in core/init.lua.** If the
+  C module failed to build / link, the hub still starts; loadsettings
+  detects `_cfg_zlif.enabled = true and use "zlib_stream" == false`
+  and overrides to `false` with an out_error so ZLIF is silently
+  disabled rather than crashing at connect time.
+
+  **CI:** Linux job apt-installs `zlib1g-dev`; Windows MSYS2 job
+  adds `mingw-w64-ucrt-x86_64-zlib`. Maintainer's local Windows
+  MinGW needed a one-time zlib 1.3.2 source + libz.a static
+  install into `C:\MinGW\{include,lib}` - documented in
+  docs/BUILDING.md (TODO: actually add the note).
+
+  Tests: iostream unit tests grow to 66/66 (was 51), with a
+  mock-zlib `_real` shim entry so inflate/deflate stages can be
+  unit-tested without loading the real C binding (standalone Lua
+  cannot load the hub-bundled liblua-linked .dll). The real C
+  binding is exercised via the new smoke test
+  `test_zlif_roundtrip`: stops the hub, flips `zlif_enabled =
+  true`, restarts, runs a full ADC login + `+help` reply over the
+  zlib-compressed inbound (Python `zlib.decompressobj()`,
+  matches Z_SYNC_FLUSH cadence). Default-off smoke run (47 tests)
+  stays green unchanged.
+
+  Next: security-focused two-pass review (decompression-bomb
+  path, TLS-over-ZLIF cfg gate, ZON reshape correctness, missing-
+  module graceful degradation) -> sub-PR into phase8-io ->
+  phase8-io review gate -> phase8-io merge to master.

--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -34,7 +34,7 @@ return { -- the settings are a lua table, do not tough this!
     http_port = false,  -- local read-only HTTP API (#82): false = OFF (default, no socket bound); a number = bind hardened HTTP framer on 127.0.0.1:<n> ONLY (loopback; use a reverse proxy for non-loopback). S3 serves only /health; auth + data endpoints come in a later release
 
     zlif_enabled = false,  -- ADC-EXT ZLIF stream compression (#147 T3.2): false = OFF (default, hub does not advertise ADZLIF, no compression). true = hub advertises ADZLIF in SUP, initiates IZON on plain-ADC connections whose client also advertised ADZLIF, decompresses inbound on client's ZON. Saves bandwidth on busy hubs; costs CPU per connection.
-    zlif_over_tls = false,  -- separately gates ZLIF over TLS (boolean). Default OFF: TLS already encrypts the wire, and TLS+stream compression has a theoretical CRIME-class chosen-plaintext-length leak surface (eavesdropper-only; see docs/SECURITY.md). Set true only if the bandwidth saving outweighs that residual risk for your deployment.
+    zlif_over_tls = false,  -- NOT RECOMMENDED on ADCS / TLS hubs (boolean). Default OFF: TLS already encrypts the wire, and stacking compression UNDER TLS opens a theoretical CRIME-class chosen-plaintext-length leak surface (eavesdropper-only; see docs/SECURITY.md §6). The mitigation cost is one cfg flag; the bandwidth saving on already-encrypted connections is usually not worth the residual risk. Only set true on busy hubs where you have specifically weighed the trade-off. Plain ADC connections see ZLIF regardless.
 
     use_ssl = true,  -- use ssl (boolean); you have to make a cert for adcs!; use "certs/make_cert.bat/.sh" or "Luadch-NG Certmanager"
 

--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -33,6 +33,9 @@ return { -- the settings are a lua table, do not tough this!
 
     http_port = false,  -- local read-only HTTP API (#82): false = OFF (default, no socket bound); a number = bind hardened HTTP framer on 127.0.0.1:<n> ONLY (loopback; use a reverse proxy for non-loopback). S3 serves only /health; auth + data endpoints come in a later release
 
+    zlif_enabled = false,  -- ADC-EXT ZLIF stream compression (#147 T3.2): false = OFF (default, hub does not advertise ADZLIF, no compression). true = hub advertises ADZLIF in SUP, initiates IZON on plain-ADC connections whose client also advertised ADZLIF, decompresses inbound on client's ZON. Saves bandwidth on busy hubs; costs CPU per connection.
+    zlif_over_tls = false,  -- separately gates ZLIF over TLS (boolean). Default OFF: TLS already encrypts the wire, and TLS+stream compression has a theoretical CRIME-class chosen-plaintext-length leak surface (eavesdropper-only; see docs/SECURITY.md). Set true only if the bandwidth saving outweighs that residual risk for your deployment.
+
     use_ssl = true,  -- use ssl (boolean); you have to make a cert for adcs!; use "certs/make_cert.bat/.sh" or "Luadch-NG Certmanager"
 
     hub_website = "https://yourwebsite.org",  -- your website (string)

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -2102,6 +2102,117 @@ def test_zlif_roundtrip(staging_dir: Path, proc=None):
         sock.sendall(f"BMSG {sid} +help\n".encode("utf-8"))
         pump_recv(b"MSG ", timeout=PROTOCOL_TIMEOUT_SEC * 2)
 
+        # 8. Now flip the CLIENT outbound to compression too so the
+        # hub's inbound inflate stage gets exercised end-to-end
+        # against real zlib (the unit test only mocks zlib). The
+        # security review correctly flagged that the unit test
+        # cannot catch a real-zlib Z_SYNC_FLUSH boundary / buffering
+        # bug; this assertion covers the hub-inbound inflate path in
+        # CI.
+        #
+        # Drain all pending hub bytes first (the +help reply from
+        # step 7 may still be arriving in MSG fragments) so the
+        # post-BZON marker check below cannot match a stale frame.
+        sock.settimeout(0.5)
+        while True:
+            try:
+                chunk = sock.recv(4096)
+            except socket.timeout:
+                break
+            if not chunk:
+                break
+            comp_buf.extend(chunk)
+        if comp_buf:
+            decoded.extend(decomp.decompress(bytes(comp_buf)))
+            del comp_buf[:]
+        boundary = len(decoded)
+
+        # Send `BZON <sid>` uncompressed (last plain client frame),
+        # then a single TCP write that bundles the compressed BMSG
+        # right after the ZON `\n` - this is the same-TCP-segment
+        # case S4a's pipeline reshape exists to handle. If the hub
+        # mis-frames the post-ZON tail (i.e. pre-S4a behaviour), the
+        # +zlif_compose-test command never reaches the hub command
+        # dispatcher and the assertion below times out.
+        comp = zlib.compressobj()
+        compressed = (
+            comp.compress(f"BMSG {sid} +help\n".encode("utf-8"))
+            + comp.flush(zlib.Z_SYNC_FLUSH)
+        )
+        zon_then_compressed = f"BZON {sid}\n".encode("utf-8") + compressed
+        sock.sendall(zon_then_compressed)
+
+        # Wait for a NEW MSG to appear AFTER the drain boundary. With
+        # the boundary anchored on a true zero-pending state, any
+        # MSG past it must be the reply to our compressed +help.
+        end = time.monotonic() + PROTOCOL_TIMEOUT_SEC * 2
+        while True:
+            if comp_buf:
+                decoded.extend(decomp.decompress(bytes(comp_buf)))
+                del comp_buf[:]
+            if decoded.find(b"MSG ", boundary) != -1:
+                break
+            remaining = end - time.monotonic()
+            if remaining <= 0:
+                raise TestFailure(
+                    "ZLIF inbound inflate: client compressed BZON + BMSG "
+                    "+help did not produce a new hub reply; possible "
+                    "mid-segment reshape regression or adc_parse rejecting "
+                    "BZON. "
+                    f"Decoded after boundary: "
+                    f"{bytes(decoded[boundary:])!r}"
+                )
+            sock.settimeout(remaining)
+            try:
+                chunk = sock.recv(4096)
+            except socket.timeout:
+                continue
+            if not chunk:
+                raise TestFailure(
+                    "ZLIF inbound: hub closed during compressed "
+                    "BMSG roundtrip"
+                )
+            comp_buf.extend(chunk)
+
+    finally:
+        sock.close()
+
+
+def test_zlif_pre_hsup_zon_rejected(staging_dir: Path, proc=None):
+    """Phase 8 S4b security gate (security review BLOCKER B1): a
+    `BZON` arriving BEFORE the HSUP handshake completes must be
+    rejected with ISTA 240 + connection close, NOT silently install
+    an inflate stage on a connection whose peer identity has not yet
+    been negotiated. Runs under zlif_enabled = true to prove the
+    state gate fires regardless of the operator cfg.
+
+    Pre-fix (no `userstate == "protocol"` check): the hub installed
+    inflate inbound, the client's plain follow-up bytes triggered a
+    zlib Z_DATA_ERROR, the connection closed without any ISTA. This
+    test specifically asserts the ISTA 240 marker which only the
+    fix emits."""
+    wait_for_port(HUB_HOST, TEST_PORT_PLAIN, START_TIMEOUT_SEC)
+
+    sock = socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    )
+    try:
+        sock.sendall(b"BZON AAAA\n")    # pre-HSUP - sid is bogus, irrelevant
+        buf = b""
+        end = time.monotonic() + PROTOCOL_TIMEOUT_SEC
+        while b"\n" not in buf and time.monotonic() < end:
+            sock.settimeout(end - time.monotonic())
+            try:
+                chunk = sock.recv(4096)
+            except socket.timeout:
+                break
+            if not chunk:
+                break
+            buf += chunk
+        if b"ISTA 240" not in buf:
+            raise TestFailure(
+                f"pre-HSUP BZON: expected ISTA 240 close marker; got {buf!r}"
+            )
     finally:
         sock.close()
 
@@ -2656,6 +2767,17 @@ def main():
             failed.append("ZLIF stream compression roundtrip (#147 T3.2)")
         else:
             log("PASS  ZLIF stream compression roundtrip (#147 T3.2)")
+
+        # Security review B1 follow-up: pre-HSUP BZON must be rejected
+        # with ISTA 240, not silently install the inflate stage on an
+        # un-identified peer.
+        try:
+            test_zlif_pre_hsup_zon_rejected(staging_dir, proc=proc)
+        except Exception as e:
+            log(f"FAIL  ZLIF pre-HSUP ZON rejected (S4b B1): {e}")
+            failed.append("ZLIF pre-HSUP ZON rejected (S4b B1)")
+        else:
+            log("PASS  ZLIF pre-HSUP ZON rejected (S4b B1)")
     finally:
         if proc is not None:
             stop_hub(proc, log_file)

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -33,6 +33,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import zlib
 from pathlib import Path
 
 # Vendored pure-Python Tiger-192 hash. Used to compute CIDs (Tiger(PID)) and
@@ -1944,6 +1945,167 @@ def test_http_health_roundtrip(staging_dir: Path, proc=None):
         reader.recv_until(lambda f: f.startswith("ISUP "))
 
 
+def _switch_to_zlif_mode(staging_dir: Path, current_proc, current_log_file):
+    """Phase 8 S4b (#147 T3.2) setup: stop the hub, flip
+    `zlif_enabled = false` to `true` in cfg.tbl so the next test
+    exercises ADC-EXT ZLIF stream compression. `zlif_over_tls` stays
+    false - we test the plain-ADC path only (the TLS gate is a
+    separate flag, and TLS+ZLIF has a documented CRIME-class
+    concern). Returns the new (proc, log_file)."""
+    stop_hub(current_proc, current_log_file)
+
+    cfg_path = staging_dir / "cfg" / "cfg.tbl"
+    text = cfg_path.read_text(encoding="utf-8")
+    new_text, n = re.subn(
+        r"zlif_enabled\s*=\s*false",
+        "zlif_enabled = true",
+        text,
+        count=1,
+    )
+    if n != 1:
+        raise TestFailure(
+            "could not flip zlif_enabled in cfg.tbl - is the key present in "
+            "examples/cfg/cfg.tbl with default false?"
+        )
+    cfg_path.write_text(new_text, encoding="utf-8")
+
+    time.sleep(1.0)
+    proc, log_file = start_hub(staging_dir)
+    return proc, log_file
+
+
+def test_zlif_roundtrip(staging_dir: Path, proc=None):
+    """Phase 8 S4b: ADC-EXT ZLIF full roundtrip. With zlif_enabled =
+    true and the client advertising ADZLIF in HSUP, the hub:
+
+      - advertises ADZLIF in its ISUP response (plain frames)
+      - sends `IZON\\n` as the last plain frame
+      - deflate(Z_SYNC_FLUSH)s every subsequent outbound byte
+
+    The test client decompresses inbound after the IZON boundary
+    using Python's stdlib zlib (incremental, matches the Z_SYNC_FLUSH
+    cadence). It does NOT send its own BZON, so its outbound stays
+    plain - this exercises the asymmetric per-direction nature of
+    ZLIF (hub compresses outbound; client outbound is plain).
+    Validates: SUP advertise, IZON emission, outbound deflate stage
+    installation, full ADC login flow over compression, +help reply
+    routed back through deflate."""
+    wait_for_port(HUB_HOST, TEST_PORT_PLAIN, START_TIMEOUT_SEC)
+
+    sock = socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    )
+    try:
+        sock.sendall(b"HSUP ADBASE ADTIGR ADZLIF\n")
+
+        # Read uncompressed bytes until the IZON\n boundary. Anything
+        # before IZON is plain ADC; the moment we see IZON, the hub
+        # has switched its outbound to deflate.
+        buf = b""
+        deadline = time.monotonic() + PROTOCOL_TIMEOUT_SEC
+        while b"IZON\n" not in buf:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TestFailure(
+                    f"timed out waiting for IZON; got {buf!r}"
+                )
+            sock.settimeout(remaining)
+            try:
+                chunk = sock.recv(4096)
+            except socket.timeout:
+                continue
+            if not chunk:
+                raise TestFailure(
+                    f"connection closed before IZON arrived; got {buf!r}"
+                )
+            buf += chunk
+
+        plain, compressed_tail = buf.split(b"IZON\n", 1)
+
+        # 1. SUP advertise check.
+        if b"ADZLIF" not in plain:
+            raise TestFailure(
+                f"hub did not advertise ADZLIF in plain SUP; got {plain!r}"
+            )
+
+        # 2. ISID parse out of plain frames.
+        sid = None
+        for f in plain.split(b"\n"):
+            if f.startswith(b"ISID "):
+                sid = f.split(b" ", 1)[1].decode("ascii")
+                break
+        if not sid:
+            raise TestFailure(f"no ISID in plain SUP frames; got {plain!r}")
+
+        # 3. From here on the hub's stream is zlib (Z_SYNC_FLUSH).
+        decomp = zlib.decompressobj()
+        decoded = bytearray()
+        comp_buf = bytearray(compressed_tail)
+
+        def pump_recv(needle: bytes, timeout=PROTOCOL_TIMEOUT_SEC):
+            """Read+decompress until `needle` (bytes) appears in
+            `decoded`, or timeout."""
+            end = time.monotonic() + timeout
+            while needle not in decoded:
+                if comp_buf:
+                    decoded.extend(decomp.decompress(bytes(comp_buf)))
+                    del comp_buf[:]
+                    if needle in decoded:
+                        return
+                remaining = end - time.monotonic()
+                if remaining <= 0:
+                    raise TestFailure(
+                        f"ZLIF timed out waiting for {needle!r}; "
+                        f"decoded so far: {bytes(decoded)!r}"
+                    )
+                sock.settimeout(remaining)
+                try:
+                    chunk = sock.recv(4096)
+                except socket.timeout:
+                    continue
+                if not chunk:
+                    raise TestFailure(
+                        f"connection closed mid-ZLIF; decoded "
+                        f"{bytes(decoded)!r}"
+                    )
+                comp_buf.extend(chunk)
+
+        # 4. Send BINF for dummy/test (client outbound stays plain -
+        # we did not BZON the hub).
+        pid_bytes = secrets.token_bytes(24)
+        cid_b32 = _b32_encode(_tiger.tiger(pid_bytes))
+        pid_b32 = _b32_encode(pid_bytes)
+        binf = (
+            f"BINF {sid}"
+            f" ID{cid_b32}"
+            f" PD{pid_b32}"
+            f" NIdummy"
+            f" I40.0.0.0"
+            f" SUTCP4\n"
+        )
+        sock.sendall(binf.encode("utf-8"))
+
+        # 5. Hub responds IGPA <salt>, compressed.
+        pump_recv(b"IGPA ")
+        idx = decoded.index(b"IGPA ")
+        nl = decoded.index(b"\n", idx)
+        gpa = decoded[idx:nl].decode("ascii")
+        salt_b32 = gpa.split(" ", 1)[1]
+        salt_bytes = _b32_decode(salt_b32)
+        response = _tiger.tiger(b"test" + salt_bytes)
+        sock.sendall(f"HPAS {_b32_encode(response)}\n".encode("utf-8"))
+
+        # 6. Login completes when the hub echoes our own BINF.
+        pump_recv(f"BINF {sid}".encode("ascii"))
+
+        # 7. Send +help BMSG and expect a chat reply (hubbot E/IMSG).
+        sock.sendall(f"BMSG {sid} +help\n".encode("utf-8"))
+        pump_recv(b"MSG ", timeout=PROTOCOL_TIMEOUT_SEC * 2)
+
+    finally:
+        sock.close()
+
+
 def _switch_to_public_hub_mode(staging_dir: Path, current_proc, current_log_file):
     """#162 setup: stop the hub, flip reg_only to false in cfg.tbl,
     restart. Required so the next test exercises the
@@ -2468,8 +2630,7 @@ def main():
             log("PASS  dual-stack same-port binding (#107)")
 
         # Phase 8 S3 (#82): enable the local HTTP API and exercise the
-        # hardened framer + /health router (last test - mutates
-        # http_port; no later test depends on it).
+        # hardened framer + /health router.
         try:
             proc, log_file = _switch_to_http_mode(
                 staging_dir, proc, log_file
@@ -2480,6 +2641,21 @@ def main():
             failed.append("HTTP /health roundtrip + hardening (#82 S3)")
         else:
             log("PASS  HTTP /health roundtrip + hardening (#82 S3)")
+
+        # Phase 8 S4b (#147 T3.2): flip zlif_enabled on, run a full
+        # ADC login + +help reply over zlib-compressed inbound. Last
+        # test because the cfg mutation is non-trivial and no later
+        # test should depend on the post-ZLIF hub state.
+        try:
+            proc, log_file = _switch_to_zlif_mode(
+                staging_dir, proc, log_file
+            )
+            test_zlif_roundtrip(staging_dir, proc=proc)
+        except Exception as e:
+            log(f"FAIL  ZLIF stream compression roundtrip (#147 T3.2): {e}")
+            failed.append("ZLIF stream compression roundtrip (#147 T3.2)")
+        else:
+            log("PASS  ZLIF stream compression roundtrip (#147 T3.2)")
     finally:
         if proc is not None:
             stop_hub(proc, log_file)

--- a/tests/unit/iostream_test.lua
+++ b/tests/unit/iostream_test.lua
@@ -24,9 +24,36 @@
 
 -- minimal sandbox shim: core/iostream.lua does `local x = use "x"`.
 -- Keep this in lockstep with iostream.lua's `use` imports.
+--
+-- zlib_stream is mocked: the real C binding cannot be loaded by a
+-- standalone lua interpreter against the hub's bundled liblua. The
+-- mock implements a trivial "compression" (prefix the input with
+-- "C:") so we can verify the inflate / deflate STAGES wire the
+-- module correctly + propagate errors. C-binding correctness is
+-- covered by the smoke test (which runs the hub with real zlib).
+local _mock_zlib_stream = {
+    deflate = function( )
+        return setmetatable( { }, { __index = {
+            push = function( _, b ) return "C:" .. ( b or "" ) end,
+        } } )
+    end,
+    inflate = function( )
+        return setmetatable( { }, { __index = {
+            push = function( _, b )
+                if not b or b == "" then return "" end
+                if b:sub( 1, 2 ) ~= "C:" then
+                    error( "mock inflate: not compressed input" )
+                end
+                return b:sub( 3 )
+            end,
+        } } )
+    end,
+}
+
 local _real = {
     string = string, table = table,
     setmetatable = setmetatable, tonumber = tonumber,
+    zlib_stream = _mock_zlib_stream,
 }
 _G.use = function( name )
     local v = _real[ name ]
@@ -311,6 +338,71 @@ local add_y = setmetatable( { }, { __index = { write = function( _, b ) return b
 op2:prepend( add_y )    -- stages = { add_y, passthrough }
 op2:prepend( add_x )    -- stages = { add_x, add_y, passthrough }
 eq( "out: prepend ordering (front-to-back)", op2:write( "a" ), "aXY" )
+
+----------------------------------------------------------------------
+-- S4b ZLIF stages. Wires the iostream stage shapes against the
+-- mock zlib_stream installed at the top of this file. The mock
+-- prefixes input with "C:" for "compression", strips it for
+-- "decompression", and errors on bad input - just enough surface to
+-- prove the stages a) call the C-binding method, b) propagate
+-- errors as overflow, c) compose with the framer the way ZLIF
+-- needs (inflate prepended ahead of adcline = decompress-then-frame
+-- chain).
+----------------------------------------------------------------------
+
+-- inbound inflate stage: wraps zlib_stream.inflate.
+local inf = iostream.newinflatestage( )
+local infunit, infov = inf:push( "C:hello" )
+eq( "inflate: pushes through mock zlib", infunit, "hello" )
+eq( "inflate: no overflow on success", infov, false )
+-- residual is always "" - inflate has no movable input buffer.
+eq( "inflate: residual is empty", inf:residual( ), "" )
+-- empty input -> no unit.
+local inf2 = iostream.newinflatestage( )
+local emptyunit, emptyov = inf2:push( "" )
+eq( "inflate: empty input -> nil unit", emptyunit, nil )
+eq( "inflate: empty input -> no overflow", emptyov, false )
+-- malformed compressed input -> mock errors -> stage signals overflow.
+local inf3 = iostream.newinflatestage( )
+local badunit, badov = inf3:push( "not-compressed" )
+eq( "inflate: malformed input -> overflow", badov, true )
+eq( "inflate: malformed input -> nil unit", badunit, nil )
+
+-- Composition: prepend inflate ahead of the ADC-line framer. Feed a
+-- "compressed" stream that decompresses to two ADC frames. Asserts
+-- inflate -> adcline ordering (the ZLIF runtime topology).
+local zp = iostream.newpipeline( 1048576 )
+zp:prepend( iostream.newinflatestage( ) )
+zp:feed( "C:BMSG x +help" .. NL .. "BMSG x +done" .. NL )
+local zf1 = zp:next( ); local zf2 = zp:next( ); local zf3 = zp:next( )
+eq( "ZLIF compose: frame 1 after inflate", zf1, "BMSG x +help" )
+eq( "ZLIF compose: frame 2 after inflate", zf2, "BMSG x +done" )
+eq( "ZLIF compose: pipeline drains", zf3, nil )
+
+-- The full reshape sequence that S4b's ZON dispatcher will execute:
+-- arrive with "ZON\n<compressed-tail>" in one chunk, dispatch ZON,
+-- prepend inflate, the residual compressed-tail emerges as
+-- decompressed ADC frames through the new pipeline. This is the
+-- *integration* of S4a's reshape and S4b's inflate stage.
+local rp = iostream.newpipeline( 1048576 )
+rp:feed( "ZON" .. NL .. "C:BMSG x +help" .. NL )
+local rf1 = rp:next( )
+eq( "ZON reshape: first frame is ZON", rf1, "ZON" )
+rp:prepend( iostream.newinflatestage( ) )
+eq( "ZON reshape: post-ZON tail decompressed + framed", rp:next( ), "BMSG x +help" )
+
+-- outbound deflate stage: wraps zlib_stream.deflate. write(bytes) =
+-- compressed bytes. Empty input -> empty output.
+local df = iostream.newdeflatestage( )
+eq( "deflate: pushes through mock zlib", df:write( "hello" ), "C:hello" )
+eq( "deflate: empty input -> empty output", df:write( "" ), "" )
+
+-- Composition: prepend deflate ahead of the outbound passthrough.
+-- Asserts the outbound topology for ZLIF (deflate runs FIRST, then
+-- the rest of the stack = nothing meaningful in S4b, just identity).
+local zop = iostream.newoutpipeline( )
+zop:prepend( iostream.newdeflatestage( ) )
+eq( "ZLIF outbound: write deflated", zop:write( "BMSG hi" .. NL ), "C:BMSG hi" .. NL )
 
 ----------------------------------------------------------------------
 

--- a/tests/unit/iostream_test.lua
+++ b/tests/unit/iostream_test.lua
@@ -53,6 +53,7 @@ local _mock_zlib_stream = {
 local _real = {
     string = string, table = table,
     setmetatable = setmetatable, tonumber = tonumber,
+    pcall = pcall,    -- iostream.lua's S4b inflate stage pcall's the C binding
     zlib_stream = _mock_zlib_stream,
 }
 _G.use = function( name )

--- a/zlib_stream/CMakeLists.txt
+++ b/zlib_stream/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Build the zlib_stream native plugin: minimal zlib binding for the
+# ADC-EXT ZLIF stream-compression feature (Phase 8 S4b). Wraps the two
+# stream operations the hub needs:
+#
+#   - deflate_stream:push(bytes) -> compressed bytes (Z_SYNC_FLUSH)
+#   - inflate_stream:push(bytes) -> decompressed bytes (Z_SYNC_FLUSH,
+#       with a hard total-output cap to bound decompression bombs)
+#
+# Output: lib/zlib_stream/zlib_stream.so (Linux) /
+#         lib/zlib_stream/zlib_stream.dll (Windows). Loaded by the
+# hub as require("zlib_stream"). Mirrors the layout of adclib.
+
+add_library(zlib_stream MODULE
+    zlib_stream.c
+)
+
+target_link_libraries(zlib_stream PRIVATE lua ZLIB::ZLIB)
+
+# Lua C modules conventionally have no "lib" prefix on Linux either —
+# require("zlib_stream") looks for zlib_stream.so directly.
+set_target_properties(zlib_stream PROPERTIES
+    PREFIX ""
+)
+
+# On Windows force .dll suffix to match the adclib precedent.
+if(WIN32)
+    set_target_properties(zlib_stream PROPERTIES SUFFIX ".dll")
+endif()
+
+# Static link of libgcc on Windows so the .dll does not drag in a
+# runtime dependency on the toolchain. Mirrors adclib.
+if(WIN32)
+    target_link_options(zlib_stream PRIVATE
+        -static-libgcc -static
+    )
+endif()
+
+install(TARGETS zlib_stream LIBRARY DESTINATION lib/zlib_stream RUNTIME DESTINATION lib/zlib_stream)

--- a/zlib_stream/zlib_stream.c
+++ b/zlib_stream/zlib_stream.c
@@ -1,0 +1,324 @@
+/*
+ * zlib_stream.c - minimal zlib stream binding for luadch Phase 8 S4b.
+ *
+ * Two userdata types:
+ *
+ *   zlib_stream.deflate( [level] ) -> stream
+ *       :push( input ) -> compressed bytes
+ *
+ *       Compresses `input` with deflate(..., Z_SYNC_FLUSH). Empty
+ *       input still returns whatever output deflate flushes. Stateful:
+ *       hold one of these per outbound TCP connection for its
+ *       lifetime. `level` defaults to Z_DEFAULT_COMPRESSION (6); pass
+ *       Z_BEST_SPEED (1) on heavily-loaded hubs that prefer CPU over
+ *       bandwidth savings.
+ *
+ *   zlib_stream.inflate( ) -> stream
+ *       :push( input ) -> decompressed bytes
+ *
+ *       Decompresses `input` with inflate(..., Z_SYNC_FLUSH). Caps the
+ *       decompressed bytes produced PER PUSH CALL at 4 MiB
+ *       (ZS_INFLATE_MAX_PER_PUSH below). Exceeding the cap throws a
+ *       Lua error so the caller can recognise a decompression-bomb
+ *       attempt and close the connection. The cap is high enough that
+ *       a full 1 MiB ADC frame burst is comfortably handled, low
+ *       enough that a 1 KB compressed bomb cannot drive multi-GiB
+ *       allocations per tick.
+ *
+ *       Throws a Lua error on malformed compressed input (zlib
+ *       Z_DATA_ERROR / Z_NEED_DICT). The caller is expected to log
+ *       and close.
+ *
+ *   :close()  -- frees the underlying zlib z_stream early
+ *   __gc      -- safety net for forgotten :close()
+ *
+ * Design notes:
+ *
+ *   - Z_SYNC_FLUSH after EVERY push, on both sides. ADC-EXT explicitly
+ *     mandates partial flush so the peer can decompress promptly; the
+ *     trailing 00 00 FF FF sync marker is what makes the stream
+ *     resumable mid-frame.
+ *
+ *   - We never call deflateReset / inflateReset. ADC's ZON/ZOF are
+ *     stream-level signals; once a connection is in ZON mode the
+ *     stream stays compressed until ZOF (which the hub handles by
+ *     removing the iostream stage, not by resetting the zlib state).
+ *
+ *   - Output buffer growth: a single push may need multiple zlib
+ *     output buffer rounds. We use a doubling 16 KB starter buffer
+ *     (Lua's luaL_Buffer keeps it on the Lua stack); zlib doubles its
+ *     consume rate. For the inflate cap we tally bytes across rounds.
+ *
+ *   - No support for raw deflate, gzip, custom window bits, or
+ *     dictionaries: spec mandates plain zlib stream (windowBits = 15
+ *     default), this binding stays minimal.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+
+#include <zlib.h>
+
+#include <lua.h>
+#include <lauxlib.h>
+
+#define DEFLATE_META  "luadch.zlib_stream.deflate"
+#define INFLATE_META  "luadch.zlib_stream.inflate"
+
+/* Hard ceiling on decompressed bytes produced per :push call. 4 MiB
+ * comfortably exceeds the largest plausible ADC frame burst (1 MiB
+ * cap per frame, a handful per tick) while bounding the memory
+ * pressure a single tick can drive. Exceeding this is treated as a
+ * decompression-bomb attempt: the binding throws so the caller
+ * can close the connection. */
+#define ZS_INFLATE_MAX_PER_PUSH (4 * 1024 * 1024)
+
+/* Initial output buffer chunk size. Most ADC frames fit; doubles as
+ * needed inside the push loop. */
+#define ZS_CHUNK 16384
+
+typedef struct {
+    z_stream strm;
+    int      closed;
+} zs_state;
+
+
+/* ---------- shared helpers ---------- */
+
+static zs_state *check_deflate( lua_State *L, int idx ) {
+    return (zs_state *) luaL_checkudata( L, idx, DEFLATE_META );
+}
+
+static zs_state *check_inflate( lua_State *L, int idx ) {
+    return (zs_state *) luaL_checkudata( L, idx, INFLATE_META );
+}
+
+static int zs_closed_error( lua_State *L, const char *side ) {
+    return luaL_error( L, "zlib_stream: %s stream is closed", side );
+}
+
+
+/* ---------- deflate ---------- */
+
+static int deflate_push( lua_State *L ) {
+    zs_state *st = check_deflate( L, 1 );
+    if ( st->closed ) {
+        return zs_closed_error( L, "deflate" );
+    }
+
+    size_t in_len = 0;
+    const char *in = luaL_checklstring( L, 2, &in_len );
+
+    st->strm.next_in  = (Bytef *)( in_len ? in : "" );
+    st->strm.avail_in = (uInt) in_len;
+
+    luaL_Buffer b;
+    luaL_buffinit( L, &b );
+
+    /* deflate(Z_SYNC_FLUSH) until avail_out is non-zero (= zlib has
+     * consumed all input and emitted everything pending). Empty
+     * input still flushes any leftover compressor state - this is
+     * what makes a "ZON\n" header line that goes through deflate
+     * produce something on the wire even though it is short. */
+    do {
+        char *out = luaL_prepbuffsize( &b, ZS_CHUNK );
+        st->strm.next_out  = (Bytef *) out;
+        st->strm.avail_out = (uInt) ZS_CHUNK;
+
+        int rc = deflate( &st->strm, Z_SYNC_FLUSH );
+        if ( rc != Z_OK && rc != Z_BUF_ERROR ) {
+            /* Z_STREAM_ERROR / Z_MEM_ERROR / etc. Never expected on
+             * a sync-flush'ing live stream - surface it. */
+            return luaL_error( L, "zlib_stream: deflate failed (rc=%d, msg=%s)",
+                rc, st->strm.msg ? st->strm.msg : "?" );
+        }
+
+        size_t produced = ZS_CHUNK - st->strm.avail_out;
+        luaL_addsize( &b, produced );
+
+        /* Stop when zlib left output room AND no input remains: the
+         * flush is complete. */
+        if ( st->strm.avail_out > 0 && st->strm.avail_in == 0 ) {
+            break;
+        }
+    } while ( 1 );
+
+    luaL_pushresult( &b );
+    return 1;
+}
+
+static int deflate_close( lua_State *L ) {
+    zs_state *st = check_deflate( L, 1 );
+    if ( !st->closed ) {
+        deflateEnd( &st->strm );
+        st->closed = 1;
+    }
+    return 0;
+}
+
+static int deflate_gc( lua_State *L ) {
+    return deflate_close( L );
+}
+
+static int zlib_stream_deflate( lua_State *L ) {
+    int level = (int) luaL_optinteger( L, 1, Z_DEFAULT_COMPRESSION );
+    if ( level != Z_DEFAULT_COMPRESSION
+         && ( level < Z_NO_COMPRESSION || level > Z_BEST_COMPRESSION ) ) {
+        return luaL_error( L, "zlib_stream.deflate: invalid level %d", level );
+    }
+
+    zs_state *st = (zs_state *) lua_newuserdata( L, sizeof( zs_state ) );
+    memset( st, 0, sizeof( *st ) );
+
+    int rc = deflateInit( &st->strm, level );
+    if ( rc != Z_OK ) {
+        return luaL_error( L, "zlib_stream.deflate: deflateInit failed (rc=%d, msg=%s)",
+            rc, st->strm.msg ? st->strm.msg : "?" );
+    }
+
+    luaL_setmetatable( L, DEFLATE_META );
+    return 1;
+}
+
+
+/* ---------- inflate ---------- */
+
+static int inflate_push( lua_State *L ) {
+    zs_state *st = check_inflate( L, 1 );
+    if ( st->closed ) {
+        return zs_closed_error( L, "inflate" );
+    }
+
+    size_t in_len = 0;
+    const char *in = luaL_checklstring( L, 2, &in_len );
+
+    st->strm.next_in  = (Bytef *)( in_len ? in : "" );
+    st->strm.avail_in = (uInt) in_len;
+
+    luaL_Buffer b;
+    luaL_buffinit( L, &b );
+
+    size_t produced_total = 0;
+
+    do {
+        char *out = luaL_prepbuffsize( &b, ZS_CHUNK );
+        st->strm.next_out  = (Bytef *) out;
+        st->strm.avail_out = (uInt) ZS_CHUNK;
+
+        int rc = inflate( &st->strm, Z_SYNC_FLUSH );
+        if ( rc == Z_NEED_DICT || rc == Z_DATA_ERROR || rc == Z_MEM_ERROR ) {
+            /* Malformed compressed input or out-of-memory. The caller
+             * is expected to log and close - a sustained connection
+             * cannot reasonably recover from a corrupted stream. */
+            return luaL_error( L, "zlib_stream: inflate failed (rc=%d, msg=%s)",
+                rc, st->strm.msg ? st->strm.msg : "?" );
+        }
+        /* Z_STREAM_END is legal: the remote sent a complete zlib
+         * stream (rare in ADC ZLIF since the stream is open-ended,
+         * but spec-permitted). We swallow trailing input. */
+
+        size_t produced = ZS_CHUNK - st->strm.avail_out;
+        produced_total += produced;
+        if ( produced_total > ZS_INFLATE_MAX_PER_PUSH ) {
+            return luaL_error(
+                L,
+                "zlib_stream: inflate output exceeds %d bytes per push (bomb guard)",
+                ZS_INFLATE_MAX_PER_PUSH
+            );
+        }
+        luaL_addsize( &b, produced );
+
+        if ( rc == Z_STREAM_END ) {
+            break;
+        }
+        /* Continue until zlib has consumed all input AND left output
+         * room (= cannot produce more from current state). */
+        if ( st->strm.avail_out > 0 && st->strm.avail_in == 0 ) {
+            break;
+        }
+    } while ( 1 );
+
+    luaL_pushresult( &b );
+    return 1;
+}
+
+static int inflate_close( lua_State *L ) {
+    zs_state *st = check_inflate( L, 1 );
+    if ( !st->closed ) {
+        inflateEnd( &st->strm );
+        st->closed = 1;
+    }
+    return 0;
+}
+
+static int inflate_gc( lua_State *L ) {
+    return inflate_close( L );
+}
+
+static int zlib_stream_inflate( lua_State *L ) {
+    (void) L;
+    zs_state *st = (zs_state *) lua_newuserdata( L, sizeof( zs_state ) );
+    memset( st, 0, sizeof( *st ) );
+
+    int rc = inflateInit( &st->strm );
+    if ( rc != Z_OK ) {
+        return luaL_error( L, "zlib_stream.inflate: inflateInit failed (rc=%d, msg=%s)",
+            rc, st->strm.msg ? st->strm.msg : "?" );
+    }
+
+    luaL_setmetatable( L, INFLATE_META );
+    return 1;
+}
+
+
+/* ---------- module ---------- */
+
+static const luaL_Reg deflate_methods[] = {
+    { "push",  deflate_push  },
+    { "close", deflate_close },
+    { NULL, NULL },
+};
+
+static const luaL_Reg inflate_methods[] = {
+    { "push",  inflate_push  },
+    { "close", inflate_close },
+    { NULL, NULL },
+};
+
+static const luaL_Reg module_funcs[] = {
+    { "deflate", zlib_stream_deflate },
+    { "inflate", zlib_stream_inflate },
+    { NULL, NULL },
+};
+
+static void register_meta( lua_State *L, const char *name, const luaL_Reg *methods, lua_CFunction gc ) {
+    luaL_newmetatable( L, name );
+
+    lua_pushvalue( L, -1 );
+    lua_setfield( L, -2, "__index" );
+
+    lua_pushcfunction( L, gc );
+    lua_setfield( L, -2, "__gc" );
+
+    luaL_setfuncs( L, methods, 0 );
+
+    lua_pop( L, 1 );
+}
+
+int luaopen_zlib_stream( lua_State *L ) {
+    register_meta( L, DEFLATE_META, deflate_methods, deflate_gc );
+    register_meta( L, INFLATE_META, inflate_methods, inflate_gc );
+
+    lua_newtable( L );
+    luaL_setfuncs( L, module_funcs, 0 );
+
+    /* Expose zlib version + the per-push cap so callers can log it /
+     * tests can assert it. */
+    lua_pushstring( L, zlibVersion( ) );
+    lua_setfield( L, -2, "version" );
+
+    lua_pushinteger( L, ZS_INFLATE_MAX_PER_PUSH );
+    lua_setfield( L, -2, "inflate_max_per_push" );
+
+    return 1;
+}

--- a/zlib_stream/zlib_stream.c
+++ b/zlib_stream/zlib_stream.c
@@ -256,7 +256,6 @@ static int inflate_gc( lua_State *L ) {
 }
 
 static int zlib_stream_inflate( lua_State *L ) {
-    (void) L;
     zs_state *st = (zs_state *) lua_newuserdata( L, sizeof( zs_state ) );
     memset( st, 0, sizeof( *st ) );
 


### PR DESCRIPTION
Second half of S4 - the actual ZLIF feature on top of S4a's iterator pipeline + outbound seam. Operator opt-in (`zlif_enabled = false` default); TLS path gated separately (`zlif_over_tls = false` default) for CRIME-class defence-in-depth.

## Summary

- New C module `zlib_stream/` (~250 LoC, links system zlib). Exposes deflate_stream + inflate_stream with `Z_SYNC_FLUSH` semantics + 4 MiB decompression-bomb cap per inflate push.
- New Lua stages `iostream.newinflatestage` / `newdeflatestage`. pcall-wrapped around the C binding so a corrupt / bomb-cap stream surfaces as the pipeline overflow signal -> server.lua closes the connection.
- `handler.inframer_prepend` / `outframer_prepend` accessors on server.lua so the dispatcher can splice stages mid-stream. Built on S4a's reshape semantic.
- `cfg.zlif_enabled` + `cfg.zlif_over_tls` (booleans). hub.lua packs both into a single `_cfg_zlif = { enabled, over_tls }` table because hub.lua sits at Lua 5.4's 200-locals-per-chunk ceiling.
- HSUP handler in hub_dispatch.lua: when `zlif_enabled`, gsubs `ADZLIF` into the SUP advertise, sends `IZON\n` after the SUP response, prepends the outbound deflate stage. TLS path additionally gated by `zlif_over_tls`. PING (hublist) handshakes are excluded.
- Inbound `ZON` intercept in hub.lua's `incoming()` before plugins + state dispatch. Pre-HSUP `ZON` / `ZOF` get ISTA 240 + close. Post-HSUP `ZON` -> install inflate stage; post-ZON residual buf re-feeds via S4a's reshape. `ZOF` closes the connection politely.
- ADC: ZON / ZOF added to `_protocol_commands` + a new `streamctl = "[BIH]"` context so the framer accepts BZON / IZON / HZON (real-world clients vary on the fourcc class).
- SECURITY.md §6: new "TLS + ZLIF (zlif_over_tls) - CRIME-class length leak" subsection.
- BUILDING.md: zlib added as a Linux prereq + a "zlib on Windows" subsection (vanilla MinGW does not ship zlib dev files; build-from-source recipe).

## Test plan

- [x] Unit: `tests/unit/iostream_test.lua` 66/66. New cases: inflate-stage push + residual contract + overflow propagation on malformed input, deflate-stage write + empty-input, ZLIF-style composition (inflate ahead of adcline), mid-chunk ZON reshape end-to-end. Real C binding mocked - the standalone Lua test harness cannot load the hub's liblua-linked .dll.
- [x] Smoke: full Windows roundtrip green (49 PASS = the original 47 + ZLIF roundtrip + pre-HSUP ZON rejection). New `test_zlif_roundtrip` flips `zlif_enabled = true`, runs a full ADC login + +help reply over zlib-compressed inbound + outbound (Python `zlib.compressobj` / `decompressobj`, matches `Z_SYNC_FLUSH` cadence; step 8 sends `BZON <sid>` + a compressed `BMSG +help` in a SINGLE TCP write to exercise S4a's same-segment ZON reshape against real zlib). New `test_zlif_pre_hsup_zon_rejected` asserts ISTA 240 on pre-HSUP BZON (B1 fix).
- [x] Default-off path: existing 47 tests run unchanged with `zlif_enabled = false` - hub binds, handshakes, plugin loads, encryption-at-rest, dual-stack, HTTP /health all green.
- [x] Independent security review (CLAUDE.md §1a.6 + §1.1): 1 BLOCKER + 5 CONCERN + 4 NIT. All BLOCKER + worthwhile CONCERN + NIT fixed in-branch in a follow-up commit (B1 pre-HSUP gate, C1 smoke covers real-zlib inbound, C2 PING excluded from ZLIF activation, C3 BUILDING.md zlib docs, N2 / N3 / N4 cosmetic).

## Discovery notes

- Lua 5.4's 200-locals-per-chunk ceiling fired twice during dev. hub.lua now uses a packed cfg table + an inline `use "iostream"` lookup at ZON dispatch instead of top-level locals.
- The core sandbox env (`core/init.lua` setenv) does not expose `assert` or `pcall` - both were initially missed. iostream.lua now imports pcall via `use`; the gsub-anchor sanity check was replaced with a structural smoke assertion + a DO-NOT-REMOVE comment on the template.

## Spec

`docs/phases/PHASE_8_IO.md` S4 spec section (S4a + S4b).

Sub-PR into the `phase8-io` integration branch. Part of #147 T3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)