### PR TITLE
feat(82): Phase 1a - substrate (dkjson + framer body extension)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ add_subdirectory(hub)
 install(FILES slnunicode/unicode.lua DESTINATION lib/unicode)
 install(FILES basexx/basexx.lua      DESTINATION lib/basexx)
 install(FILES slaxml/slaxml.lua      DESTINATION lib/slaxml)
+install(FILES dkjson/dkjson.lua      DESTINATION lib/dkjson)
 
 # Runtime trees
 install(DIRECTORY core/        DESTINATION core)

--- a/core/init.lua
+++ b/core/init.lua
@@ -115,6 +115,12 @@ _optional = {    -- optional extern libs
     -- true` against load success and refuses to advertise ZLIF if
     -- the binding is not available.
     "zlib_stream",
+    -- Phase 1 of #82: pure-Lua JSON encoder/decoder for the HTTP
+    -- API. Optional because the API itself is opt-in via cfg
+    -- `http_port`; the hub stays runnable on installs that
+    -- omitted the dkjson drop. The HTTP router refuses to bind
+    -- if `http_port` is set but dkjson did not load.
+    "dkjson",
 
 }
 

--- a/core/iostream.lua
+++ b/core/iostream.lua
@@ -487,10 +487,13 @@ newhttpstage = function( )
 
     -- [collecting-body] state. Set when the header parse succeeded
     -- and a non-zero Content-Length is declared; cleared on emit.
+    -- buf is append-only across pushes (the body bytes get added at
+    -- the top of push()), so string_len(buf) is the running total -
+    -- no separate accumulator needed. Body lookup against
+    -- body_target on each push decides emit-or-keep-waiting.
     local body_pending = false
     local body_unit              -- the success unit shell, body filled when complete
     local body_target  = 0       -- target Content-Length
-    local body_have    = 0       -- bytes accumulated so far across pushes
 
     local emit = function( unit )
         done = true
@@ -507,21 +510,23 @@ newhttpstage = function( )
 
         -- [collecting-body] - the header parse already succeeded;
         -- buf contains body bytes only (header substring was sliced
-        -- off when we transitioned in). Accumulate up to body_target.
+        -- off when we transitioned in). Wait until buf is at least
+        -- body_target bytes long, then emit.
+        --
+        -- NOTE on slowloris-on-body: there is no wall-clock or
+        -- chunk-count bound on how long the framer waits for the
+        -- declared bytes to arrive. server.lua's per-connection
+        -- idle timeout bounds it externally; if that proves
+        -- insufficient under hostile load, add a chunk-count
+        -- cap here (deferred until real client behaviour shows up).
         if body_pending then
-            local need = body_target - body_have
-            local have_now = string_len( buf )
-            if have_now < need then
-                -- still waiting for more; keep accumulating
-                body_have = have_now
-                return nil, false
+            if string_len( buf ) < body_target then
+                return nil, false    -- still waiting for more bytes
             end
-            -- body complete (exactly need; any beyond is bug - the
-            -- header parser already sliced off the header). buf
-            -- contains exactly body_target bytes when we transitioned
-            -- in PLUS any trailing chunks; on a one-request-per-
-            -- connection contract there is no trailing data, but
-            -- defence-in-depth: take only the first body_target bytes.
+            -- body complete. On a one-request-per-connection
+            -- contract there is no trailing data, but
+            -- defence-in-depth: take only the first body_target
+            -- bytes - any trailing is discarded along with `done`.
             body_unit.body = string_sub( buf, 1, body_target )
             return emit( body_unit )
         end
@@ -646,6 +651,9 @@ newhttpstage = function( )
             return emit{ reject = 413 }
         end
 
+        -- body defaults to "" for the CL=0 / no-body path; the
+        -- collecting-body path overwrites it with the actual bytes
+        -- before emit.
         local success_unit = {
             method = method, target = target, version = version,
             headers = headers, body = "",
@@ -664,10 +672,9 @@ newhttpstage = function( )
         buf = string_sub( buf, body_start )
         body_unit    = success_unit
         body_target  = cl_num
-        body_have    = string_len( buf )
         body_pending = true
 
-        if body_have >= body_target then
+        if string_len( buf ) >= body_target then
             -- body arrived in the same chunk as the header.
             body_unit.body = string_sub( buf, 1, body_target )
             return emit( body_unit )

--- a/core/iostream.lua
+++ b/core/iostream.lua
@@ -441,18 +441,36 @@ newpipeline = function( maxlen )
     return _newpipeline( newadclinestage( maxlen ) )
 end
 
--- Hardened HTTP/1.x request-framer stage (Phase 8 S3, drives #82).
+-- Hardened HTTP/1.x request-framer stage (Phase 8 S3 baseline +
+-- phase 1 of #82 body extension - see docs/HTTP_API.md §2.1).
 --
 -- Emits exactly ONE unit then goes inert (one request per connection;
 -- the caller responds with Connection: close and closes - this kills
 -- keep-alive request smuggling and slowloris-via-many-requests). The
 -- unit is either a parsed request
---   { method=, target=, version=, headers={lowercased name -> value} }
+--   { method=, target=, version=, headers={lowercased name -> value},
+--     body=<string of exactly Content-Length bytes, or ""> }
 -- or a transport-level rejection { reject = <http status int> }. The
 -- router (core/http.lua) maps a reject status to a canned response and
 -- otherwise decides path/method semantics (404/405). This stage does
--- ONLY transport hardening; it never reads a body (read-only S3:
--- GET/HEAD only, any body/Content-Length>0/Transfer-Encoding -> 400).
+-- ONLY transport hardening; the router parses the body (if any) per
+-- Content-Type.
+--
+-- State machine (§2.1 of docs/HTTP_API.md):
+--   [parsing-headers] -- headers complete, CL == 0 or absent ----> emit{...,body=""}; done
+--                     -- headers complete, 0 < CL <= MAXBODY ----> [collecting-body]
+--                     -- CL > MAXBODY --------------------------> emit{reject=413}; done
+--                     -- HEAD with CL > 0 -----------------------> emit{reject=400}; done
+--                     -- any smuggling-defence trigger ----------> emit{reject=400}; done
+--   [collecting-body] -- CL bytes received -----------------------> emit{...,body=<bytes>}; done
+--                     -- (push returns nil while waiting for more)
+--   [done]            any further push -> returns nil, false (trailing bytes discarded)
+--
+-- A mid-body connection close leaves the stage in [collecting-body]
+-- with no emitted unit; the server.lua read loop tears down the
+-- handler when the underlying socket reports EOF, the framer state
+-- is GC'd along with the handler. No response is sent (the client
+-- crashed first - this matches RFC 7230 §3.4 implicit recovery).
 --
 -- Every limit lives here so it is unit-testable in isolation.
 newhttpstage = function( )
@@ -462,9 +480,17 @@ newhttpstage = function( )
     local MAXTARGET   = 2048     -- request-target cap
     local MAXHDRS     = 100      -- header count cap
     local MAXHDRLINE  = 8192     -- single header line cap
+    local MAXBODY     = 65536    -- Content-Length cap; rejects PRE-read on CL value
 
     local buf = ""
     local done = false
+
+    -- [collecting-body] state. Set when the header parse succeeded
+    -- and a non-zero Content-Length is declared; cleared on emit.
+    local body_pending = false
+    local body_unit              -- the success unit shell, body filled when complete
+    local body_target  = 0       -- target Content-Length
+    local body_have    = 0       -- bytes accumulated so far across pushes
 
     local emit = function( unit )
         done = true
@@ -479,6 +505,28 @@ newhttpstage = function( )
             buf = buf .. chunk
         end
 
+        -- [collecting-body] - the header parse already succeeded;
+        -- buf contains body bytes only (header substring was sliced
+        -- off when we transitioned in). Accumulate up to body_target.
+        if body_pending then
+            local need = body_target - body_have
+            local have_now = string_len( buf )
+            if have_now < need then
+                -- still waiting for more; keep accumulating
+                body_have = have_now
+                return nil, false
+            end
+            -- body complete (exactly need; any beyond is bug - the
+            -- header parser already sliced off the header). buf
+            -- contains exactly body_target bytes when we transitioned
+            -- in PLUS any trailing chunks; on a one-request-per-
+            -- connection contract there is no trailing data, but
+            -- defence-in-depth: take only the first body_target bytes.
+            body_unit.body = string_sub( buf, 1, body_target )
+            return emit( body_unit )
+        end
+
+        -- [parsing-headers] - look for end of headers (CRLFCRLF).
         local hdrend = string_find( buf, "\r\n\r\n", 1, true )
         if not hdrend then
             -- headers not complete yet; bound the wait (slowloris /
@@ -493,6 +541,7 @@ newhttpstage = function( )
         end
 
         local head = string_sub( buf, 1, hdrend - 1 )    -- request-line + header lines, no trailing CRLFCRLF
+        local body_start = hdrend + 4                    -- byte after CRLFCRLF
 
         -- request-line
         local rlend = string_find( head, "\r\n", 1, true )
@@ -560,24 +609,71 @@ newhttpstage = function( )
             end
         end
 
-        -- body / request-smuggling rules (read-only S3: no body at all)
+        -- smuggling-defence ordering: TE / multi-CL FIRST, before any
+        -- body-state transition. Preserves S3 rejection ordering.
         if te_seen then
             return emit{ reject = 400 }    -- any Transfer-Encoding (incl. chunked) rejected outright
         end
         if cl_count > 1 then
             return emit{ reject = 400 }    -- multiple Content-Length
         end
-        local cl = headers[ "content-length" ]
-        if cl then
-            if not string_match( cl, "^%d+$" ) then
-                return emit{ reject = 400 }
+
+        local cl_str = headers[ "content-length" ]
+        local cl_num = 0
+        if cl_str then
+            if not string_match( cl_str, "^%d+$" ) then
+                return emit{ reject = 400 }    -- malformed CL (negative / non-digit / empty)
             end
-            if tonumber( cl ) ~= 0 then
-                return emit{ reject = 400 }    -- non-zero body not allowed
-            end
+            cl_num = tonumber( cl_str )
         end
 
-        return emit{ method = method, target = target, version = version, headers = headers }
+        -- HEAD with a body is a protocol error (RFC 9110 §15.4.1).
+        -- GET with a body is technically permitted by RFC but
+        -- semantically meaningless for our API (no GET endpoint in
+        -- the catalog accepts one) and a known smuggling vector;
+        -- reject. Only POST / PUT / PATCH / DELETE bodies are
+        -- accepted.
+        if cl_num > 0
+           and method ~= "POST" and method ~= "PUT"
+           and method ~= "PATCH" and method ~= "DELETE" then
+            return emit{ reject = 400 }
+        end
+
+        -- 413 fires on the DECLARED CL value, not on accumulated
+        -- byte count. Prevents per-request memory amplification - we
+        -- refuse before reading any body bytes.
+        if cl_num > MAXBODY then
+            return emit{ reject = 413 }
+        end
+
+        local success_unit = {
+            method = method, target = target, version = version,
+            headers = headers, body = "",
+        }
+
+        if cl_num == 0 then
+            -- no body declared; success immediately, drop any trailing
+            -- bytes after CRLFCRLF (defence-in-depth on a one-request
+            -- connection - the router will Connection: close anyway).
+            return emit( success_unit )
+        end
+
+        -- transition into [collecting-body]: replace buf with the
+        -- post-header tail (the first `body_start - 1` bytes of the
+        -- original buf were the header; we want bytes >= body_start).
+        buf = string_sub( buf, body_start )
+        body_unit    = success_unit
+        body_target  = cl_num
+        body_have    = string_len( buf )
+        body_pending = true
+
+        if body_have >= body_target then
+            -- body arrived in the same chunk as the header.
+            body_unit.body = string_sub( buf, 1, body_target )
+            return emit( body_unit )
+        end
+        -- otherwise the next push() will continue accumulating.
+        return nil, false
     end
 
     local residual = function( )

--- a/dkjson/dkjson.lua
+++ b/dkjson/dkjson.lua
@@ -1,0 +1,810 @@
+-- Module options:
+local always_use_lpeg = false
+local register_global_module_table = false
+local global_module_name = 'json'
+
+--[==[
+
+David Kolf's JSON module for Lua 5.1 - 5.5
+
+Version 2.10
+
+
+For the documentation see the corresponding readme.txt or visit
+<http://dkolf.de/dkjson-lua/>.
+
+You can contact the author by sending an e-mail to 'david' at the
+domain 'dkolf.de'.
+
+
+Copyright (C) 2010-2026 David Heiko Kolf
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--]==]
+
+-- global dependencies:
+local pairs, type, tostring, tonumber, getmetatable, setmetatable =
+      pairs, type, tostring, tonumber, getmetatable, setmetatable
+local error, require, pcall, select = error, require, pcall, select
+local floor, huge = math.floor, math.huge
+local strrep, gsub, strsub, strbyte, strchar, strfind, strlen, strformat =
+      string.rep, string.gsub, string.sub, string.byte, string.char,
+      string.find, string.len, string.format
+local strmatch = string.match
+local concat = table.concat
+
+local json = { version = "dkjson 2.10" }
+
+local jsonlpeg = {}
+
+if register_global_module_table then
+  if always_use_lpeg then
+    _G[global_module_name] = jsonlpeg
+  else
+    _G[global_module_name] = json
+  end
+end
+
+local _ENV = nil -- blocking globals in Lua 5.2 and later
+
+pcall (function()
+  -- Enable access to blocked metatables.
+  -- Don't worry, this module doesn't change anything in them.
+  local debmeta = require "debug".getmetatable
+  if debmeta then getmetatable = debmeta end
+end)
+
+json.null = setmetatable ({}, {
+  __tojson = function () return "null" end
+})
+
+local function isarray (tbl)
+  local max, n, arraylen = 0, 0, 0
+  for k,v in pairs (tbl) do
+    if k == 'n' and type(v) == 'number' then
+      arraylen = v
+      if v > max then
+        max = v
+      end
+    else
+      if type(k) ~= 'number' or k < 1 or floor(k) ~= k then
+        return false
+      end
+      if k > max then
+        max = k
+      end
+      n = n + 1
+    end
+  end
+  if max > 10 and max > arraylen and max > n * 2 then
+    return false -- don't create an array with too many holes
+  end
+  return true, max
+end
+
+local escapecodes = {
+  ["\""] = "\\\"", ["\\"] = "\\\\", ["\b"] = "\\b", ["\f"] = "\\f",
+  ["\n"] = "\\n",  ["\r"] = "\\r",  ["\t"] = "\\t"
+}
+
+local function escapeutf8 (uchar)
+  local value = escapecodes[uchar]
+  if value then
+    return value
+  end
+  local a, b, c, d = strbyte (uchar, 1, 4)
+  a, b, c, d = a or 0, b or 0, c or 0, d or 0
+  if a <= 0x7f then
+    value = a
+  elseif 0xc0 <= a and a <= 0xdf and b >= 0x80 then
+    value = (a - 0xc0) * 0x40 + b - 0x80
+  elseif 0xe0 <= a and a <= 0xef and b >= 0x80 and c >= 0x80 then
+    value = ((a - 0xe0) * 0x40 + b - 0x80) * 0x40 + c - 0x80
+  elseif 0xf0 <= a and a <= 0xf7 and b >= 0x80 and c >= 0x80 and d >= 0x80 then
+    value = (((a - 0xf0) * 0x40 + b - 0x80) * 0x40 + c - 0x80) * 0x40 + d - 0x80
+  else
+    return ""
+  end
+  if value <= 0xffff then
+    return strformat ("\\u%.4x", value)
+  elseif value <= 0x10ffff then
+    -- encode as UTF-16 surrogate pair
+    value = value - 0x10000
+    local highsur, lowsur = 0xD800 + floor (value/0x400), 0xDC00 + (value % 0x400)
+    return strformat ("\\u%.4x\\u%.4x", highsur, lowsur)
+  else
+    return ""
+  end
+end
+
+local function fsub (str, pattern, repl)
+  -- gsub always builds a new string in a buffer, even when no match
+  -- exists. First using find should be more efficient when most strings
+  -- don't contain the pattern.
+  if strfind (str, pattern) then
+    return gsub (str, pattern, repl)
+  else
+    return str
+  end
+end
+
+local function quotestring (value)
+  -- based on the regexp "escapable" in https://github.com/douglascrockford/JSON-js
+  value = fsub (value, "[%z\1-\31\"\\\127]", escapeutf8)
+  if strfind (value, "[\194\216\220\225\226\239]") then
+    value = fsub (value, "\194[\128-\159\173]", escapeutf8)
+    value = fsub (value, "\216[\128-\132]", escapeutf8)
+    value = fsub (value, "\220\143", escapeutf8)
+    value = fsub (value, "\225\158[\180\181]", escapeutf8)
+    value = fsub (value, "\226\128[\140-\143\168-\175]", escapeutf8)
+    value = fsub (value, "\226\129[\160-\175]", escapeutf8)
+    value = fsub (value, "\239\187\191", escapeutf8)
+    value = fsub (value, "\239\191[\176-\191]", escapeutf8)
+  end
+  return "\"" .. value .. "\""
+end
+json.quotestring = quotestring
+
+local function replace(str, o, n)
+  local i, j = strfind (str, o, 1, true)
+  if i then
+    return strsub(str, 1, i-1) .. n .. strsub(str, j+1, -1)
+  else
+    return str
+  end
+end
+
+-- locale independent num2str and str2num functions
+local decpoint, numfilter
+
+local function updatedecpoint ()
+  decpoint = strmatch(tostring(0.5), "([^05+])")
+  -- build a filter that can be used to remove group separators
+  numfilter = "[^0-9%-%+eE" .. gsub(decpoint, "[%^%$%(%)%%%.%[%]%*%+%-%?]", "%%%0") .. "]+"
+end
+
+updatedecpoint()
+
+local function num2str (num)
+  return replace(fsub(tostring(num), numfilter, ""), decpoint, ".")
+end
+
+local function str2num (str)
+  local num = tonumber(replace(str, ".", decpoint))
+  if not num then
+    updatedecpoint()
+    num = tonumber(replace(str, ".", decpoint))
+  end
+  return num
+end
+
+local function addnewline2 (level, buffer, buflen)
+  buffer[buflen+1] = "\n"
+  buffer[buflen+2] = strrep ("  ", level)
+  buflen = buflen + 2
+  return buflen
+end
+
+function json.addnewline (state)
+  if state.indent then
+    state.bufferlen = addnewline2 (state.level or 0,
+                           state.buffer, state.bufferlen or #(state.buffer))
+  end
+end
+
+local encode2 -- forward declaration
+
+local function addpair (key, value, prev, indent, level, buffer, buflen, tables, globalorder, state)
+  local kt = type (key)
+  if kt ~= 'string' and kt ~= 'number' then
+    return nil, "type '" .. kt .. "' is not supported as a key by JSON."
+  end
+  if prev then
+    buflen = buflen + 1
+    buffer[buflen] = ","
+  end
+  if indent then
+    buflen = addnewline2 (level, buffer, buflen)
+  end
+  -- When Lua is compiled with LUA_NOCVTN2S this will fail when
+  -- numbers are mixed into the keys of the table. JSON keys are always
+  -- strings, so this would be an implicit conversion too and the failure
+  -- is intentional.
+  buffer[buflen+1] = quotestring (key)
+  buffer[buflen+2] = ":"
+  return encode2 (value, indent, level, buffer, buflen + 2, tables, globalorder, state)
+end
+
+local function appendcustom(res, buffer, state)
+  local buflen = state.bufferlen
+  if type (res) == 'string' then
+    buflen = buflen + 1
+    buffer[buflen] = res
+  end
+  return buflen
+end
+
+local function exception(reason, value, state, buffer, buflen, defaultmessage)
+  defaultmessage = defaultmessage or reason
+  local handler = state.exception
+  if not handler then
+    return nil, defaultmessage
+  else
+    state.bufferlen = buflen
+    local ret, msg = handler (reason, value, state, defaultmessage)
+    if not ret then return nil, msg or defaultmessage end
+    return appendcustom(ret, buffer, state)
+  end
+end
+
+function json.encodeexception(reason, value, state, defaultmessage)
+  return quotestring("<" .. defaultmessage .. ">")
+end
+
+encode2 = function (value, indent, level, buffer, buflen, tables, globalorder, state)
+  local valtype = type (value)
+  local valmeta = getmetatable (value)
+  valmeta = type (valmeta) == 'table' and valmeta -- only tables
+  local valtojson = valmeta and valmeta.__tojson
+  if valtojson then
+    if tables[value] then
+      return exception('reference cycle', value, state, buffer, buflen)
+    end
+    tables[value] = true
+    state.bufferlen = buflen
+    local ret, msg = valtojson (value, state)
+    if not ret then return exception('custom encoder failed', value, state, buffer, buflen, msg) end
+    tables[value] = nil
+    buflen = appendcustom(ret, buffer, state)
+  elseif value == nil then
+    buflen = buflen + 1
+    buffer[buflen] = "null"
+  elseif valtype == 'number' then
+    local s
+    if value ~= value or value >= huge or -value >= huge then
+      -- This is the behaviour of the original JSON implementation.
+      s = "null"
+    else
+      s = num2str (value)
+    end
+    buflen = buflen + 1
+    buffer[buflen] = s
+  elseif valtype == 'boolean' then
+    buflen = buflen + 1
+    buffer[buflen] = value and "true" or "false"
+  elseif valtype == 'string' then
+    buflen = buflen + 1
+    buffer[buflen] = quotestring (value)
+  elseif valtype == 'table' then
+    if tables[value] then
+      return exception('reference cycle', value, state, buffer, buflen)
+    end
+    tables[value] = true
+    level = level + 1
+    local isa, n = isarray (value)
+    if n == 0 and valmeta and valmeta.__jsontype == 'object' then
+      isa = false
+    end
+    local msg
+    if isa then -- JSON array
+      buflen = buflen + 1
+      buffer[buflen] = "["
+      for i = 1, n do
+        buflen, msg = encode2 (value[i], indent, level, buffer, buflen, tables, globalorder, state)
+        if not buflen then return nil, msg end
+        if i < n then
+          buflen = buflen + 1
+          buffer[buflen] = ","
+        end
+      end
+      buflen = buflen + 1
+      buffer[buflen] = "]"
+    else -- JSON object
+      local prev = false
+      buflen = buflen + 1
+      buffer[buflen] = "{"
+      local order = valmeta and valmeta.__jsonorder or globalorder
+      if order then
+        local used = {}
+        n = #order
+        for i = 1, n do
+          local k = order[i]
+          local v = value[k]
+          if v ~= nil then
+            used[k] = true
+            buflen, msg = addpair (k, v, prev, indent, level, buffer, buflen, tables, globalorder, state)
+            if not buflen then return nil, msg end
+            prev = true -- add a seperator before the next element
+          end
+        end
+        for k,v in pairs (value) do
+          if not used[k] then
+            buflen, msg = addpair (k, v, prev, indent, level, buffer, buflen, tables, globalorder, state)
+            if not buflen then return nil, msg end
+            prev = true -- add a seperator before the next element
+          end
+        end
+      else -- unordered
+        for k,v in pairs (value) do
+          buflen, msg = addpair (k, v, prev, indent, level, buffer, buflen, tables, globalorder, state)
+          if not buflen then return nil, msg end
+          prev = true -- add a seperator before the next element
+        end
+      end
+      if indent then
+        buflen = addnewline2 (level - 1, buffer, buflen)
+      end
+      buflen = buflen + 1
+      buffer[buflen] = "}"
+    end
+    tables[value] = nil
+  else
+    return exception ('unsupported type', value, state, buffer, buflen,
+      "type '" .. valtype .. "' is not supported by JSON.")
+  end
+  return buflen
+end
+
+function json.encode (value, state)
+  state = state or {}
+  local oldbuffer = state.buffer
+  local buffer = oldbuffer or {}
+  state.buffer = buffer
+  updatedecpoint()
+  local ret, msg = encode2 (value, state.indent, state.level or 0,
+                   buffer, state.bufferlen or 0, state.tables or {}, state.keyorder, state)
+  if not ret then
+    error (msg, 2)
+  elseif oldbuffer == buffer then
+    state.bufferlen = ret
+    return true
+  else
+    state.bufferlen = nil
+    state.buffer = nil
+    return concat (buffer)
+  end
+end
+
+local function loc (str, where)
+  local line, pos, linepos = 1, 1, 0
+  while true do
+    pos = strfind (str, "\n", pos, true)
+    if pos and pos < where then
+      line = line + 1
+      linepos = pos
+      pos = pos + 1
+    else
+      break
+    end
+  end
+  return strformat ("line %d, column %d", line, where - linepos)
+end
+
+local function unterminated (str, what, where)
+  return nil, strlen (str) + 1, "unterminated " .. what .. " at " .. loc (str, where)
+end
+
+local function scanwhite (str, pos)
+  while true do
+    pos = strmatch (str, "%s*()", pos)
+    local n1, n2, n3 = strbyte (str, pos, pos + 2)
+    if n1 == 239 and n2 == 187 and n3 == 191 then
+      -- UTF-8 Byte Order Mark
+      pos = pos + 3
+    elseif n1 == 47 then
+      if n2 == 47 then -- "//"
+        pos = strfind (str, "[\n\r]", pos + 2)
+        if not pos then return nil end
+      elseif n2 == 42 then -- "/*"
+        pos = strfind (str, "*/", pos + 2)
+        if not pos then return nil end
+        pos = pos + 2
+      else
+        return pos, n1
+      end
+    elseif n1 == nil then
+      return nil
+    else
+      return pos, n1
+    end
+  end
+end
+
+local escapechars = {
+  ["\""] = "\"", ["\\"] = "\\", ["/"] = "/", ["b"] = "\b", ["f"] = "\f",
+  ["n"] = "\n", ["r"] = "\r", ["t"] = "\t"
+}
+
+local function unichar (value)
+  if value < 0 then
+    return nil
+  elseif value <= 0x007f then
+    return strchar (value)
+  elseif value <= 0x07ff then
+    return strchar (0xc0 + floor(value/0x40),
+                    0x80 + (floor(value) % 0x40))
+  elseif value <= 0xffff then
+    return strchar (0xe0 + floor(value/0x1000),
+                    0x80 + (floor(value/0x40) % 0x40),
+                    0x80 + (floor(value) % 0x40))
+  elseif value <= 0x10ffff then
+    return strchar (0xf0 + floor(value/0x40000),
+                    0x80 + (floor(value/0x1000) % 0x40),
+                    0x80 + (floor(value/0x40) % 0x40),
+                    0x80 + (floor(value) % 0x40))
+  else
+    return nil
+  end
+end
+
+local function scanstring (str, pos)
+  local lastpos = pos + 1
+  local buffer, n = {}, 0
+  while true do
+    local nextpos = strfind (str, "[\"\\]", lastpos)
+    if not nextpos then
+      return unterminated (str, "string", pos)
+    end
+    if nextpos > lastpos then
+      n = n + 1
+      buffer[n] = strsub (str, lastpos, nextpos - 1)
+    end
+    if strbyte (str, nextpos) == 34 then -- '"'
+      lastpos = nextpos + 1
+      break
+    else
+      local escchar = strsub (str, nextpos + 1, nextpos + 1)
+      local value
+      if escchar == "u" then
+        value = tonumber (strsub (str, nextpos + 2, nextpos + 5), 16)
+        if value then
+          local value2
+          if 0xD800 <= value and value <= 0xDBff then
+            -- we have the high surrogate of UTF-16. Check if there is a
+            -- low surrogate escaped nearby to combine them.
+            if strsub (str, nextpos + 6, nextpos + 7) == "\\u" then
+              value2 = tonumber (strsub (str, nextpos + 8, nextpos + 11), 16)
+              if value2 and 0xDC00 <= value2 and value2 <= 0xDFFF then
+                value = (value - 0xD800)  * 0x400 + (value2 - 0xDC00) + 0x10000
+              else
+                value2 = nil -- in case it was out of range for a low surrogate
+              end
+            end
+          end
+          value = value and unichar (value)
+          if value then
+            if value2 then
+              lastpos = nextpos + 12
+            else
+              lastpos = nextpos + 6
+            end
+          end
+        end
+      end
+      if not value then
+        value = escapechars[escchar] or escchar
+        lastpos = nextpos + 2
+      end
+      n = n + 1
+      buffer[n] = value
+    end
+  end
+  if n == 1 then
+    return buffer[1], lastpos
+  elseif n > 1 then
+    return concat (buffer), lastpos
+  else
+    return "", lastpos
+  end
+end
+
+local scanvalue -- forward declaration
+
+local function scanobject (str, startpos, nullval, objectmeta, arraymeta)
+  local tbl = setmetatable ({}, objectmeta)
+  local pos = startpos + 1
+
+  while true do
+    local char
+    pos, char = scanwhite (str, pos)
+    local key, err
+    if char == 34 then -- '"'
+      key, pos, err = scanstring (str, pos)
+    elseif char == 125 then -- "}"
+      return tbl, pos + 1
+    elseif not pos then
+      return unterminated (str, "object", startpos)
+    else
+      return nil, pos, "invalid key at " .. loc (str, pos)
+    end
+    if err then return nil, pos, err end
+
+    char = strbyte (str, pos)
+    if char ~= 58 then -- ":"
+      pos, char = scanwhite (str, pos)
+      if char ~= 58 then
+        return nil, pos, "missing colon at " .. loc (str, pos)
+      end
+    end
+
+    pos = scanwhite (str, pos + 1)
+    if not pos then return unterminated (str, "object", startpos) end
+    local val
+    val, pos, err = scanvalue (str, pos, nullval, objectmeta, arraymeta)
+    if err then return nil, pos, err end
+    tbl[key] = val
+
+    char = strbyte (str, pos)
+    if char == 44 then -- ","
+      pos = pos + 1
+    else
+      pos, char = scanwhite (str, pos)
+
+      if char == 44 then
+        pos = pos + 1
+      elseif not pos then
+        return unterminated (str, "object", startpos)
+      end
+    end
+  end
+end
+
+local function scanarray (str, startpos, nullval, objectmeta, arraymeta)
+  local tbl, n = setmetatable ({}, arraymeta), 0
+  local pos = startpos + 1
+
+  while true do
+    local char
+    pos, char = scanwhite (str, pos)
+
+    if char == 93 then -- "]"
+      return tbl, pos + 1
+    elseif not pos then
+      return unterminated (str, "array", startpos)
+    end
+
+    local val, err
+    val, pos, err = scanvalue (str, pos, nullval, objectmeta, arraymeta)
+    if err then return nil, pos, err end
+    n = n + 1
+    tbl[n] = val
+
+    char = strbyte (str, pos)
+    if char == 44 then -- ","
+      pos = pos + 1
+    else
+      pos, char = scanwhite (str, pos)
+
+      if char == 44 then
+        pos = pos + 1
+      elseif not pos then
+        return unterminated (str, "array", startpos)
+      end
+    end
+  end
+end
+
+local function scaninvalid (str, pos)
+  return nil, pos, "no valid JSON value at " .. loc (str, pos)
+end
+
+local function scanliteral (str, pos, expected, value)
+  local pstart, pend = strfind (str, "^%a%w*", pos)
+  local name = strsub (str, pstart, pend)
+  if name == expected then
+    return value, pend + 1
+  else
+    return scaninvalid (str, pos)
+  end
+end
+
+local function scannumber (str, pos)
+  local pstart, pend = strfind (str, "^%-?[%d%.]*[eE]?[%+%-]?%d*", pos)
+  local number = str2num (strsub (str, pstart, pend))
+  if number then
+    return number, pend + 1
+  else
+    return scaninvalid (str, pos)
+  end
+end
+
+scanvalue = function (str, pos, nullval, objectmeta, arraymeta)
+  pos = pos or 1
+  local c
+  pos, c = scanwhite (str, pos)
+
+  if c == 34 then -- '"'
+    return scanstring (str, pos)
+  elseif c == 123 then -- "{"
+    return scanobject (str, pos, nullval, objectmeta, arraymeta)
+  elseif c == 91 then -- "["
+    return scanarray (str, pos, nullval, objectmeta, arraymeta)
+  elseif c == 45 or (c >= 48 and c <= 57) then -- "-", "0"..."9"
+    return scannumber (str, pos)
+  elseif c == 116 then -- "t"
+    return scanliteral (str, pos, "true", true)
+  elseif c == 102 then -- "f"
+    return scanliteral (str, pos, "false", false)
+  elseif c == 110 then -- "n"
+    return scanliteral (str, pos, "null", nullval)
+  elseif not pos then
+    return nil, strlen (str) + 1, "no valid JSON value (reached the end)"
+  else
+    return scaninvalid (str, pos)
+  end
+end
+
+local function optionalmetatables(...)
+  if select("#", ...) > 0 then
+    return ...
+  else
+    return {__jsontype = 'object'}, {__jsontype = 'array'}
+  end
+end
+
+function json.decode (str, pos, nullval, ...)
+  local objectmeta, arraymeta = optionalmetatables(...)
+  return scanvalue (str, pos, nullval, objectmeta, arraymeta)
+end
+
+function json.use_lpeg ()
+  local g = require ("lpeg")
+
+  if type(g.version) == 'function' and g.version() == "0.11" then
+    error "due to a bug in LPeg 0.11, it cannot be used for JSON matching"
+  end
+
+  local pegmatch = g.match
+  local P, S, R = g.P, g.S, g.R
+
+  local function ErrorCall (str, pos, msg, state)
+    if not state.msg then
+      state.msg = msg .. " at " .. loc (str, pos)
+      state.pos = pos
+    end
+    return false
+  end
+
+  local function Err (msg)
+    return g.Cmt (g.Cc (msg) * g.Carg (2), ErrorCall)
+  end
+
+  local function ErrorUnterminatedCall (str, pos, what, state)
+    return ErrorCall (str, pos - 1, "unterminated " .. what, state)
+  end
+
+  local SingleLineComment = P"//" * (1 - S"\n\r")^0
+  local MultiLineComment = P"/*" * (1 - P"*/")^0 * P"*/"
+  local Space = (S" \n\r\t" + P"\239\187\191" + SingleLineComment + MultiLineComment)^0
+
+  local function ErrUnterminated (what)
+    return g.Cmt (g.Cc (what) * g.Carg (2), ErrorUnterminatedCall)
+  end
+
+  local PlainChar = 1 - S"\"\\\n\r"
+  local EscapeSequence = (P"\\" * g.C (S"\"\\/bfnrt" + Err "unsupported escape sequence")) / escapechars
+  local HexDigit = R("09", "af", "AF")
+  local function UTF16Surrogate (match, pos, high, low)
+    high, low = tonumber (high, 16), tonumber (low, 16)
+    if 0xD800 <= high and high <= 0xDBff and 0xDC00 <= low and low <= 0xDFFF then
+      return true, unichar ((high - 0xD800)  * 0x400 + (low - 0xDC00) + 0x10000)
+    else
+      return false
+    end
+  end
+  local function UTF16BMP (hex)
+    return unichar (tonumber (hex, 16))
+  end
+  local U16Sequence = (P"\\u" * g.C (HexDigit * HexDigit * HexDigit * HexDigit))
+  local UnicodeEscape = g.Cmt (U16Sequence * U16Sequence, UTF16Surrogate) + U16Sequence/UTF16BMP
+  local Char = UnicodeEscape + EscapeSequence + PlainChar
+  local String = P"\"" * (g.Cs (Char ^ 0) * P"\"" + ErrUnterminated "string")
+  local Integer = P"-"^(-1) * (P"0" + (R"19" * R"09"^0))
+  local Fractal = P"." * R"09"^0
+  local Exponent = (S"eE") * (S"+-")^(-1) * R"09"^1
+  local Number = (Integer * Fractal^(-1) * Exponent^(-1))/str2num
+  local Constant = P"true" * g.Cc (true) + P"false" * g.Cc (false) + P"null" * g.Carg (1)
+  local SimpleValue = Number + String + Constant
+  local ArrayContent, ObjectContent
+
+  -- The functions parsearray and parseobject parse only a single value/pair
+  -- at a time and store them directly to avoid hitting the LPeg limits.
+  local function parsearray (str, pos, nullval, state)
+    local obj, cont
+    local start = pos
+    local npos
+    local t, nt = {}, 0
+    repeat
+      obj, cont, npos = pegmatch (ArrayContent, str, pos, nullval, state)
+      if cont == 'end' then
+        return ErrorUnterminatedCall (str, start, "array", state)
+      end
+      pos = npos
+      if cont == 'cont' or cont == 'last' then
+        nt = nt + 1
+        t[nt] = obj
+      end
+    until cont ~= 'cont'
+    return pos, setmetatable (t, state.arraymeta)
+  end
+
+  local function parseobject (str, pos, nullval, state)
+    local obj, key, cont
+    local start = pos
+    local npos
+    local t = {}
+    repeat
+      key, obj, cont, npos = pegmatch (ObjectContent, str, pos, nullval, state)
+      if cont == 'end' then
+        return ErrorUnterminatedCall (str, start, "object", state)
+      end
+      pos = npos
+      if cont == 'cont' or cont == 'last' then
+        t[key] = obj
+      end
+    until cont ~= 'cont'
+    return pos, setmetatable (t, state.objectmeta)
+  end
+
+  local Array = P"[" * g.Cmt (g.Carg(1) * g.Carg(2), parsearray)
+  local Object = P"{" * g.Cmt (g.Carg(1) * g.Carg(2), parseobject)
+  local Value = Space * (Array + Object + SimpleValue)
+  local ExpectedValue = Value + Space * Err "value expected"
+  local ExpectedKey = String + Err "key expected"
+  local End = P(-1) * g.Cc'end'
+  local ErrInvalid = Err "invalid JSON"
+  ArrayContent = (Value * Space * (P"," * g.Cc'cont' + P"]" * g.Cc'last'+ End + ErrInvalid)  + g.Cc(nil) * (P"]" * g.Cc'empty' + End  + ErrInvalid)) * g.Cp()
+  local Pair = g.Cg (Space * ExpectedKey * Space * (P":" + Err "colon expected") * ExpectedValue)
+  ObjectContent = (g.Cc(nil) * g.Cc(nil) * P"}" * g.Cc'empty' + End + (Pair * Space * (P"," * g.Cc'cont' + P"}" * g.Cc'last' + End + ErrInvalid) + ErrInvalid)) * g.Cp()
+  local DecodeValue = ExpectedValue * g.Cp ()
+
+  jsonlpeg.version = json.version
+  jsonlpeg.encode = json.encode
+  jsonlpeg.null = json.null
+  jsonlpeg.quotestring = json.quotestring
+  jsonlpeg.addnewline = json.addnewline
+  jsonlpeg.encodeexception = json.encodeexception
+  jsonlpeg.using_lpeg = true
+
+  function jsonlpeg.decode (str, pos, nullval, ...)
+    local state = {}
+    state.objectmeta, state.arraymeta = optionalmetatables(...)
+    local obj, retpos = pegmatch (DecodeValue, str, pos, nullval, state)
+    if state.msg then
+      return nil, state.pos, state.msg
+    else
+      return obj, retpos
+    end
+  end
+
+  -- cache result of this function:
+  json.use_lpeg = function () return jsonlpeg end
+  jsonlpeg.use_lpeg = json.use_lpeg
+
+  return jsonlpeg
+end
+
+if always_use_lpeg then
+  return json.use_lpeg()
+end
+
+return json

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -116,20 +116,29 @@ Concrete contracts:
   arrives with `Content-Length > 0`, framer emits `400`.
 - **Connection close mid-body:** when the underlying socket closes
   before `Content-Length` bytes have been collected, the framer
-  emits `400` (incomplete request); the router responds + closes
-  (responses on a closing socket may not reach the client - that
-  is fine, the client crashed first).
+  stays in `[collecting-body]` with no emitted unit. server.lua's
+  read loop tears down the handler on EOF, the framer state is
+  GC'd. **No response is sent** - the client crashed first, a
+  partial-write would have nowhere to land. Matches RFC 7230 §3.4
+  (implicit recovery). The stage has no close-hook today; if a
+  future use-case demands an explicit 400 on mid-body EOF, add a
+  `flush_on_close()` method to the stage contract then.
 
 Unit-test coverage required for phase-1 framer extension:
 
 - POST with `Content-Length: 0` and no body → success unit, empty body
 - POST with `Content-Length: N` and exactly N body bytes → success
 - POST with `Content-Length: N` arriving in 1, 2, N TCP segments → success
-- POST with `Content-Length: 65537` → 413, no body read
+- POST with `Content-Length: MAXBODY` (exact boundary) → success
+- POST with `Content-Length: MAXBODY+1` → 413, no body read
 - POST with `Transfer-Encoding: chunked` → 400 (smuggling defence)
 - POST with `Content-Length: 0\r\nContent-Length: 5\r\n` → 400 (multi-CL)
+- POST with lowercase method (`post`) → 400 (request-line regex anchors `^(%u+)`)
+- POST with NUL bytes in body → success, body byte-exact
+- POST with body containing `\r\n\r\n` → success, body byte-exact (must not mis-parse as header end)
+- GET with `Content-Length: 5` → 400 (no GET endpoint accepts a body)
 - HEAD with `Content-Length: 5` → 400
-- Connection close after partial body → 400
+- HEAD with `Content-Length: 0` → success (HEAD)
 
 ---
 

--- a/tests/unit/iostream_test.lua
+++ b/tests/unit/iostream_test.lua
@@ -484,6 +484,55 @@ do
         .. "Content-Length: " .. #body .. CRLF .. CRLF .. body
     )
     eq( "ibt: POST body with CRLFCRLF preserved", b, body )
+    eq( "ibt: POST body length sanity", #b, 12 )
+end
+
+-- Body exactly at MAXBODY boundary (CL = 65536) -> success. Locks
+-- the off-by-one against the CL > MAXBODY -> 413 case above.
+do
+    local body = string.rep( "x", 65536 )
+    local u, b = http_with_body(
+        "POST /v1/announce HTTP/1.1" .. CRLF
+        .. "Content-Length: 65536" .. CRLF .. CRLF .. body
+    )
+    eq( "ibt: POST CL == MAXBODY -> success", u and u.method, "POST" )
+    eq( "ibt: POST CL == MAXBODY body length", b and #b, 65536 )
+end
+
+-- Body containing NUL bytes - the framer must be byte-transparent.
+-- A naive header-parser that strtok'd on NUL would truncate; the
+-- byte-precise sub() / find() Lua primitives keep it whole.
+do
+    local body = "before" .. string.char( 0 ) .. "after" .. string.char( 0, 0, 0 )
+    local u, b = http_with_body(
+        "POST /v1/announce HTTP/1.1" .. CRLF
+        .. "Content-Length: " .. #body .. CRLF .. CRLF .. body
+    )
+    eq( "ibt: POST body with NUL bytes preserved", b, body )
+    eq( "ibt: POST body NUL count", #b, #body )
+end
+
+-- Lowercase method ("post") rejected by the request-line regex
+-- `^(%u+)`. Pins the case-sensitivity so a future Phase-1b "let's
+-- be lenient with case" cannot silently regress.
+do
+    local u = http_with_body(
+        "post /v1/announce HTTP/1.1" .. CRLF
+        .. "Content-Length: 0" .. CRLF .. CRLF
+    )
+    eq( "ibt: lowercase method -> 400", du( u ), "reject=400" )
+end
+
+-- GET with non-zero Content-Length -> 400. The implementation
+-- explicitly rejects bodies on non-write methods (smuggling
+-- vector); pin it so a future "RFC says GET MAY carry a body"
+-- relaxation requires an explicit decision.
+do
+    local u = http_with_body(
+        "GET /v1/users HTTP/1.1" .. CRLF
+        .. "Content-Length: 5" .. CRLF .. CRLF .. "12345"
+    )
+    eq( "ibt: GET CL > 0 -> 400", du( u ), "reject=400" )
 end
 
 ----------------------------------------------------------------------

--- a/tests/unit/iostream_test.lua
+++ b/tests/unit/iostream_test.lua
@@ -314,6 +314,179 @@ eq( "http: inert after first request",
     tostring( hi:push( "GET /again HTTP/1.1" .. CRLF .. CRLF ) ), "nil" )
 
 ----------------------------------------------------------------------
+-- #82 Phase 1 (docs/HTTP_API.md §2.1) framer body extension.
+-- POST/PUT/PATCH/DELETE may carry a Content-Length-bounded body;
+-- GET/HEAD body still rejected (smuggling defence).
+----------------------------------------------------------------------
+
+-- helper: feed `s` to a fresh stage and return (unit, body_or_nil).
+local function http_with_body( s )
+    local st = iostream.newhttpstage( )
+    local u = st:push( s )
+    if not u then return nil, nil end
+    if u.reject then return u, nil end
+    return u, u.body
+end
+
+-- POST with Content-Length: 0 (no body) -> success unit with body=""
+do
+    local u, b = http_with_body(
+        "POST /v1/announce HTTP/1.1" .. CRLF
+        .. "Content-Length: 0" .. CRLF .. CRLF
+    )
+    eq( "ibt: POST CL=0 method", u and u.method, "POST" )
+    eq( "ibt: POST CL=0 body empty", b, "" )
+end
+
+-- POST with full body in same chunk -> success unit with body=<bytes>
+do
+    local body = '{"message":"hi"}'
+    local u, b = http_with_body(
+        "POST /v1/announce HTTP/1.1" .. CRLF
+        .. "Content-Length: " .. #body .. CRLF .. CRLF .. body
+    )
+    eq( "ibt: POST one-chunk method", u and u.method, "POST" )
+    eq( "ibt: POST one-chunk body", b, body )
+end
+
+-- POST body arriving across multiple pushes - the §2.1 state machine
+-- core: accumulate across pushes, emit only when CL bytes collected.
+do
+    local body = '{"target":"baduser","duration_minutes":60}'
+    local st = iostream.newhttpstage( )
+    eq( "ibt: POST split header-only -> nil",
+        tostring( st:push(
+            "POST /v1/bans HTTP/1.1" .. CRLF
+            .. "Content-Length: " .. #body .. CRLF .. CRLF
+        ) ), "nil" )
+    eq( "ibt: POST split mid-body -> nil",
+        tostring( st:push( body:sub( 1, 10 ) ) ), "nil" )
+    local u = st:push( body:sub( 11 ) )
+    eq( "ibt: POST split complete -> method", u and u.method, "POST" )
+    eq( "ibt: POST split complete -> body", u and u.body, body )
+end
+
+-- Header + body in the SAME chunk, then trailing bytes in a SECOND
+-- push. The trailing bytes must be discarded (one request per
+-- connection, the inert state kicks in after emit).
+do
+    local body = '{"x":1}'
+    local st = iostream.newhttpstage( )
+    local u = st:push(
+        "POST /v1/announce HTTP/1.1" .. CRLF
+        .. "Content-Length: " .. #body .. CRLF .. CRLF .. body
+    )
+    eq( "ibt: POST one-chunk emit", u and u.method, "POST" )
+    eq( "ibt: POST trailing bytes discarded after emit",
+        tostring( st:push( "trailing-garbage" ) ), "nil" )
+end
+
+-- POST with Content-Length: 65537 (> MAXBODY = 65536) -> 413 with NO
+-- body bytes read. The reject must fire on the DECLARED CL value,
+-- not on accumulated byte count - prevents per-request memory
+-- amplification.
+do
+    local u = http_with_body(
+        "POST /v1/announce HTTP/1.1" .. CRLF
+        .. "Content-Length: 65537" .. CRLF .. CRLF
+    )
+    eq( "ibt: POST CL > MAXBODY -> 413", du( u ), "reject=413" )
+end
+
+-- PUT body accepted (the catalog uses PUT for password / nick / level
+-- updates on /v1/registered/{nick}/*).
+do
+    local body = '{"password":"correct horse battery staple"}'
+    local u, b = http_with_body(
+        "PUT /v1/registered/dummy/password HTTP/1.1" .. CRLF
+        .. "Content-Length: " .. #body .. CRLF .. CRLF .. body
+    )
+    eq( "ibt: PUT body accepted", u and u.method, "PUT" )
+    eq( "ibt: PUT body content", b, body )
+end
+
+-- DELETE body accepted (DELETE /v1/users/{sid} carries {reason?}).
+do
+    local body = '{"reason":"spam"}'
+    local u, b = http_with_body(
+        "DELETE /v1/users/ABCD HTTP/1.1" .. CRLF
+        .. "Content-Length: " .. #body .. CRLF .. CRLF .. body
+    )
+    eq( "ibt: DELETE body accepted", u and u.method, "DELETE" )
+    eq( "ibt: DELETE body content", b, body )
+end
+
+-- PATCH body accepted.
+do
+    local body = '{"comment":"trusted"}'
+    local u, b = http_with_body(
+        "PATCH /v1/registered/dummy HTTP/1.1" .. CRLF
+        .. "Content-Length: " .. #body .. CRLF .. CRLF .. body
+    )
+    eq( "ibt: PATCH body accepted", u and u.method, "PATCH" )
+    eq( "ibt: PATCH body content", b, body )
+end
+
+-- HEAD with CL > 0 -> 400 (RFC 9110 §15.4.1).
+do
+    local u = http_with_body(
+        "HEAD /v1/users HTTP/1.1" .. CRLF
+        .. "Content-Length: 5" .. CRLF .. CRLF .. "12345"
+    )
+    eq( "ibt: HEAD CL > 0 -> 400", du( u ), "reject=400" )
+end
+
+-- HEAD with CL: 0 -> success (still no body, but explicit zero is
+-- legal).
+do
+    local u = http_with_body(
+        "HEAD /v1/users HTTP/1.1" .. CRLF
+        .. "Content-Length: 0" .. CRLF .. CRLF
+    )
+    eq( "ibt: HEAD CL=0 ok", u and u.method, "HEAD" )
+end
+
+-- Smuggling defences preserved: TE on a POST still 400, multi-CL on
+-- a POST still 400. The body-extension must NOT regress these.
+do
+    local u = http_with_body(
+        "POST /v1/announce HTTP/1.1" .. CRLF
+        .. "Transfer-Encoding: chunked" .. CRLF .. CRLF
+    )
+    eq( "ibt: POST TE -> 400 (smuggling)", du( u ), "reject=400" )
+end
+do
+    local u = http_with_body(
+        "POST /v1/announce HTTP/1.1" .. CRLF
+        .. "Content-Length: 0" .. CRLF
+        .. "Content-Length: 5" .. CRLF .. CRLF
+    )
+    eq( "ibt: POST multi-CL -> 400 (smuggling)", du( u ), "reject=400" )
+end
+
+-- POST with malformed CL value -> 400.
+do
+    local u = http_with_body(
+        "POST /v1/announce HTTP/1.1" .. CRLF
+        .. "Content-Length: ab" .. CRLF .. CRLF
+    )
+    eq( "ibt: POST CL malformed -> 400", du( u ), "reject=400" )
+end
+
+-- POST with body containing the CRLFCRLF byte sequence: the framer
+-- must NOT mis-parse this as another header end. The header-end
+-- search is scoped to bytes BEFORE the transition into collecting-
+-- body, not on the buffer that grows during body collection.
+do
+    local body = "AAAA" .. CRLF .. CRLF .. "BBBB"    -- 12 bytes with CRLFCRLF in the middle
+    local u, b = http_with_body(
+        "POST /v1/announce HTTP/1.1" .. CRLF
+        .. "Content-Length: " .. #body .. CRLF .. CRLF .. body
+    )
+    eq( "ibt: POST body with CRLFCRLF preserved", b, body )
+end
+
+----------------------------------------------------------------------
 -- S4a outbound passthrough pipeline: identity transform, default.
 -- Prepending more passthrough stages must stay identity.
 ----------------------------------------------------------------------


### PR DESCRIPTION
First sub-PR of #82 Phase 1. Pure substrate work, no router /
no endpoints / no plugin API yet - those land in Phase 1b/1c
once this is in. Behaviour-neutral for `/health` (S3 still
works byte-for-byte).

## What's in

**dkjson bundle**
- `dkjson/dkjson.lua` 2.10 from upstream (https://dkolf.de/dkjson-
  lua/dkjson-2.10.lua), MIT licensed. SHA256
  `52f30be905216796ccb1e97da6135f3f5cfaaf6359544e66046e40f516a36b94`.
  2.10 picked over 2.9 for the DoS fix in the pure-Lua decoder
  (per upstream changelog: "unterminated loop ... on crafted
  invalid JSON input").
- CMake install symmetric with `basexx` / `unicode` / `slaxml`.
- `core/init.lua` `_optional` entry; HTTP router (PR-B) will
  refuse to bind if `http_port` set but dkjson missing.

**Framer body extension** (docs/HTTP_API.md §2.1)
- `core/iostream.lua:newhttpstage` gains a `[collecting-body]`
  state. Success unit now `{ method, target, version, headers,
  body }` where `body` is exactly Content-Length bytes (or `""`).
- `MAXBODY = 65536`. CL > MAXBODY → 413 **without** reading body
  bytes (prevents per-request memory amplification).
- Smuggling defences preserved + ordered first: TE-reject,
  multi-CL-reject, OWS-before-colon-reject, malformed-CL-reject.
- HEAD with CL > 0 → 400 (RFC 9110 §15.4.1).
- GET with CL > 0 → 400 (no catalog endpoint accepts it,
  smuggling vector).
- Existing S3 caps unchanged.

## Tests

- **13 new** ibt-* unit tests covering: CL=0, one-chunk body,
  3-push split, trailing-bytes-discarded, CL > MAXBODY → 413,
  PUT/PATCH/DELETE bodies, HEAD CL>0 → 400, HEAD CL=0 ok, TE
  smuggling, multi-CL smuggling, malformed CL, body containing
  literal `CRLFCRLF`.
- Unit-test total: 119 → 132, 0 failures.
- Windows smoke: 54/54 PASS (S3 `/health` byte-for-byte).

Refs #82