### PR TITLE
feat(82): Phase 2 PR-2 - cmd_redirect HTTP migration

### DIFF
--- a/core/util.lua
+++ b/core/util.lua
@@ -168,6 +168,7 @@ local difftime
 local convertepochdate
 
 local trimstring
+local strip_control_bytes
 local getlowestlevel
 local spairs
 
@@ -696,6 +697,23 @@ trimstring = function( str )
     return string_find( str, "^%s*$" ) and "" or string_match( str, "^%s*(.*%S)" )
 end
 
+-- Replace every Lua-class control byte (\r, \n, \t, NUL, ...) with
+-- '?'. Defence in depth around `adclib::escape`, which only handles
+-- ' ', '\n', '\\' - a `\r`, `\0` or `\t` smuggled through any
+-- free-form operator-supplied or HTTP-body-supplied text field
+-- (kick reason, redirect URL, ban comment, gag reason, etc.) would
+-- otherwise mis-frame the outbound ADC frame on the wire. Lifted
+-- here from cmd_disconnect / cmd_redirect (Phase 2 of #82) so all
+-- bundled-plugin write-endpoint migrations share a single source
+-- of truth - a future tightening (e.g. also strip DEL/0x7F, or
+-- enforce a stricter character set) hits every surface atomically.
+-- A stricter `adclib::escape` is orthogonal hardening for a future
+-- phase. Non-string inputs return ""; that lets callers feed
+-- possibly-nil values without a separate guard.
+strip_control_bytes = function( str )
+    return ( type( str ) == "string" ) and ( str:gsub( "%c", "?" ) ) or ""
+end
+
 --// get lowest level with rights from permission table (for help/ucmd)
 getlowestlevel = function( tbl )
     local err
@@ -843,6 +861,7 @@ return {
     difftime = difftime,
     convertepochdate = convertepochdate,
     trimstring = trimstring,
+    strip_control_bytes = strip_control_bytes,
     getlowestlevel = getlowestlevel,
     spairs = spairs,
     maketable = maketable,

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -817,9 +817,11 @@ is disabled in `cfg.scripts`, the endpoint returns 404
 | Method | Path | Scope | Plugin | Status |
 |---|---|---|---|---|
 | DELETE | `/v1/users/{sid}` | admin | `cmd_disconnect` | **migrated (Phase 2 PR-1)** |
-| POST | `/v1/users/{sid}/redirect` | admin | `cmd_redirect` | pending (Phase 2 PR-2) |
+| POST | `/v1/users/{sid}/redirect` | admin | `cmd_redirect` | **migrated (Phase 2 PR-2)** [^http-redirect-1] |
 | POST | `/v1/users/{sid}/gag` | admin | `cmd_gag` | pending (Phase 2 PR-3) |
 | DELETE | `/v1/users/{sid}/gag` | admin | `cmd_gag` | pending (Phase 2 PR-3) |
+
+[^http-redirect-1]: Body `{url: string?}`, URL scheme locked to `adc://` / `adcs://`. The ADC-side level-hierarchy guard (operator's `permission[level]` must be ≥ target's level) does NOT apply on the HTTP path: the bearer token's `admin` scope IS the authorisation gate. If the body has no `url` field, the cfg key `cmd_redirect_url` is used as the default. Body URL strings undergo control-byte sanitisation before reaching the `RD` field of the outbound IQUI; an admin operator with a leaked token can still redirect any user, by design - issue admin tokens accordingly.
 
 #### Registered users
 

--- a/scripts/cmd_disconnect.lua
+++ b/scripts/cmd_disconnect.lua
@@ -97,16 +97,6 @@ local ucmd_menu2 = lang.ucmd_menu2 or { "Disconnecten", "OK" }
 --[CODE]--
 ----------
 
--- Strip Lua-class control bytes (\r, \n, \t, NUL, ...) to '?'.
--- Defence in depth: `hub.escapeto` (adclib::escape) only handles
--- ' ', '\n' and '\\'. A `\r`, `\0` or `\t` smuggled through the
--- HTTP `reason` body or a cfg `comment` field survives escapeto
--- and could mis-frame the ISTA message on the wire. Belt-and-
--- braces here; a stricter adclib::escape is its own follow-up.
-local function strip_control_bytes( s )
-    return ( type( s ) == "string" ) and ( s:gsub( "%c", "?" ) ) or ""
-end
-
 -- Shared action helper used by BOTH the ADC `+disconnect` chat-cmd
 -- path AND the HTTP `DELETE /v1/users/{sid}` path (#82 Phase 2).
 -- Performs ONLY the kill; does NOT fire the opchat report itself.
@@ -123,11 +113,13 @@ end
 -- `actor_label` is what shows in the opchat report and the kicked
 -- user's ISTA message: a nick for the ADC path, a non-secret
 -- token label for the HTTP path. Both `reason` and `actor_label`
--- are control-byte sanitised here (defence in depth around
--- adclib::escape which only handles ' ', '\n', '\\').
+-- are control-byte sanitised via `util.strip_control_bytes`
+-- (single source of truth across the Phase 2 bundled-plugin
+-- migrations - defence in depth around adclib::escape, which only
+-- handles ' ', '\n', '\\').
 local do_disconnect = function( targetuser, reason, actor_label )
-    local clean_reason = strip_control_bytes( reason )
-    local clean_actor  = strip_control_bytes( actor_label )
+    local clean_reason = util.strip_control_bytes( reason )
+    local clean_actor  = util.strip_control_bytes( actor_label )
     local targetuser_nick = targetuser:nick()
     local msg_target = utf.format( user_msg, clean_actor, clean_reason )
     targetuser:kill( "ISTA 230 " .. hub.escapeto( msg_target ) .. "\n", "TL30" )

--- a/scripts/cmd_redirect.lua
+++ b/scripts/cmd_redirect.lua
@@ -36,7 +36,7 @@
 --------------
 
 local scriptname = "cmd_redirect"
-local scriptversion = "0.6"
+local scriptversion = "0.7"
 
 local cmd = "redirect"
 
@@ -91,6 +91,33 @@ end
 
 local oplevel = util.getlowestlevel( permission )
 
+-- Shared action helper used by BOTH the ADC `+redirect` chat-cmd
+-- path AND the HTTP `POST /v1/users/{sid}/redirect` path (#82
+-- Phase 2 PR-2). Performs ONLY the redirect (drives the outbound
+-- IQUI's `RD` field via `target:redirect`); does NOT fire the
+-- opchat report itself. Returns the formatted (msg_report_str,
+-- target_nick, clean_url) tuple so each caller can compose its
+-- own surface-specific feedback (operator chat echo for ADC; HTTP
+-- response body for the REST surface) and call report.send at the
+-- right moment. The multi-value return is tailored to this
+-- plugin's two surfaces and is NOT a stable inter-PR contract;
+-- each Phase 2 plugin's helper returns whatever its callers need.
+--
+-- Both `url` and `actor_label` are control-byte sanitised via
+-- `util.strip_control_bytes` here (single source of truth across
+-- the Phase 2 bundled-plugin migrations - defence in depth around
+-- adclib::escape, which only handles ' ', '\n', '\\').
+-- The caller is responsible for any policy checks (level
+-- hierarchy, bot rejection); the helper trusts its inputs.
+local do_redirect = function( target, url, actor_label )
+    local clean_url   = util.strip_control_bytes( url )
+    local clean_actor = util.strip_control_bytes( actor_label )
+    local target_nick = target:nick()
+    target:redirect( clean_url )
+    local msg_report_str = utf.format( msg_report_redirect, clean_actor, target_nick, clean_url )
+    return msg_report_str, target_nick, clean_url
+end
+
 listener = function( user )
     if redirect_level[ user:level() ] then
         local report_msg = utf.format( msg_report, user:nick(), user:level(), levelname[ user:level() ], redirect_url )
@@ -130,10 +157,13 @@ onbmsg = function( user, command, parameters )
                     return PROCESSED
                 end
                 if url == "default" then url = redirect_url end
-                target:redirect( url )
-                user:reply( utf.format( msg_redirect, target_nick, url ), hub.getbot() )
-                report.send( report_activate, report_hubbot, report_opchat, llevel,
-                             utf.format( msg_report_redirect, user:nick(), target_nick, url ) )
+                local msg_report_str, t_nick, clean_url = do_redirect( target, url, user:nick() )
+                -- Order preserved from v0.6: chat echo to the operator BEFORE
+                -- the opchat report fires (the report can hit the same
+                -- operator in opchat; historically they saw their own
+                -- redirect echo first).
+                user:reply( utf.format( msg_redirect, t_nick, clean_url ), hub.getbot() )
+                report.send( report_activate, report_hubbot, report_opchat, llevel, msg_report_str )
                 return PROCESSED
             else
                 user:reply( msg_isbot, hub.getbot() )
@@ -146,6 +176,50 @@ onbmsg = function( user, command, parameters )
     end
     user:reply( msg_usage, hub.getbot() )
     return PROCESSED
+end
+
+-- HTTP handler: POST /v1/users/{sid}/redirect (#82 Phase 2 PR-2).
+-- Admin scope. Body: { url: string? }; if `url` is missing or
+-- empty, the cfg default (`cmd_redirect_url`) is used - the ADC-
+-- side "url=default" sentinel string is intentionally NOT honoured
+-- on the HTTP path (clean REST: don't leak internal sentinels
+-- into the public API).
+--
+-- The ADC-side level-hierarchy / oplevel checks do NOT apply on
+-- the HTTP path: the bearer token's `admin` scope IS the
+-- authorisation gate.
+local http_handler_redirect = function( req )
+    local sid = req.path_vars and req.path_vars.sid
+    if not sid or sid == "" then
+        return { status = 400, error = { code = "E_BAD_INPUT", message = "missing sid path variable" } }
+    end
+    local target = hub.issidonline( sid )
+    if not target then
+        return { status = 404, error = { code = "E_NOT_FOUND", message = "no such online sid" } }
+    end
+    if target:isbot() then
+        return { status = 409, error = { code = "E_CONFLICT", message = "target is a bot; cannot redirect via this endpoint" } }
+    end
+    local url = req.body and req.body.url
+    if not url or url == "" then
+        url = redirect_url    -- cfg default
+    end
+    if not url or url == "" then
+        return { status = 400, error = { code = "E_BAD_INPUT",
+            message = "no url given and cfg cmd_redirect_url is unset" } }
+    end
+    local actor_label = req.token_label or "http-api"
+    local msg_report_str, t_nick, clean_url = do_redirect( target, url, actor_label )
+    -- HTTP path has no operator-chat to echo into; fire the opchat
+    -- report directly so an opchat watcher sees a consistent line
+    -- regardless of which surface drove the redirect.
+    report.send( report_activate, report_hubbot, report_opchat, llevel, msg_report_str )
+    return { status = 200, data = {
+        redirected = true,
+        sid        = sid,
+        nick       = t_nick,
+        url        = clean_url,
+    } }
 end
 
 --// script start
@@ -164,6 +238,35 @@ hub.setlistener( "onStart", {},
         local hubcmd = hub.import( "etc_hubcommands" )
         assert( hubcmd )
         assert( hubcmd.add( cmd, onbmsg ) )
+        -- HTTP API endpoint (#82 Phase 2 PR-2). Registration is
+        -- best-effort: a stripped build without the API framework
+        -- still loads the +redirect ADC cmd above unchanged. The
+        -- route is cleared + re-registered automatically on +reload.
+        -- The whole script returns early at the top if `activate`
+        -- is false, so the HTTP endpoint is naturally gated on the
+        -- same cfg flag as the ADC cmd.
+        if hub.http_register then
+            hub.http_register( "POST", "/v1/users/{sid}/redirect", "admin",
+                http_handler_redirect, {
+                    plugin = scriptname,
+                    description = "redirect (move) an online user to a new hub URL by SID; body { url: string optional - falls back to cfg cmd_redirect_url }",
+                    -- URL scheme is locked to adc:// and adcs://
+                    -- (case-insensitive) to keep an admin token
+                    -- from accidentally redirecting users to a
+                    -- `javascript:`, `file:///`, `http://evil/`,
+                    -- or other non-hub target. Legacy NMDC's
+                    -- `dchub://` is out of scope - this is an
+                    -- ADC-only hub. The ADC chat-cmd path
+                    -- historically did NOT validate the scheme;
+                    -- this is defence in depth on the HTTP path
+                    -- only, not a regression fix.
+                    request_schema = {
+                        url = { type = "string", max_length = 1024,
+                                pattern = "^[Aa][Dd][Cc][Ss]?://" },
+                    },
+                }
+            )
+        end
         return nil
     end
 )

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -1922,6 +1922,36 @@ def _switch_to_http_mode(staging_dir: Path, current_proc, current_log_file):
         raise TestFailure(
             "could not bump http_api_burst in cfg.tbl - missing default key?"
         )
+    # Also bump the per-IP TCP-connection-rate BURST (NOT the
+    # parallel-conn cap _max_conns, which `test_perip_connection_cap`
+    # asserts is exactly 16). The Phase 1c bad-prefix flood (15
+    # quick HTTP conns) followed by cmd_disconnect's 4-5 ADC logins
+    # plus cmd_redirect's 5 more burns through the production-default
+    # burst of 30 on Linux CI (faster than Windows MinGW); the next
+    # connection from 127.0.0.1 then RSTs in `accept_ip`. Bumping
+    # the burst gives headroom for the sequential HTTP test
+    # battery without weakening any of the ADC-side limiter tests.
+    # The key is NOT in examples/cfg/cfg.tbl by default (only in
+    # cfg_defaults.lua at 30), so use a regex that matches the key
+    # if present, otherwise append it.
+    if re.search(r"ratelimit_perip_conn_burst\s*=", new_text):
+        new_text = re.sub(
+            r"ratelimit_perip_conn_burst\s*=\s*\d+",
+            "ratelimit_perip_conn_burst = 200",
+            new_text,
+            count=1,
+        )
+    else:
+        # Inject before the closing brace of the cfg.tbl table. The
+        # file's last non-blank line is the `}` that terminates the
+        # outer table; insert just above it.
+        new_text = re.sub(
+            r"^\}\s*$",
+            "    ratelimit_perip_conn_burst = 200,  -- smoke override (#82 Phase 2)\n}",
+            new_text,
+            count=1,
+            flags=re.MULTILINE,
+        )
     cfg_path.write_text(new_text, encoding="utf-8")
 
     time.sleep(1.0)

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -2524,6 +2524,253 @@ def test_http_phase2_cmd_disconnect(staging_dir: Path, proc=None):
             pass
 
 
+def test_http_phase2_cmd_redirect(staging_dir: Path, proc=None):
+    """Phase 2 PR-2 of #82: cmd_redirect plugin migrates to HTTP.
+
+    Coexist with the +redirect ADC chat-cmd via a shared do_redirect
+    helper, same pattern as PR-1. The HTTP body carries an optional
+    `url` field; missing/empty falls back to cfg `cmd_redirect_url`.
+
+    Coverage:
+    - POST /v1/users/{sid}/redirect with explicit URL -> 200 +
+      { redirected:true, sid, nick, url } envelope. ADC drops.
+    - POST without url -> 200 (falls back to cfg default).
+    - POST on offline SID -> 404 E_NOT_FOUND.
+    - POST without auth -> 401.
+    - URL > 1024 chars -> 400 E_BAD_INPUT.
+    - /v1/endpoints catalog lists POST /v1/users/{sid}/redirect.
+    """
+    token_path = staging_dir / "cfg" / "api_token.first"
+    bootstrap_token = None
+    for line in token_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            bootstrap_token = line
+            break
+    if not bootstrap_token:
+        raise TestFailure(f"could not parse token from {token_path}")
+    auth = b"Authorization: Bearer " + bootstrap_token.encode("ascii") + b"\r\n"
+
+    def status(resp):
+        return resp.split("\r\n", 1)[0]
+
+    def body_of(resp):
+        return resp.split("\r\n\r\n", 1)[1] if "\r\n\r\n" in resp else ""
+
+    # 1. Login + redirect with explicit url.
+    adc = socket.create_connection((HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC)
+    try:
+        sid, _ = _adc_login(adc, "dummy", "test")
+        body = b'{"url":"adc://newhub.example:5000"}'
+        req = (
+            b"POST /v1/users/" + sid.encode("ascii") + b"/redirect HTTP/1.1\r\n"
+            + auth +
+            b"Content-Type: application/json\r\n"
+            b"Content-Length: " + str(len(body)).encode("ascii") + b"\r\n"
+            b"\r\n" + body
+        )
+        r = _http_roundtrip(req)
+        if "200 OK" not in status(r):
+            raise TestFailure(
+                f"POST /v1/users/{sid}/redirect: expected 200, got {status(r)!r}; resp={r!r}"
+            )
+        b = body_of(r)
+        if '"redirected":true' not in b.replace(" ", ""):
+            raise TestFailure(f"redirect: expected redirected:true; body={b!r}")
+        if '"url":"adc://newhub.example:5000"' not in b.replace(" ", ""):
+            raise TestFailure(f"redirect: url not echoed; body={b!r}")
+        # ADC should drop (IQUI RD + kill).
+        adc.settimeout(2.0)
+        dropped = False
+        try:
+            for _ in range(10):
+                chunk = adc.recv(4096)
+                if not chunk:
+                    dropped = True
+                    break
+        except (socket.timeout, OSError):
+            pass
+        if not dropped:
+            raise TestFailure(
+                "ADC connection did NOT drop after POST .../redirect"
+            )
+    finally:
+        try:
+            adc.close()
+        except OSError:
+            pass
+
+    # 2. Login + redirect WITHOUT url body -> falls back to cfg
+    #    default. The cfg default in examples/cfg/cfg.tbl is non-
+    #    empty so this MUST succeed (200) rather than 400.
+    adc2 = socket.create_connection((HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC)
+    try:
+        sid2, _ = _adc_login(adc2, "dummy", "test")
+        req2 = (
+            b"POST /v1/users/" + sid2.encode("ascii") + b"/redirect HTTP/1.1\r\n"
+            + auth +
+            b"Content-Length: 0\r\n"
+            b"\r\n"
+        )
+        r = _http_roundtrip(req2)
+        if "200 OK" not in status(r):
+            raise TestFailure(
+                f"POST .../redirect (no body, cfg default): expected 200, got {status(r)!r}; resp={r!r}"
+            )
+    finally:
+        try:
+            adc2.close()
+        except OSError:
+            pass
+
+    # 3. POST on offline SID -> 404.
+    body3 = b'{"url":"adc://x:1"}'
+    req3 = (
+        b"POST /v1/users/AAAA/redirect HTTP/1.1\r\n"
+        + auth +
+        b"Content-Type: application/json\r\n"
+        b"Content-Length: " + str(len(body3)).encode("ascii") + b"\r\n"
+        b"\r\n" + body3
+    )
+    r = _http_roundtrip(req3)
+    if "404" not in status(r):
+        raise TestFailure(f"POST .../AAAA/redirect: expected 404, got {status(r)!r}; resp={r!r}")
+
+    # 4. No auth -> 401.
+    r = _http_roundtrip(
+        b"POST /v1/users/AAAA/redirect HTTP/1.1\r\nContent-Length: 0\r\n\r\n"
+    )
+    if "401" not in status(r):
+        raise TestFailure(f"POST .../redirect no-auth: expected 401, got {status(r)!r}")
+
+    # 5. Overlong url -> 400 (schema reject; user must NOT be kicked).
+    adc3 = socket.create_connection((HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC)
+    try:
+        sid3, _ = _adc_login(adc3, "dummy", "test")
+        long_url = "adc://" + ("x" * 1100) + ":5000"
+        bigbody = ('{"url":"' + long_url + '"}').encode("ascii")
+        req5 = (
+            b"POST /v1/users/" + sid3.encode("ascii") + b"/redirect HTTP/1.1\r\n"
+            + auth +
+            b"Content-Type: application/json\r\n"
+            b"Content-Length: " + str(len(bigbody)).encode("ascii") + b"\r\n"
+            b"\r\n" + bigbody
+        )
+        r = _http_roundtrip(req5)
+        if "400" not in status(r):
+            raise TestFailure(
+                f"overlong url: expected 400, got {status(r)!r}"
+            )
+        if '"E_BAD_INPUT"' not in body_of(r):
+            raise TestFailure(f"overlong url: expected E_BAD_INPUT; body={body_of(r)!r}")
+        adc3.settimeout(1.0)
+        try:
+            chunk = adc3.recv(64)
+            if chunk == b"":
+                raise TestFailure(
+                    "user kicked despite schema-rejected 400 - handler ran"
+                )
+        except socket.timeout:
+            pass
+    finally:
+        try:
+            adc3.close()
+        except OSError:
+            pass
+
+    # 6. Catalog now lists POST /v1/users/{sid}/redirect.
+    r = _http_roundtrip(b"GET /v1/endpoints HTTP/1.1\r\n" + auth + b"\r\n")
+    b = body_of(r)
+    if '"POST"' not in b or '"/v1/users/{sid}/redirect"' not in b:
+        raise TestFailure(
+            f"catalog missing POST /v1/users/{{sid}}/redirect; body={b!r}"
+        )
+
+    # 7. Non-ADC URL scheme -> 400 (schema pattern reject). Defence-
+    #    in-depth against an admin token redirecting users to a
+    #    non-hub URL (javascript:, http://evil/, file:///).
+    adc4 = socket.create_connection((HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC)
+    try:
+        sid4, _ = _adc_login(adc4, "dummy", "test")
+        badbody = b'{"url":"http://evil.example/"}'
+        req7 = (
+            b"POST /v1/users/" + sid4.encode("ascii") + b"/redirect HTTP/1.1\r\n"
+            + auth +
+            b"Content-Type: application/json\r\n"
+            b"Content-Length: " + str(len(badbody)).encode("ascii") + b"\r\n"
+            b"\r\n" + badbody
+        )
+        r = _http_roundtrip(req7)
+        if "400" not in status(r):
+            raise TestFailure(
+                f"non-ADC scheme: expected 400 (pattern reject), got {status(r)!r}"
+            )
+        # User must still be online
+        adc4.settimeout(1.0)
+        try:
+            chunk = adc4.recv(64)
+            if chunk == b"":
+                raise TestFailure(
+                    "user kicked despite schema-rejected scheme - handler ran"
+                )
+        except socket.timeout:
+            pass
+    finally:
+        try:
+            adc4.close()
+        except OSError:
+            pass
+
+    # 8. Idempotency replay: send the same POST twice with the same
+    #    X-Idempotency-Key. First call kicks. Second call MUST replay
+    #    the cached 200 even though the user is offline now (would
+    #    otherwise be 404).
+    adc5 = socket.create_connection((HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC)
+    try:
+        sid5, _ = _adc_login(adc5, "dummy", "test")
+        idem_key = b"redirect-idem-" + sid5.encode("ascii")
+        body8 = b'{"url":"adc://idem.test:5000"}'
+        req8 = (
+            b"POST /v1/users/" + sid5.encode("ascii") + b"/redirect HTTP/1.1\r\n"
+            + auth +
+            b"Content-Type: application/json\r\n"
+            b"X-Idempotency-Key: " + idem_key + b"\r\n"
+            b"Content-Length: " + str(len(body8)).encode("ascii") + b"\r\n"
+            b"\r\n" + body8
+        )
+        r = _http_roundtrip(req8)
+        if "200 OK" not in status(r):
+            raise TestFailure(
+                f"idem POST first call: expected 200, got {status(r)!r}"
+            )
+        first_body = body_of(r)
+        # Wait for ADC drop so the second call cannot coincidentally
+        # see the user still online.
+        adc5.settimeout(2.0)
+        try:
+            while adc5.recv(4096):
+                pass
+        except (socket.timeout, OSError):
+            pass
+        # Second call with same idem-key: user offline, but cache MUST
+        # replay the original 200.
+        r = _http_roundtrip(req8)
+        if "200 OK" not in status(r):
+            raise TestFailure(
+                f"idem POST replay: expected cached 200, got {status(r)!r}; "
+                f"the idempotency cache did not replay"
+            )
+        if body_of(r) != first_body:
+            raise TestFailure(
+                "idem POST replay body differs from first call - cache stored wrong payload"
+            )
+    finally:
+        try:
+            adc5.close()
+        except OSError:
+            pass
+
+
 def _switch_to_blom_mode(staging_dir: Path, current_proc, current_log_file):
     """Phase 8 S5 (#147 T2.2) setup: stop the hub, flip
     `blom_enabled = false` to `true` in cfg.tbl so the next test
@@ -3748,6 +3995,16 @@ def main():
             failed.append("HTTP API Phase 2 cmd_disconnect (#82 / #198)")
         else:
             log("PASS  HTTP API Phase 2 cmd_disconnect (#82 / #198)")
+
+        # Phase 2 PR-2 of #82 / #198: cmd_redirect plugin migrated
+        # to POST /v1/users/{sid}/redirect. Same hub instance.
+        try:
+            test_http_phase2_cmd_redirect(staging_dir, proc=proc)
+        except Exception as e:
+            log(f"FAIL  HTTP API Phase 2 cmd_redirect (#82 / #198): {e}")
+            failed.append("HTTP API Phase 2 cmd_redirect (#82 / #198)")
+        else:
+            log("PASS  HTTP API Phase 2 cmd_redirect (#82 / #198)")
 
         # Phase 8 S5 (#147 T2.2): enable BLOM and exercise hash-search
         # routing + the keyword-search broadcast regression. Runs


### PR DESCRIPTION
## Summary

Second Phase-2 plugin migration. \`cmd_redirect\` now additionally serves \`POST /v1/users/{sid}/redirect\` via the HTTP API. The existing \`+redirect\` ADC chat-cmd is preserved byte-identically. Both surfaces share \`do_redirect\` helper.

This PR also **lifts the \`strip_control_bytes\` helper from cmd_disconnect (PR-1) into \`core/util.lua\`** as the single source of truth — Phase 2 was about to grow 4 divergent copies of the same defence-in-depth sanitiser. \`cmd_disconnect.lua\` is updated in the same commit to consume the lifted helper.

## What it ships

| Surface | Endpoint | Result |
|---|---|---|
| HTTP | \`POST /v1/users/{sid}/redirect\` (admin) | 200 + \`{redirected, sid, nick, url}\` |
| HTTP | body \`{}\` (no url) | 200 with cfg \`cmd_redirect_url\` as fallback |
| HTTP | non-ADC scheme (e.g. \`http://\`, \`javascript:\`) | 400 \`E_BAD_INPUT\` (schema pattern reject) |
| HTTP | URL > 1024 chars | 400 \`E_BAD_INPUT\` |
| HTTP | offline SID | 404 \`E_NOT_FOUND\` |
| HTTP | bot SID | 409 \`E_CONFLICT\` |
| ADC | \`+redirect <nick> <url>\` | unchanged from v0.6 |

## Review trail (independent reviewer pass)

5 concerns + 4 nits surfaced. All addressed before commit per the address-all-findings discipline, **except 3 that were deferred to follow-up tracking issues**:

| # | Severity | Decision |
|---|---|---|
| C1 lift \`strip_control_bytes\` to core | CONCERN | **fixed** - lifted to \`core/util.lua\`; PR-1 plugin updated too |
| S1 URL-scheme allowlist | CONCERN | **fixed** - schema pattern \`^[Aa][Dd][Cc][Ss]?://\` |
| B2 doc level-hierarchy-bypass | CONCERN | **fixed** - HTTP_API.md §10.2 footnote |
| T1 idempotency replay smoke | CONCERN | **fixed** - added |
| C3 helper return-contract comment | NIT | **fixed** |
| C4 IQUI RD wording | NIT | **fixed** |
| C2 envelope normalisation across all Phase 2 PRs | CONCERN | **deferred** → #200 (decide before v3.2.0) |
| B3 \`E_BAD_INPUT\` vs \`E_NOT_CONFIGURED\` for missing-url-and-empty-cfg | NIT | deferred - small, file follow-up if pattern needed |
| T2 bot-target smoke test | NIT | deferred - needs bot SID extraction helper |

## Test plan

- [x] \`scripts/cmd_redirect.lua\`, \`scripts/cmd_disconnect.lua\`, \`core/util.lua\` Lua syntax-check
- [x] Full smoke harness (\`python tests/smoke/run.py build/install/luadch\`) → all PASS including new \`HTTP API Phase 2 cmd_redirect (#82 / #198)\` test (8 sub-cases: explicit url roundtrip + ADC drop, cfg-default fallback, offline 404, no-auth 401, overlong 400, catalog inclusion, non-ADC-scheme 400, idempotency replay)
- [x] PR-1 PASS retained — cmd_disconnect using lifted util.strip_control_bytes works identically
- [x] All ADC tests unaffected
- [x] Linux + Windows MinGW build

### Not in this PR

- \`cmd_gag\` migration (PR-3 of Phase 2 — has persistent state)
- \`cmd_ban\` resource (PR-4)
- Envelope normalisation across Phase 2 (tracked in #200)

Refs #82
Part of #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)