### PR TITLE
docs(82): normalise Phase 2 write-endpoint response envelope (closes #200)

### DIFF
--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -646,6 +646,48 @@ HTTP status carries the high-level outcome (200 / 201 / 204) and the
 `data` field carries the payload. For 204 No Content, `data` is `null`
 and the body may be empty.
 
+#### 7.1.1 Write-endpoint response convention (Phase 2 lock-in, #200)
+
+Write endpoints (POST / PUT / PATCH / DELETE that mutate hub state)
+follow a uniform `data` shape so a generic admin client can dispatch
+on a single field rather than switching on N per-endpoint boolean
+verb flags:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "action": "<verb>",
+    "sid":    "<sid>",
+    "nick":   "<nick>",
+    ...                    // action-specific fields, e.g. `reason`, `url`, `gag_duration_minutes`
+  }
+}
+```
+
+- `action` is a short kebab-case (or single-word) verb identifying
+  the operation that just happened. Stable across the API: a client
+  can map `action` to a handler table.
+- `sid` + `nick` identify the target where applicable. Endpoints that
+  don't operate on a single online user (e.g. `/v1/announce`,
+  `/v1/topic`) omit them.
+- Action-specific fields (`reason`, `url`, `duration_minutes`, ...)
+  sit flat alongside, NOT nested under a `params` block. The flat
+  shape was chosen over `{action, target, params, result}` because
+  client code reads `data.url` more naturally than
+  `data.params.url`, and the extra nesting costs bytes on the wire
+  without a corresponding payoff for the read case.
+- Verb-boolean fields (`disconnected: true`, `redirected: true`)
+  are NOT used. The early Phase-2 PRs (#199, #201) shipped that
+  shape; #200 is the tracker that normalised on the current
+  convention.
+
+Read endpoints (GET) MAY use any shape under `data` they like
+(e.g. `/v1/users` carries a `pagination` sibling, `/v1/version`
+carries flat fields directly). The `action`-verb convention is
+specifically for state-mutating endpoints; reads don't perform an
+action.
+
 ### 7.2 Error
 
 ```json

--- a/scripts/cmd_disconnect.lua
+++ b/scripts/cmd_disconnect.lua
@@ -197,11 +197,18 @@ local http_handler_disconnect = function( req )
     -- operator watching opchat sees a consistent line regardless
     -- of which surface drove the kick.
     report.send( report_activate, report_hubbot, report_opchat, llevel, msg_report )
+    -- Response envelope follows the Phase-2 convention locked in
+    -- docs/HTTP_API.md §7.1: flat data with an explicit `action`
+    -- verb string. Clients switch on `data.action` to dispatch on
+    -- the kind of operation that just happened; the per-action
+    -- fields below it (`reason` here, `url` for redirect, etc.)
+    -- carry the operation-specific result data. No verb-boolean
+    -- (`disconnected: true`) - that was the pre-#200 shape.
     return { status = 200, data = {
-        disconnected = true,
-        sid          = sid,
-        nick         = targetuser_nick,
-        reason       = reason,
+        action = "disconnect",
+        sid    = sid,
+        nick   = targetuser_nick,
+        reason = reason,
     } }
 end
 

--- a/scripts/cmd_redirect.lua
+++ b/scripts/cmd_redirect.lua
@@ -214,11 +214,13 @@ local http_handler_redirect = function( req )
     -- report directly so an opchat watcher sees a consistent line
     -- regardless of which surface drove the redirect.
     report.send( report_activate, report_hubbot, report_opchat, llevel, msg_report_str )
+    -- Response envelope follows the Phase-2 convention locked in
+    -- docs/HTTP_API.md §7.1 (flat data + explicit `action` verb).
     return { status = 200, data = {
-        redirected = true,
-        sid        = sid,
-        nick       = t_nick,
-        url        = clean_url,
+        action = "redirect",
+        sid    = sid,
+        nick   = t_nick,
+        url    = clean_url,
     } }
 end
 

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -2348,7 +2348,8 @@ def test_http_phase2_cmd_disconnect(staging_dir: Path, proc=None):
     Coverage:
     - Login a real ADC user (dummy/test), capture SID.
     - DELETE /v1/users/{sid} with admin token + reason body -> 200 +
-      envelope { ok:true, data:{ disconnected:true, sid, nick, reason } }.
+      envelope { ok:true, data:{ action:"disconnect", sid, nick, reason } }
+      (Phase-2 normalised shape per #200 / HTTP_API.md §7.1.1).
     - ADC connection drops shortly after (the kick is asynchronous to
       the HTTP response but happens within the request handler tick).
     - Subsequent DELETE on the same SID -> 404 E_NOT_FOUND.
@@ -2397,8 +2398,11 @@ def test_http_phase2_cmd_disconnect(staging_dir: Path, proc=None):
         if "200 OK" not in status(r):
             raise TestFailure(f"DELETE /v1/users/{sid}: expected 200, got {status(r)!r}; resp={r!r}")
         b = body_of(r)
-        if '"disconnected":true' not in b.replace(" ", ""):
-            raise TestFailure(f"DELETE /v1/users/{{sid}}: expected disconnected:true; body={b!r}")
+        # Phase-2 envelope normalisation (#200): write-endpoint
+        # responses carry `action:"<verb>"` instead of a per-
+        # endpoint verb-boolean (pre-#200 was {disconnected:true,...}).
+        if '"action":"disconnect"' not in b.replace(" ", ""):
+            raise TestFailure(f"DELETE /v1/users/{{sid}}: expected action:disconnect; body={b!r}")
         # The nick may be auto-prefixed by the level tag (e.g.
         # "[HUBOWNER]dummy"); substring-match is enough.
         if '"nick":"' not in b or "dummy" not in b:
@@ -2563,7 +2567,8 @@ def test_http_phase2_cmd_redirect(staging_dir: Path, proc=None):
 
     Coverage:
     - POST /v1/users/{sid}/redirect with explicit URL -> 200 +
-      { redirected:true, sid, nick, url } envelope. ADC drops.
+      { action:"redirect", sid, nick, url } envelope. ADC drops.
+      (Phase-2 normalised shape per #200 / HTTP_API.md §7.1.1.)
     - POST without url -> 200 (falls back to cfg default).
     - POST on offline SID -> 404 E_NOT_FOUND.
     - POST without auth -> 401.
@@ -2605,8 +2610,10 @@ def test_http_phase2_cmd_redirect(staging_dir: Path, proc=None):
                 f"POST /v1/users/{sid}/redirect: expected 200, got {status(r)!r}; resp={r!r}"
             )
         b = body_of(r)
-        if '"redirected":true' not in b.replace(" ", ""):
-            raise TestFailure(f"redirect: expected redirected:true; body={b!r}")
+        # Phase-2 envelope normalisation (#200): see cmd_disconnect
+        # smoke for context.
+        if '"action":"redirect"' not in b.replace(" ", ""):
+            raise TestFailure(f"redirect: expected action:redirect; body={b!r}")
         if '"url":"adc://newhub.example:5000"' not in b.replace(" ", ""):
             raise TestFailure(f"redirect: url not echoed; body={b!r}")
         # ADC should drop (IQUI RD + kill).


### PR DESCRIPTION
## Summary

Locks the response envelope shape for **all** Phase 2 write endpoints on the convention:

\`\`\`json
{
  "ok": true,
  "data": {
    "action": "<verb>",
    "sid":    "<sid>",
    "nick":   "<nick>",
    ...action-specific fields (reason, url, ...)
  }
}
\`\`\`

Replaces the per-action verb-boolean shape PR-1 / PR-2 shipped (\`{disconnected: true, ...}\` / \`{redirected: true, ...}\`) with a uniform \`action:"<verb>"\` string. A generic admin client can dispatch on a single \`data.action\` field rather than switching on N per-endpoint boolean flags.

## Why now

- PR-1 (#199) and PR-2 (#201) merged on 2026-05-22 but are not in a tagged release yet (v3.2.0-dev). Changing the wire shape now is cheap; after a 3.2.x tag it requires \`/v2/\` prefix or breaking change.
- PR-3 (cmd_gag) and PR-4 (cmd_ban) start fresh with the locked shape — no per-PR drift in flight.

## Why flat, not nested

\`{action, target:{sid, nick}, params:{url}, result:"ok"}\` was the alternative. Rejected because:
- Clients read \`data.url\` more naturally than \`data.params.url\`. Most code paths walk the flat shape.
- The nesting costs bytes without a corresponding payoff for the read case.
- \`action\` as a flat sibling already gives clients the dispatch field they need.

## Files

- \`scripts/cmd_disconnect.lua\` — handler return uses \`action:"disconnect"\`
- \`scripts/cmd_redirect.lua\` — handler return uses \`action:"redirect"\`
- \`docs/HTTP_API.md\` §7.1.1 — new subsection locks the convention with the rationale
- \`tests/smoke/run.py\` — assertions + docstrings on both Phase-2 smokes updated

## Review trail

Independent reviewer found 1 concern + 1 nit:
- Smoke docstrings still mentioned the old shape → fixed
- \`PR #??\` placeholder in HTTP_API.md → replaced with #200 reference

Both addressed before commit.

## Test plan

- [x] \`scripts/cmd_disconnect.lua\` + \`scripts/cmd_redirect.lua\` Lua syntax-check
- [x] Full smoke harness → all PASS, both \`HTTP API Phase 2 cmd_disconnect\` and \`cmd_redirect\` tests confirm the new \`action:\"<verb>\"\` field
- [x] Linux + Windows MinGW build

Read endpoints (GET) are NOT touched — they may keep any \`data\` shape (e.g. \`/v1/users\` carries a \`pagination\` sibling). The \`action\`-verb convention is specifically for state-mutating endpoints; reads don't perform an action.

Refs #82
Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)