### PR TITLE
refactor(82): util_http.http_register_user_action helper

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -52,6 +52,14 @@ jobs:
       - name: Run http_router unit test
         run: lua5.4 tests/unit/http_router_test.lua
 
+      # Phase 2 PR-B of #82: util_http.http_register_user_action helper
+      # tests cover the preflight (sid + online + non-bot), the
+      # §7.1.1 response envelope construction, the spoof-guard that
+      # drops handler-supplied convention fields, and the fail-soft
+      # registration path.
+      - name: Run util_http unit test
+        run: lua5.4 tests/unit/util_http_test.lua
+
       - name: Configure
         run: cmake -B build -DCMAKE_BUILD_TYPE=Release
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,6 +340,29 @@ notes:
 Each Phase-8+ item gets its own discrete phase or issue with its own scope
 and review gate. The strict "one phase at a time" discipline still applies.
 
+### In flight: HTTP API (#82)
+
+Phase 1 (read API: framework + auth + 5 core endpoints + rate-limit +
+idempotency) is merged. Phase 2 (#198) migrates the bundled write-action
+plugins to dual ADC-cmd + HTTP-endpoint surfaces; in progress.
+
+**For new plugins that need an HTTP write endpoint** (kick, redirect, gag,
+mute, ...): use `util_http.http_register_user_action` from
+[`core/util_http.lua`](core/util_http.lua), NOT raw `hub.http_register`.
+It handles the standard preflight (SID extraction + online check + non-bot
+rejection) and constructs the §7.1.1 response envelope so the plugin only
+owns the action-specific handler body. See [`docs/HTTP_API.md`](docs/HTTP_API.md)
+§5.1.1 for the contract; `scripts/cmd_disconnect.lua` and
+`scripts/cmd_redirect.lua` are reference call sites.
+
+Raw `hub.http_register` is the lower-level escape hatch for read endpoints,
+resources with non-SID target keys (e.g. cmd_ban with nick/cid/ip), or
+endpoints that need a different envelope shape.
+
+Plugin sandbox already exposes both `util` (for `strip_control_bytes`,
+generic helpers) and `util_http` (for the HTTP helper) as globals via the
+standard `_G` iteration in [`core/scripts.lua`](core/scripts.lua).
+
 ---
 
 ## 6. External state & memory

--- a/core/init.lua
+++ b/core/init.lua
@@ -91,6 +91,13 @@ _core = {    -- luadch core, order is important
     "server",
     "adc",
     "hub",
+    -- core/util_http.lua: HTTP-API-specific plugin helpers (#82
+    -- Phase 2 PR-B). Loaded AFTER hub.lua because the helper does
+    -- a lazy `use "hub"` at registration time, not at module-load
+    -- time, but kept ordered alongside the other HTTP-API
+    -- machinery (core/http.lua / core/http_router.lua are loaded
+    -- on demand via `use`, not from _core).
+    "util_http",
     "scripts",
     "types",
     --"test",

--- a/core/util.lua
+++ b/core/util.lua
@@ -714,6 +714,11 @@ strip_control_bytes = function( str )
     return ( type( str ) == "string" ) and ( str:gsub( "%c", "?" ) ) or ""
 end
 
+-- HTTP API helper `http_register_user_action` was extracted into
+-- core/util_http.lua per the PR-B independent review (avoid the
+-- util.lua-dumping-ground failure mode as Phase 2 grows). Plugins
+-- call it as `util_http.http_register_user_action( ... )`.
+
 --// get lowest level with rights from permission table (for help/ucmd)
 getlowestlevel = function( tbl )
     local err

--- a/core/util_http.lua
+++ b/core/util_http.lua
@@ -1,0 +1,155 @@
+--[[
+
+    util_http.lua - HTTP-API-specific plugin helpers (#82 Phase 2 PR-B).
+
+    Extracted from core/util.lua to keep the HTTP-API plugin surface
+    separate from the generic string / file / table helpers in
+    util.lua. As the HTTP API grows (Phase 2 PR-3 cmd_gag, PR-4
+    cmd_ban, Phase 3 destructive ops, Phase 4 subsystem managers),
+    a dedicated module avoids the "util.lua dumping ground" failure
+    mode flagged in the PR-B independent review.
+
+    Generic helpers (`strip_control_bytes`) stay in util.lua because
+    they are useful outside the HTTP API too (any string that hits
+    an ADC frame benefits from the same defence in depth).
+
+    Public surface:
+
+        util_http.http_register_user_action(
+            scriptname, method, path, action_verb, handler_fn, meta?
+        )
+            Register an admin-scope HTTP endpoint that operates on
+            ONE online user identified by `{sid}` in the path. The
+            helper handles the preflight (sid + online + non-bot
+            check) and constructs the response envelope per
+            docs/HTTP_API.md §7.1.1 (action / sid / nick + handler
+            data). `handler_fn(req, target)` returns either a flat
+            table of action-specific data fields or
+            (nil, error_table) for a custom error response.
+
+    Loaded as a core module via init.lua's _core list; plugins see
+    `util_http` as a global in their sandbox env via the standard
+    _G iteration in core/scripts.lua.
+
+]]--
+
+----------------------------------// DECLARATION //--
+
+local use = use
+
+local pairs = use "pairs"
+local type = use "type"
+
+----------------------------------// DEFINITION //--
+
+-- HTTP API helper: register a "user action by SID" endpoint with
+-- shared preflight + envelope (#82 Phase 2 PR-B). Captures the
+-- pattern PR-1 (cmd_disconnect) and PR-2 (cmd_redirect) both
+-- duplicated by hand, and keeps the HTTP_API.md §7.1.1 response
+-- envelope shape correct by construction. Future Phase 2 plugin
+-- migrations (PR-3 cmd_gag, PR-4 cmd_ban where the target is a
+-- SID) SHOULD prefer this helper over a raw hub.http_register
+-- call. Plugins that need a different scope, a non-SID target
+-- (cmd_ban with nick/cid/ip), or a different envelope shape use
+-- the lower-level hub.http_register directly.
+--
+-- Arguments:
+--   scriptname    - the calling plugin's name string; embedded in
+--                   the route's `meta.plugin` field for /v1/endpoints
+--                   discovery. Pass the script's local `scriptname`.
+--   method        - uppercase HTTP method ("POST", "DELETE", ...)
+--   path          - URL path template with `{sid}` placeholder, e.g.
+--                   "/v1/users/{sid}" or "/v1/users/{sid}/gag"
+--   action_verb   - short string used for two things: (a) the
+--                   `data.action` field in the response envelope,
+--                   (b) the bot-rejection error message
+--                   ("cannot <verb> via this endpoint"). MUST be
+--                   a static literal at registration time, never
+--                   user-controlled input (it is interpolated
+--                   into an error string without further sanitisation).
+--                   Should be a single-word verb ("disconnect",
+--                   "redirect", "gag", "ungag", ...) in lower-case.
+--   handler_fn    - function(req, target) -> (data_or_nil, err_or_nil)
+--                   Called AFTER the helper has already verified
+--                   the SID is online and non-bot; the target arg
+--                   is the live user object. Returns either:
+--                     - a flat table of action-specific fields to
+--                       merge into the response envelope (e.g.
+--                       {reason="flood"}); the helper adds the
+--                       `action`/`sid`/`nick` convention fields
+--                       and SILENTLY drops any handler-supplied
+--                       value at those three keys (the envelope
+--                       owns them per §7.1.1)
+--                     - nil, error_table to bail out with a custom
+--                       error response (e.g. 409 if the user is
+--                       already in the right state for this action)
+--   meta          - optional table forwarded to hub.http_register
+--                   (description, request_schema, response_schema).
+--                   `plugin = scriptname` is filled in automatically.
+--
+-- Returns:
+--   the registration's result (or false if hub.http_register is
+--   absent - the helper is fail-soft so a hypothetical stripped
+--   build without the API framework still loads the plugin's ADC
+--   surface unchanged).
+--
+-- Scope is always "admin" - user actions are by-definition admin
+-- operations in the current Phase-2 design. A future read-only
+-- endpoint or per-user-self surface would NOT use this helper and
+-- call hub.http_register directly with its own scope.
+local function http_register_user_action( scriptname, method, path, action_verb, handler_fn, meta )
+    -- `use "hub"` returns the hub MODULE table (`{init, loop, object}`),
+    -- NOT the plugin-facing `_luadch`. The `http_register` /
+    -- `issidonline` / etc methods live on `_luadch`, which is
+    -- exposed via the `object()` thunk (see core/hub.lua return).
+    local _hub_mod = use "hub"
+    local hub_obj = _hub_mod and _hub_mod.object and _hub_mod.object( )
+    if not hub_obj or not hub_obj.http_register then return false end
+    meta = meta or { }
+    meta.plugin = meta.plugin or scriptname
+    return hub_obj.http_register( method, path, "admin", function( req )
+        local sid = req.path_vars and req.path_vars.sid
+        if not sid or sid == "" then
+            return { status = 400, error = { code = "E_BAD_INPUT",
+                message = "missing sid path variable" } }
+        end
+        local target = hub_obj.issidonline( sid )
+        if not target then
+            return { status = 404, error = { code = "E_NOT_FOUND",
+                message = "no such online sid" } }
+        end
+        if target:isbot() then
+            return { status = 409, error = { code = "E_CONFLICT",
+                message = "target is a bot; cannot " .. action_verb ..
+                          " via this endpoint" } }
+        end
+        local data, err = handler_fn( req, target )
+        if err then return err end
+        local out = {
+            action = action_verb,
+            sid    = sid,
+            nick   = target:nick(),
+        }
+        if type( data ) == "table" then
+            for k, v in pairs( data ) do
+                -- Convention fields are owned by the envelope; a
+                -- handler MUST NOT override them. Silently skip
+                -- any collision - the handler can stash a custom
+                -- nick / action / sid value under a different key
+                -- if it really needs one.
+                if k ~= "action" and k ~= "sid" and k ~= "nick" then
+                    out[ k ] = v
+                end
+            end
+        end
+        return { status = 200, data = out }
+    end, meta )
+end
+
+----------------------------------// PUBLIC INTERFACE //--
+
+return {
+
+    http_register_user_action = http_register_user_action,
+
+}

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -363,6 +363,46 @@ hub.http_register( method, path, scope, handler, meta )
 | `handler` | function | `function(req) -> result` (see §6 + §7) |
 | `meta` | table or nil | Optional metadata - `{description=, request_schema=, response_schema=}`. Surfaced via `/v1/endpoints`. Used by WebUI for form rendering |
 
+#### 5.1.1 Higher-level helper: `util_http.http_register_user_action`
+
+For the common "user action by SID" pattern (kick / redirect /
+gag / etc — an admin endpoint that operates on one online user
+identified by `{sid}` in the path), prefer the helper in
+`core/util_http.lua`:
+
+```lua
+util_http.http_register_user_action(
+    scriptname,          -- plugin name (for /v1/endpoints discovery)
+    method,              -- "POST" / "DELETE" / ...
+    path,                -- "/v1/users/{sid}" or "/v1/users/{sid}/<action>"
+    action_verb,         -- "disconnect" / "redirect" / ... (static literal)
+    handler_fn,          -- function(req, target) -> data | (nil, err)
+    meta                 -- optional, same shape as hub.http_register's meta
+)
+```
+
+The helper:
+- Verifies `{sid}` is present, the SID is online, and the user is
+  not a bot — returns 400 / 404 / 409 with the standard error
+  codes on failure. The plugin handler never sees those cases.
+- Constructs the §7.1.1 response envelope (`{action, sid, nick,
+  ...handler_fields}`); the plugin handler returns just the
+  action-specific fields (e.g. `{reason="flood"}` or
+  `{url="adc://..."}`).
+- Is fail-soft: returns `false` if `hub.http_register` is absent
+  (stripped builds without the HTTP API framework still load the
+  plugin's ADC chat-cmd surface unchanged).
+- Hard-codes scope = `"admin"` — user-action endpoints are
+  always admin by definition. Read-only or per-user-self
+  surfaces use `hub.http_register` directly with their own scope.
+
+When to use the lower-level `hub.http_register` instead:
+- Read endpoints (`GET`) that need scope `"read"`.
+- Resource endpoints with non-SID target keys (e.g. `cmd_ban`
+  with nick / cid / ip targets — Phase 2 PR-4).
+- Endpoints with a different response envelope shape (none in
+  Phase 2; `/health` and `/v1/endpoints` in Phase 1).
+
 ### 5.2 Registration lifecycle
 
 - Plugin calls `hub.http_register` from inside its `onStart` listener.

--- a/scripts/cmd_disconnect.lua
+++ b/scripts/cmd_disconnect.lua
@@ -168,48 +168,26 @@ local onbmsg = function( user, adccmd, parameters )
     return PROCESSED
 end
 
--- HTTP handler: DELETE /v1/users/{sid} (#82 Phase 2).
--- Admin scope (enforced by the router via the route registration).
--- Audit log is emitted automatically by the router; this handler
--- only performs the kick + opchat report. The ADC-side level
--- hierarchy check does NOT apply on the HTTP path: the bearer
--- token's `admin` scope IS the authorisation gate.
-local http_handler_disconnect = function( req )
-    local sid = req.path_vars and req.path_vars.sid
-    if not sid or sid == "" then
-        return { status = 400, error = { code = "E_BAD_INPUT", message = "missing sid path variable" } }
-    end
-    local targetuser = hub.issidonline( sid )
-    if not targetuser then
-        return { status = 404, error = { code = "E_NOT_FOUND", message = "no such online sid" } }
-    end
-    if targetuser:isbot() then
-        -- bots are not in /v1/users (which uses the nobot getter);
-        -- a sid that resolves to a bot here is an operator mistake.
-        return { status = 409, error = { code = "E_CONFLICT", message = "target is a bot; cannot disconnect via this endpoint" } }
-    end
-    local targetuser_nick = targetuser:nick()
+-- HTTP handler body: DELETE /v1/users/{sid} (#82 Phase 2). The
+-- shared `util.http_register_user_action` helper handles the
+-- preflight (SID extraction + online check + non-bot rejection)
+-- and the response envelope (action/sid/nick); the handler below
+-- just does the action-specific bits: pull `reason` from the
+-- body, drive the kick + opchat report, return the
+-- action-specific fields to merge into the envelope.
+--
+-- Audit log is emitted automatically by the router; the ADC-side
+-- level hierarchy check does NOT apply on the HTTP path: the
+-- bearer token's `admin` scope IS the authorisation gate.
+local http_handler_disconnect = function( req, target )
     local reason = ( req.body and req.body.reason ) or ""
     local actor_label = req.token_label or "http-api"
-    local msg_report = do_disconnect( targetuser, reason, actor_label )
-    -- HTTP path has no operator-chat to echo into; just fire the
-    -- opchat report directly. Same payload as the ADC path so an
-    -- operator watching opchat sees a consistent line regardless
-    -- of which surface drove the kick.
+    local msg_report = do_disconnect( target, reason, actor_label )
+    -- HTTP path has no operator-chat to echo into; fire the
+    -- opchat report directly so an operator watching opchat sees
+    -- a consistent line regardless of which surface drove the kick.
     report.send( report_activate, report_hubbot, report_opchat, llevel, msg_report )
-    -- Response envelope follows the Phase-2 convention locked in
-    -- docs/HTTP_API.md §7.1: flat data with an explicit `action`
-    -- verb string. Clients switch on `data.action` to dispatch on
-    -- the kind of operation that just happened; the per-action
-    -- fields below it (`reason` here, `url` for redirect, etc.)
-    -- carry the operation-specific result data. No verb-boolean
-    -- (`disconnected: true`) - that was the pre-#200 shape.
-    return { status = 200, data = {
-        action = "disconnect",
-        sid    = sid,
-        nick   = targetuser_nick,
-        reason = reason,
-    } }
+    return { reason = reason }
 end
 
 hub.setlistener( "onStart", {},
@@ -226,22 +204,19 @@ hub.setlistener( "onStart", {},
         hubcmd = hub.import( "etc_hubcommands" )
         assert( hubcmd )
         assert( hubcmd.add( cmd, onbmsg ) )
-        -- HTTP API endpoint (#82 Phase 2). Registration is best-effort:
-        -- if http_register is missing (hub built without the API, or
-        -- a stripped 3.1.x backport that lacks the framework) the
-        -- ADC `+disconnect` cmd above still works unchanged. The
-        -- route is cleared + re-registered automatically on +reload.
-        if hub.http_register then
-            hub.http_register( "DELETE", "/v1/users/{sid}", "admin",
-                http_handler_disconnect, {
-                    plugin = scriptname,
-                    description = "disconnect (kick) an online user by SID; body { reason: string optional }",
-                    request_schema = {
-                        reason = { type = "string", max_length = 256 },
-                    },
-                }
-            )
-        end
+        -- HTTP API endpoint (#82 Phase 2). The util_http helper
+        -- does the fail-soft check, the preflight, the envelope,
+        -- and the audit-log integration; this plugin only owns the
+        -- action-specific handler body above.
+        util_http.http_register_user_action( scriptname,
+            "DELETE", "/v1/users/{sid}", "disconnect",
+            http_handler_disconnect, {
+                description = "disconnect (kick) an online user by SID; body { reason: string optional }",
+                request_schema = {
+                    reason = { type = "string", max_length = 256 },
+                },
+            }
+        )
         return nil
     end
 )

--- a/scripts/cmd_redirect.lua
+++ b/scripts/cmd_redirect.lua
@@ -178,7 +178,12 @@ onbmsg = function( user, command, parameters )
     return PROCESSED
 end
 
--- HTTP handler: POST /v1/users/{sid}/redirect (#82 Phase 2 PR-2).
+-- HTTP handler body: POST /v1/users/{sid}/redirect (#82 Phase 2 PR-2).
+-- Preflight + envelope are owned by util.http_register_user_action
+-- (PR-B); the handler below just resolves the url (body field or
+-- cfg default fallback), drives the redirect, and returns the
+-- url field for the envelope.
+--
 -- Admin scope. Body: { url: string? }; if `url` is missing or
 -- empty, the cfg default (`cmd_redirect_url`) is used - the ADC-
 -- side "url=default" sentinel string is intentionally NOT honoured
@@ -188,40 +193,22 @@ end
 -- The ADC-side level-hierarchy / oplevel checks do NOT apply on
 -- the HTTP path: the bearer token's `admin` scope IS the
 -- authorisation gate.
-local http_handler_redirect = function( req )
-    local sid = req.path_vars and req.path_vars.sid
-    if not sid or sid == "" then
-        return { status = 400, error = { code = "E_BAD_INPUT", message = "missing sid path variable" } }
-    end
-    local target = hub.issidonline( sid )
-    if not target then
-        return { status = 404, error = { code = "E_NOT_FOUND", message = "no such online sid" } }
-    end
-    if target:isbot() then
-        return { status = 409, error = { code = "E_CONFLICT", message = "target is a bot; cannot redirect via this endpoint" } }
-    end
+local http_handler_redirect = function( req, target )
     local url = req.body and req.body.url
     if not url or url == "" then
         url = redirect_url    -- cfg default
     end
     if not url or url == "" then
-        return { status = 400, error = { code = "E_BAD_INPUT",
+        return nil, { status = 400, error = { code = "E_BAD_INPUT",
             message = "no url given and cfg cmd_redirect_url is unset" } }
     end
     local actor_label = req.token_label or "http-api"
-    local msg_report_str, t_nick, clean_url = do_redirect( target, url, actor_label )
+    local msg_report_str, _t_nick, clean_url = do_redirect( target, url, actor_label )
     -- HTTP path has no operator-chat to echo into; fire the opchat
     -- report directly so an opchat watcher sees a consistent line
     -- regardless of which surface drove the redirect.
     report.send( report_activate, report_hubbot, report_opchat, llevel, msg_report_str )
-    -- Response envelope follows the Phase-2 convention locked in
-    -- docs/HTTP_API.md §7.1 (flat data + explicit `action` verb).
-    return { status = 200, data = {
-        action = "redirect",
-        sid    = sid,
-        nick   = t_nick,
-        url    = clean_url,
-    } }
+    return { url = clean_url }
 end
 
 --// script start
@@ -240,35 +227,29 @@ hub.setlistener( "onStart", {},
         local hubcmd = hub.import( "etc_hubcommands" )
         assert( hubcmd )
         assert( hubcmd.add( cmd, onbmsg ) )
-        -- HTTP API endpoint (#82 Phase 2 PR-2). Registration is
-        -- best-effort: a stripped build without the API framework
-        -- still loads the +redirect ADC cmd above unchanged. The
-        -- route is cleared + re-registered automatically on +reload.
-        -- The whole script returns early at the top if `activate`
-        -- is false, so the HTTP endpoint is naturally gated on the
-        -- same cfg flag as the ADC cmd.
-        if hub.http_register then
-            hub.http_register( "POST", "/v1/users/{sid}/redirect", "admin",
-                http_handler_redirect, {
-                    plugin = scriptname,
-                    description = "redirect (move) an online user to a new hub URL by SID; body { url: string optional - falls back to cfg cmd_redirect_url }",
-                    -- URL scheme is locked to adc:// and adcs://
-                    -- (case-insensitive) to keep an admin token
-                    -- from accidentally redirecting users to a
-                    -- `javascript:`, `file:///`, `http://evil/`,
-                    -- or other non-hub target. Legacy NMDC's
-                    -- `dchub://` is out of scope - this is an
-                    -- ADC-only hub. The ADC chat-cmd path
-                    -- historically did NOT validate the scheme;
-                    -- this is defence in depth on the HTTP path
-                    -- only, not a regression fix.
-                    request_schema = {
-                        url = { type = "string", max_length = 1024,
-                                pattern = "^[Aa][Dd][Cc][Ss]?://" },
-                    },
-                }
-            )
-        end
+        -- HTTP API endpoint (#82 Phase 2 PR-2). The util_http
+        -- helper is fail-soft; the whole script returns at module
+        -- top if `cmd_redirect_activate` is false, so this
+        -- registration is naturally gated on the same cfg flag as
+        -- the ADC cmd.
+        --
+        -- URL scheme is locked to adc:// and adcs:// (case-
+        -- insensitive) to keep an admin token from accidentally
+        -- redirecting users to a `javascript:`, `file:///`,
+        -- `http://evil/`, or other non-hub target. Legacy NMDC's
+        -- `dchub://` is out of scope. The ADC chat-cmd path
+        -- historically did NOT validate the scheme; this is
+        -- defence in depth on the HTTP path only.
+        util_http.http_register_user_action( scriptname,
+            "POST", "/v1/users/{sid}/redirect", "redirect",
+            http_handler_redirect, {
+                description = "redirect (move) an online user to a new hub URL by SID; body { url: string optional - falls back to cfg cmd_redirect_url }",
+                request_schema = {
+                    url = { type = "string", max_length = 1024,
+                            pattern = "^[Aa][Dd][Cc][Ss]?://" },
+                },
+            }
+        )
         return nil
     end
 )

--- a/tests/unit/util_http_test.lua
+++ b/tests/unit/util_http_test.lua
@@ -1,0 +1,238 @@
+--[[
+
+    tests/unit/util_http_test.lua
+
+    Unit tests for core/util_http.lua's
+    `http_register_user_action` helper (#82 Phase 2 PR-B).
+    Focus: the preflight (sid + online + non-bot) + response
+    envelope construction, including the spoof-guard that drops
+    handler-supplied values at the convention keys
+    (`action` / `sid` / `nick`).
+
+    Stubs `use "hub"` to return a fake hub module table with a
+    capturable `http_register` and a controllable
+    `issidonline`. The test invokes the captured route handler
+    directly with synthetic `req` tables to exercise each branch.
+
+    Run: lua5.4 tests/unit/util_http_test.lua
+    Exit 0 = all pass, 1 = a failure (CI-friendly).
+
+]]--
+
+----------------------------------------------------------------------
+-- shim layer (matches the http_router_test pattern)
+----------------------------------------------------------------------
+
+local _captured_route = nil    -- last (method, path, scope, handler, meta) registered
+
+local _stub_users = { }    -- sid -> mock user object | "_bot_sid_marker"
+
+local _mock_hub_obj = {
+    http_register = function( method, path, scope, handler, meta )
+        _captured_route = { method = method, path = path, scope = scope,
+                            handler = handler, meta = meta }
+        return true
+    end,
+    issidonline = function( sid )
+        return _stub_users[ sid ]
+    end,
+}
+
+local _mock_hub_module = { object = function( ) return _mock_hub_obj end }
+
+local _real = {
+    pairs = pairs, type = type,
+    hub   = _mock_hub_module,
+}
+_G.use = function( name )
+    local v = _real[ name ]
+    assert( v ~= nil, "util_http_test shim missing dep: use \"" .. name .. "\"" )
+    return v
+end
+
+local util_http = assert( loadfile( "core/util_http.lua" ) )( )
+
+----------------------------------------------------------------------
+-- minimal test framework
+----------------------------------------------------------------------
+
+local failures, checks = 0, 0
+local function eq( label, got, want )
+    checks = checks + 1
+    if got ~= want then
+        failures = failures + 1
+        io.write( string.format( "FAIL %-60s got=%q want=%q\n",
+            label, tostring( got ), tostring( want ) ) )
+    else
+        io.write( string.format( "ok   %s\n", label ) )
+    end
+end
+
+----------------------------------------------------------------------
+-- mock user-object factory
+----------------------------------------------------------------------
+
+local function make_user( nick, isbot )
+    return {
+        nick = function( _ ) return nick end,
+        isbot = function( _ ) return isbot or false end,
+    }
+end
+
+----------------------------------------------------------------------
+-- 1. Registration: helper proxies through to hub.http_register
+----------------------------------------------------------------------
+
+do
+    _captured_route = nil
+    local handler_calls = 0
+    local rv = util_http.http_register_user_action(
+        "test_plugin", "DELETE", "/v1/users/{sid}", "disconnect",
+        function( req, target ) handler_calls = handler_calls + 1; return { } end,
+        { description = "test" }
+    )
+    eq( "register: returns true (hub_obj.http_register stub returned true)", rv, true )
+    eq( "register: captured method", _captured_route.method, "DELETE" )
+    eq( "register: captured path", _captured_route.path, "/v1/users/{sid}" )
+    eq( "register: hard-coded scope == admin", _captured_route.scope, "admin" )
+    eq( "register: meta.plugin filled with scriptname",
+        _captured_route.meta.plugin, "test_plugin" )
+    eq( "register: meta.description preserved",
+        _captured_route.meta.description, "test" )
+    eq( "register: handler was NOT called at registration time", handler_calls, 0 )
+end
+
+----------------------------------------------------------------------
+-- 2. Preflight: missing sid -> 400 E_BAD_INPUT
+----------------------------------------------------------------------
+
+do
+    local handler_calls = 0
+    local route_handler = _captured_route.handler
+    local resp = route_handler( { path_vars = { } } )
+    eq( "preflight: missing sid -> 400", resp.status, 400 )
+    eq( "preflight: missing sid -> E_BAD_INPUT", resp.error.code, "E_BAD_INPUT" )
+
+    local resp2 = route_handler( { path_vars = { sid = "" } } )
+    eq( "preflight: empty sid -> 400", resp2.status, 400 )
+end
+
+----------------------------------------------------------------------
+-- 3. Preflight: SID not online -> 404 E_NOT_FOUND
+----------------------------------------------------------------------
+
+do
+    _stub_users = { }
+    local route_handler = _captured_route.handler
+    local resp = route_handler( { path_vars = { sid = "ZZZZ" } } )
+    eq( "preflight: offline sid -> 404", resp.status, 404 )
+    eq( "preflight: offline sid -> E_NOT_FOUND", resp.error.code, "E_NOT_FOUND" )
+end
+
+----------------------------------------------------------------------
+-- 4. Preflight: target is a bot -> 409 E_CONFLICT with verb in msg
+----------------------------------------------------------------------
+
+do
+    _stub_users = { BOT1 = make_user( "hubbot", true ) }
+    local route_handler = _captured_route.handler
+    local resp = route_handler( { path_vars = { sid = "BOT1" } } )
+    eq( "preflight: bot sid -> 409", resp.status, 409 )
+    eq( "preflight: bot sid -> E_CONFLICT", resp.error.code, "E_CONFLICT" )
+    eq( "preflight: bot error mentions action_verb",
+        resp.error.message:find( "disconnect", 1, true ) ~= nil, true )
+end
+
+----------------------------------------------------------------------
+-- 5. Success: helper builds the §7.1.1 envelope; handler data merged
+----------------------------------------------------------------------
+
+do
+    _stub_users = { ABCD = make_user( "alice" ) }
+    -- re-register with a handler that returns {reason="flood"}
+    _captured_route = nil
+    util_http.http_register_user_action(
+        "p", "DELETE", "/v1/users/{sid}", "disconnect",
+        function( req, target ) return { reason = "flood" } end,
+        nil
+    )
+    local route_handler = _captured_route.handler
+    local resp = route_handler( { path_vars = { sid = "ABCD" } } )
+    eq( "envelope: status 200", resp.status, 200 )
+    eq( "envelope: data.action == disconnect", resp.data.action, "disconnect" )
+    eq( "envelope: data.sid", resp.data.sid, "ABCD" )
+    eq( "envelope: data.nick", resp.data.nick, "alice" )
+    eq( "envelope: data.reason (handler-supplied)", resp.data.reason, "flood" )
+end
+
+----------------------------------------------------------------------
+-- 6. SECURITY: handler MUST NOT be able to spoof convention fields
+----------------------------------------------------------------------
+
+do
+    _stub_users = { ABCD = make_user( "alice" ) }
+    _captured_route = nil
+    util_http.http_register_user_action(
+        "p", "DELETE", "/v1/users/{sid}", "disconnect",
+        function( req, target )
+            -- A buggy or malicious plugin tries to lie about who
+            -- got disconnected. The helper MUST silently drop the
+            -- spoof attempt and keep the canonical values.
+            return {
+                action = "EVIL_ACTION",
+                sid    = "EVIL_SID",
+                nick   = "EVIL_NICK",
+                reason = "innocent-looking",
+            }
+        end,
+        nil
+    )
+    local route_handler = _captured_route.handler
+    local resp = route_handler( { path_vars = { sid = "ABCD" } } )
+    eq( "spoof-guard: action stays canonical", resp.data.action, "disconnect" )
+    eq( "spoof-guard: sid stays canonical", resp.data.sid, "ABCD" )
+    eq( "spoof-guard: nick stays canonical", resp.data.nick, "alice" )
+    eq( "spoof-guard: handler's non-convention field IS merged",
+        resp.data.reason, "innocent-looking" )
+end
+
+----------------------------------------------------------------------
+-- 7. Handler error path: (nil, err) returned -> err passed through verbatim
+----------------------------------------------------------------------
+
+do
+    _stub_users = { ABCD = make_user( "alice" ) }
+    _captured_route = nil
+    util_http.http_register_user_action(
+        "p", "POST", "/v1/users/{sid}/x", "x",
+        function( req, target )
+            return nil, { status = 409, error = { code = "E_CONFLICT",
+                message = "already in that state" } }
+        end,
+        nil
+    )
+    local resp = _captured_route.handler( { path_vars = { sid = "ABCD" } } )
+    eq( "handler-error: status passes through", resp.status, 409 )
+    eq( "handler-error: error code passes through", resp.error.code, "E_CONFLICT" )
+    eq( "handler-error: no envelope wrapping", resp.data, nil )
+end
+
+----------------------------------------------------------------------
+-- 8. Fail-soft: missing hub.http_register -> returns false, no crash
+----------------------------------------------------------------------
+
+do
+    local saved = _mock_hub_obj.http_register
+    _mock_hub_obj.http_register = nil
+    local rv = util_http.http_register_user_action(
+        "p", "GET", "/v1/foo", "foo",
+        function( ) return { } end, nil
+    )
+    eq( "fail-soft: returns false when http_register absent", rv, false )
+    _mock_hub_obj.http_register = saved
+end
+
+----------------------------------------------------------------------
+
+io.write( string.format( "\n%d checks, %d failures\n", checks, failures ) )
+os.exit( failures == 0 and 0 or 1 )


### PR DESCRIPTION
## Summary

Phase 2 PR-B: extracts the "user action by SID" boilerplate that PR-1 (#199 cmd_disconnect) and PR-2 (#201 cmd_redirect) duplicated by hand into a single helper. PR-3 (cmd_gag) and PR-4 (cmd_ban) start with a 5-LoC handler body instead of 25-LoC of preflight + envelope.

## What the helper does

\`\`\`lua
util_http.http_register_user_action(
    scriptname, method, path, action_verb, handler_fn, meta?
)
\`\`\`

- **Preflight**: verifies \`{sid}\` is present, the SID is online, and the user is not a bot. Returns 400 / 404 / 409 with the standard error codes before \`handler_fn\` is even called.
- **Envelope**: constructs the §7.1.1 response (\`{action, sid, nick, ...handler_fields}\`). The plugin handler returns just the action-specific fields (\`{reason="flood"}\` / \`{url="adc://..."}\`).
- **Spoof guard**: a handler returning \`{action="EVIL", ...}\` is silently dropped — the canonical convention fields survive. Test-covered.
- **Fail-soft**: returns \`false\` if \`hub.http_register\` is missing (stripped builds still load the plugin's ADC chat-cmd surface).
- **Scope hard-coded to \`"admin"\`**: user actions are admin by definition in Phase 2; read or per-user-self endpoints use \`hub.http_register\` directly.

## Files

- \`core/util_http.lua\` (NEW): the helper. Loaded as a core module via \`init.lua\` after hub.lua. Plugins see \`util_http\` as a sandbox global.
- \`core/init.lua\`: adds \`util_http\` to the _core list.
- \`core/util.lua\`: comment-only — notes the extraction so future readers don't re-add the helper here.
- \`scripts/cmd_disconnect.lua\` + \`scripts/cmd_redirect.lua\`: handler bodies shrink ~75% each; preflight + envelope code removed.
- \`docs/HTTP_API.md\` §5.1.1: documents the helper as the preferred entry point for "user action by SID" endpoints.
- \`tests/unit/util_http_test.lua\` (NEW, 28 checks): covers registration, all preflight branches, envelope construction, **spoof guard**, error-passthrough, and fail-soft.
- \`.github/workflows/smoke.yml\`: wires the new unit test into CI.

## Review trail

Independent reviewer pass flagged **3 concerns** + 3 nits. **All addressed before commit** per the fix-all discipline:

| # | Class | Action |
|---|---|---|
| util.lua creep risk as Phase 2 grows | CONCERN | extracted to \`core/util_http.lua\` |
| HTTP_API.md §5 missing helper docs | CONCERN | added §5.1.1 with "when to use lower-level instead" |
| spoof-guard untested | CONCERN | new unit test, 4 spoof-attempt checks |
| docstring "prefer this" guidance | NIT | now in §5.1.1 |
| action_verb-must-be-static caveat | NIT | in docstring |
| blast-radius observation | NIT | resolved by the unit-test addition |

A debugging note: an earlier draft used \`(use "hub").http_register\` directly, which is \`nil\` because the hub module return is \`{init, loop, object}\` and \`http_register\` lives on the \`object()\` thunk. The fix and a clarifying comment land in the final helper.

## Test plan

- [x] 61/61 http_router unit checks unchanged
- [x] 28/28 new util_http unit checks pass (incl. spoof guard)
- [x] Full smoke harness → all PASS, both \`HTTP API Phase 2 cmd_disconnect\` and \`cmd_redirect\` tests still green (the helper produces the same envelope the smoke harness already asserts)
- [x] Linux + Windows MinGW build
- [x] ADC \`+disconnect\` and \`+redirect\` chat-cmds byte-identical to PR-1 / PR-2 — no edits to \`onbmsg\` in either plugin

Refs #82
Part of #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)