### PR TITLE
feat(82): Phase 2 PR-3 - cmd_gag HTTP migration

### DIFF
--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -403,6 +403,22 @@ When to use the lower-level `hub.http_register` instead:
 - Endpoints with a different response envelope shape (none in
   Phase 2; `/health` and `/v1/endpoints` in Phase 1).
 
+**Convention: who fires `report.send`?** Within the
+`handler_fn(req, target)` body, the plugin owns the opchat-report
+firing. Both styles are valid; pick the one that matches the
+plugin's existing ADC code path so the ADC-vs-HTTP behaviour stays
+symmetric:
+- **Caller-invoked report** (PR-1 `cmd_disconnect`, PR-2
+  `cmd_redirect`): the shared `do_<verb>()` helper returns the
+  formatted report message; both the ADC `onbmsg` path and the
+  HTTP handler call `report.send` themselves at the right moment.
+  Needed when the ADC path interleaves a chat-echo to the operator
+  between the kick and the report.
+- **Helper-internal report** (PR-3 `cmd_gag`): the existing
+  `add_user` / `remove_user` helpers already call `report.send`
+  inline; the HTTP handler just invokes them and returns. Simpler
+  but harder to override the report timing.
+
 ### 5.2 Registration lifecycle
 
 - Plugin calls `hub.http_register` from inside its `onStart` listener.
@@ -900,10 +916,14 @@ is disabled in `cfg.scripts`, the endpoint returns 404
 |---|---|---|---|---|
 | DELETE | `/v1/users/{sid}` | admin | `cmd_disconnect` | **migrated (Phase 2 PR-1)** |
 | POST | `/v1/users/{sid}/redirect` | admin | `cmd_redirect` | **migrated (Phase 2 PR-2)** [^http-redirect-1] |
-| POST | `/v1/users/{sid}/gag` | admin | `cmd_gag` | pending (Phase 2 PR-3) |
-| DELETE | `/v1/users/{sid}/gag` | admin | `cmd_gag` | pending (Phase 2 PR-3) |
+| POST | `/v1/users/{sid}/gag` | admin | `cmd_gag` | **migrated (Phase 2 PR-3)** [^http-gag-1] |
+| DELETE | `/v1/users/{sid}/gag` | admin | `cmd_gag` | **migrated (Phase 2 PR-3)** [^http-gag-2] |
 
 [^http-redirect-1]: Body `{url: string?}`, URL scheme locked to `adc://` / `adcs://`. The ADC-side level-hierarchy guard (operator's `permission[level]` must be ≥ target's level) does NOT apply on the HTTP path: the bearer token's `admin` scope IS the authorisation gate. If the body has no `url` field, the cfg key `cmd_redirect_url` is used as the default. Body URL strings undergo control-byte sanitisation before reaching the `RD` field of the outbound IQUI; an admin operator with a leaked token can still redirect any user, by design - issue admin tokens accordingly.
+
+[^http-gag-1]: Body `{mode: "mute"|"kennylize"|"shadowmute" required, duration_minutes: integer optional}`. `mode` is enum-validated, `duration_minutes` is range-clamped at the schema layer to `1..5256000` (~10 years cap matching the ADC-side `MAX_DURATION` in `parse_duration`). Missing/omitted duration = permanent gag (no `expires_at`). Returns 200 with `data: {action:"gag", sid, nick, mode, duration_minutes?, expires_at?}` (ISO 8601 UTC). Returns **409 E_CONFLICT** if the user is already gagged - the operator must `DELETE` first to change mode (matches the ADC-side `msg_error_in` semantic; mode-change-in-place is intentionally NOT supported to keep the audit trail clean). The HTTP path is **online-only**: the helper rejects offline SIDs with 404 before the handler runs. Offline registered users can still be ungagged via the ADC `+gag ungag` cmd.
+
+[^http-gag-2]: No body. Returns 200 with `data: {action:"ungag", sid, nick, previous_mode}` so the caller learns which mode was lifted. Returns **404 E_NOT_FOUND** if the user is not currently gagged - chosen over an idempotent 200-no-op so admin tools can distinguish "I just ungagged" from "user was already free" (matches REST-orthodox DELETE-of-missing semantics). The ADC `+gag ungag` cmd uses the verbose `msg_error_out` "user has no restriction set" message for the same intent.
 
 #### Registered users
 

--- a/scripts/cmd_gag.lua
+++ b/scripts/cmd_gag.lua
@@ -5,6 +5,30 @@
             - this script adds a command "gag" to mute, kennylize or shadowmute a user
             - usage: [+!#]gag mute|kennylize|shadowmute|ungag|show <NICK> [<DURATION>]
 
+            v0.10: by Aybo
+                - HTTP API endpoints (#82 Phase 2 PR-3):
+                    POST   /v1/users/{sid}/gag    (body: mode, duration_minutes?)
+                    DELETE /v1/users/{sid}/gag
+                  Both via util_http.http_register_user_action; the
+                  helper handles the preflight (online + non-bot) and
+                  the §7.1.1 response envelope. The ADC `+gag` cmd is
+                  unchanged. HTTP path is online-only; offline-
+                  registered ungag stays ADC-only.
+                - signature change: `add_user(target, mode, duration,
+                  actor_nick)` and `remove_user(first_nick, display_nick,
+                  online_obj, actor_nick)` now take `actor_nick` as a
+                  string (was a user object). Both ADC call sites
+                  pass `user:nick()` instead. The helper applies
+                  `util.strip_control_bytes(actor_nick)` so an HTTP
+                  caller's `req.token_label` (operator-controlled cfg
+                  comment field) cannot smuggle `\r` / `\n` / NUL into
+                  the opchat report frame or the persisted
+                  `entry.added_by` value.
+                - HTTP 409 E_CONFLICT on re-POST of an already-gagged
+                  user (operator must DELETE first to change mode);
+                  HTTP 404 E_NOT_FOUND on DELETE of a non-gagged user
+                  (REST-orthodox over idempotent 200-no-op).
+
             v0.09: by Aybo
                 - new shadowmute mode (closes luadch-ng/luadch#85): the
                   sender sees their own messages echoed back, others see
@@ -75,7 +99,7 @@
 --// settings begin //--
 
 local scriptname = "cmd_gag"
-local scriptversion = "0.09"
+local scriptversion = "0.10"
 
 local cmd = "gag"
 local prm_mute = "mute"
@@ -183,6 +207,8 @@ local parse_duration
 local find_entry
 local resolve_target_for_ungag
 local cleanup_expired
+local http_handler_gag
+local http_handler_ungag
 
 
 local minlevel = util.getlowestlevel(permission)
@@ -297,7 +323,7 @@ local onbmsg = function(user, command, parameters)
             user:reply(msg_god, hub.getbot())
             return PROCESSED
         end
-        user:reply(remove_user(first_nick, display_nick, online_obj, user), hub.getbot())
+        user:reply(remove_user(first_nick, display_nick, online_obj, user:nick()), hub.getbot())
         return PROCESSED
     end
 
@@ -330,7 +356,7 @@ local onbmsg = function(user, command, parameters)
         return PROCESSED
     end
 
-    user:reply(add_user(target, action, duration, user), hub.getbot())
+    user:reply(add_user(target, action, duration, user:nick()), hub.getbot())
     return PROCESSED
 end
 
@@ -420,6 +446,37 @@ hub.setlistener("onStart", {},
         hubcmd = hub.import("etc_hubcommands")
         assert(hubcmd)
         assert(hubcmd.add(cmd, onbmsg))
+        -- HTTP API endpoints (#82 Phase 2 PR-3). The util_http
+        -- helper handles the standard SID-online-non-bot preflight,
+        -- the §7.1.1 response envelope, and the audit log. This
+        -- plugin only owns the handler bodies above. The HTTP path
+        -- is online-only by design - offline registered ungag is
+        -- ADC-only via `+gag ungag` (the helper rejects offline
+        -- SIDs with 404 before the handler is reached).
+        --
+        -- MAX_DURATION_MINUTES caps duration_minutes at ~10 years,
+        -- matching the Lua-side MAX_DURATION cap on parse_duration.
+        -- Beyond this the schema validator rejects with 400 before
+        -- any state mutation.
+        local MAX_DURATION_MINUTES = 10 * 365 * 24 * 60
+        util_http.http_register_user_action(scriptname,
+            "POST", "/v1/users/{sid}/gag", "gag",
+            http_handler_gag, {
+                description = "gag (silence) an online user by SID; body { mode: \"mute\"|\"kennylize\"|\"shadowmute\" required, duration_minutes: integer optional (omitted = permanent) }",
+                request_schema = {
+                    mode = { type = "string", required = true,
+                             enum = { prm_mute, prm_kennylize, prm_shadowmute } },
+                    duration_minutes = { type = "integer",
+                                         min = 1, max = MAX_DURATION_MINUTES },
+                },
+            }
+        )
+        util_http.http_register_user_action(scriptname,
+            "DELETE", "/v1/users/{sid}/gag", "ungag",
+            http_handler_ungag, {
+                description = "remove an existing gag from an online user by SID",
+            }
+        )
         return nil
     end
 )
@@ -451,15 +508,24 @@ show_users = function()
         counts.shadowmute, lists.shadowmute)
 end
 
-add_user = function(target, mode, duration, user)
+-- v0.10 (#82 Phase 2 PR-3): `user` arg replaced by `actor_nick`
+-- string so both the ADC `+gag` path (passing user:nick()) and the
+-- HTTP `POST /v1/users/{sid}/gag` path (passing
+-- util.strip_control_bytes(req.token_label)) can share the helper.
+-- The actor_nick is also control-byte sanitised here as
+-- defence-in-depth around adclib::escape - the ADC side's
+-- user:nick() is already login-validated but the HTTP side
+-- inherits whatever the operator put in cfg.http_api_tokens[].comment.
+add_user = function(target, mode, duration, actor_nick)
     local nick = target:firstnick()
     if find_entry(nick) then
         return utf.format(msg_error_in, nick)
     end
+    local clean_actor = util.strip_control_bytes(actor_nick)
     local entry = {
         user_nick = nick,
         mode = mode,
-        added_by = user:nick(),
+        added_by = clean_actor,
         added_at = os.time(),
     }
     if duration then
@@ -478,9 +544,9 @@ add_user = function(target, mode, duration, user)
         local y, d, h, m, s = util.formatseconds(duration)
         report_msg = utf.format(msg_add_user_with_duration, target:nick(), mode,
             y .. "y " .. d .. "d " .. h .. "h " .. m .. "m " .. s .. "s",
-            user:nick())
+            clean_actor)
     else
-        report_msg = utf.format(msg_add_user, target:nick(), mode, user:nick())
+        report_msg = utf.format(msg_add_user, target:nick(), mode, clean_actor)
     end
     report.send(report_activate, report_hubbot, report_opchat, llevel, report_msg)
     return report_msg
@@ -488,8 +554,9 @@ end
 
 -- target_firstnick is the canonical lookup key. display_nick is for
 -- the report. online_obj is the user object if currently online, used
--- to send the target notification. user is the caller.
-remove_user = function(target_firstnick, display_nick, online_obj, user)
+-- to send the target notification. actor_nick (v0.10) is the
+-- operator/token name for the opchat report; sanitised here.
+remove_user = function(target_firstnick, display_nick, online_obj, actor_nick)
     local idx, entry = find_entry(target_firstnick)
     if not idx then
         return utf.format(msg_error_out, display_nick)
@@ -502,9 +569,72 @@ remove_user = function(target_firstnick, display_nick, online_obj, user)
     if online_obj and mode ~= prm_shadowmute and user_notifiy then
         online_obj:reply(msg_user_restriction_removed, hub.getbot(), hub.getbot())
     end
-    local report_msg = utf.format(msg_remove_user, display_nick, user:nick())
+    local clean_actor = util.strip_control_bytes(actor_nick)
+    local report_msg = utf.format(msg_remove_user, display_nick, clean_actor)
     report.send(report_activate, report_hubbot, report_opchat, llevel, report_msg)
     return report_msg
+end
+
+-- HTTP handler body: POST /v1/users/{sid}/gag (#82 Phase 2 PR-3).
+-- Preflight + envelope owned by util_http.http_register_user_action;
+-- this handler resolves the mode + duration, calls add_user (which
+-- fires the opchat report internally), and returns the
+-- action-specific fields for the §7.1.1 envelope.
+--
+-- Body schema:
+--   mode              required string enum {mute, kennylize, shadowmute}
+--   duration_minutes  optional integer 1..5256000 (~10 years cap)
+--                     missing/omitted -> permanent gag (no expires_at)
+--
+-- Errors:
+--   409 E_CONFLICT  - user is already gagged (matches ADC msg_error_in;
+--                     operator must DELETE first to change mode).
+-- Schema rejects (mode missing / wrong enum / duration out of range)
+-- land as 400 E_BAD_INPUT via the router BEFORE this handler runs.
+--
+-- The util_http helper rejects offline / bot SIDs with 404 / 409
+-- before this handler is called; the HTTP path is online-only by
+-- design (use the ADC `+gag` cmd for offline registered targets).
+http_handler_gag = function(req, target)
+    local mode = req.body and req.body.mode
+    if find_entry(target:firstnick()) then
+        return nil, { status = 409, error = { code = "E_CONFLICT",
+            message = "user is already gagged; ungag first to change mode" } }
+    end
+    local duration_minutes = req.body and req.body.duration_minutes
+    local duration_seconds = duration_minutes and ( duration_minutes * 60 ) or nil
+    local actor_label = req.token_label or "http-api"
+    -- add_user fires report.send + persists gag_tbl internally; we
+    -- only need the side-effect, not the returned report-message
+    -- string (the HTTP audit log already covers the operator trail).
+    add_user(target, mode, duration_seconds, actor_label)
+    local data = { mode = mode }
+    if duration_seconds then
+        data.duration_minutes = duration_minutes
+        data.expires_at = os.date("!%Y-%m-%dT%H:%M:%SZ", os.time() + duration_seconds)
+    end
+    return data
+end
+
+-- HTTP handler body: DELETE /v1/users/{sid}/gag (#82 Phase 2 PR-3).
+-- Errors:
+--   404 E_NOT_FOUND - user is not currently gagged. This is the
+--   strict "REST-orthodox" choice over the idempotent 200-no-op
+--   alternative: an admin tool benefits from knowing whether their
+--   DELETE actually changed state. ADC `+gag ungag` returns a
+--   verbose "user has no restriction set" message which is the same
+--   intent (informs the operator their action was a no-op).
+http_handler_ungag = function(req, target)
+    local first_nick = target:firstnick()
+    local _idx, entry = find_entry(first_nick)
+    if not entry then
+        return nil, { status = 404, error = { code = "E_NOT_FOUND",
+            message = "user is not currently gagged" } }
+    end
+    local previous_mode = entry.mode
+    local actor_label = req.token_label or "http-api"
+    remove_user(first_nick, target:nick(), target, actor_label)
+    return { previous_mode = previous_mode }
 end
 
 check_user_input = function(target, msg)

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -2787,6 +2787,198 @@ def test_http_phase2_cmd_redirect(staging_dir: Path, proc=None):
             )
 
 
+def test_http_phase2_cmd_gag(staging_dir: Path, proc=None):
+    """Phase 2 PR-3 of #82: cmd_gag plugin migrates to HTTP.
+
+    First Phase-2 plugin with persistent state (gag list survives
+    +reload via scripts/data/cmd_gag.tbl). Two endpoints:
+
+    - POST /v1/users/{sid}/gag (body { mode, duration_minutes? })
+    - DELETE /v1/users/{sid}/gag
+
+    Same coexist pattern as PR-1 / PR-2: ADC `+gag` cmd unchanged,
+    HTTP endpoints registered via util_http.http_register_user_action.
+    The ADC user is NOT kicked (gag suppresses outbound chat, not the
+    session) so the smoke uses _assert_adc_alive between phases.
+
+    Coverage:
+    - POST mute with no duration -> 200 + envelope w/ action:"gag",
+      mode:"mute", no expires_at; user stays online (gag does not kick).
+    - POST again on same user -> 409 E_CONFLICT.
+    - POST invalid mode -> 400 (schema enum reject).
+    - DELETE -> 200 + envelope w/ action:"ungag", previous_mode.
+    - DELETE again -> 404 E_NOT_FOUND.
+    - POST kennylize with duration_minutes=30 -> 200 + expires_at
+      field set, ISO 8601 format.
+    - POST shadowmute on fresh user -> 200.
+    - Catalog lists POST + DELETE /v1/users/{sid}/gag.
+    """
+    token_path = staging_dir / "cfg" / "api_token.first"
+    bootstrap_token = None
+    for line in token_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            bootstrap_token = line
+            break
+    if not bootstrap_token:
+        raise TestFailure(f"could not parse token from {token_path}")
+    auth = b"Authorization: Bearer " + bootstrap_token.encode("ascii") + b"\r\n"
+
+    def status(resp):
+        return resp.split("\r\n", 1)[0]
+
+    def body_of(resp):
+        return resp.split("\r\n\r\n", 1)[1] if "\r\n\r\n" in resp else ""
+
+    def post_gag(sid: str, body: bytes) -> str:
+        req = (
+            b"POST /v1/users/" + sid.encode("ascii") + b"/gag HTTP/1.1\r\n"
+            + auth +
+            b"Content-Type: application/json\r\n"
+            b"Content-Length: " + str(len(body)).encode("ascii") + b"\r\n"
+            b"\r\n" + body
+        )
+        return _http_roundtrip(req)
+
+    def delete_gag(sid: str) -> str:
+        req = (
+            b"DELETE /v1/users/" + sid.encode("ascii") + b"/gag HTTP/1.1\r\n"
+            + auth +
+            b"\r\n"
+        )
+        return _http_roundtrip(req)
+
+    # 1. POST mute (no duration) + 200 + user stays alive + DELETE flow.
+    with _logged_in_user() as (adc, sid, _reader):
+        # 1a. Fresh POST -> 200 + correct envelope.
+        r = post_gag(sid, b'{"mode":"mute"}')
+        if "200 OK" not in status(r):
+            raise TestFailure(f"POST .../gag mute: expected 200, got {status(r)!r}; resp={r!r}")
+        b = body_of(r)
+        if '"action":"gag"' not in b.replace(" ", ""):
+            raise TestFailure(f"gag: expected action:gag; body={b!r}")
+        if '"mode":"mute"' not in b.replace(" ", ""):
+            raise TestFailure(f"gag: expected mode:mute; body={b!r}")
+        if '"expires_at"' in b:
+            raise TestFailure(f"gag (no duration): expires_at must be absent; body={b!r}")
+
+        # 1b. Gag does NOT kick - user must still be online.
+        _assert_adc_alive(adc)
+
+        # 1c. Re-POST -> 409 Conflict (already gagged).
+        r = post_gag(sid, b'{"mode":"mute"}')
+        if "409" not in status(r):
+            raise TestFailure(f"re-POST .../gag: expected 409, got {status(r)!r}")
+        if '"E_CONFLICT"' not in body_of(r):
+            raise TestFailure(f"re-POST .../gag: expected E_CONFLICT; resp={r!r}")
+
+        # 1d. Invalid mode -> 400 (schema enum reject).
+        r = post_gag(sid, b'{"mode":"flaschenpost"}')
+        if "400" not in status(r):
+            raise TestFailure(f"invalid mode: expected 400, got {status(r)!r}")
+        if '"E_BAD_INPUT"' not in body_of(r):
+            raise TestFailure(f"invalid mode: expected E_BAD_INPUT; resp={r!r}")
+
+        # 1e. DELETE -> 200 with previous_mode.
+        r = delete_gag(sid)
+        if "200 OK" not in status(r):
+            raise TestFailure(f"DELETE .../gag: expected 200, got {status(r)!r}; resp={r!r}")
+        b = body_of(r)
+        if '"action":"ungag"' not in b.replace(" ", ""):
+            raise TestFailure(f"ungag: expected action:ungag; body={b!r}")
+        if '"previous_mode":"mute"' not in b.replace(" ", ""):
+            raise TestFailure(f"ungag: expected previous_mode:mute; body={b!r}")
+
+        # 1f. DELETE again -> 404.
+        r = delete_gag(sid)
+        if "404" not in status(r):
+            raise TestFailure(f"re-DELETE .../gag: expected 404, got {status(r)!r}")
+        if '"E_NOT_FOUND"' not in body_of(r):
+            raise TestFailure(f"re-DELETE .../gag: expected E_NOT_FOUND; resp={r!r}")
+
+        # 1g. Sanity: user still alive after the whole flow.
+        _assert_adc_alive(adc)
+
+    # 2. POST kennylize with duration_minutes=30 -> envelope carries
+    #    duration_minutes + expires_at (ISO 8601). Verify the
+    #    timestamp format roughly (YYYY-MM-DDTHH:MM:SSZ).
+    with _logged_in_user() as (adc2, sid2, _reader):
+        r = post_gag(sid2, b'{"mode":"kennylize","duration_minutes":30}')
+        if "200 OK" not in status(r):
+            raise TestFailure(f"POST .../gag kennylize+30min: expected 200, got {status(r)!r}; resp={r!r}")
+        b = body_of(r)
+        if '"duration_minutes":30' not in b.replace(" ", ""):
+            raise TestFailure(f"gag w/ duration: expected duration_minutes:30; body={b!r}")
+        m = re.search(r'"expires_at":"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)"', b)
+        if not m:
+            raise TestFailure(f"gag w/ duration: expires_at not in ISO 8601 form; body={b!r}")
+        _assert_adc_alive(adc2)
+        # Cleanup (otherwise the gag persists in cmd_gag.tbl across
+        # later harness invocations on the same staging dir).
+        r = delete_gag(sid2)
+        if "200 OK" not in status(r):
+            raise TestFailure(f"cleanup DELETE: expected 200, got {status(r)!r}")
+
+    # 3. POST shadowmute on fresh user -> 200 + clean up.
+    with _logged_in_user() as (adc3, sid3, _reader):
+        r = post_gag(sid3, b'{"mode":"shadowmute"}')
+        if "200 OK" not in status(r):
+            raise TestFailure(f"POST .../gag shadowmute: expected 200, got {status(r)!r}")
+        if '"mode":"shadowmute"' not in body_of(r).replace(" ", ""):
+            raise TestFailure(f"shadowmute: mode missing in envelope; resp={r!r}")
+        _assert_adc_alive(adc3)
+        r = delete_gag(sid3)
+        if "200 OK" not in status(r):
+            raise TestFailure(f"cleanup shadowmute DELETE: expected 200, got {status(r)!r}")
+
+    # 4. Catalog now lists POST + DELETE /v1/users/{sid}/gag.
+    r = _http_roundtrip(b"GET /v1/endpoints HTTP/1.1\r\n" + auth + b"\r\n")
+    b = body_of(r)
+    if '"/v1/users/{sid}/gag"' not in b:
+        raise TestFailure(f"catalog missing /v1/users/{{sid}}/gag; body={b!r}")
+    # Catalog includes both POST and DELETE entries on the same path.
+    if b.count('"/v1/users/{sid}/gag"') < 2:
+        raise TestFailure(f"catalog should list BOTH POST and DELETE /v1/users/{{sid}}/gag; body={b!r}")
+
+    # 5. Persistence: POST creates a gag entry, and the on-disk
+    #    scripts/data/cmd_gag.tbl must contain the user's firstnick.
+    #    A subsequent DELETE removes it. This verifies the disk-
+    #    write side of persistence; the re-load path
+    #    (util.loadtable(gag_path) at plugin onStart) is unchanged
+    #    from pre-PR-3 and shared with every other persist-on-disk
+    #    plugin in the codebase, so a full restart cycle here would
+    #    only cover surface already covered by Phase-7 user.tbl
+    #    persistence tests. A dedicated hub-restart-and-survive
+    #    test is a worthwhile Phase-2 polish item but deferred to
+    #    keep PR-3 small.
+    gag_tbl_path = staging_dir / "scripts" / "data" / "cmd_gag.tbl"
+    with _logged_in_user() as (adc, sid, _reader):
+        r = post_gag(sid, b'{"mode":"mute"}')
+        if "200 OK" not in status(r):
+            raise TestFailure(f"persistence POST: expected 200, got {status(r)!r}")
+        if not gag_tbl_path.exists():
+            raise TestFailure(f"persistence: cmd_gag.tbl not written at {gag_tbl_path}")
+        # The serialised entry must include the user's firstnick.
+        # dummy may be auto-prefixed by level (e.g. "[HUBOWNER]dummy"),
+        # but the firstnick is the registered nick which IS plain "dummy".
+        contents = gag_tbl_path.read_text(encoding="utf-8")
+        if 'user_nick = "dummy"' not in contents:
+            raise TestFailure(
+                f"persistence: cmd_gag.tbl after POST missing user_nick "
+                f"entry; contents={contents!r}"
+            )
+        # Clean up + verify the disk-write of removal too.
+        r = delete_gag(sid)
+        if "200 OK" not in status(r):
+            raise TestFailure(f"persistence cleanup DELETE: expected 200, got {status(r)!r}")
+        contents = gag_tbl_path.read_text(encoding="utf-8")
+        if 'user_nick = "dummy"' in contents:
+            raise TestFailure(
+                f"persistence: cmd_gag.tbl after DELETE still has entry; "
+                f"contents={contents!r}"
+            )
+
+
 def _switch_to_blom_mode(staging_dir: Path, current_proc, current_log_file):
     """Phase 8 S5 (#147 T2.2) setup: stop the hub, flip
     `blom_enabled = false` to `true` in cfg.tbl so the next test
@@ -4021,6 +4213,17 @@ def main():
             failed.append("HTTP API Phase 2 cmd_redirect (#82 / #198)")
         else:
             log("PASS  HTTP API Phase 2 cmd_redirect (#82 / #198)")
+
+        # Phase 2 PR-3 of #82 / #198: cmd_gag plugin migrated to
+        # POST + DELETE /v1/users/{sid}/gag. First plugin migration
+        # with persistent state (scripts/data/cmd_gag.tbl).
+        try:
+            test_http_phase2_cmd_gag(staging_dir, proc=proc)
+        except Exception as e:
+            log(f"FAIL  HTTP API Phase 2 cmd_gag (#82 / #198): {e}")
+            failed.append("HTTP API Phase 2 cmd_gag (#82 / #198)")
+        else:
+            log("PASS  HTTP API Phase 2 cmd_gag (#82 / #198)")
 
         # Phase 8 S5 (#147 T2.2): enable BLOM and exercise hash-search
         # routing + the keyword-search broadcast regression. Runs


### PR DESCRIPTION
## Summary

Third Phase-2 plugin migration. \`cmd_gag\` additionally serves \`POST /v1/users/{sid}/gag\` and \`DELETE /v1/users/{sid}/gag\` via the HTTP API. ADC \`+gag\` cmd (mute / kennylize / shadowmute / ungag / show) is preserved byte-identically.

**First Phase-2 migration with persistent state**: the gag list lives in \`scripts/data/cmd_gag.tbl\` and survives \`+reload\` + hub restart via atomic-write on every state change. The util_http helper from PR-B carries the preflight + envelope; this plugin owns the handler bodies + the existing persistence layer (unchanged from v0.09).

## What it ships

| Surface | Endpoint | Result |
|---|---|---|
| HTTP | \`POST /v1/users/{sid}/gag\` (admin) | 200 + \`{action:"gag", sid, nick, mode, duration_minutes?, expires_at?}\` |
| HTTP | re-POST on already-gagged | **409 E_CONFLICT** (operator must DELETE first) |
| HTTP | POST with invalid \`mode\` enum | **400 E_BAD_INPUT** (schema reject) |
| HTTP | POST with \`duration_minutes\` out of \`1..5256000\` | **400 E_BAD_INPUT** (schema range) |
| HTTP | \`DELETE /v1/users/{sid}/gag\` (admin) | 200 + \`{action:"ungag", sid, nick, previous_mode}\` |
| HTTP | DELETE on not-gagged | **404 E_NOT_FOUND** (REST-orthodox over idempotent 200) |
| ADC | \`+gag mute|kennylize|shadowmute|ungag|show ...\` | unchanged from v0.09 |

## Body schema

\`\`\`json
{
  "mode": "mute" | "kennylize" | "shadowmute",   // required
  "duration_minutes": 30                           // optional, omitted = permanent
}
\`\`\`

\`duration_minutes\` is capped at \`5256000\` (~10 years), matching the Lua-side \`MAX_DURATION\` constant in \`parse_duration\`.

## Why 409 not 200-no-op on re-POST

Matches the ADC \`+gag mute\` semantic (\`msg_error_in\` "user already gagged"). Forcing the operator to \`DELETE\` first keeps the audit trail clean: a mode change shows up as one ungag + one gag entry, not a silent mutation.

## Why 404 not 200-no-op on DELETE-of-missing

REST-orthodox. Admin tools benefit from knowing whether their action changed state ("I just ungagged" vs "user was already free"). The ADC \`+gag ungag\` cmd's \`msg_error_out\` "user has no restriction set" message expresses the same intent.

## Review trail

Independent reviewer found **0 blockers, 0 concerns, 3 nits**. All addressed before commit per the fix-all discipline:

| # | Class | Action |
|---|---|---|
| N1 v0.10 changelog stanza missing | NIT | added with signature change + control-byte sanitisation + 409/404 rationale |
| N2 persistence smoke gap | NIT | added cmd_gag.tbl file-content check on disk-write side. Full hub-restart-and-survive cycle deferred as Phase-2 polish (re-load path is util.loadtable, shared with every persist-on-disk plugin) |
| N3 report.send convention diff vs PR-1/PR-2 | NIT | documented in HTTP_API.md §5.1.1 "Convention: who fires report.send?" |

## Test plan

- [x] Lua syntax-check \`scripts/cmd_gag.lua\`
- [x] Full smoke harness → all PASS, new \`HTTP API Phase 2 cmd_gag\` test green (~10 sub-cases: POST/409/400, DELETE/404, kennylize+duration ISO 8601, shadowmute, catalog, persistence on disk)
- [x] Phase 1 + Phase 2 prior tests unaffected
- [x] Linux + Windows MinGW build
- [x] ADC \`+gag\` chat-cmd byte-identical to v0.09 (only \`onbmsg\` change: \`user\` → \`user:nick()\` at the two call sites)

Refs #82
Part of #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)