### PR TITLE
fix(scripts): explicit plugin sandbox whitelist (Tier 1 of #206)

### DIFF
--- a/core/scripts.lua
+++ b/core/scripts.lua
@@ -97,6 +97,67 @@ _code = {    -- mhh...
 
 }
 
+-- Plugin sandbox whitelist (Tier 1 of #206). Each plugin loaded
+-- via `startscripts()` gets an _ENV table seeded with ONLY the
+-- globals listed below; everything else in `_G` (the hub's runtime
+-- namespace) is unreachable from plugin code.
+--
+-- Notably EXCLUDED (the genuinely-dangerous Lua VM primitives):
+--   debug      VM introspection, getlocal/setlocal of other funcs,
+--              metatable poking via debug.setmetatable
+--   load       compile-arbitrary-string-to-callable
+--   loadfile   compile-arbitrary-file-to-callable
+--   dofile    load + immediately invoke arbitrary file
+--   rawget    bypass __index trap (defeats strict-mode write detect)
+--   rawset    bypass __newindex trap
+--   rawlen    bypass __len trap
+--   rawequal  bypass __eq trap
+--   _G        the underlying global env (would re-expose everything)
+--   _ENV      escape to parent env
+--
+-- Notably KEPT but flagged for Tier 2:
+--   os, io     plugins use os.time / os.date / os.difftime + io.open
+--              (read mode in cmd_errors / etc_keyprint) + io.popen
+--              (cmd_hubinfo reads /proc & shells `uname`). A
+--              follow-up tier will replace `os` and `io` with
+--              curated shims that expose only the methods bundled
+--              plugins actually need. For now exposed as-is so the
+--              66-plugin audit stays green.
+--   require    cmd_hubinfo / etc_keyprint use require("ssl") /
+--              "ssl.x509" / "basexx". `ssl`/`basexx` are also in
+--              the whitelist so plugins could `local ssl = ssl`,
+--              but rewriting 4 require call sites is outside the
+--              scope of this Tier-1 PR. require is constrained to
+--              package.path / cpath (locked down in init.lua).
+--   package    cmd_hubinfo:446 reads `package.config:sub(1,1)` for
+--              the host's path separator. Exposed for the same
+--              compat reason. Tier 2 should remove and replace
+--              with a `util.path_sep` helper.
+--
+-- `hub`, `utf`, `string`, and `PROCESSED` are NOT in the whitelist
+-- because they are written into env explicitly later (see lines
+-- ~200-205 below) - `hub` gets a curated copy of the public hub
+-- API (underscore-prefixed methods filtered out), `utf` is the
+-- unicode shim, `string` is REPLACED with `utf` so plugins get
+-- UTF-aware string functions instead of the byte-oriented standard
+-- library, and `PROCESSED` is the listener-return constant.
+local SANDBOX_GLOBALS = {
+    -- Lua language basics (safe by spec)
+    "assert", "error", "ipairs", "next", "pairs", "pcall", "print",
+    "select", "tonumber", "tostring", "type", "xpcall",
+    "setmetatable", "getmetatable", "collectgarbage",
+    -- Standard libraries (safe)
+    "table", "math", "coroutine",
+    -- Compat-keep (see Tier-2 notes above)
+    "os", "io", "require", "package",
+    -- luadch core modules (always present in _G after init.lua)
+    "cfg", "util", "util_http", "adc", "adclib", "signal", "out",
+    "unicode",
+    -- Extern + optional libs (some are `false` if their require()
+    -- in init.lua failed - guarded by `or false` in the iterator below)
+    "ssl", "socket", "basexx", "zlib_stream", "dkjson",
+}
+
 index = function( tbl, key )
     error( "attempt to read undeclared var: '" .. tostring( key ) .. "'", 2 )
 end
@@ -194,12 +255,37 @@ startscripts = function( hub )
 
             env.PROCESSED = _code.scriptsbypass + _code.hubbypass    -- should be enough
 
-            for i, k in pairs( _G ) do
-                env[ i ] = k
+            -- Sandbox whitelist (Tier 1 of #206). Replaces the
+            -- previous verbatim `for k,v in pairs(_G) do env[k]=v end`
+            -- which exposed `debug`, `loadfile`, `dofile`, `load`,
+            -- `rawget/rawset` etc. to every plugin. The new
+            -- behaviour: ONLY names in `SANDBOX_GLOBALS` are
+            -- imported from _G; everything else is unreachable
+            -- (`env.debug` is nil, indexing it raises
+            -- "attempt to index nil value" or - with the optional
+            -- `setenv` trap below - the explicit "undeclared var"
+            -- error). Curated `hub` / `utf` / `string` overrides
+            -- happen after this loop.
+            for _, name in ipairs( SANDBOX_GLOBALS ) do
+                env[ name ] = _G[ name ]
             end
             env.hub = hubobject
             env.utf = utf
             env.string = utf
+            -- `no_global_scripting` cfg key (default true): with the
+            -- explicit whitelist above, accessing a forbidden global
+            -- like `debug` already raises "attempt to index nil
+            -- value" at the plugin's first dereference. The setenv()
+            -- wrapper merely UPGRADES the error to the more explicit
+            -- "attempt to read undeclared var: 'debug'" via __index,
+            -- AND adds an __newindex trap that blocks
+            -- plugin-created globals (`myvar = 5` outside a `local`
+            -- binding). The cfg key remains for the __newindex
+            -- behaviour - legacy plugins that create globals
+            -- unintentionally rely on the lax mode. Operators who
+            -- want maximum strictness leave the default true.
+            -- Candidate for deprecation alongside the Tier 2 os/io
+            -- curation pass for #206.
             if cfg_get "no_global_scripting" then
                 setenv( env )
             end


### PR DESCRIPTION
## Summary

Tier 1 of #206 (Plugin Sandbox Escape - Full \`_G\` Exposure).

Replaces the verbatim \`for k,v in pairs(_G) do env[k]=v end\` in
\`core/scripts.lua:startscripts()\` with an explicit
\`SANDBOX_GLOBALS\` whitelist. The previous code exposed every Lua
standard library plus every loaded core/extern module to every plugin;
the metatable traps only caught typos, not escape attempts.

## Tier 1 wins (closed)

| Removed primitive | Threat |
|---|---|
| \`debug\` | VM introspection, setlocal / setupvalue / getregistry |
| \`load\` | compile arbitrary string |
| \`loadfile\` | compile arbitrary file |
| \`dofile\` | load + immediate invoke |
| \`rawget\` / \`rawset\` / \`rawlen\` / \`rawequal\` | bypass metatable traps |
| \`_G\` / \`_ENV\` | re-expose the underlying namespace |

## Tier 2 explicitly out of scope

The fix DOES NOT block \`os.execute(\"rm -rf /\")\`. \`os\` / \`io\`
/ \`require\` / \`package\` remain in the whitelist because four
bundled plugins use them (cmd_hubinfo for OS info via \`io.popen\` +
\`package.config\`, etc_keyprint / cmd_errors for cert/log file reads
via \`io.open\` read-only, etc_keyprint / cmd_hubinfo for
\`require(\"ssl\")\` / \"ssl.x509\" / \"basexx\"). A Tier-2 pass will
curate these into restricted shims (\`os_safe\`, \`io_safe\`,
\`util.path_sep\` helper, refactor \`require\` call sites to use
the already-whitelisted module references).

The Tier-1 cut closes the Lua VM introspection vectors the issue
calls out as the genuinely-dangerous primitives, without breaking
any of the 66 bundled plugins. Tier 2 is a follow-up issue.

## Validation

- **Audit:** 66 bundled plugins in \`scripts/*.lua\` grepped for every
  global identifier; whitelist confirmed complete.
- **Smoke:** local Windows smoke pipeline (all 60+ checks pass) +
  the existing \"no script errors in log\" assertion catches any
  plugin that breaks under the new whitelist.
- **Two-pass review:** independent Explore reviewer + maintainer
  spot-check. No blockers. CONCERN 2 (no_global_scripting cfg
  redundancy under whitelist) addressed via inline doc-comment
  explaining the narrowed role.

## \`no_global_scripting\` cfg semantics narrow but stay

Default \`true\`. Was \"add __index/__newindex traps so unknown
globals error loudly\". Now (with whitelist): \"add __newindex trap
so accidental plugin-created globals are blocked + upgrade __index
diagnostic from 'attempt to index nil' to 'attempt to read undeclared
var: <name>'\". Candidate for deprecation alongside the Tier-2 pass.

## Test plan

- [x] Local Windows smoke: all green incl. cmd_disconnect /
  cmd_redirect / cmd_gag / cmd_ban (Phase-2 plugins exercise the
  whitelist via HTTP).
- [x] CI Linux + Windows smoke green.
- [x] Two-pass review subagent green (done locally, will re-run in PR).

Part of #206 (Tier 1; Tier 2 issue will follow once this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)