### PR TITLE
fix(scripts): curate io + extract sysinfo (Tier-2 Sub-PR-3 of #206)

### DIFF
--- a/core/init.lua
+++ b/core/init.lua
@@ -98,6 +98,14 @@ _core = {    -- luadch core, order is important
     -- machinery (core/http.lua / core/http_router.lua are loaded
     -- on demand via `use`, not from _core).
     "util_http",
+    -- #206 Tier-2 Sub-PR-3: host OS / CPU / RAM detection
+    -- helpers. Lives in core (not in a plugin) so the bundled
+    -- `cmd_hubinfo` plugin can use `sysinfo.os_name()` etc. via
+    -- the whitelisted `sysinfo` global without needing `io.popen`
+    -- in the plugin sandbox. Loaded BEFORE scripts.lua so the
+    -- module is in _G when the plugin sandbox iterates the
+    -- whitelist.
+    "sysinfo",
     "scripts",
     "types",
     --"test",

--- a/core/scripts.lua
+++ b/core/scripts.lua
@@ -116,13 +116,6 @@ _code = {    -- mhh...
 --   _G        the underlying global env (would re-expose everything)
 --   _ENV      escape to parent env
 --
--- Notably KEPT but flagged for further Tier-2 sub-PRs:
---   io         cmd_errors / etc_keyprint use io.open (read mode);
---              cmd_hubinfo uses io.popen (reads /proc, shells
---              `uname`). Sub-PR-3 will replace with curated
---              `io_safe` once the io.popen system-info path is
---              factored out / moved to a hub helper.
---
 -- Removed across Tier-2 sub-PRs (cumulative):
 --   require    Sub-PR-1: plugins now reach modules through
 --              whitelisted globals (`ssl`, `basexx`); ssl submodules
@@ -137,6 +130,14 @@ _code = {    -- mhh...
 --              use). Blocks os.execute / os.remove / os.rename /
 --              os.exit / os.setlocale / os.tmpname / os.tmpfile /
 --              os.getenv reachability from plugin code.
+--   io         Sub-PR-3: replaced by a curated `_io_safe` shim
+--              exposing ONLY io.open with path-restriction (no
+--              absolute paths, no parent-dir traversal). Blocks
+--              io.popen entirely; cmd_hubinfo's old system-info
+--              io.popen calls migrated to the new
+--              `core/sysinfo.lua` core module (whitelisted as
+--              `sysinfo`). Closes the last major sandbox-escape
+--              vector identified in #206.
 
 -- Curated `os` shim for the plugin sandbox (#206 Tier-2 Sub-PR-2).
 -- Plugin code that needs current-time / date-format / time-arithmetic
@@ -153,6 +154,69 @@ local _os_safe = {
     date     = os.date,
     difftime = os.difftime,
 }
+
+-- Curated `io` shim for the plugin sandbox (#206 Tier-2 Sub-PR-3).
+-- `io.popen` is no longer in the shim - the only legitimate caller
+-- (`cmd_hubinfo` for system-info detection) now reaches the curated
+-- core helper `sysinfo` instead. `io.open` is path-restricted:
+-- absolute paths and parent-dir traversal are rejected so a
+-- compromised plugin can't read `/etc/shadow`, `C:\Windows\…`,
+-- or escape its working dir via `../../`. Bundled plugins write
+-- to relative paths under `log/`, `cfg/`, `certs/`, `scripts/data/`
+-- - all permitted.
+--
+-- NOT in the shim (left absent on purpose):
+--   io.popen        shell-arbitrary-command via pipe
+--   io.input        replaces the process-global stdin handle
+--   io.output       replaces the process-global stdout handle
+--   io.read         reads from the current process-global input
+--   io.write        writes to the current process-global output
+--   io.stdin / stdout / stderr   plugin should not touch the
+--                                 hub's tty handles
+--   io.lines        relies on io.input / io.open semantics
+--   io.tmpfile      tempfile handle
+--   io.close        no-op without io.open's matching handle
+--   io.type         introspection of file handles
+--
+-- The file handle returned by `_io_safe.open` IS the real Lua
+-- file handle (same userdata) - its methods (`:read`, `:write`,
+-- `:close`, `:lines`, `:seek`, `:setvbuf`) work normally. The
+-- shim only narrows the entry point.
+local _io_safe = {
+    open = function( path, mode )
+        if type( path ) ~= "string" then
+            return nil, "io_safe: path must be a string"
+        end
+        -- Reject absolute POSIX paths ("/..."), absolute Windows
+        -- paths ("C:\..." / "C:/..." / "\\\\server\\..."), and
+        -- parent-dir traversal anywhere in the string. The
+        -- restriction is intentionally conservative; the bundled
+        -- plugins use only relative paths like "log/error.log",
+        -- "cfg/cfg.tbl", "certs/cert.pem", "scripts/data/<x>.tbl".
+        local first = path:sub( 1, 1 )
+        if first == "/" or first == "\\" then
+            return nil, "io_safe: absolute paths blocked (got '" .. path .. "')"
+        end
+        if path:match( "^[A-Za-z]:[/\\]" ) then
+            return nil, "io_safe: absolute Windows paths blocked (got '" .. path .. "')"
+        end
+        -- Block parent-dir traversal: reject if ANY path component
+        -- (between `/` or `\` separators) is exactly "..". This
+        -- catches `..`, `../foo`, `foo/..`, `foo/../bar`,
+        -- `log\..\etc\shadow` etc. while ALLOWING legitimate
+        -- filenames that happen to contain two consecutive dots
+        -- (`thesis..v2.lua`, `foo..bar`) - the earlier
+        -- `path:find("%.%.")` check produced false positives on
+        -- those. A single dot `.` (current dir) stays allowed
+        -- because `.` isn't a traversal escape.
+        for component in path:gmatch( "[^/\\]+" ) do
+            if component == ".." then
+                return nil, "io_safe: parent-dir traversal blocked (got '" .. path .. "')"
+            end
+        end
+        return io.open( path, mode )
+    end,
+}
 --
 -- `hub`, `utf`, `string`, and `PROCESSED` are NOT in the whitelist
 -- because they are written into env explicitly later (see lines
@@ -168,11 +232,14 @@ local SANDBOX_GLOBALS = {
     "setmetatable", "getmetatable", "collectgarbage",
     -- Standard libraries (safe)
     "table", "math", "coroutine",
-    -- Compat-keep (see Tier-2 notes above); `os` was here until
-    -- Sub-PR-2 replaced it with the curated `_os_safe` shim
-    -- (assigned to env.os explicitly after the SANDBOX_GLOBALS
-    -- loop runs).
-    "io",
+    -- `os` and `io` were here until Tier-2 Sub-PR-2 / Sub-PR-3
+    -- replaced them with curated `_os_safe` / `_io_safe` shims
+    -- (assigned to env.os / env.io explicitly after the
+    -- SANDBOX_GLOBALS loop runs).
+    -- `sysinfo` is the new core module that owns the host-OS /
+    -- CPU / RAM detection - cmd_hubinfo calls into it instead of
+    -- shelling out via io.popen directly.
+    "sysinfo",
     -- luadch core modules (always present in _G after init.lua)
     "cfg", "util", "util_http", "adc", "adclib", "signal", "out",
     "unicode",
@@ -298,6 +365,9 @@ startscripts = function( hub )
             -- use (time / date / difftime). See `_os_safe`
             -- definition near the SANDBOX_GLOBALS block above.
             env.os = _os_safe
+            -- Curated `io` shim (#206 Tier-2 Sub-PR-3). io.popen
+            -- is gone; io.open is path-restricted. See `_io_safe`.
+            env.io = _io_safe
             env.hub = hubobject
             env.utf = utf
             env.string = utf

--- a/core/sysinfo.lua
+++ b/core/sysinfo.lua
@@ -1,0 +1,184 @@
+--[[
+
+        sysinfo.lua
+
+            Host-OS detection helpers (OS name, CPU model, RAM
+            total / free). All `io.popen` calls in the hub live
+            HERE - extracted from `scripts/cmd_hubinfo.lua` so the
+            plugin sandbox no longer needs `io.popen` reach. Bundled
+            plugins call `sysinfo.os_name()` etc. via the
+            whitelisted `sysinfo` global (see core/scripts.lua
+            SANDBOX_GLOBALS).
+
+            Rationale (#206 Tier-2 Sub-PR-3): `io.popen` is the
+            single most dangerous primitive a plugin could reach -
+            it shells arbitrary commands. cmd_hubinfo only ever
+            used it for read-only system-info probes (uname,
+            /proc/cpuinfo, PowerShell CIM cmdlets); centralising
+            those calls here means the plugin sandbox can drop
+            `io.popen` entirely while preserving the
+            +hubinfo UX.
+
+            The popen targets and parsing logic are unchanged from
+            cmd_hubinfo's v0.29; semantic regressions on the
+            +hubinfo cmd should not happen as long as the host's
+            command output format also stays the same.
+
+]]--
+
+----------------------------------// DECLARATION //--
+
+local use = use
+
+local io = use "io"
+local tostring = use "tostring"
+local tonumber = use "tonumber"
+local string = use "string"
+
+local util = use "util"
+
+local io_popen = io.popen
+
+local string_find = string.find
+local string_match = string.match
+local string_sub = string.sub
+
+----------------------------------// HELPERS //--
+
+-- Trim whitespace from both ends. The `or ""` on the match is
+-- defensive only - the upstream `capture()` helper already
+-- filters nil / empty-string popen output before invoking trim,
+-- so the only input shape that reaches here is a non-empty
+-- string containing at least one non-whitespace char (the
+-- `string.find(s, "^%s*$")` branch returns "" for the
+-- whitespace-only case anyway). Kept identical-to-defensive
+-- so a future caller without the capture() filter cannot
+-- crash on a nil-from-match.
+local trim = function( s )
+    if not s then return "" end
+    return string_find( s, "^%s*$" ) and "" or ( string_match( s, "^%s*(.*%S)" ) or "" )
+end
+
+-- Run a shell command, read its stdout, return trimmed string or
+-- nil if the popen failed / output was empty. Caller owns the
+-- "is the result sensible" check.
+local capture = function( cmd )
+    local f = io_popen( cmd )
+    if not f then return nil end
+    local s = f:read( "*a" )
+    f:close( )
+    if not s or s == "" then return nil end
+    return trim( s )
+end
+
+-- Pull a colon-delimited field from /proc/cpuinfo-style output.
+-- Matches cmd_hubinfo's old `split( s, ":", "\n" )` shape:
+-- take the first line, strip everything up to and including the
+-- first ":", trim whitespace.
+local first_colon_field = function( s )
+    if not s or s == "" then return nil end
+    local i = string_find( s, ":" )
+    if not i then return nil end
+    local j = string_find( s, "\n", i + 1 )
+    local field = string_sub( s, i + 1, j and ( j - 1 ) or -1 )
+    return trim( field )
+end
+
+----------------------------------// PUBLIC //--
+
+-- Returns "win", "unix", or "unknown" based on the host path
+-- separator. Cached at module load (path-sep cannot change
+-- mid-process).
+local _os_kind
+do
+    local sep = util.path_sep( )
+    if sep == "\\" then _os_kind = "win"
+    elseif sep == "/" then _os_kind = "unix"
+    else _os_kind = "unknown" end
+end
+local os_kind = function( ) return _os_kind end
+
+local os_name = function( )
+    if _os_kind == "win" then
+        -- wmic was removed in Windows 11 24H2+; use PowerShell's
+        -- CIM cmdlets instead (matches cmd_hubinfo v0.29).
+        local s = capture( 'powershell -NoProfile -Command "(Get-CimInstance Win32_OperatingSystem).Caption"' )
+        return s or "Microsoft Windows"
+    elseif _os_kind == "unix" then
+        local s = capture( "uname -s -r -v -m" )
+        return s or "Unknown Unix/Linux"
+    else
+        return "Unknown Operating System"
+    end
+end
+
+local cpu_info = function( )
+    if _os_kind == "win" then
+        local s = capture( 'powershell -NoProfile -Command "(Get-CimInstance Win32_Processor).Name"' )
+        return s
+    elseif _os_kind == "unix" then
+        -- Try /proc/cpuinfo with three known label variants:
+        -- "Processor" (older ARM), "model name" (x86/x64), "Model" (Pi).
+        local s = capture( "grep \"Processor\" /proc/cpuinfo" )
+        if s then return first_colon_field( s ) end
+        s = capture( "grep \"model name\" /proc/cpuinfo" )
+        if s then return first_colon_field( s ) end
+        s = capture( "grep \"Model\" /proc/cpuinfo" )
+        if s then
+            if string_find( s, "Raspberry Pi 4" ) then
+                return "Broadcom Quad core Cortex-A72 (ARM v8) 64-bit SoC @ 1.5GHz"
+            end
+            return first_colon_field( s )
+        end
+        return nil
+    else
+        return nil
+    end
+end
+
+local ram_total = function( )
+    if _os_kind == "win" then
+        local s = capture( 'powershell -NoProfile -Command "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory"' )
+        if not s then return nil end
+        return util.formatbytes( tonumber( s ) or s )
+    elseif _os_kind == "unix" then
+        local s = capture( "grep MemTotal /proc/meminfo | awk '{ print $2 }'" )
+        if not s then return nil end
+        return util.formatbytes( ( tonumber( s ) or 0 ) * 1024 )
+    else
+        return nil
+    end
+end
+
+-- NOTE: ram_free re-shells on every call (intended: free-RAM is
+-- volatile so a startup-cached value would be stale by the time
+-- `+hubinfo` is invoked). cmd_hubinfo's pre-refactor v0.29 had
+-- the same shape - `check_ram_free` was NOT in the onStart
+-- cache list alongside `check_os` / `check_cpu` /
+-- `check_ram_total`. Preserved deliberately.
+local ram_free = function( )
+    if _os_kind == "win" then
+        -- FreePhysicalMemory is in KiB on both PowerShell paths.
+        local s = capture( 'powershell -NoProfile -Command "(Get-CimInstance Win32_OperatingSystem).FreePhysicalMemory"' )
+        if not s then return nil end
+        return util.formatbytes( ( tonumber( s ) or 0 ) * 1024 )
+    elseif _os_kind == "unix" then
+        local s = capture( "grep MemFree /proc/meminfo | awk '{ print $2 }'" )
+        if not s then return nil end
+        return util.formatbytes( ( tonumber( s ) or 0 ) * 1024 )
+    else
+        return nil
+    end
+end
+
+----------------------------------// PUBLIC INTERFACE //--
+
+return {
+
+    os_kind   = os_kind,
+    os_name   = os_name,
+    cpu_info  = cpu_info,
+    ram_total = ram_total,
+    ram_free  = ram_free,
+
+}

--- a/scripts/cmd_hubinfo.lua
+++ b/scripts/cmd_hubinfo.lua
@@ -444,103 +444,35 @@ check_users = function()
     return regged_total, online_total, online_regged, online_unregged, online_active, online_passive
 end
 
+-- #206 Tier-2 Sub-PR-3: the host-OS / CPU / RAM probes (which
+-- shell out via io.popen) moved into `core/sysinfo.lua`. The
+-- plugin sandbox no longer reaches `io.popen` at all; the
+-- bundled `sysinfo` core module exposes the same data through
+-- a curated interface.
+
 --// system environment
 get_os = function()
-    -- #206 Tier 2: `util.path_sep()` replaces direct
-    -- `package.config` access so `package` can be dropped from
-    -- the plugin sandbox whitelist.
-    local path_sep = util.path_sep()
-    if path_sep == "\\" then return "win" elseif path_sep == "/" then return "unix" else return "unknown" end
+    return sysinfo.os_kind()
 end
 
 --// operating system
 check_os = function()
-    local s, f = nil, nil
-    local oss = get_os() -- returns win/unix/unknown
-    if oss == "win" then
-        -- wmic was removed in Windows 11 24H2+; use PowerShell's CIM cmdlets instead
-        f = io.popen( 'powershell -NoProfile -Command "(Get-CimInstance Win32_OperatingSystem).Caption"' )
-        if f then s = f:read( "*a" ); f:close() end
-        if s and s ~= "" then return trim( s ) else return "Microsoft Windows" end
-    elseif oss == "unix" then
-        f = io.popen( "uname -s -r -v -m" )
-        if f then s = f:read( "*a" ); f:close() end
-        if s ~= "" then return trim( s ) else return "Unknown Unix/Linux" end
-    else
-        return "Unknow Operating System"
-    end
+    return sysinfo.os_name()
 end
 
 --// processor
 check_cpu = function()
-    local s, f = nil, nil
-    local oss = get_os() -- returns win/unix/unknown
-    if oss == "win" then
-        -- wmic replacement, see check_os
-        f = io.popen( 'powershell -NoProfile -Command "(Get-CimInstance Win32_Processor).Name"' )
-        if f then s = f:read( "*a" ); f:close() end
-        if s and s ~= "" then return trim( s ) else return msg_unknown end
-    elseif oss == "unix" then
-        f = io.popen( "grep \"Processor\" /proc/cpuinfo" )
-        if f then
-            s = f:read( "*a" ); f:close()
-            if s ~= "" then return trim( split( s, ":", "\n" ) ) end
-        end
-        f = io.popen( "grep \"model name\" /proc/cpuinfo" )
-        if f then
-            s = f:read( "*a" ); f:close()
-            if s ~= "" then return trim( split( s, ":", "\n" ) ) end
-        end
-        f = io.popen( "grep \"Model\" /proc/cpuinfo" )
-        if f then
-            s = f:read( "*a" ); f:close()
-            if s ~= "" then
-                if string.find( s, "Raspberry Pi 4" ) then
-                    return "Broadcom Quad core Cortex-A72 (ARM v8) 64-bit SoC @ 1.5GHz"
-                else
-                    return trim( split( s, ":", "\n" ) )
-                end
-            end
-        end
-    else
-        return msg_unknown
-    end
+    return sysinfo.cpu_info() or msg_unknown
 end
 
 --// ram total
 check_ram_total = function()
-    local s, f = nil, nil
-    local oss = get_os() -- returns win/unix/unknown
-    if oss == "win" then
-        -- wmic replacement, see check_os
-        f = io.popen( 'powershell -NoProfile -Command "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory"' )
-        if f then s = f:read( "*a" ); f:close() end
-        if s and s ~= "" then return util.formatbytes( trim( s ) ) else return msg_unknown end
-    elseif oss == "unix" then
-        f = io.popen( "grep MemTotal /proc/meminfo | awk '{ print $2 }'" )
-        if f then s = f:read( "*a" ); f:close() end
-        if s ~= "" then return util.formatbytes( s * 1024 ) else return msg_unknown end
-    else
-        return msg_unknown
-    end
+    return sysinfo.ram_total() or msg_unknown
 end
 
 --// ram free
 check_ram_free = function()
-    local s, f = nil, nil
-    local oss = get_os() -- returns win/unix/unknown
-    if oss == "win" then
-        -- wmic replacement, see check_os; FreePhysicalMemory is in KiB on both
-        f = io.popen( 'powershell -NoProfile -Command "(Get-CimInstance Win32_OperatingSystem).FreePhysicalMemory"' )
-        if f then s = f:read( "*a" ); f:close() end
-        if s and s ~= "" then return util.formatbytes( trim( s ) * 1024 ) else return msg_unknown end
-    elseif oss == "unix" then
-        f = io.popen( "grep MemFree /proc/meminfo | awk '{ print $2 }'" )
-        if f then s = f:read( "*a" ); f:close() end
-        if s ~= "" then return util.formatbytes( s * 1024 ) else return msg_unknown end
-    else
-        return msg_unknown
-    end
+    return sysinfo.ram_free() or msg_unknown
 end
 
 --// check if ports table are empty or 0


### PR DESCRIPTION
## Summary

Final Tier-2 sub-PR of #206. Closes the last sandbox-escape vector:

- **\`io.popen\` gone** from the plugin sandbox. The only legitimate caller (\`cmd_hubinfo\` for system-info detection) now reaches a new core module \`sysinfo\` instead.
- **\`io.open\` path-restricted**: absolute paths and parent-dir traversal (as path components) are rejected. Bundled plugins' relative writes/reads to \`log/\`, \`cfg/\`, \`certs/\`, \`scripts/data/\` are permitted.

## Tier-2 status after this PR

| Vector | Status | PR |
|---|---|---|
| \`require\` / \`package\` | gone | #211 |
| \`os.execute\` etc. | curated to time/date/difftime only | #212 |
| \`io.popen\` | gone | **this PR** |
| \`io.open\` unrestricted | curated to relative-only | **this PR** |
| \`debug\` / \`loadfile\` / \`dofile\` / \`rawget\` | gone (Tier 1) | #210 |

## What's still reachable from plugins

- Lua language basics (assert, error, pairs, type, setmetatable, pcall, ...)
- Standard libs: table, math, coroutine, string (via utf shim)
- Curated \`os\` (time/date/difftime) + curated \`io\` (path-restricted open)
- luadch core: hub, cfg, util, util_http, adc, adclib, signal, out, unicode, **sysinfo**
- Extern libs: ssl, socket, basexx, zlib_stream, dkjson

## Files

- \`core/sysinfo.lua\` (NEW, ~180 LoC): host-OS / CPU / RAM detection. All io.popen lives here. Parsing logic is a verbatim port of cmd_hubinfo v0.29.
- \`core/init.lua\`: register sysinfo in _core load order.
- \`core/scripts.lua\`: \`_io_safe\` shim with component-wise traversal check. Add sysinfo to whitelist, drop io.
- \`scripts/cmd_hubinfo.lua\`: ~95 LoC removed; check_* are now thin proxies into sysinfo.

## Two-pass review

Independent reviewer found 1 BLOCKER + 2 NITs. All addressed:
- BLOCKER (\`foo..bar\` false-positive in traversal check) → fixed via component-wise rejection.
- NIT (trim defensive \`or \"\"\`) → documented inline.
- NIT (ram_free re-shells per call) → documented inline, matches v0.29.

## Test plan

- [x] Local Windows smoke pipeline green (60+ checks incl. all HTTP API Phase-2 tests).
- [x] CI smoke matrix green.

Closes #206 Tier 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)