### PR TITLE
docs(etc_trafficmanager): expand HTTP-handler design note post-#258

### DIFF
--- a/scripts/etc_trafficmanager.lua
+++ b/scripts/etc_trafficmanager.lua
@@ -1070,19 +1070,44 @@ hub.setlistener( "onSearchResult", {},
 
 --// HTTP API handlers (#82 Phase 4 PR-7).
 --
--- Design note: the existing `add()` / `del()` functions defined
--- above carry a latent bug in their internal/external dispatch
--- check (`( not scriptname ) or ( not scriptname == 1 )` should
--- be `... or ( scriptname ~= 1 )`; the second clause is always
--- false because `not X` is a boolean). The bug is dead in
--- practice because the only existing external caller
--- (cmd_usercleaner) passes `scriptname = nil` which satisfies
--- the first clause. Rather than drive-by fix the existing
--- functions in this feature PR, the HTTP handlers below
--- implement the block / unblock cascade directly using the
--- shared file-locals (block_tbl, flag_blocked, format_description,
--- find_online_by_firstnick) - cleaner reuse than wrestling with
--- the buggy dispatch.
+-- Design note: the HTTP handlers deliberately re-implement the
+-- block / unblock cascade rather than calling the `add()` /
+-- `del()` exports above. The dispatch bug that originally drove
+-- this decision was fixed in #257 / #258 (v2.5) and the external
+-- path now works correctly - but the duplication remains
+-- intentional because the two surfaces have different semantics:
+--
+-- 1. add()'s external branch appends `"  |  blocked by
+--    scriptname: <label>"` to the stored reason (line 610). The
+--    HTTP API's spec contract stores the reason verbatim;
+--    routing through add() would silently change what API
+--    clients see in the `reason` field of GET responses.
+--
+-- 2. add() / del() return `PROCESSED` or `false, err` with
+--    localised err strings (msg_isbot / msg_autoblock /
+--    msg_stillblocked). The HTTP path needs clean HTTP status
+--    codes (400 / 404 / 409); pre-checking the conditions
+--    before calling add() means we still own all the validation
+--    logic. Routing through add() and then matching the
+--    localised err strings would be locale-fragile.
+--
+-- 3. The HTTP response envelope `{action, nick, by, reason,
+--    online_kicked, removed: {...}}` is built outside add() /
+--    del() either way - they only return PROCESSED. The shape
+--    construction stays here regardless of who runs the
+--    cascade.
+--
+-- 4. HTTP sanitises `req.token_label` with
+--    `util.strip_control_bytes` before any state touches the
+--    block_tbl or report frame. add() trusts its inputs - the
+--    HTTP path's pre-cascade sanitisation is the correct
+--    boundary.
+--
+-- Net: the ~40 lines of cascade duplication buy a stable
+-- spec contract + clean HTTP status mapping. Future external
+-- block.add callers (e.g. a hypothetical AbuseIPDB plugin from
+-- #79) can use add() directly via hub.import and get the
+-- ADC-side cascade semantics.
 
 -- Stringify a single block_tbl entry into the HTTP wire shape.
 -- Block-table values come in three legacy variants (boolean,


### PR DESCRIPTION
## Summary

Reine Kommentar-Aktualisierung. Der bisherige design-note in den HTTP-Handlern von PR #256 erklärte die ~40 Zeilen Cascade-Duplikation als Workaround für den #257 Dispatch-Bug. Nach dem Fix in #258 ist dieser Bug behoben - die Duplikation bleibt trotzdem intentional, aber aus anderen Gründen:

1. **reason-append:** add()'s external branch hängt automatisch `" \| blocked by scriptname: LABEL"` an reason. HTTP-API-clients würden plötzlich verändertes `reason` Feld sehen.
2. **localised err strings:** add()/del() geben msg_isbot / msg_autoblock / msg_stillblocked zurück - HTTP braucht saubere status codes (400/404/409); pre-check ist locale-stabil.
3. **response shape construction:** HTTP envelope wird ohnehin außerhalb gebaut.
4. **sanitisation boundary:** HTTP sanitises token_label vor dem cascade. add() trusts inputs.

Keine Code-Änderung; nur Kommentar.

## Test plan

- [x] Smoke harness PASSes locally (Kommentar-only change)
- [ ] CI smoke green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
