### PR TITLE
fix(hub): strip unverified secondary IP family before broadcast (#214 Gap 1)

### DIFF
--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -232,6 +232,42 @@ local function bind( deps )
     _i18n_reg_only           = deps._i18n_reg_only
 end
 
+-- #214 Gap 1: the hub can only authenticate the IP family matching the
+-- TCP source (userfam, validated in _identify.BINF). The OTHER family's
+-- address is unverified - a sender connecting on v4 has no v6 socket
+-- through which we could authenticate a claimed v6 address. Broadcasting
+-- the unverified secondary lets a hostile client conscript other users
+-- into directing CTM / RCM connection attempts at an arbitrary victim
+-- address (the historical DC++ DDoS-amplification pattern). Strip the
+-- unverified secondary family's I/U address fields and its SU transport
+-- flags before the INF is stored + broadcast. Real HBRI (#214 PR-B)
+-- re-adds a secondary address only after validating it over a
+-- second-family side-channel socket.
+local function strip_unverified_secondary( adccmd, userfam )
+    local ip_field, udp_field, tcp_flag, udp_flag
+    if userfam == "I4" then
+        ip_field, udp_field, tcp_flag, udp_flag = "I6", "U6", "TCP6", "UDP6"
+    else
+        ip_field, udp_field, tcp_flag, udp_flag = "I4", "U4", "TCP4", "UDP4"
+    end
+    adccmd:deletenp( ip_field )
+    adccmd:deletenp( udp_field )
+    local su = adccmd:getnp "SU"
+    if su then
+        local kept
+        for tok in su:gmatch( "[^,]+" ) do
+            if tok ~= tcp_flag and tok ~= udp_flag then
+                kept = kept and ( kept .. "," .. tok ) or tok
+            end
+        end
+        if kept then
+            adccmd:setnp( "SU", kept )
+        else
+            adccmd:deletenp( "SU" )
+        end
+    end
+end
+
 -- The four state-machine handler tables follow verbatim from hub.lua.
 -- The only edits are: replace bare _user_count with _get_user_count(),
 -- since _user_count mutates during normal hub operation and our cached
@@ -395,13 +431,13 @@ _identify = {
         -- accepts no-IP login and fills the slot with the TCP-source
         -- IP under the connection's address family - see #161.
         --
-        -- T3.1 HBRI (#147): probe I4 and I6 independently so a
-        -- dual-stack peer can advertise both in one BINF. The hub
-        -- can only verify the family matching the TCP source against
-        -- userip; the OTHER family stays unverified-but-stored. That
-        -- is a known trade-off of HBRI - a sender connecting on v4
-        -- has no v6 socket through which we could authenticate their
-        -- v6 address. Documented in docs/SECURITY.md.
+        -- #147 T3.1: probe I4 and I6 independently so a dual-stack peer
+        -- can advertise both in one BINF. The hub verifies only the
+        -- family matching the TCP source against userip; the OTHER
+        -- family is unverified and is STRIPPED before broadcast by
+        -- strip_unverified_secondary (#214 Gap 1) - it is not stored or
+        -- forwarded. Real HBRI (#214 PR-B) re-adds a validated secondary
+        -- via a second-family side-channel socket.
         local inf_i4 = adccmd:getnp "I4"
         local inf_i6 = adccmd:getnp "I6"
         local hash = user.hash( )
@@ -413,7 +449,7 @@ _identify = {
         local userip = user.ip( ) or ""
         local userfam = ( userip:find( ":", 1, true ) and "I6" or "I4" )
         -- Field that the TCP source's family can authenticate. The
-        -- other field (if both were advertised) stays as-sent.
+        -- other family (if advertised) is stripped below, post-stamp.
         local infip_match = ( userfam == "I4" ) and inf_i4 or inf_i6
         if ( not inf_i4 and not inf_i6 )
                 or infip_match == nil
@@ -424,7 +460,7 @@ _identify = {
             -- family - which is unusual but legal for a v6-only peer
             -- reaching us via a v4 socket via a relay etc.). Stamp
             -- the connecting family with userip. The other family,
-            -- if the client did set it, stays in adccmd untouched.
+            -- if the client did set it, is stripped below (#214 Gap 1).
             adccmd:setnp( userfam, userip )
         elseif infip_match ~= userip then
             if _cfg_kill_wrong_ips then
@@ -439,7 +475,9 @@ _identify = {
                 -- clients would then direct CTM / RCM at the spoofed
                 -- address (DDoS-amplification, see issue body). Stamp
                 -- the authenticated TCP-source IP over the lie so the
-                -- broadcast INF carries `userip`, not the claim.
+                -- broadcast INF carries `userip`, not the claim. (The
+                -- secondary family, if any, is additionally stripped
+                -- below by strip_unverified_secondary - #214 Gap 1.)
                 adccmd:setnp( userfam, userip )
             end
         end
@@ -483,6 +521,7 @@ _identify = {
             end
         end
         adccmd:deletenp "PD"
+        strip_unverified_secondary( adccmd, userfam )
         user:inf( adccmd )
         if user:hasfeature "CCPM" then user:hasccpm( true ) end
         -- F-AUTH-NICK (#91): defer insertuser + onConnect when this BINF

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -1033,11 +1033,13 @@ def test_binf_without_i4_or_i6_accepted():
 
 
 def test_binf_with_both_i4_and_i6_accepted():
-    """#147 T3.1 (HBRI): a BINF that carries BOTH I4 AND I6 must be
+    """#147 T3.1: a BINF that carries BOTH I4 AND I6 must be
     accepted, with the hub validating ONLY the family matching the
-    connecting TCP source against userip. The OTHER family is the
-    "other-family-than-the-connection" and stays unverified-but-
-    stored (the trade-off documented in docs/SECURITY.md).
+    connecting TCP source against userip. The OTHER (secondary)
+    family is unverified; since #214 Gap 1 it is STRIPPED before
+    broadcast (see test_binf_secondary_family_stripped). This test
+    only asserts the login is ACCEPTED (advances to IGPA); the
+    strip-on-broadcast assertion lives in the Gap 1 test.
 
     This test exercises the HBRI differentiator: it connects via
     **IPv6** (TEST_PORT_PLAIN_V6) and sends BINF with a wrong I4
@@ -1050,8 +1052,8 @@ def test_binf_with_both_i4_and_i6_accepted():
 
     Post-T3.1 the hub probes both families, picks the field matching
     the v6 connection (= I6), validates ::1 == ::1, passes. The wrong
-    I4 stays unverified but is preserved in adccmd for downstream
-    forwarding - peers can choose to ignore it.
+    secondary I4 is unverified and is stripped before broadcast
+    (#214 Gap 1); this test only checks acceptance.
 
     Test uses the registered `dummy` account so success advances to
     IGPA (password challenge), distinguishing the fix from the bug:
@@ -1105,6 +1107,105 @@ def test_binf_with_both_i4_and_i6_accepted():
             raise TestFailure(
                 f"unexpected response to dual-stack BINF: {frame!r}. "
                 f"Expected IGPA (registered user password challenge)."
+            )
+    finally:
+        sock.close()
+
+
+def test_binf_secondary_family_stripped():
+    """#214 Gap 1: a dual-stack login over IPv4 may advertise a
+    secondary I6 / U6 (+ TCP6 / UDP6 in SU), but the hub cannot
+    authenticate the v6 address over a v4 socket. The unverified
+    secondary family MUST be stripped before the INF is broadcast -
+    otherwise a hostile client could publish a spoofed I6 and have
+    other users direct CTM / RCM at that victim (DC++ DDoS
+    amplification).
+
+    Connect via v4 as the registered `dummy` account, log in fully
+    with a BINF carrying a correct I4 (127.0.0.1) plus a claimed
+    secondary (I6 2001:db8::1, U6, SU TCP6/UDP6). Capture the hub's
+    own-SID BINF broadcast echo and assert:
+      - the verified primary survives (I4 present, SU TCP4 present)
+      - the unverified secondary is gone (no I6 / U6 param; no
+        TCP6 / UDP6 SU flag)
+
+    Falsifiable: pre-#214-Gap-1 the hub stored + broadcast the
+    secondary as-sent (#147 T3.1 trade-off), so the echo carried
+    I6 / U6 / TCP6 / UDP6 and the asserts below FAIL.
+    """
+    sock = socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    )
+    try:
+        reader = _ADCReader(sock)
+        sock.sendall(b"HSUP ADBASE ADTIGR\n")
+        reader.recv_until(lambda f: f.startswith("ISUP "))
+        isid = reader.recv_until(lambda f: f.startswith("ISID "))
+        sid = isid.split(" ", 1)[1].strip()
+        reader.recv_until(lambda f: f.startswith("IINF "))
+
+        pid_bytes = secrets.token_bytes(24)
+        cid_b32 = _b32_encode(_tiger.tiger(pid_bytes))
+        pid_b32 = _b32_encode(pid_bytes)
+        binf = (
+            f"BINF {sid}"
+            f" ID{cid_b32}"
+            f" PD{pid_b32}"
+            f" NIdummy"
+            f" I4127.0.0.1"
+            f" I62001:db8::1"
+            f" U65555"
+            f" SUTCP4,UDP4,TCP6,UDP6\n"
+        )
+        sock.sendall(binf.encode("utf-8"))
+
+        gpa = reader.recv_until(lambda f: f.startswith("IGPA "))
+        salt_bytes = _b32_decode(gpa.split(" ", 1)[1].strip())
+        response = _tiger.tiger("test".encode("utf-8") + salt_bytes)
+        sock.sendall(f"HPAS {_b32_encode(response)}\n".encode("utf-8"))
+
+        echo = reader.recv_until(
+            lambda f: f.startswith(f"BINF {sid}") or f.startswith("ISTA "),
+            timeout=PROTOCOL_TIMEOUT_SEC,
+        )
+        if echo.startswith("ISTA "):
+            raise TestFailure(f"login failed: hub returned {echo!r}")
+
+        # Parse the broadcast INF into space-separated params so we
+        # inspect the SU flag-list and I6/U6 params precisely (a raw
+        # substring search for "TCP6" could false-match a base32
+        # CID/PID by chance).
+        params = echo.strip().split(" ")
+        su = next((p[2:] for p in params if p.startswith("SU")), "")
+        su_flags = su.split(",") if su else []
+        has_i4 = any(p.startswith("I4") for p in params)
+        has_i6 = any(p.startswith("I6") for p in params)
+        has_u6 = any(p.startswith("U6") for p in params)
+
+        if has_i6:
+            raise TestFailure(
+                f"broadcast INF still carries unverified secondary I6: "
+                f"{echo!r}. #214 Gap 1 must strip it."
+            )
+        if has_u6:
+            raise TestFailure(
+                f"broadcast INF still carries unverified secondary U6: "
+                f"{echo!r}. #214 Gap 1 must strip it."
+            )
+        if "TCP6" in su_flags or "UDP6" in su_flags:
+            raise TestFailure(
+                f"broadcast INF SU still advertises secondary transport "
+                f"flags (TCP6/UDP6): SU={su!r}. #214 Gap 1 must strip them."
+            )
+        if not has_i4:
+            raise TestFailure(
+                f"broadcast INF lost the VERIFIED primary I4: {echo!r}. "
+                f"Gap 1 must strip only the secondary family."
+            )
+        if "TCP4" not in su_flags:
+            raise TestFailure(
+                f"broadcast INF SU lost the primary-family TCP4 flag: "
+                f"SU={su!r}. Gap 1 must strip only secondary flags."
             )
     finally:
         sock.close()
@@ -9815,6 +9916,7 @@ TESTS = [
     ("literal [+!#] bracket hint + no-arg-echo (#137)", test_literal_bracket_command_hint),
     ("BINF without I4/I6 accepted (#161)", test_binf_without_i4_or_i6_accepted),
     ("BINF with both I4 and I6 accepted (#147 T3.1 HBRI)", test_binf_with_both_i4_and_i6_accepted),
+    ("BINF unverified secondary family stripped (#214 Gap 1)", test_binf_secondary_family_stripped),
     ("post-login INF with I4 silent-stripped (#222)", test_post_login_i4_silent_stripped),
     ("CSPRNG salts are unique across connections", test_csprng_salt_uniqueness),
     ("per-IP connection cap refuses overflow", test_perip_connection_cap),


### PR DESCRIPTION
Part of #214 (PR-A of the secure-first split). Standalone security fix; HBRI handshake follows in PR-B.

## Problem

A dual-stack client logging in over one IP family may also advertise a secondary family in its BINF (`I6`/`U6` + `SU` `TCP6`/`UDP6` over a v4 connection, or the v4 fields over v6). The hub can only authenticate the family matching the TCP source - it has no socket on the other family. Previously (#147 T3.1) the unverified secondary was stored and broadcast as-sent.

That is a DC++ DDoS-amplification vector: a hostile client publishes a spoofed secondary address; other users then direct CTM/RCM connection attempts at that victim.

## Fix

New helper `strip_unverified_secondary( adccmd, userfam )` in `core/hub_dispatch.lua`, called in `_identify.BINF` after the primary family is validated/stamped and before `user:inf( adccmd )` stores the INF. It deletes the secondary family's `I`/`U` address params and removes its `TCP`/`UDP` transport tokens from `SU`. Single chokepoint: every broadcast path reads the stored `_inf`. Real HBRI (PR-B) re-adds a secondary only after validating it over a second-family side-channel socket.

Stale "unverified-but-stored" trade-off comments in the handler updated. `docs/SECURITY.md` rewrite is deferred to PR-C.

## Test

`test_binf_secondary_family_stripped` (smoke): v4 login with a spoofed `I6`/`U6`/`TCP6`/`UDP6`, asserts the broadcast echo carries the verified primary and not the secondary. SU parse is token-exact to avoid base32 false-matches.

- Falsifiable (CLAUDE.md 1a.7): PASSES patched; with the strip neutralized FAILS with `broadcast INF still carries unverified secondary I6: ... I62001:db8::1 U65555 SUTCP4,UDP4,TCP6,UDP6`.
- Full smoke suite green otherwise; neighbor test `test_binf_with_both_i4_and_i6_accepted` (#147 T3.1) still passes (it only asserts acceptance).

## Review

Two-pass (CLAUDE.md 1a.6): independent reviewer APPROVE, no blockers/concerns; maintainer spot-check confirmed `_inf = _inf or adccmd` stores the stripped command and no path broadcasts the raw BINF pre-strip.

## Test plan
- [x] `python tests/smoke/run.py build/install/luadch` green (Windows)
- [x] Falsifiability demonstrated (FAIL on neutralized fix)
- [ ] CI smoke green on Linux + Windows