### PR TITLE
feat(hub): HBRI secondary-IP side-channel validation (#214 PR-B)

### DIFF
--- a/core/adc.lua
+++ b/core/adc.lua
@@ -465,6 +465,31 @@ _protocol = {
             nonpclones = false,
 
         },
+        -- #214 HBRI side-channel validation. The client opens a second
+        -- connection on the opposite IP family and sends HTCP carrying
+        -- the claimed secondary address (I4 / I6, plus optional U4 / U6)
+        -- and the token (TO) the hub minted in its ITCP. Hub-direction
+        -- (H) only on our side; the ITCP the hub sends is built by
+        -- string concat in core/hbri.lua and never parsed here. No
+        -- positional params; P4 / P6 are accepted for symmetry with the
+        -- hub-sent frame even though the client does not echo them.
+        TCP = {
+
+            pp = { len = 0, },
+            np = {
+
+                I4 = _regex.default,
+                I6 = _regex.default,
+                U4 = _regex.integer,
+                U6 = _regex.integer,
+                P4 = _regex.integer,
+                P6 = _regex.integer,
+                TO = _regex.default,
+
+            },
+            nonpclones = true,
+
+        },
         SCH = {
 
             pp = { len = 0, },
@@ -665,6 +690,7 @@ _protocol = {
         SND = _regex.context.hub,
         ZON = _regex.context.streamctl,    -- Phase 8 S4b ADC-EXT ZLIF stream-on
         ZOF = _regex.context.streamctl,    -- Phase 8 S4b ADC-EXT ZLIF stream-off
+        TCP = _regex.context.hub,          -- #214 HBRI HTCP (client -> hub)
 
     }
 

--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -179,6 +179,50 @@ local defaults = {
             return true
         end
     },
+    -- #214 HBRI (Hub-Bridged Reverse Initiation). Opt-in. When a
+    -- dual-stack client logs in, the hub can only authenticate the IP
+    -- family matching the TCP source; the secondary family is stripped
+    -- before broadcast (DDoS-amplification safety). With HBRI enabled
+    -- the hub asks such a client to validate its secondary address over
+    -- a second-family side-channel connection and, on success, restores
+    -- the verified secondary to the broadcast INF. Effective ONLY when
+    -- the hub has a plain listener on BOTH families AND both public
+    -- advertise addresses below are set (otherwise the hub does not
+    -- advertise ADHBRI / never initiates - the secondary just stays
+    -- stripped).
+    hbri_enabled = { false,
+        function( value )
+            return types_boolean( value, nil, true )
+        end
+    },
+    -- Seconds the hub waits for the side-channel validation before
+    -- giving up and letting the client into the hub without the
+    -- secondary (adchpp default is 5).
+    hbri_timeout = { 5,
+        function( value )
+            return types_number( value, nil, true )
+                and value >= 1 and value <= 60 and value % 1 == 0
+        end
+    },
+    -- The hub's PUBLIC IPv4 / IPv6 address that an HBRI client connects
+    -- to for the side-channel. Required when hbri_enabled (the hub
+    -- cannot reliably auto-detect its routable address behind NAT /
+    -- a "::" bind). Empty = do not advertise / initiate HBRI.
+    hbri_advertise_v4 = { "",
+        function( value )
+            if not types_utf8( value, nil, true ) then return false end
+            -- Reject whitespace / control bytes: this value is
+            -- concatenated raw into the ITCP frame sent to clients, so a
+            -- space or newline would inject extra params / frames.
+            return value == "" or not value:find( "[%s%c]" )
+        end
+    },
+    hbri_advertise_v6 = { "",
+        function( value )
+            if not types_utf8( value, nil, true ) then return false end
+            return value == "" or not value:find( "[%s%c]" )
+        end
+    },
     use_ssl = { true,
         function( value )
             return types_boolean( value, nil, true )

--- a/core/hbri.lua
+++ b/core/hbri.lua
@@ -1,0 +1,269 @@
+--[[
+
+    hbri.lua - HBRI (Hub-Bridged Reverse Initiation), #214.
+
+    Verifies a dual-stack client's SECONDARY IP family over a
+    second-family side-channel TCP connection, so the hub can safely
+    broadcast it. Without HBRI the secondary family is stripped before
+    broadcast (#214 Gap 1, core/hub_dispatch.lua) because the hub has
+    no socket on the other family through which to authenticate the
+    claimed address - broadcasting an unverified secondary is a DC++
+    DDoS-amplification vector.
+
+    Flow (client main connection on family X, secondary family Y):
+
+      1. Client advertises ADHBRI in HSUP and a secondary IY in BINF.
+         core/hub_dispatch.lua captures the claim (user._hbri_claim)
+         BEFORE Gap 1 strips it.
+      2. After login (HPAS accepted), hub.lua's login() calls
+         initiate(): mint a CSPRNG token, send the client an ITCP
+         frame pointing at the hub's family-Y listener + token, move
+         the user to the "hbri" state and DELAY entry into NORMAL.
+      3. Client opens a SECOND TCP connection to the hub on family Y
+         and sends `HTCP IY<addr> [UY<udp>] TO<token>`. That fresh
+         connection is a transient "protocol"-state user; its first
+         frame (HTCP, not HSUP) is routed to validate() by the
+         _protocol.HTCP handler in core/hub_dispatch.lua.
+      4. validate() checks: token known, validation-socket family ==
+         the expected secondary family (and != the main family), and
+         the validation-socket TCP source IP == the claimed address.
+         On success the verified secondary is committed to the main
+         user's INF and the user enters NORMAL (now broadcasting the
+         validated secondary). On any failure - or a timeout swept by
+         sweep() on the ~1s hub timer - the user enters NORMAL anyway
+         with the secondary left stripped (failHBRI).
+
+    No core/server.lua change: the validation socket rides the normal
+    accept path and is identified purely by its HTCP+token first frame.
+
+    Token generation is OpenSSL-CSPRNG-backed (adclib.createsalt ->
+    adclib.random_bytes), per the Yorhel security note that the token
+    must not be guessable.
+
+]]--
+
+local use = use
+
+local pairs    = use "pairs"
+local tostring = use "tostring"
+local ipairs   = use "ipairs"
+local os       = use "os"
+local adclib   = use "adclib"
+local cfg      = use "cfg"
+
+local cfg_get           = cfg.get
+local adclib_createsalt = adclib.createsalt
+local os_time           = os.time
+
+-- // late-bound from hub.lua via bind(): the NORMAL-entry completion
+-- // and the per-reload cfg caches.
+local enter_normal           -- enter_normal(user): runs the deferred login
+local _enabled               -- hbri_enabled cfg
+local _timeout               -- hbri_timeout seconds (clamped)
+local _advertise = { I4 = "", I6 = "" }   -- hub public address per family
+local _port      = { I4 = nil,  I6 = nil } -- plain listener port per family
+local _dual_stack = false    -- a plain listener exists on BOTH families
+
+-- // token table: token -> {
+-- //   user        = main user object,
+-- //   family      = expected secondary family ("I4" | "I6"),
+-- //   claimed_ip  = secondary address the client advertised in BINF,
+-- //   claimed_udp = secondary UDP port (string) or nil,
+-- //   su_flags    = { secondary transport flags present in BINF SU },
+-- //   deadline    = os.time() second past which the attempt times out,
+-- // }
+local _tokens = { }
+
+-- // The IP family of an address string: ADC IPv6 contains ":".
+local function fam_of( ip )
+    return ( ip and ip:find( ":", 1, true ) ) and "I6" or "I4"
+end
+
+local function other_fam( f )
+    return ( f == "I4" ) and "I6" or "I4"
+end
+
+local function bind( deps )
+    enter_normal = deps.enter_normal
+    _enabled     = deps.hbri_enabled and true or false
+    _timeout     = deps.hbri_timeout
+    _advertise.I4 = deps.hbri_advertise_v4 or ""
+    _advertise.I6 = deps.hbri_advertise_v6 or ""
+    _port.I4      = deps.hbri_port_v4
+    _port.I6      = deps.hbri_port_v6
+    _dual_stack   = deps.hbri_dual_stack and true or false
+end
+
+-- // Hub can drive HBRI at all: enabled, both families have a plain
+-- // listener, and both public advertise addresses are configured.
+-- // (Advertised in SUP only when this holds, so a client never gets
+-- // an ITCP it cannot reach.)
+local function active( )
+    return _enabled and _dual_stack
+        and _advertise.I4 ~= "" and _advertise.I6 ~= ""
+        and _port.I4 and _port.I6 and true or false
+end
+
+-- // This user should be HBRI-validated: the hub is HBRI-active, the
+-- // client advertised ADHBRI, and the client claimed a secondary IP
+-- // (captured pre-strip by the BINF handler) on the family opposite
+-- // its main connection.
+local function eligible( user )
+    if not active( ) then return false end
+    if not ( user.supports and user:supports( "HBRI" ) ) then return false end
+    local claim = user._hbri_claim
+    if not claim or not claim.ip or claim.ip == "" then return false end
+    local main_fam = fam_of( user.ip( ) or "" )
+    return claim.family == other_fam( main_fam )
+end
+
+-- // Begin HBRI: mint a token, register it, send the ITCP pointer to
+-- // the hub's secondary-family listener, and park the user in the
+-- // "hbri" state. enter_normal() is deferred until validate() or
+-- // sweep() resolves the attempt.
+local function initiate( user )
+    local claim   = user._hbri_claim
+    local sec_fam = claim.family
+    local token   = adclib_createsalt( 16 )
+    _tokens[ token ] = {
+        user        = user,
+        family      = sec_fam,
+        claimed_ip  = claim.ip,
+        claimed_udp = claim.udp,
+        su_flags    = claim.su_flags or { },
+        deadline    = os_time( ) + _timeout,
+    }
+    user._hbri_token = token
+    user:state( "hbri" )
+    -- ITCP I<fam><hub-addr> P<fam><port> TO<token>. The digit is the
+    -- secondary family the client must validate over.
+    local digit = ( sec_fam == "I6" ) and "6" or "4"
+    user.write( "ITCP I" .. digit .. _advertise[ sec_fam ]
+        .. " P" .. digit .. tostring( _port[ sec_fam ] )
+        .. " TO" .. token .. "\n" )
+end
+
+-- // Commit the verified secondary onto the main user's INF, then run
+-- // the deferred NORMAL entry (which broadcasts the now-complete INF).
+local function commit_and_complete( entry, verified_ip )
+    local user = entry.user
+    local inf  = user:inf( )
+    if inf then
+        inf:setnp( entry.family, verified_ip )
+        if entry.claimed_udp and entry.claimed_udp ~= "" then
+            inf:setnp( ( entry.family == "I6" ) and "U6" or "U4", entry.claimed_udp )
+        end
+        -- Re-add the secondary transport flags that Gap 1 stripped.
+        if #entry.su_flags > 0 then
+            local su = inf:getnp "SU" or ""
+            for _, flag in ipairs( entry.su_flags ) do
+                if not su:find( flag, 1, true ) then
+                    su = ( su == "" ) and flag or ( su .. "," .. flag )
+                end
+            end
+            inf:setnp( "SU", su )
+        end
+    end
+    user._hbri_token = nil
+    enter_normal( user )
+end
+
+-- // Give up on the secondary: drop the ADHBRI support flag (no
+-- // post-login retry loop) and enter NORMAL with the secondary still
+-- // stripped. The user stays connected; only the secondary family is
+-- // unverified.
+local function fail( entry )
+    local user = entry.user
+    user._hbri_token = nil
+    enter_normal( user )
+end
+
+-- // Drop a pending attempt without completing login - used when the
+-- // main user disconnects mid-HBRI so the token cannot dangle.
+local function cancel( user )
+    local token = user._hbri_token
+    if token then
+        _tokens[ token ] = nil
+        user._hbri_token = nil
+    end
+end
+
+-- // Handle an HTCP frame arriving on a fresh (transient) connection.
+-- // `vuser` is that validation socket's throwaway user object; it is
+-- // never entered into NORMAL and is closed here on every path.
+local function validate( vuser, adccmd )
+    local token = adccmd:getnp "TO"
+    local entry = token and _tokens[ token ]
+    if not entry then
+        vuser.write( "ISTA 220 " .. "Unknown\\svalidation\\stoken" .. "\n" )
+        vuser:client( ):close( )
+        return
+    end
+    _tokens[ token ] = nil    -- single-use
+
+    -- Validation socket's real TCP source - the authenticated address.
+    local vip  = vuser.ip( ) or ""
+    local vfam = fam_of( vip )
+
+    -- The validation socket MUST arrive on the expected secondary
+    -- family (which is necessarily != the main connection's family).
+    if vfam ~= entry.family then
+        vuser.write( "ISTA 155 " .. "Validation\\srequest\\son\\swrong\\sIP\\sprotocol" .. "\n" )
+        vuser:client( ):close( )
+        fail( entry )
+        return
+    end
+
+    -- The address the client claims on the validation socket must
+    -- match the socket's real TCP source (anti-spoof).
+    local claimed = adccmd:getnp( entry.family )
+    if claimed and claimed ~= vip then
+        vuser.write( "ISTA 155 " .. "Validation\\saddress\\smismatch" .. "\n" )
+        vuser:client( ):close( )
+        fail( entry )
+        return
+    end
+
+    -- Success: commit the authenticated TCP-source IP (not the BINF
+    -- claim - the side-channel source is ground truth).
+    vuser.write( "ISTA 000 " .. "Validation\\ssucceed" .. "\n" )
+    vuser:client( ):close( )
+    commit_and_complete( entry, vip )
+end
+
+-- // Sweep timed-out attempts. Driven by hub.lua on the existing ~1s
+-- // server timer. Resolves each expired attempt via fail() so the
+-- // user proceeds into the hub without the unverified secondary.
+local function sweep( )
+    local now = os_time( )
+    local expired
+    for token, entry in pairs( _tokens ) do
+        if now > entry.deadline then
+            expired = expired or { }
+            expired[ #expired + 1 ] = token
+        end
+    end
+    if expired then
+        for _, token in ipairs( expired ) do
+            local entry = _tokens[ token ]
+            if entry then
+                _tokens[ token ] = nil
+                local user = entry.user
+                if user and not user.waskilled then
+                    user.write( "ISTA 155 " .. "Secondary\\saddress\\svalidation\\stimed\\sout" .. "\n" )
+                    fail( entry )
+                end
+            end
+        end
+    end
+end
+
+return {
+    bind     = bind,
+    active   = active,
+    eligible = eligible,
+    initiate = initiate,
+    validate = validate,
+    sweep    = sweep,
+    cancel   = cancel,
+}

--- a/core/hub.lua
+++ b/core/hub.lua
@@ -682,10 +682,22 @@ end
 
 debug = out_scriptmsg    -- public
 
-login = function( user, bot )
+login = function( user, bot, hbri_done )
     if bot then
         sendtoall( user:inf( ):adcstring( ) )
     elseif user then
+        -- #214 HBRI: a dual-stack client that advertised a secondary
+        -- IP family is parked in the "hbri" state while it validates
+        -- that address over a second-family side-channel connection.
+        -- login() is re-entered with hbri_done=true on validation
+        -- success or on the timeout sweep (core/hbri.lua). Non-HBRI
+        -- logins (single-stack, no ADHBRI, or HBRI not configured)
+        -- fall straight through to NORMAL entry.
+        local _hbri = use "hbri"
+        if ( not hbri_done ) and _hbri.eligible( user ) then
+            _hbri.initiate( user )
+            return true
+        end
         local sendonly = user:sup( ):hasparam( "ADOSNR" )
         if not sendonly then
             for sid, onlineuser in pairs( _normalstatesids ) do
@@ -1482,6 +1494,12 @@ disconnect = function( client, err, user, quitstring )
             sendtoall( quitstring or ( "IQUI " .. usersid .. "\n" ) )
             scripts_firelistener( "onLogout", user )
         end
+        -- #214 HBRI: drop any pending side-channel token so a user
+        -- disconnecting mid-validation cannot leave it dangling. The
+        -- sweeper also self-heals via the waskilled guard, but this
+        -- frees the token (and its reference to this user object)
+        -- immediately rather than at the timeout deadline.
+        if user._hbri_token then use( "hbri" ).cancel( user ) end
         user.destroy( )
         out_put( "hub.lua: function 'disconnect': remove user ", usersid, " ", ip, ":", port )
     end
@@ -1590,6 +1608,29 @@ loadsettings = function( )    -- caching table lookups...
         -- AFTER inflate and captures decompressed payload bytes
         -- rather than raw deflated wire bytes). Both flags may be
         -- enabled simultaneously.
+    end
+    -- #214 HBRI: (re)bind the secondary-family validator. enter_normal
+    -- re-enters login() with hbri_done=true so a validated (or timed-
+    -- out) HBRI session completes its NORMAL entry. The hub advertises
+    -- / initiates HBRI only when a listener exists on BOTH families AND
+    -- both public advertise addresses are set (see core/hbri.lua). The
+    -- side-channel port is the first plain port for the family, falling
+    -- back to the first TLS port.
+    do
+        local v4_plain, v4_ssl = cfg_get "tcp_ports", cfg_get "ssl_ports"
+        local v6_plain, v6_ssl = cfg_get "tcp_ports_ipv6", cfg_get "ssl_ports_ipv6"
+        local p4 = ( v4_plain and v4_plain[ 1 ] ) or ( v4_ssl and v4_ssl[ 1 ] )
+        local p6 = ( v6_plain and v6_plain[ 1 ] ) or ( v6_ssl and v6_ssl[ 1 ] )
+        use( "hbri" ).bind{
+            enter_normal      = function( u ) login( u, false, true ) end,
+            hbri_enabled      = cfg_get "hbri_enabled",
+            hbri_timeout      = cfg_get "hbri_timeout",
+            hbri_advertise_v4 = cfg_get "hbri_advertise_v4",
+            hbri_advertise_v6 = cfg_get "hbri_advertise_v6",
+            hbri_port_v4      = p4,
+            hbri_port_v6      = p6,
+            hbri_dual_stack   = ( p4 ~= nil ) and ( p6 ~= nil ),
+        }
     end
     _bind_dispatch_module()
 end
@@ -1775,6 +1816,15 @@ init = function( )
     server.addtimer(
         function( )
             scripts_firelistener "onTimer"
+        end
+    )
+    -- #214 HBRI: sweep timed-out secondary-family validation attempts
+    -- (~1s cadence). An attempt whose side-channel did not complete in
+    -- hbri_timeout seconds is failed: the user enters NORMAL with the
+    -- secondary left stripped. Cheap (iterates the small token table).
+    server.addtimer(
+        function( )
+            use( "hbri" ).sweep( )
         end
     )
     cfg.registerevent( "reload", loadlanguage )

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -56,6 +56,7 @@ local signal = use "signal"
 local unicode = use "unicode"
 local util = use "util"
 local os = use "os"
+local hbri = use "hbri"    -- #214 HBRI secondary-family validation
 
 local out_put = out.put
 
@@ -345,6 +346,7 @@ _protocol = {
                 local extras = ""
                 if _cfg_zlif_enabled then extras = extras .. " ADZLIF" end
                 if _cfg_blom_enabled then extras = extras .. " ADBLOM" end
+                if hbri.active( ) then extras = extras .. " ADHBRI" end    -- #214
                 if extras ~= "" then
                     tpl = tpl:gsub( "ADUCMD\n", "ADUCMD" .. extras .. "\n", 1 )
                 end
@@ -360,6 +362,7 @@ _protocol = {
                 local extras = ""
                 if _cfg_zlif_enabled then extras = extras .. " ADZLIF" end
                 if _cfg_blom_enabled then extras = extras .. " ADBLOM" end
+                if hbri.active( ) then extras = extras .. " ADHBRI" end    -- #214
                 if extras ~= "" then
                     tpl = tpl:gsub( "ADUCMD\n", "ADUCMD" .. extras .. "\n", 1 )
                 end
@@ -414,6 +417,18 @@ _protocol = {
     -- others because state != "normal" (hub.lua:1325).
     HQUI = function( user, adccmd )
         user:client():close()
+        return true
+    end,
+    -- #214 HBRI: a fresh connection whose FIRST frame is HTCP (not the
+    -- usual HSUP) is an HBRI side-channel - a client validating its
+    -- secondary IP family for a session it already logged in on. This
+    -- transient connection is never a real hub user: hand it to the
+    -- validator, which checks the token + family + source IP, answers
+    -- ISTA, and closes the socket. No server.lua hook needed - the
+    -- validation socket rides the normal accept path and is identified
+    -- purely by this HTCP+token first frame.
+    HTCP = function( user, adccmd )
+        hbri.validate( user, adccmd )
         return true
     end,
 
@@ -521,6 +536,33 @@ _identify = {
             end
         end
         adccmd:deletenp "PD"
+        -- #214 HBRI: when the hub can validate secondaries, capture the
+        -- client's unverified secondary claim BEFORE Gap 1 strips it so
+        -- HBRI can re-add it after the side-channel proves the address.
+        -- core/hbri.lua's eligible()/initiate() read user._hbri_claim.
+        if hbri.active( ) then
+            local sec_fam = ( userfam == "I4" ) and "I6" or "I4"
+            local sec_ip  = ( sec_fam == "I6" ) and inf_i6 or inf_i4
+            if sec_ip and sec_ip ~= "" then
+                local su_flags = { }
+                local su = adccmd:getnp "SU"
+                if su then
+                    local tcp_flag = ( sec_fam == "I6" ) and "TCP6" or "TCP4"
+                    local udp_flag = ( sec_fam == "I6" ) and "UDP6" or "UDP4"
+                    for tok in su:gmatch( "[^,]+" ) do
+                        if tok == tcp_flag or tok == udp_flag then
+                            su_flags[ #su_flags + 1 ] = tok
+                        end
+                    end
+                end
+                user._hbri_claim = {
+                    family   = sec_fam,
+                    ip       = sec_ip,
+                    udp      = adccmd:getnp( ( sec_fam == "I6" ) and "U6" or "U4" ),
+                    su_flags = su_flags,
+                }
+            end
+        end
         strip_unverified_secondary( adccmd, userfam )
         user:inf( adccmd )
         if user:hasfeature "CCPM" then user:hasccpm( true ) end

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -109,7 +109,18 @@ def override_test_ports(staging_dir: Path):
         (r"tcp_ports\s*=\s*\{[^}]*\}", f"tcp_ports = {{ {TEST_PORT_PLAIN} }}"),
         (r"ssl_ports\s*=\s*\{[^}]*\}", f"ssl_ports = {{ {TEST_PORT_TLS} }}"),
         (r"tcp_ports_ipv6\s*=\s*\{[^}]*\}", f"tcp_ports_ipv6 = {{ {TEST_PORT_PLAIN_V6} }}"),
-        (r"ssl_ports_ipv6\s*=\s*\{[^}]*\}", f"ssl_ports_ipv6 = {{ {TEST_PORT_TLS_V6} }}"),
+        # Append the #214 HBRI knobs onto the ssl_ports_ipv6 line so the
+        # dual-stack validation smoke tests have an HBRI-active hub. HBRI
+        # is opt-in PER CLIENT (only clients advertising ADHBRI in HSUP
+        # ever trigger it), so every other smoke test is unaffected. The
+        # advertise addresses are the loopback addresses the test
+        # listeners already bind; the side-channel port the hub derives
+        # is the first plain port per family (TEST_PORT_PLAIN_V6 here).
+        (r"ssl_ports_ipv6\s*=\s*\{[^}]*\}",
+            f"ssl_ports_ipv6 = {{ {TEST_PORT_TLS_V6} }},\n"
+            f"\thbri_enabled = true,\n"
+            f"\thbri_advertise_v4 = \"{HUB_HOST}\",\n"
+            f"\thbri_advertise_v6 = \"::1\""),
         # Enable event-log writes so tests can assert on parser / dispatcher
         # log traces (e.g. #265 regression test scans event.log for the
         # 'invalid named parameter' line emitted on `nowhitespace` reject).
@@ -1209,6 +1220,195 @@ def test_binf_secondary_family_stripped():
             )
     finally:
         sock.close()
+
+
+def _hbri_param(frame, name):
+    """Extract a named ADC param value (e.g. 'TO', 'P6') from a frame."""
+    for tok in frame.strip().split(" "):
+        if tok.startswith(name):
+            return tok[len(name):]
+    return None
+
+
+def _hbri_main_login(sock):
+    """Drive a dual-stack v4 login that advertises ADHBRI and claims an
+    I6 secondary as the registered `dummy` account. The HBRI-active
+    smoke hub parks such a client in the 'hbri' state after HPAS and
+    sends an ITCP pointer instead of completing NORMAL entry. Returns
+    (reader, sid, itcp_frame)."""
+    reader = _ADCReader(sock)
+    sock.sendall(b"HSUP ADBASE ADTIGR ADHBRI\n")
+    isup = reader.recv_until(lambda f: f.startswith("ISUP "))
+    if "ADHBRI" not in isup:
+        raise TestFailure(f"HBRI-active hub did not advertise ADHBRI in ISUP: {isup!r}")
+    isid = reader.recv_until(lambda f: f.startswith("ISID "))
+    sid = isid.split(" ", 1)[1].strip()
+    reader.recv_until(lambda f: f.startswith("IINF "))
+    pid_bytes = secrets.token_bytes(24)
+    cid_b32 = _b32_encode(_tiger.tiger(pid_bytes))
+    pid_b32 = _b32_encode(pid_bytes)
+    binf = (
+        f"BINF {sid}"
+        f" ID{cid_b32}"
+        f" PD{pid_b32}"
+        f" NIdummy"
+        f" I4127.0.0.1"
+        f" I6::1"
+        f" SUTCP4,TCP6\n"
+    )
+    sock.sendall(binf.encode("utf-8"))
+    gpa = reader.recv_until(lambda f: f.startswith("IGPA "))
+    salt_bytes = _b32_decode(gpa.split(" ", 1)[1].strip())
+    response = _tiger.tiger("test".encode("utf-8") + salt_bytes)
+    sock.sendall(f"HPAS {_b32_encode(response)}\n".encode("utf-8"))
+    itcp = reader.recv_until(
+        lambda f: f.startswith("ITCP ") or f.startswith(f"BINF {sid}") or f.startswith("ISTA "),
+        timeout=PROTOCOL_TIMEOUT_SEC,
+    )
+    if not itcp.startswith("ITCP "):
+        raise TestFailure(
+            f"expected an ITCP HBRI pointer after HPAS (dual-stack + ADHBRI); got {itcp!r}. "
+            f"The hub should park the user in the 'hbri' state, not complete login."
+        )
+    return reader, sid, itcp
+
+
+def test_hbri_success():
+    """#214 HBRI happy path. A dual-stack client logs in over v4
+    advertising ADHBRI + a secondary I6, is parked in the 'hbri' state
+    and sent an ITCP pointer. It opens the v6 side-channel, sends HTCP
+    with the token; the hub validates the v6 TCP source matches the
+    claim and restores the verified I6 to the broadcast INF.
+
+    Falsifiable: without the HBRI mechanism the hub never sends ITCP
+    (login completes immediately) and never restores the stripped I6 -
+    each assert below (ITCP present, ISTA 000 on the side-channel, I6
+    in the broadcast echo) fails."""
+    main = socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    )
+    side = None
+    try:
+        reader, sid, itcp = _hbri_main_login(main)
+        token = _hbri_param(itcp, "TO")
+        port = _hbri_param(itcp, "P6")
+        if not token or not port:
+            raise TestFailure(f"ITCP missing TO / P6 params: {itcp!r}")
+        side = socket.create_connection(
+            ("::1", int(port)), timeout=PROTOCOL_TIMEOUT_SEC
+        )
+        sreader = _ADCReader(side)
+        side.sendall(f"HTCP I6::1 TO{token}\n".encode("utf-8"))
+        sta = sreader.recv_until(lambda f: f.startswith("ISTA "))
+        if not sta.startswith("ISTA 000"):
+            raise TestFailure(
+                f"expected ISTA 000 (validation success) on the side-channel, got {sta!r}"
+            )
+        # The main connection now completes NORMAL entry, broadcasting
+        # the validated secondary.
+        echo = reader.recv_until(
+            lambda f: f.startswith(f"BINF {sid}"), timeout=PROTOCOL_TIMEOUT_SEC
+        )
+        params = echo.strip().split(" ")
+        if not any(p == "I6::1" for p in params):
+            raise TestFailure(
+                f"validated secondary I6 was not restored to the broadcast INF: {echo!r}"
+            )
+    finally:
+        try:
+            main.close()
+        except OSError:
+            pass
+        if side:
+            try:
+                side.close()
+            except OSError:
+                pass
+
+
+def test_hbri_timeout():
+    """#214 HBRI timeout. If the client never opens the side-channel,
+    the hub's sweep fails the attempt after hbri_timeout seconds, sends
+    ISTA 155, and lets the client into the hub WITHOUT the unverified
+    secondary (it stays stripped, per Gap 1).
+
+    Falsifiable: a hub that committed the secondary without validation
+    leaks I6 into the echo; a hub that never released the parked user
+    never sends the BINF echo at all."""
+    main = socket.create_connection((HUB_HOST, TEST_PORT_PLAIN), timeout=12)
+    try:
+        reader, sid, itcp = _hbri_main_login(main)
+        # Do NOT open the side-channel. The hub fails the attempt on the
+        # ~1s sweep once hbri_timeout (5s) elapses: ISTA 155 first, then
+        # the completed-login BINF echo (without I6).
+        sta = reader.recv_until(
+            lambda f: f.startswith("ISTA 155") or f.startswith(f"BINF {sid}"),
+            timeout=11,
+        )
+        if sta.startswith(f"BINF {sid}"):
+            raise TestFailure(
+                f"expected ISTA 155 (validation timed out) before login completed, got {sta!r}"
+            )
+        echo = reader.recv_until(
+            lambda f: f.startswith(f"BINF {sid}"), timeout=PROTOCOL_TIMEOUT_SEC
+        )
+        params = echo.strip().split(" ")
+        if any(p == "I6::1" for p in params):
+            raise TestFailure(
+                f"unverified secondary I6 leaked into the broadcast INF after timeout: {echo!r}"
+            )
+    finally:
+        try:
+            main.close()
+        except OSError:
+            pass
+
+
+def test_hbri_unknown_token():
+    """#214 HBRI: an HTCP on a fresh connection bearing a token the hub
+    never minted is rejected with ISTA 220 and the socket closed. Stops
+    a blind attacker from completing (or probing) someone else's HBRI
+    validation."""
+    side = socket.create_connection(
+        ("::1", TEST_PORT_PLAIN_V6), timeout=PROTOCOL_TIMEOUT_SEC
+    )
+    try:
+        sreader = _ADCReader(side)
+        side.sendall(b"HTCP I6::1 TOAAAAAAAAAAAAAAAA\n")
+        sta = sreader.recv_until(lambda f: f.startswith("ISTA "))
+        if not sta.startswith("ISTA 220"):
+            raise TestFailure(
+                f"expected ISTA 220 (unknown validation token), got {sta!r}"
+            )
+    finally:
+        try:
+            side.close()
+        except OSError:
+            pass
+
+
+def test_hbri_disconnect_cleanup():
+    """#214 HBRI: a client that is parked in the 'hbri' state and then
+    drops its main connection (never validating) must be cleaned up
+    without wedging the hub - the pending token is cancelled and the
+    transient parked user torn down. Exercises the disconnect-mid-HBRI
+    path (the cancel hook) and confirms the hub still serves a fresh
+    login afterwards. The end-of-run 'no script errors' canary catches
+    any crash in the teardown."""
+    main = socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    )
+    try:
+        reader, sid, itcp = _hbri_main_login(main)
+        # Parked in 'hbri'; drop the main connection without validating.
+    finally:
+        try:
+            main.close()
+        except OSError:
+            pass
+    # The hub must remain healthy: a fresh normal login still succeeds.
+    with _logged_in_user("dummy", "test") as (sock, sid2, reader2):
+        _assert_adc_alive(sock)
 
 
 def test_post_login_i4_silent_stripped():
@@ -9917,6 +10117,10 @@ TESTS = [
     ("BINF without I4/I6 accepted (#161)", test_binf_without_i4_or_i6_accepted),
     ("BINF with both I4 and I6 accepted (#147 T3.1 HBRI)", test_binf_with_both_i4_and_i6_accepted),
     ("BINF unverified secondary family stripped (#214 Gap 1)", test_binf_secondary_family_stripped),
+    ("HBRI success: side-channel validates secondary (#214)", test_hbri_success),
+    ("HBRI timeout: unvalidated secondary stays stripped (#214)", test_hbri_timeout),
+    ("HBRI unknown token rejected (#214)", test_hbri_unknown_token),
+    ("HBRI disconnect mid-validation cleans up (#214)", test_hbri_disconnect_cleanup),
     ("post-login INF with I4 silent-stripped (#222)", test_post_login_i4_silent_stripped),
     ("CSPRNG salts are unique across connections", test_csprng_salt_uniqueness),
     ("per-IP connection cap refuses overflow", test_perip_connection_cap),


### PR DESCRIPTION
Part of #214 (PR-B of the secure-first split). Builds on PR-A (#283).

## What

HBRI (Hub-Bridged Reverse Initiation) verifies a dual-stack client's **secondary** IP family over a second-family side-channel connection, so the hub can safely broadcast it. PR-A strips the unverified secondary (DC++ DDoS-amplification safety); PR-B re-adds it **only after** validation.

## Flow

1. Client logs in on family X advertising `ADHBRI` + a secondary `IY` in BINF.
2. After HPAS the hub mints a CSPRNG token, sends `ITCP IY<hub-addr> PY<port> TO<token>`, parks the user in a new `"hbri"` state (NOT yet in the normal-users table).
3. Client opens a second TCP connection on family Y and sends `HTCP IY<addr> TO<token>`. That fresh connection's first frame routes to the validator (`_protocol.HTCP`).
4. Validator checks: token known + single-use; validation-socket family == expected secondary (and != main family); validation-socket real TCP source matches. On success the **authenticated TCP-source IP** (never a client-supplied value) is committed to the main user's INF and the user enters NORMAL, broadcasting the validated secondary.
5. On failure or a `hbri_timeout`-second timeout (swept on the ~1s hub timer): NORMAL entry with the secondary left stripped.

No `core/server.lua` change - the validation socket rides the normal accept path, identified purely by its `HTCP`+token first frame.

## Files

- **core/hbri.lua** (new): token table, `mint`/`validate`/`sweep`/`fail`/`cancel`. CSPRNG token via `adclib.createsalt` (OpenSSL `RAND_bytes`).
- **core/hub.lua**: `login()` + `hbri_done` param and HBRI fork; `hbri.bind` in `loadsettings`; sweep timer; token cancel in `disconnect`.
- **core/hub_dispatch.lua**: pre-strip claim capture in `_identify.BINF`; `_protocol.HTCP` validator; `ADHBRI` in the two SUP advertise blocks (gated on `hbri.active()`).
- **core/adc.lua**: register the `TCP` command, **H-context only**, so inbound `HTCP` parses through.
- **core/cfg_defaults.lua**: `hbri_enabled` (default `false`), `hbri_timeout` (1..60), `hbri_advertise_v4`/`v6` (whitespace/control rejected -> no ITCP frame injection).

Opt-in + gated: advertised/initiated only when `hbri_enabled` AND a listener exists on both families AND both advertise addresses are set; otherwise the secondary stays stripped (PR-A behaviour).

## Security (maintainer's "no attack vector" priority)

- Token = 80-bit OpenSSL-CSPRNG, sent only to the authenticated client, single-use, unknown -> `ISTA 220` + close.
- Committed secondary is always the validation socket's real TCP source - no client-supplied address is ever broadcast.
- Parked `"hbri"` user is never in `_normalstatesids`, so invisible/inert until validated.
- Parser widening fenced to `[H]` (no `BTCP`/`DTCP`).
- Token table bounded; freed on success/failure/timeout/disconnect.

## Review

Two-pass (CLAUDE.md 1a.6): independent reviewer flagged one blocker (disconnect cancel hook landed in dead commented code) + one concern (advertise validators accepted whitespace -> frame injection); both fixed in this PR. Maintainer spot-check confirmed the committed address is the authenticated source and there is no path that broadcasts an unverified secondary.

## Tests

`tests/smoke/run.py` enables HBRI in the staging cfg (opt-in per client, so other tests are unaffected) + four tests: success, timeout, unknown-token, disconnect-mid-validation cleanup. Falsifiable by construction (without the mechanism the login never yields ITCP; `HTCP` draws `ISTA 125` not `220`).

## Out of scope (-> PR-C)

`#147` doc correction, `docs/SECURITY.md` rewrite, example `cfg.tbl` discoverability block, consumer audit.

## Test plan
- [x] `python tests/smoke/run.py build/install/luadch` green (Windows), incl. 4 HBRI tests
- [x] Baseline smoke green with HBRI disabled (no-op)
- [ ] CI smoke green on Linux + Windows