### PR TITLE
docs(hub): HBRI holistic-review follow-up - comment/doc accuracy (#214)

### DIFF
--- a/core/hbri.lua
+++ b/core/hbri.lua
@@ -59,7 +59,7 @@ local os_time           = os.time
 -- // and the per-reload cfg caches.
 local enter_normal           -- enter_normal(user): runs the deferred login
 local _enabled               -- hbri_enabled cfg
-local _timeout               -- hbri_timeout seconds (clamped)
+local _timeout               -- hbri_timeout seconds (cfg-validated 1..60)
 local _advertise = { I4 = "", I6 = "" }   -- hub public address per family
 local _port      = { I4 = nil,  I6 = nil } -- plain listener port per family
 local _dual_stack = false    -- a plain listener exists on BOTH families
@@ -168,10 +168,11 @@ local function commit_and_complete( entry, verified_ip )
     enter_normal( user )
 end
 
--- // Give up on the secondary: drop the ADHBRI support flag (no
--- // post-login retry loop) and enter NORMAL with the secondary still
--- // stripped. The user stays connected; only the secondary family is
--- // unverified.
+-- // Give up on the secondary and enter NORMAL with it still stripped.
+-- // The user stays connected; only the secondary family is unverified.
+-- // No post-login retry: the secondary is never re-offered (post-login
+-- // INF updates carrying I4 / I6 are stripped by hub_inf_manager), so
+-- // there is no loop to guard against and no support flag to clear.
 local function fail( entry )
     local user = entry.user
     user._hbri_token = nil

--- a/scripts/hub_inf_manager.lua
+++ b/scripts/hub_inf_manager.lua
@@ -79,13 +79,15 @@ local forbidden = {
     -- (stored _inf never mutated, broadcast doesn't carry the new
     -- claim) without disconnecting legitimate sessions.
     --
-    -- T3.1 HBRI re-affirms this: under HBRI a BINF carries BOTH
-    -- I4 and I6, but the hub validates only the family that
-    -- matches the TCP source. The other family is unverified-
-    -- but-stored. If a future contributor relaxes the post-login
-    -- strip on the assumption "hub validated I4 / I6 at BINF so
-    -- post-login mutation is OK", they re-open #97 because the
-    -- OTHER family was never validated to begin with.
+    -- Dual-stack (#147 T3.1 / #214): a BINF may carry BOTH I4 and
+    -- I6, but the hub authenticates only the family matching the TCP
+    -- source. The OTHER family is stripped before broadcast (#214
+    -- Gap 1) unless proven via the HBRI side-channel at login. Post-
+    -- login INF mutation is NEVER validated, so I4 / I6 stay forbidden
+    -- here: a future contributor relaxing this on the assumption "the
+    -- hub validated I4 / I6 at BINF so post-login mutation is OK"
+    -- re-opens #97, because the secondary family was never accepted
+    -- unvalidated at BINF either - only stripped or HBRI-proven.
     flags_on_inf_strip = {
 
         "I4",

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -1105,8 +1105,8 @@ def test_binf_with_both_i4_and_i6_accepted():
             raise TestFailure(
                 f"hub rejected dual-stack BINF with ISTA 246 invalid_ip: "
                 f"{frame!r}. T3.1 must validate ONLY the family matching "
-                f"the TCP source (I6 here); the I4 is the 'other family' "
-                f"and stays unverified-but-stored."
+                f"the TCP source (I6 here); the I4 is the 'other family', "
+                f"accepted on login then stripped before broadcast (#214 Gap 1)."
             )
         if frame.startswith("ISTA "):
             raise TestFailure(
@@ -1334,15 +1334,16 @@ def test_hbri_timeout():
     Falsifiable: a hub that committed the secondary without validation
     leaks I6 into the echo; a hub that never released the parked user
     never sends the BINF echo at all."""
-    main = socket.create_connection((HUB_HOST, TEST_PORT_PLAIN), timeout=12)
+    main = socket.create_connection((HUB_HOST, TEST_PORT_PLAIN), timeout=20)
     try:
         reader, sid, itcp = _hbri_main_login(main)
         # Do NOT open the side-channel. The hub fails the attempt on the
         # ~1s sweep once hbri_timeout (5s) elapses: ISTA 155 first, then
-        # the completed-login BINF echo (without I6).
+        # the completed-login BINF echo (without I6). Worst case is ~6s;
+        # the generous recv window keeps this robust under heavy CI load.
         sta = reader.recv_until(
             lambda f: f.startswith("ISTA 155") or f.startswith(f"BINF {sid}"),
-            timeout=11,
+            timeout=18,
         )
         if sta.startswith(f"BINF {sid}"):
             raise TestFailure(


### PR DESCRIPTION
Post-merge follow-up addressing the non-blocking findings from the 3-agent holistic review of the #214 HBRI arc (#283 / #284 / #285). **Comment / text + test-timing only - no logic change.**

The review verdict was clean: no exploitable attack vector, no correctness bug, no blocker. It surfaced four stale-comment / stale-text spots and one tracked feature gap:

- **core/hbri.lua** - `fail()` comment claimed it drops the ADHBRI support flag (it never did, and need not - post-login I4/I6 are stripped so HBRI is not retried); `_timeout` "(clamped)" comment (cfg *validates* 1..60, doesn't clamp). Both reworded to match the code.
- **scripts/hub_inf_manager.lua** - the post-login-strip rationale still said "unverified-but-stored", contradicting the merged Gap-1 strip. Reworded; the #97/#222 forbid-on-post-login invariant is preserved.
- **tests/smoke/run.py** - drop the stale "unverified-but-stored" phrase from a TestFailure message; widen `test_hbri_timeout`'s recv window (worst case ~6s) for robustness under heavy CI load.

The one feature gap (a secondary advertised only in a post-login INF can never be validated - safe, but a gap vs adchpp) is tracked in #286, not fixed here.

## Test plan
- [x] `python tests/smoke/run.py build/install/luadch` green (Windows), all 6 dual-stack/HBRI tests pass
- [ ] CI smoke green on Linux + Windows