### PR TITLE
fix(hub): don't solicit HBRI for clients without a secondary (#214)

### DIFF
--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -542,8 +542,18 @@ _identify = {
         -- core/hbri.lua's eligible()/initiate() read user._hbri_claim.
         if hbri.active( ) then
             local sec_fam = ( userfam == "I4" ) and "I6" or "I4"
-            local sec_ip  = ( sec_fam == "I6" ) and inf_i6 or inf_i4
-            if sec_ip and sec_ip ~= "" then
+            -- NOT `(sec_fam=="I6") and inf_i6 or inf_i4`: the and/or
+            -- ternary returns inf_i4 when inf_i6 is nil (the classic Lua
+            -- trap), which would mint a bogus secondary claim for every
+            -- v4 client that sent only I4 -> spurious HBRI + 5s timeout
+            -- on every such login. Branch explicitly.
+            local sec_ip
+            if sec_fam == "I6" then sec_ip = inf_i6 else sec_ip = inf_i4 end
+            -- A spec placeholder (0.0.0.0 / ::) means "no real secondary
+            -- for this family" - treat it as absent so we do not solicit
+            -- a pointless side-channel (mirrors the primary-family
+            -- placeholder handling above).
+            if sec_ip and sec_ip ~= "" and sec_ip ~= "0.0.0.0" and sec_ip ~= "::" then
                 local su_flags = { }
                 local su = adccmd:getnp "SU"
                 if su then

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -1411,6 +1411,64 @@ def test_hbri_disconnect_cleanup():
         _assert_adc_alive(sock)
 
 
+def test_hbri_no_secondary_no_solicit():
+    """#214 regression: a client that advertises ADHBRI but connects on
+    one family WITHOUT a secondary (the common case - e.g. a v4-only
+    AirDC++) must NOT be solicited for HBRI. It logs in immediately; no
+    ITCP, no timeout delay.
+
+    Guards the and/or-ternary trap (`(sec_fam=="I6") and inf_i6 or
+    inf_i4`) that minted a bogus '0.0.0.0' secondary claim for every v4
+    client sending only I4, making every such login eat the ~5s HBRI
+    timeout. Caught via a live AirDC++ 4.30 test, missed by the other
+    HBRI smoke tests because they all send a real I6.
+
+    Falsifiable: on the buggy code the hub sends an ITCP right after
+    HPAS (the assert below fires); on the fix the next frame is the
+    login BINF echo."""
+    main = socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    )
+    try:
+        reader = _ADCReader(main)
+        main.sendall(b"HSUP ADBASE ADTIGR ADHBRI\n")
+        reader.recv_until(lambda f: f.startswith("ISUP "))
+        isid = reader.recv_until(lambda f: f.startswith("ISID "))
+        sid = isid.split(" ", 1)[1].strip()
+        reader.recv_until(lambda f: f.startswith("IINF "))
+        pid_bytes = secrets.token_bytes(24)
+        cid_b32 = _b32_encode(_tiger.tiger(pid_bytes))
+        pid_b32 = _b32_encode(pid_bytes)
+        # v4 connection, ADHBRI advertised, NO I6 secondary - mirrors a
+        # real v4 AirDC++ login (passive I40.0.0.0, SU TCP4/UDP4 only).
+        binf = (
+            f"BINF {sid} ID{cid_b32} PD{pid_b32} NIdummy"
+            f" I40.0.0.0 SUTCP4,UDP4\n"
+        )
+        main.sendall(binf.encode("utf-8"))
+        gpa = reader.recv_until(lambda f: f.startswith("IGPA "))
+        salt_bytes = _b32_decode(gpa.split(" ", 1)[1].strip())
+        response = _tiger.tiger("test".encode("utf-8") + salt_bytes)
+        main.sendall(f"HPAS {_b32_encode(response)}\n".encode("utf-8"))
+        # Promptly (well under hbri_timeout=5s) the hub must complete the
+        # login with the BINF echo and must NEVER send an ITCP.
+        frame = reader.recv_until(
+            lambda f: f.startswith("ITCP ") or f.startswith(f"BINF {sid}"),
+            timeout=3,
+        )
+        if frame.startswith("ITCP "):
+            raise TestFailure(
+                f"hub solicited HBRI for a client with NO secondary: {frame!r}. "
+                f"A client advertising ADHBRI but no I6 must not be HBRI'd "
+                f"(the and/or-ternary bogus-claim regression)."
+            )
+    finally:
+        try:
+            main.close()
+        except OSError:
+            pass
+
+
 def test_post_login_i4_silent_stripped():
     """#222: post-login BINF carrying `I4 <new_ip>` MUST be silent-
     stripped, not killed. Pre-fix the `forbidden.flags_on_inf` check
@@ -10121,6 +10179,7 @@ TESTS = [
     ("HBRI timeout: unvalidated secondary stays stripped (#214)", test_hbri_timeout),
     ("HBRI unknown token rejected (#214)", test_hbri_unknown_token),
     ("HBRI disconnect mid-validation cleans up (#214)", test_hbri_disconnect_cleanup),
+    ("HBRI not solicited for client without secondary (#214)", test_hbri_no_secondary_no_solicit),
     ("post-login INF with I4 silent-stripped (#222)", test_post_login_i4_silent_stripped),
     ("CSPRNG salts are unique across connections", test_csprng_salt_uniqueness),
     ("per-IP connection cap refuses overflow", test_perip_connection_cap),


### PR DESCRIPTION
Regression from #284 (HBRI), caught by a live AirDC++ 4.30 test.

## Symptom

On an HBRI-enabled hub, a v4 client that advertises `ADHBRI` but has **no** secondary IPv6 (the common case - e.g. a host with only IPv4) was sent a pointless `ITCP` and its login only completed after the ~5s HBRI timeout (`ISTA 155 ... timed out`). End state was correct (no I6 broadcast), but every such login ate a 5-second delay.

Live log excerpt:
```
... BINF ... SUSEGA,ADC0,CCPM,TCP4,UDP4,ASCH I40.0.0.0 U431242     <- no I6
... sent 'ITCP I62a14:...:a P65004 TO...'                          <- spurious
(5s later) sent 'ISTA 155 Secondary address validation timed out'
```

## Root cause

The secondary-claim capture in `_identify.BINF` used the Lua and/or ternary:

```lua
local sec_ip = ( sec_fam == "I6" ) and inf_i6 or inf_i4
```

When the connecting family is v4 (`sec_fam == "I6"`) and the client sent no `I6`, `inf_i6` is nil, so `(true and nil) or inf_i4` returns `inf_i4` - minting a bogus secondary claim `{ family = "I6", ip = <client's I4> }`. `eligible()` then passed and `initiate()` fired the ITCP.

## Fix

- Branch explicitly instead of the and/or ternary.
- Treat a spec placeholder (`0.0.0.0` / `::`) secondary as absent too, so a passive client is not solicited either (mirrors the primary-family placeholder handling).

## Why the smoke suite missed it

All existing HBRI tests send a **real** `I6`, so the `and` branch was always taken correctly. New regression test `test_hbri_no_secondary_no_solicit`: a v4 client advertising `ADHBRI` with no `I6` must complete login promptly with **no** ITCP.

- Falsifiable (CLAUDE.md 1a.7): with the buggy ternary restored the test FAILS (`hub solicited HBRI for a client with NO secondary: 'ITCP I6::1 ...'`), reproducing the live symptom; passes on the fix.
- Full smoke suite green (Windows), all 7 dual-stack/HBRI tests.

3.2.x only (HBRI is master-only), no backport.

## Test plan
- [x] smoke green with fix; new regression test passes
- [x] falsifiability demonstrated (fails on buggy ternary)
- [ ] CI smoke green on Linux + Windows