### PR TITLE
feat(regserver-announce): send SS (total hub share) in the IINF

### DIFF
--- a/scripts/etc_regserver_announce.lua
+++ b/scripts/etc_regserver_announce.lua
@@ -27,8 +27,11 @@
         the single-threaded hub never freezes on a slow/unreachable
         regserver. Only PUBLIC hub fields are sent (name / app /
         version / address / description / website / network / owner /
-        user count) - never any secret or internal state.
+        user count / total share) - never any secret or internal state.
 
+        v0.04: send SS (total hub share, summed over humans-only
+               users) in the IINF so the regserver can expose a
+               `share` field in its flat hublist output.
         v0.03: don't log a checkfile error on first start when the
                state file does not exist yet (probe with io.open
                before util.loadtable; the HubSecurity bot was
@@ -43,7 +46,7 @@
 --// settings begin //--
 
 local scriptname = "etc_regserver_announce"
-local scriptversion = "0.03"
+local scriptversion = "0.04"
 
 --// settings end //--
 
@@ -126,9 +129,16 @@ end
 -- empty optional fields are omitted.
 local build_iinf = function( hh )
     local online = 0
+    local total_share = 0
     local nobots = hub_getusers( )    -- first return = humans-only
     if type( nobots ) == "table" then
-        for _ in pairs( nobots ) do online = online + 1 end
+        for _, u in pairs( nobots ) do
+            online = online + 1
+            -- u:share() is the F-INF-2-clamped accessor (>=0). Bots are
+            -- excluded already (humans-only table); guard the method in
+            -- case a future user object omits it.
+            if u and u.share then total_share = total_share + ( u:share( ) or 0 ) end
+        end
     end
     local fields = {
         { "NI", cfg_get( "hub_name" ) },
@@ -140,6 +150,9 @@ local build_iinf = function( hh )
         { "NE", cfg_get( "hub_network" ) },
         { "OW", cfg_get( "hub_owner" ) },
         { "UC", tostring( online ) },
+        -- SS = total bytes shared across the hub (ADC-EXT 3.4.1); the
+        -- regserver exposes it as the flat-output `share` field.
+        { "SS", tostring( total_share ) },
     }
     local parts = { "IINF" }
     for _, f in ipairs( fields ) do


### PR DESCRIPTION
The standalone regserver ([Aybook/regserver](https://github.com/Aybook/regserver)) gained a flat hublist output with a `share` field (for Hades's PHP frontend). This populates it from the hub side.

## Change

`scripts/etc_regserver_announce.lua` (v0.03 → v0.04): `build_iinf` now sums each humans-only user's share via the F-INF-2-clamped `user:share()` accessor and sends it as `SS` (ADC-EXT 3.4.1) alongside the existing public fields (`NI/AP/VE/HH/DE/WS/NE/OW/UC`).

- Bots are already excluded (the humans-only `hub.getusers()` table); the `u.share and ...` guard is defensive.
- Only PUBLIC aggregate data - consistent with the rest of the announced IINF (no per-user detail, no secrets).

## Test

Existing smoke `regserver announce (http_client e2e)` passes (the IINF POST with the new `SS` field reaches the loopback fake regserver and the hub answers a normal ADC handshake). Full suite green locally (Windows).

3.2.x only.

## Test plan
- [x] `python tests/smoke/run.py build/install/luadch` green incl. regserver-announce e2e
- [ ] CI smoke green on Linux + Windows