### PR TITLE
fix(server): guard timer loop against a list cleared mid-iteration

### DIFF
--- a/core/server.lua
+++ b/core/server.lua
@@ -1200,7 +1200,12 @@ tick = function( )
                 elseif status ~= "running" then
                     coroutine.resume(timer)
                 end
-            else
+            elseif timer then
+                -- `_timerlistlen` is captured once as the numeric-for
+                -- bound; if a timer callback clears the timer list
+                -- mid-loop (killall() on graceful shutdown sets
+                -- `_timerlist = {}`), the remaining slots read nil. Skip
+                -- them instead of calling nil (teardown-time crash).
                 timer( )
             end
         end


### PR DESCRIPTION
## Symptom

On graceful (SIGTERM / `docker compose down`) shutdown the hub logs:

```
core/server.lua:1204: attempt to call a nil value (local 'timer')
```

Harmless to the running hub - it fires during teardown, after sockets are closed and state is saved - but a real latent bug. Surfaced while deploying the hub in Docker host-mode; pre-existing and independent of how many timers are registered (HBRI's sweep timer just made it more visible).

## Cause

`tick()`'s per-second timer loop uses `for i = 1, _timerlistlen`, which captures the bound once. `killall()` (graceful shutdown) sets `_timerlist = {}` and `_timerlistlen = 0`. If that happens while the loop is iterating, the remaining slots read `nil` and the `else` branch called `timer()` on nil.

## Fix

Skip nil slots (`elseif timer then`) instead of calling them. A valid timer (function or thread) is always truthy, so **normal operation is byte-identical** - only a nil left by a mid-loop clear is now skipped instead of crashing.

## Testing

Full smoke green (Windows) - no regression in boot/run. The crash itself is **not smoke-reproducible**: the harness SIGKILLs the hub, so the graceful timer-during-shutdown path never runs. The fix is a minimal, provably non-regressive guard (a valid timer is always truthy).

3.2.x only.

## Test plan
- [x] `python tests/smoke/run.py build/install/luadch` green
- [ ] CI smoke green on Linux + Windows