### PR TITLE
feat(hbri): discover secondary via placeholder I6:: at login (#291)

### DIFF
--- a/core/hbri.lua
+++ b/core/hbri.lua
@@ -67,11 +67,14 @@ local _dual_stack = false    -- a plain listener exists on BOTH families
 -- // token table: token -> {
 -- //   user        = main user object,
 -- //   family      = expected secondary family ("I4" | "I6"),
--- //   claimed_ip  = secondary address the client advertised in BINF,
 -- //   claimed_udp = secondary UDP port (string) or nil,
 -- //   su_flags    = { secondary transport flags present in BINF SU },
 -- //   deadline    = os.time() second past which the attempt times out,
 -- // }
+-- // The BINF-claimed secondary ADDRESS is deliberately NOT stored:
+-- // validate() only ever commits the validation socket's getpeername
+-- // (the authenticated source), never a client-stated address. Keeping
+-- // it out of the table makes that invariant structural (#291).
 local _tokens = { }
 
 -- // The IP family of an address string: ADC IPv6 contains ":".
@@ -128,7 +131,6 @@ local function initiate( user )
     _tokens[ token ] = {
         user        = user,
         family      = sec_fam,
-        claimed_ip  = claim.ip,
         claimed_udp = claim.udp,
         su_flags    = claim.su_flags or { },
         deadline    = os_time( ) + _timeout,
@@ -215,10 +217,15 @@ local function validate( vuser, adccmd )
         return
     end
 
-    -- The address the client claims on the validation socket must
-    -- match the socket's real TCP source (anti-spoof).
+    -- #291: a placeholder (or absent) claimed value on the validation
+    -- socket is a DISCOVERY request - "learn my address from this
+    -- connection's source". Commit the authenticated getpeername (done
+    -- below); the placeholder is not an address to cross-check. Only a
+    -- CONCRETE stated address must equal the socket's real TCP source
+    -- (anti-spoof of a self-named address). Mirrors adchpp validateIP.
     local claimed = adccmd:getnp( entry.family )
-    if claimed and claimed ~= vip then
+    if claimed and claimed ~= "" and claimed ~= "0.0.0.0" and claimed ~= "::"
+            and claimed ~= vip then
         vuser.write( "ISTA 155 " .. "Validation\\saddress\\smismatch" .. "\n" )
         vuser:client( ):close( )
         fail( entry )

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -549,11 +549,17 @@ _identify = {
             -- on every such login. Branch explicitly.
             local sec_ip
             if sec_fam == "I6" then sec_ip = inf_i6 else sec_ip = inf_i4 end
-            -- A spec placeholder (0.0.0.0 / ::) means "no real secondary
-            -- for this family" - treat it as absent so we do not solicit
-            -- a pointless side-channel (mirrors the primary-family
-            -- placeholder handling above).
-            if sec_ip and sec_ip ~= "" and sec_ip ~= "0.0.0.0" and sec_ip ~= "::" then
+            -- #291: a non-empty secondary field is an HBRI request even
+            -- when it is the spec placeholder (0.0.0.0 / ::). Per the
+            -- adchpp HBRI contract the placeholder means "I'm capable on
+            -- this family but cannot self-report my address; discover it
+            -- via the side-channel getpeername()" - the COMMON real-client
+            -- case (AirDC++ auto-detect). hbri.validate() commits the
+            -- authenticated socket source for a placeholder claim and
+            -- only cross-checks a CONCRETE stated address. A genuinely
+            -- ABSENT field (nil / "") - the family is not offered at all -
+            -- must NOT be solicited (the #288 v4-only-client guard, above).
+            if sec_ip and sec_ip ~= "" then
                 local su_flags = { }
                 local su = adccmd:getnp "SU"
                 if su then

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -1229,12 +1229,15 @@ def _hbri_param(frame, name):
     return None
 
 
-def _hbri_main_login(sock):
-    """Drive a dual-stack v4 login that advertises ADHBRI and claims an
-    I6 secondary as the registered `dummy` account. The HBRI-active
-    smoke hub parks such a client in the 'hbri' state after HPAS and
-    sends an ITCP pointer instead of completing NORMAL entry. Returns
-    (reader, sid, itcp_frame)."""
+def _hbri_main_login(sock, i6="::1"):
+    """Drive a dual-stack v4 login that advertises ADHBRI and a secondary
+    I6 as the registered `dummy` account. The HBRI-active smoke hub parks
+    such a client in the 'hbri' state after HPAS and sends an ITCP pointer
+    instead of completing NORMAL entry. Returns (reader, sid, itcp_frame).
+
+    `i6` is the secondary value placed in the BINF: the default "::1" is a
+    concrete v6 (verify path); pass "::" to drive the #291 discovery path
+    (placeholder = "discover my v6 from the side-channel getpeername")."""
     reader = _ADCReader(sock)
     sock.sendall(b"HSUP ADBASE ADTIGR ADHBRI\n")
     isup = reader.recv_until(lambda f: f.startswith("ISUP "))
@@ -1252,7 +1255,7 @@ def _hbri_main_login(sock):
         f" PD{pid_b32}"
         f" NIdummy"
         f" I4127.0.0.1"
-        f" I6::1"
+        f" I6{i6}"
         f" SUTCP4,TCP6\n"
     )
     sock.sendall(binf.encode("utf-8"))
@@ -1312,6 +1315,121 @@ def test_hbri_success():
         if not any(p == "I6::1" for p in params):
             raise TestFailure(
                 f"validated secondary I6 was not restored to the broadcast INF: {echo!r}"
+            )
+    finally:
+        try:
+            main.close()
+        except OSError:
+            pass
+        if side:
+            try:
+                side.close()
+            except OSError:
+                pass
+
+
+def test_hbri_discovery_placeholder():
+    """#291 HBRI discovery - the common real-client path. A dual-stack
+    client connects over v4 advertising ADHBRI + SU TCP6 but sends the v6
+    PLACEHOLDER (I6::, "discover my address"), exactly what auto-detect
+    AirDC++ emits. The hub must (1) solicit HBRI for the placeholder and
+    (2) on the side-channel DISCOVER the v6 from getpeername rather than
+    reject the placeholder as an address mismatch - then broadcast the
+    discovered I6.
+
+    Two coupled regressions guarded (both pre-#291):
+      1. claim-capture skipped placeholders (:: / 0.0.0.0) -> no ITCP for
+         the common case, so HBRI never fired for real clients.
+      2. validate() rejected a placeholder claimed value as a mismatch
+         (claimed '::' != getpeername '::1') -> ISTA 155 not success.
+
+    Falsifiable: pre-fix the hub either never sends ITCP (regression 1,
+    _hbri_main_login's ITCP assert fires) or answers ISTA 155 on the
+    side-channel (regression 2); post-fix it answers ISTA 000 and the
+    discovered I6::1 appears in the broadcast echo."""
+    main = socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    )
+    side = None
+    try:
+        reader, sid, itcp = _hbri_main_login(main, i6="::")
+        token = _hbri_param(itcp, "TO")
+        port = _hbri_param(itcp, "P6")
+        if not token or not port:
+            raise TestFailure(f"ITCP missing TO / P6 params: {itcp!r}")
+        side = socket.create_connection(
+            ("::1", int(port)), timeout=PROTOCOL_TIMEOUT_SEC
+        )
+        sreader = _ADCReader(side)
+        # Placeholder on the side-channel too: the hub must discover the v6
+        # from the socket source (::1), not trust this stated value.
+        side.sendall(f"HTCP I6:: TO{token}\n".encode("utf-8"))
+        sta = sreader.recv_until(lambda f: f.startswith("ISTA "))
+        if not sta.startswith("ISTA 000"):
+            raise TestFailure(
+                f"expected ISTA 000 (discovery validation success) on the side-channel, got {sta!r}"
+            )
+        echo = reader.recv_until(
+            lambda f: f.startswith(f"BINF {sid}"), timeout=PROTOCOL_TIMEOUT_SEC
+        )
+        params = echo.strip().split(" ")
+        if not any(p == "I6::1" for p in params):
+            raise TestFailure(
+                f"discovered secondary I6 (getpeername ::1) was not committed to the broadcast INF: {echo!r}"
+            )
+    finally:
+        try:
+            main.close()
+        except OSError:
+            pass
+        if side:
+            try:
+                side.close()
+            except OSError:
+                pass
+
+
+def test_hbri_concrete_mismatch_rejected():
+    """#291 anti-spoof: a client that states a CONCRETE secondary address
+    on the validation socket which does NOT equal the socket's real TCP
+    source (getpeername) is rejected with ISTA 155 - the hub never accepts
+    a self-named address that the side-channel cannot prove. (The #291
+    discovery relaxation only exempts the placeholder ::/0.0.0.0; a
+    concrete claim is still cross-checked, exactly as adchpp validateIP.)
+
+    Falsifiable: drop the `claimed ~= vip` reject and the side-channel
+    answers ISTA 000 (the validation would succeed, committing getpeername
+    silently under a mismatched stated address) - the assert below fires."""
+    main = socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    )
+    side = None
+    try:
+        # Concrete secondary in the BINF (verify path, not discovery).
+        reader, sid, itcp = _hbri_main_login(main, i6="2001:db8::dead")
+        token = _hbri_param(itcp, "TO")
+        port = _hbri_param(itcp, "P6")
+        if not token or not port:
+            raise TestFailure(f"ITCP missing TO / P6 params: {itcp!r}")
+        side = socket.create_connection(
+            ("::1", int(port)), timeout=PROTOCOL_TIMEOUT_SEC
+        )
+        sreader = _ADCReader(side)
+        # Side-channel states a concrete v6 that is NOT the real source
+        # (::1). The hub must reject the mismatch, not commit it.
+        side.sendall(f"HTCP I62001:db8::dead TO{token}\n".encode("utf-8"))
+        sta = sreader.recv_until(lambda f: f.startswith("ISTA "))
+        if not sta.startswith("ISTA 155"):
+            raise TestFailure(
+                f"expected ISTA 155 (concrete address mismatch) on the side-channel, got {sta!r}"
+            )
+        # Login still completes, WITHOUT the bogus secondary.
+        echo = reader.recv_until(
+            lambda f: f.startswith(f"BINF {sid}"), timeout=PROTOCOL_TIMEOUT_SEC
+        )
+        if "2001:db8::dead" in echo:
+            raise TestFailure(
+                f"rejected secondary leaked into the broadcast INF: {echo!r}"
             )
     finally:
         try:
@@ -10176,6 +10294,8 @@ TESTS = [
     ("BINF with both I4 and I6 accepted (#147 T3.1 HBRI)", test_binf_with_both_i4_and_i6_accepted),
     ("BINF unverified secondary family stripped (#214 Gap 1)", test_binf_secondary_family_stripped),
     ("HBRI success: side-channel validates secondary (#214)", test_hbri_success),
+    ("HBRI discovery: placeholder I6:: discovered via getpeername (#291)", test_hbri_discovery_placeholder),
+    ("HBRI concrete address mismatch rejected (#291)", test_hbri_concrete_mismatch_rejected),
     ("HBRI timeout: unvalidated secondary stays stripped (#214)", test_hbri_timeout),
     ("HBRI unknown token rejected (#214)", test_hbri_unknown_token),
     ("HBRI disconnect mid-validation cleans up (#214)", test_hbri_disconnect_cleanup),


### PR DESCRIPTION
Closes #291. Follow-up from the #214 HBRI arc (Gap A of the #286 split; post-login is the separate Gap B).

## Problem

Real dual-stack clients (AirDC++ auto-detect, behind NAT) advertise the offered secondary family as the spec **placeholder** - `I6::` / `I40.0.0.0` plus the matching `SU` flag - meaning "I'm capable here but can't self-report my address; discover it via the side-channel getpeername". The #288 placeholder skip treated `::`/`0.0.0.0` as "no secondary", so HBRI never fired for this common case (it only worked when a client was manually configured with a concrete external secondary).

## Fix

- `core/hub_dispatch.lua` (claim-capture): gate is now "secondary field present and non-empty" (placeholder included). A genuinely absent field (nil/"") - family not offered - is still not solicited (the #288 v4-only guard holds).
- `core/hbri.lua` (`validate()`): a placeholder/absent claimed value on the side-channel is a discovery request - commit the authenticated getpeername; only a CONCRETE stated address is cross-checked against the socket source. Dropped the now-dead `claimed_ip` from the token table so "never commit a client-stated address" is structural.

Verified against the adchpp HBRI reference (maksis/adchpp-hbri `ClientManager.cpp`: trigger = non-empty secondary INF field; committed address = getpeername).

## Security

The committed secondary is **always** the validation socket's getpeername (authenticated source), for both placeholder and concrete claims - never a client-stated value. No DDoS-amplification vector. Token single-use + family-check unchanged. Independent two-pass review: no exploitable issue.

## Tests

Smoke (Linux + Windows CI): all HBRI tests green.
- `test_hbri_discovery_placeholder` - happy path; **falsifiable**: confirmed FAILs on unpatched code (no ITCP solicited).
- `test_hbri_concrete_mismatch_rejected` - a concrete stated address != getpeername still gets ISTA 155, not committed.

Scope: login-time only. Post-login discovery is #286 (separate PR).