### PR TITLE
feat(hbri): validate a post-login secondary INF over HBRI (#286)

### DIFF
--- a/core/hbri.lua
+++ b/core/hbri.lua
@@ -58,11 +58,20 @@ local os_time           = os.time
 -- // late-bound from hub.lua via bind(): the NORMAL-entry completion
 -- // and the per-reload cfg caches.
 local enter_normal           -- enter_normal(user): runs the deferred login
+local sendtoall              -- sendtoall(adcstring): broadcast to all normal users (#286)
 local _enabled               -- hbri_enabled cfg
 local _timeout               -- hbri_timeout seconds (cfg-validated 1..60)
 local _advertise = { I4 = "", I6 = "" }   -- hub public address per family
 local _port      = { I4 = nil,  I6 = nil } -- plain listener port per family
 local _dual_stack = false    -- a plain listener exists on BOTH families
+
+-- // #286 post-login HBRI re-solicit cooldown (seconds). A logged-in
+-- // client re-emits its full connectivity on every INF update (share
+-- // change, NAT rebind, ...); idempotence (an already-validated
+-- // secondary is skipped) covers the success case, and this bounds the
+-- // FAILED case - a v6-broken dual-stack client - to one attempt per
+-- // window per user instead of one per INF.
+local _POSTLOGIN_COOLDOWN = 60
 
 -- // token table: token -> {
 -- //   user        = main user object,
@@ -88,6 +97,7 @@ end
 
 local function bind( deps )
     enter_normal = deps.enter_normal
+    sendtoall    = deps.sendtoall
     _enabled     = deps.hbri_enabled and true or false
     _timeout     = deps.hbri_timeout
     _advertise.I4 = deps.hbri_advertise_v4 or ""
@@ -121,11 +131,17 @@ local function eligible( user )
 end
 
 -- // Begin HBRI: mint a token, register it, send the ITCP pointer to
--- // the hub's secondary-family listener, and park the user in the
--- // "hbri" state. enter_normal() is deferred until validate() or
--- // sweep() resolves the attempt.
-local function initiate( user )
-    local claim   = user._hbri_claim
+-- // the hub's secondary-family listener.
+-- //
+-- // Login path (postlogin=false): the claim comes from user._hbri_claim
+-- // (captured by the BINF handler) and the user is parked in the "hbri"
+-- // state - enter_normal() is deferred until validate()/sweep() resolves.
+-- // Post-login path (#286, postlogin=true): the claim is passed in from
+-- // a NORMAL-state INF update; the user STAYS in NORMAL (adchpp keeps
+-- // post-login HBRI flag-only, not state-changing) and a success simply
+-- // broadcasts the now-complete INF (see commit_and_complete).
+local function initiate( user, claim, postlogin )
+    claim = claim or user._hbri_claim
     local sec_fam = claim.family
     local token   = adclib_createsalt( 16 )
     _tokens[ token ] = {
@@ -134,9 +150,10 @@ local function initiate( user )
         claimed_udp = claim.udp,
         su_flags    = claim.su_flags or { },
         deadline    = os_time( ) + _timeout,
+        postlogin   = postlogin or false,
     }
     user._hbri_token = token
-    user:state( "hbri" )
+    if not postlogin then user:state( "hbri" ) end
     -- ITCP I<fam><hub-addr> P<fam><port> TO<token>. The digit is the
     -- secondary family the client must validate over.
     local digit = ( sec_fam == "I6" ) and "6" or "4"
@@ -145,8 +162,60 @@ local function initiate( user )
         .. " TO" .. token .. "\n" )
 end
 
--- // Commit the verified secondary onto the main user's INF, then run
--- // the deferred NORMAL entry (which broadcasts the now-complete INF).
+-- // #286 post-login HBRI: a NORMAL-state INF update advertised a
+-- // secondary family. The unverified secondary is still stripped from
+-- // that broadcast by hub_inf_manager (the #97/#222 invariant holds);
+-- // this solicits a side-channel to prove it and, on success, broadcasts
+-- // the validated secondary. Called from the _normal.BINF dispatcher
+-- // BEFORE the onInf strip, so it can read the secondary from adccmd.
+local function postlogin_inf( user, adccmd )
+    if not active( ) then return end
+    if not ( user.supports and user:supports( "HBRI" ) ) then return end
+    if user._hbri_token then return end    -- a validation is already in flight
+    local sec_fam = other_fam( fam_of( user.ip( ) or "" ) )
+    local sec_ip  = adccmd:getnp( sec_fam )
+    if not sec_ip or sec_ip == "" then return end    -- family not offered
+    -- Idempotent: the stored INF already carries a real (non-placeholder)
+    -- secondary -> already validated, nothing to do. This is the primary
+    -- guard against re-solicit storms (a client re-sends its full
+    -- connectivity on every INF update). getpeername never yields a
+    -- placeholder, so a committed value is always "real".
+    -- Conservative by design: a client that LATER changes its secondary
+    -- to a different real address is NOT re-validated (the old verified
+    -- value keeps being broadcast until reconnect). This is fail-safe -
+    -- an unverified new address is never broadcast, per #97 / #222 - not
+    -- a bug; relaxing it would need a "secondary changed" re-validation
+    -- path with its own loop guard.
+    local inf = user:inf( )
+    local cur = inf and inf:getnp( sec_fam )
+    if cur and cur ~= "" and cur ~= "0.0.0.0" and cur ~= "::" then return end
+    -- Backoff after a recent attempt - bounds the FAILED case.
+    local now = os_time( )
+    if user._hbri_postlogin_next and now < user._hbri_postlogin_next then return end
+    user._hbri_postlogin_next = now + _POSTLOGIN_COOLDOWN
+    local su_flags = { }
+    local su = adccmd:getnp "SU"
+    if su then
+        local tcp_flag = ( sec_fam == "I6" ) and "TCP6" or "TCP4"
+        local udp_flag = ( sec_fam == "I6" ) and "UDP6" or "UDP4"
+        for tok in su:gmatch( "[^,]+" ) do
+            if tok == tcp_flag or tok == udp_flag then
+                su_flags[ #su_flags + 1 ] = tok
+            end
+        end
+    end
+    initiate( user, {
+        family   = sec_fam,
+        ip       = sec_ip,
+        udp      = adccmd:getnp( ( sec_fam == "I6" ) and "U6" or "U4" ),
+        su_flags = su_flags,
+    }, true )
+end
+
+-- // Commit the verified secondary onto the main user's INF, then finish:
+-- // login path runs the deferred NORMAL entry (which broadcasts the
+-- // now-complete INF); post-login path (#286) broadcasts the updated INF
+-- // directly, since the user is already in NORMAL.
 local function commit_and_complete( entry, verified_ip )
     local user = entry.user
     local inf  = user:inf( )
@@ -167,18 +236,24 @@ local function commit_and_complete( entry, verified_ip )
         end
     end
     user._hbri_token = nil
-    enter_normal( user )
+    if entry.postlogin then
+        if inf then sendtoall( inf:adcstring( ) ) end
+    else
+        enter_normal( user )
+    end
 end
 
--- // Give up on the secondary and enter NORMAL with it still stripped.
--- // The user stays connected; only the secondary family is unverified.
--- // No post-login retry: the secondary is never re-offered (post-login
--- // INF updates carrying I4 / I6 are stripped by hub_inf_manager), so
--- // there is no loop to guard against and no support flag to clear.
+-- // Give up on the secondary. Login path: enter NORMAL with the
+-- // secondary still stripped (the user stays connected, secondary
+-- // unverified). Post-login path (#286): the user is already in NORMAL
+-- // and the secondary was never broadcast, so there is nothing to undo -
+-- // the next eligible INF can retry once the cooldown elapses.
 local function fail( entry )
     local user = entry.user
     user._hbri_token = nil
-    enter_normal( user )
+    if not entry.postlogin then
+        enter_normal( user )
+    end
 end
 
 -- // Drop a pending attempt without completing login - used when the
@@ -267,11 +342,12 @@ local function sweep( )
 end
 
 return {
-    bind     = bind,
-    active   = active,
-    eligible = eligible,
-    initiate = initiate,
-    validate = validate,
-    sweep    = sweep,
-    cancel   = cancel,
+    bind          = bind,
+    active        = active,
+    eligible      = eligible,
+    initiate      = initiate,
+    postlogin_inf = postlogin_inf,
+    validate      = validate,
+    sweep         = sweep,
+    cancel        = cancel,
 }

--- a/core/hub.lua
+++ b/core/hub.lua
@@ -1623,6 +1623,7 @@ loadsettings = function( )    -- caching table lookups...
         local p6 = ( v6_plain and v6_plain[ 1 ] ) or ( v6_ssl and v6_ssl[ 1 ] )
         use( "hbri" ).bind{
             enter_normal      = function( u ) login( u, false, true ) end,
+            sendtoall         = sendtoall,    -- #286 post-login INF broadcast
             hbri_enabled      = cfg_get "hbri_enabled",
             hbri_timeout      = cfg_get "hbri_timeout",
             hbri_advertise_v4 = cfg_get "hbri_advertise_v4",

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -739,6 +739,13 @@ _normal = {
     -- ADC: 6.3.4. INF
     BINF = function( user, adccmd )
         if rl_inf_drop( user ) then return true end
+        -- #286 post-login HBRI: detect a newly-advertised secondary family
+        -- and solicit a side-channel BEFORE the onInf strip removes it.
+        -- No-op unless HBRI is active and the client advertised ADHBRI; the
+        -- unverified secondary is still stripped from this broadcast by
+        -- hub_inf_manager (the #97/#222 invariant), and only re-added once
+        -- the side-channel proves it (core/hbri.lua commit_and_complete).
+        hbri.postlogin_inf( user, adccmd )
         return scripts_firelistener( "onInf", user, adccmd )
     end,
     -- ADC: 6.3.5. MSG

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -1443,6 +1443,165 @@ def test_hbri_concrete_mismatch_rejected():
                 pass
 
 
+def _hbri_normal_login_capable(sock):
+    """#286 helper. Log in as `dummy` over v4 advertising ADHBRI + SU
+    TCP4,TCP6 but WITHOUT a secondary I6, so login-time HBRI does NOT fire
+    and the user reaches NORMAL state HBRI-capable. Returns (reader, sid).
+    The post-login tests then send a NORMAL-state INF carrying I6."""
+    reader = _ADCReader(sock)
+    sock.sendall(b"HSUP ADBASE ADTIGR ADHBRI\n")
+    reader.recv_until(lambda f: f.startswith("ISUP "))
+    isid = reader.recv_until(lambda f: f.startswith("ISID "))
+    sid = isid.split(" ", 1)[1].strip()
+    reader.recv_until(lambda f: f.startswith("IINF "))
+    pid_bytes = secrets.token_bytes(24)
+    cid_b32 = _b32_encode(_tiger.tiger(pid_bytes))
+    pid_b32 = _b32_encode(pid_bytes)
+    binf = (
+        f"BINF {sid} ID{cid_b32} PD{pid_b32} NIdummy"
+        f" I40.0.0.0 SUTCP4,TCP6\n"
+    )
+    sock.sendall(binf.encode("utf-8"))
+    gpa = reader.recv_until(lambda f: f.startswith("IGPA "))
+    salt_bytes = _b32_decode(gpa.split(" ", 1)[1].strip())
+    response = _tiger.tiger("test".encode("utf-8") + salt_bytes)
+    sock.sendall(f"HPAS {_b32_encode(response)}\n".encode("utf-8"))
+    # NORMAL entry: own login BINF echo, NO ITCP (no secondary at login).
+    echo = reader.recv_until(
+        lambda f: f.startswith("ITCP ") or f.startswith(f"BINF {sid}"),
+        timeout=PROTOCOL_TIMEOUT_SEC,
+    )
+    if echo.startswith("ITCP "):
+        raise TestFailure(
+            f"login-time HBRI fired for a no-secondary login: {echo!r}"
+        )
+    return reader, sid
+
+
+def test_hbri_postlogin_success():
+    """#286 post-login HBRI happy path. An HBRI-capable client already in
+    NORMAL state that LATER advertises a secondary via a post-login INF
+    (I6::) is solicited for a side-channel WITHOUT being parked, and on
+    validation the hub broadcasts the discovered secondary. sendtoall
+    reaches the user's own connection, so the validated I6 lands on the
+    main reader.
+
+    Falsifiable: pre-#286 the post-login I6 is silently stripped and no
+    ITCP is ever sent (the ITCP recv below fires)."""
+    main = socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    )
+    side = None
+    try:
+        reader, sid = _hbri_normal_login_capable(main)
+        # Post-login INF newly advertising a v6 secondary (placeholder).
+        main.sendall(f"BINF {sid} I6:: SUTCP4,TCP6\n".encode("utf-8"))
+        itcp = reader.recv_until(
+            lambda f: f.startswith("ITCP "), timeout=PROTOCOL_TIMEOUT_SEC
+        )
+        token = _hbri_param(itcp, "TO")
+        port = _hbri_param(itcp, "P6")
+        if not token or not port:
+            raise TestFailure(f"post-login ITCP missing TO / P6: {itcp!r}")
+        side = socket.create_connection(
+            ("::1", int(port)), timeout=PROTOCOL_TIMEOUT_SEC
+        )
+        sreader = _ADCReader(side)
+        side.sendall(f"HTCP I6:: TO{token}\n".encode("utf-8"))
+        sta = sreader.recv_until(lambda f: f.startswith("ISTA "))
+        if not sta.startswith("ISTA 000"):
+            raise TestFailure(
+                f"expected ISTA 000 on the post-login side-channel, got {sta!r}"
+            )
+        # The validated secondary is now broadcast (the stripped post-login
+        # echo carries no I6, so require I6::1 explicitly).
+        reader.recv_until(
+            lambda f: f.startswith(f"BINF {sid}") and "I6::1" in f,
+            timeout=PROTOCOL_TIMEOUT_SEC,
+        )
+    finally:
+        try:
+            main.close()
+        except OSError:
+            pass
+        if side:
+            try:
+                side.close()
+            except OSError:
+                pass
+
+
+def test_hbri_postlogin_failure_stays_stripped():
+    """#286 post-login HBRI failure. If the side-channel never opens, the
+    sweep times out the attempt; the user stays in NORMAL with the
+    secondary unvalidated and NEVER broadcast (the #97/#222 strip
+    invariant holds for the failed-HBRI case).
+
+    Falsifiable: a hub that committed the secondary without validation
+    leaks I6::1; a hub that dropped the user breaks the alive check."""
+    main = socket.create_connection((HUB_HOST, TEST_PORT_PLAIN), timeout=20)
+    try:
+        reader, sid = _hbri_normal_login_capable(main)
+        main.sendall(f"BINF {sid} I6:: SUTCP4,TCP6\n".encode("utf-8"))
+        reader.recv_until(lambda f: f.startswith("ITCP "), timeout=PROTOCOL_TIMEOUT_SEC)
+        # Do NOT open the side-channel. Sweep fails the attempt after
+        # hbri_timeout; the user is told (ISTA 155) but stays connected.
+        reader.recv_until(lambda f: f.startswith("ISTA 155"), timeout=18)
+        # No validated secondary may ever be broadcast.
+        leaked = None
+        try:
+            leaked = reader.recv_until(lambda f: "I6::1" in f, timeout=2)
+        except TestFailure as e:
+            if "timed out" not in str(e):
+                raise
+        if leaked is not None:
+            raise TestFailure(
+                f"secondary leaked after a failed post-login HBRI: {leaked!r}"
+            )
+        _assert_adc_alive(main)
+    finally:
+        try:
+            main.close()
+        except OSError:
+            pass
+
+
+def test_hbri_postlogin_no_resolicit_cooldown():
+    """#286 loop guard. After a FAILED post-login HBRI the hub must not
+    re-solicit on the very next INF update - a v6-broken dual-stack client
+    re-emits its connectivity on every INF (share change, NAT rebind) and
+    would otherwise eat an HBRI timeout each time. The per-user cooldown
+    suppresses the immediate retry.
+
+    Falsifiable: drop the cooldown and the second I6:: INF re-solicits an
+    ITCP (the assert below fires)."""
+    main = socket.create_connection((HUB_HOST, TEST_PORT_PLAIN), timeout=20)
+    try:
+        reader, sid = _hbri_normal_login_capable(main)
+        main.sendall(f"BINF {sid} I6:: SUTCP4,TCP6\n".encode("utf-8"))
+        reader.recv_until(lambda f: f.startswith("ITCP "), timeout=PROTOCOL_TIMEOUT_SEC)
+        # Let it time out (no side-channel) -> fail arms the cooldown.
+        reader.recv_until(lambda f: f.startswith("ISTA 155"), timeout=18)
+        # Immediately re-advertise the secondary; the cooldown must block
+        # a fresh solicit.
+        main.sendall(f"BINF {sid} I6:: SUTCP4,TCP6\n".encode("utf-8"))
+        resolicit = None
+        try:
+            resolicit = reader.recv_until(lambda f: f.startswith("ITCP "), timeout=3)
+        except TestFailure as e:
+            if "timed out" not in str(e):
+                raise
+        if resolicit is not None:
+            raise TestFailure(
+                f"post-login HBRI re-solicited within the cooldown window: {resolicit!r}"
+            )
+    finally:
+        try:
+            main.close()
+        except OSError:
+            pass
+
+
 def test_hbri_timeout():
     """#214 HBRI timeout. If the client never opens the side-channel,
     the hub's sweep fails the attempt after hbri_timeout seconds, sends
@@ -10296,6 +10455,9 @@ TESTS = [
     ("HBRI success: side-channel validates secondary (#214)", test_hbri_success),
     ("HBRI discovery: placeholder I6:: discovered via getpeername (#291)", test_hbri_discovery_placeholder),
     ("HBRI concrete address mismatch rejected (#291)", test_hbri_concrete_mismatch_rejected),
+    ("HBRI post-login: secondary in a NORMAL-state INF validated (#286)", test_hbri_postlogin_success),
+    ("HBRI post-login failure: secondary stays stripped (#286)", test_hbri_postlogin_failure_stays_stripped),
+    ("HBRI post-login: no re-solicit within cooldown (#286)", test_hbri_postlogin_no_resolicit_cooldown),
     ("HBRI timeout: unvalidated secondary stays stripped (#214)", test_hbri_timeout),
     ("HBRI unknown token rejected (#214)", test_hbri_unknown_token),
     ("HBRI disconnect mid-validation cleans up (#214)", test_hbri_disconnect_cleanup),


### PR DESCRIPTION
Closes #286. Gap B of the #286 split (Gap A = login-time discovery shipped in #292).

## Problem

A client already logged in (NORMAL state) that LATER advertises a secondary IP family via a post-login INF update was silently stripped by `hub_inf_manager` (#97 / #222) and never validated - a feature gap vs adchpp, which fires HBRI on a post-login INF while staying in `STATE_NORMAL` (flag-only, not parked) and broadcasts the validated secondary on success.

## Fix

- `core/hub_dispatch.lua` `_normal.BINF`: calls `hbri.postlogin_inf()` BEFORE the `onInf` strip so it can read the newly-advertised secondary. It does NOT remove it - `hub_inf_manager` still strips the unverified secondary from this broadcast (the #97/#222 invariant holds).
- `core/hbri.lua`: new `postlogin_inf()` solicits a side-channel WITHOUT parking the user. Three loop guards against the re-solicit storm a client re-emitting its full connectivity on every INF would cause: in-flight token, already-validated (idempotent), and a per-user 60s cooldown bounding the failed case. `initiate()` now takes an explicit claim + a `postlogin` flag (parks only at login). `commit_and_complete` broadcasts the validated INF via `sendtoall` for the postlogin case instead of re-entering `login()`; `fail()` is a no-op for postlogin.
- `core/hub.lua`: pass `sendtoall` into `hbri.bind()`.

## Security

The committed secondary is always the side-channel getpeername (never a client-stated address); `validate()` is shared with the login path. The #97/#222 strip invariant holds for the non-HBRI and failed-HBRI cases - the only post-login broadcast carrying the secondary is the post-validation `sendtoall`. Re-solicit DoS is bounded by the three guards. Conservative posture: a secondary that changes to a new real address post-validation is not re-validated (fail-safe, documented in code).

Verified against adchpp post-login HBRI (`ClientManager.cpp verifyIp`: `STATE_NORMAL` -> `sendHBRI` immediately; success -> broadcast updated INF). Independent two-pass security review: no exploitable finding.

## Tests

Smoke (Linux + Windows CI): all HBRI tests green. Three new post-login tests, all **falsifiable** (confirmed to FAIL on the unpatched code with "timed out waiting for ITCP"):
- `test_hbri_postlogin_success` - solicit (no park) -> side-channel -> validated secondary broadcast.
- `test_hbri_postlogin_failure_stays_stripped` - no side-channel -> timeout -> no secondary broadcast, user stays connected.
- `test_hbri_postlogin_no_resolicit_cooldown` - a second INF after a failure does not re-solicit within the cooldown.