### PR TITLE
fix(hbri): require a plain listener on both families (#294 Tier-1)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -84,6 +84,13 @@ jobs:
       - name: Run http_client unit test
         run: lua5.4 tests/unit/http_client_test.lua
 
+      # core/hbri.lua (#214 / #291 / #286): unit test for the pure
+      # activation gate (active()) and eligibility (eligible()); the
+      # side-channel paths are smoke-tested. #294 locks "no plain port
+      # on a family -> active() false".
+      - name: Run hbri unit test
+        run: lua5.4 tests/unit/hbri_test.lua
+
       - name: Configure
         run: cmake -B build -DCMAKE_BUILD_TYPE=Release
 
@@ -150,6 +157,10 @@ jobs:
       - name: Run http_client unit test
         shell: msys2 {0}
         run: lua tests/unit/http_client_test.lua
+
+      - name: Run hbri unit test
+        shell: msys2 {0}
+        run: lua tests/unit/hbri_test.lua
 
       - name: Configure
         shell: msys2 {0}

--- a/core/hub.lua
+++ b/core/hub.lua
@@ -1612,15 +1612,20 @@ loadsettings = function( )    -- caching table lookups...
     -- #214 HBRI: (re)bind the secondary-family validator. enter_normal
     -- re-enters login() with hbri_done=true so a validated (or timed-
     -- out) HBRI session completes its NORMAL entry. The hub advertises
-    -- / initiates HBRI only when a listener exists on BOTH families AND
-    -- both public advertise addresses are set (see core/hbri.lua). The
-    -- side-channel port is the first plain port for the family, falling
-    -- back to the first TLS port.
+    -- / initiates HBRI only when a PLAIN listener exists on BOTH families
+    -- AND both public advertise addresses are set (see core/hbri.lua).
+    -- #294: the side-channel port is the first PLAIN port for the family
+    -- only - NO TLS fallback. The ITCP pointer and the inbound HTCP are
+    -- unencrypted; advertising a TLS-only port would make the client open
+    -- a plain connection to a TLS listener, which never yields an HTCP and
+    -- always times out. A family without a plain listener disables HBRI
+    -- (p stays nil -> hbri_dual_stack false -> secondary stays stripped,
+    -- the secure default).
     do
-        local v4_plain, v4_ssl = cfg_get "tcp_ports", cfg_get "ssl_ports"
-        local v6_plain, v6_ssl = cfg_get "tcp_ports_ipv6", cfg_get "ssl_ports_ipv6"
-        local p4 = ( v4_plain and v4_plain[ 1 ] ) or ( v4_ssl and v4_ssl[ 1 ] )
-        local p6 = ( v6_plain and v6_plain[ 1 ] ) or ( v6_ssl and v6_ssl[ 1 ] )
+        local v4_plain = cfg_get "tcp_ports"
+        local v6_plain = cfg_get "tcp_ports_ipv6"
+        local p4 = v4_plain and v4_plain[ 1 ]
+        local p6 = v6_plain and v6_plain[ 1 ]
         use( "hbri" ).bind{
             enter_normal      = function( u ) login( u, false, true ) end,
             sendtoall         = sendtoall,    -- #286 post-login INF broadcast

--- a/tests/unit/hbri_test.lua
+++ b/tests/unit/hbri_test.lua
@@ -1,0 +1,147 @@
+--[[
+
+    tests/unit/hbri_test.lua
+
+    Committed unit test for core/hbri.lua (#214 / #291 / #286 HBRI).
+    Pure Lua, no hub, no sockets: stubs the `use` sandbox shim, loads the
+    module, and asserts the activation gate (active()) and the eligibility
+    contract (eligible()) - the two pure predicates that decide whether the
+    hub solicits HBRI at all.
+
+    These two predicates are the security-relevant gate: active() must be
+    false unless the hub is fully HBRI-capable (enabled + dual-stack + both
+    plain ports + both advertise addresses), and eligible() must only fire
+    for an HBRI-supporting client that claimed a secondary on the family
+    OPPOSITE its main connection. #294 made the hub feed active() a nil
+    port for a TLS-only family (no plain listener); this test locks the
+    contract that a nil port -> active() false -> no solicit (secondary
+    stays stripped), so a regression in either the gate or the port wiring
+    is caught.
+
+    The side-effecting paths (initiate / validate / sweep / commit) need a
+    real socket + adccmd and are covered by tests/smoke/run.py; this file
+    deliberately tests only the pure predicates.
+
+    Run: lua tests/unit/hbri_test.lua   (any Lua 5.4)
+    Exit code 0 = all pass, 1 = a failure (CI-friendly).
+
+]]--
+
+-- minimal sandbox shim: core/hbri.lua does `local x = use "x"`.
+-- Keep this in lockstep with hbri.lua's `use` imports.
+local _real = {
+    pairs = pairs, tostring = tostring, ipairs = ipairs,
+    os = { time = function( ) return 0 end },
+    -- only initiate() touches adclib/cfg; the predicates under test do
+    -- not, but the module resolves these at load time.
+    adclib = { createsalt = function( ) return "TESTTOKEN0000000" end },
+    cfg = { get = function( ) return nil end },
+}
+_G.use = function( name )
+    local v = _real[ name ]
+    assert( v ~= nil, "hbri_test shim missing dep: use \"" .. name .. "\"" )
+    return v
+end
+
+local hbri = assert( loadfile( "core/hbri.lua" ) )( )
+
+local failures, checks = 0, 0
+local function eq( label, got, want )
+    checks = checks + 1
+    if got ~= want then
+        failures = failures + 1
+        io.write( string.format( "FAIL %-46s got=%q want=%q\n", label, tostring( got ), tostring( want ) ) )
+    else
+        io.write( string.format( "ok   %s\n", label ) )
+    end
+end
+
+-- Sentinel for "override this dep to nil" - a plain `{ k = nil }` table
+-- cannot express that (Lua drops nil-valued keys), which would silently
+-- no-op a nil-port test case.
+local NIL = { }
+
+-- A fully HBRI-capable bind. Individual cases clone + override one field.
+local function bind_full( over )
+    local deps = {
+        enter_normal      = function( ) end,
+        sendtoall         = function( ) end,
+        hbri_enabled      = true,
+        hbri_timeout      = 5,
+        hbri_advertise_v4 = "203.0.113.1",
+        hbri_advertise_v6 = "2001:db8::1",
+        hbri_port_v4      = 5000,
+        hbri_port_v6      = 5000,
+        hbri_dual_stack   = true,
+    }
+    if over then for k, v in pairs( over ) do deps[ k ] = ( v ~= NIL ) and v or nil end end
+    hbri.bind( deps )
+end
+
+----------------------------------------------------------------------
+-- active(): the hub-capability gate. False unless EVERY prerequisite
+-- holds; in particular a nil port (a TLS-only family after #294) or a
+-- false dual_stack flag must disable HBRI.
+----------------------------------------------------------------------
+
+bind_full( ); eq( "active: all set", hbri.active( ), true )
+bind_full{ hbri_enabled = false };          eq( "active: disabled",        hbri.active( ), false )
+bind_full{ hbri_dual_stack = false };       eq( "active: not dual-stack",  hbri.active( ), false )
+bind_full{ hbri_port_v6 = NIL };            eq( "active: no v6 plain port", hbri.active( ), false )
+bind_full{ hbri_port_v4 = NIL };            eq( "active: no v4 plain port", hbri.active( ), false )
+bind_full{ hbri_advertise_v4 = "" };        eq( "active: no v4 advertise",  hbri.active( ), false )
+bind_full{ hbri_advertise_v6 = "" };        eq( "active: no v6 advertise",  hbri.active( ), false )
+
+----------------------------------------------------------------------
+-- eligible(): per-client gate. Needs active() + ADHBRI + a claimed
+-- secondary on the family OPPOSITE the main connection. Placeholder
+-- secondaries (::/0.0.0.0) are eligible (#291 discovery).
+----------------------------------------------------------------------
+
+local function mk_user( main_ip, claim, supports_hbri )
+    return {
+        _hbri_claim = claim,
+        ip = function( ) return main_ip end,
+        supports = function( _, feat ) return supports_hbri and feat == "HBRI" end,
+    }
+end
+
+bind_full( )
+
+-- v4 main connection, concrete I6 secondary claim -> eligible.
+eq( "eligible: v4 main, concrete I6 claim",
+    hbri.eligible( mk_user( "1.2.3.4", { family = "I6", ip = "2001:db8::5" }, true ) ), true )
+
+-- v4 main, PLACEHOLDER I6 claim (the #291 discovery case) -> eligible.
+eq( "eligible: v4 main, placeholder I6 claim",
+    hbri.eligible( mk_user( "1.2.3.4", { family = "I6", ip = "::" }, true ) ), true )
+
+-- v6 main, I4 secondary claim -> eligible (symmetric direction).
+eq( "eligible: v6 main, I4 claim",
+    hbri.eligible( mk_user( "2001:db8::9", { family = "I4", ip = "0.0.0.0" }, true ) ), true )
+
+-- Client does not support HBRI -> not eligible.
+eq( "eligible: no ADHBRI support",
+    hbri.eligible( mk_user( "1.2.3.4", { family = "I6", ip = "::" }, false ) ), false )
+
+-- No claim captured -> not eligible.
+eq( "eligible: no claim",
+    hbri.eligible( mk_user( "1.2.3.4", nil, true ) ), false )
+
+-- Empty claim ip -> not eligible.
+eq( "eligible: empty claim ip",
+    hbri.eligible( mk_user( "1.2.3.4", { family = "I6", ip = "" }, true ) ), false )
+
+-- Claim family SAME as the main family (cannot happen via the BINF
+-- capture, but the gate must reject it) -> not eligible.
+eq( "eligible: claim family == main family",
+    hbri.eligible( mk_user( "1.2.3.4", { family = "I4", ip = "9.9.9.9" }, true ) ), false )
+
+-- When the hub is not active, no client is eligible.
+bind_full{ hbri_enabled = false }
+eq( "eligible: hub inactive",
+    hbri.eligible( mk_user( "1.2.3.4", { family = "I6", ip = "2001:db8::5" }, true ) ), false )
+
+----------------------------------------------------------------------
+io.write( string.format( "\n%d checks, %d failures\n", checks, failures ) )
+os.exit( failures == 0 and 0 or 1 )


### PR DESCRIPTION
Part of #294 (HBRI audit follow-ups), Tier-1.

## Problem

The HBRI side-channel port was `tcp_ports[1] or ssl_ports[1]` (plain, falling back to TLS), and `hbri_dual_stack` counted a TLS-only family as dual-stack. The hub then advertised a TLS port in the plain-text `ITCP`; the client opened a PLAIN side-channel to a TLS listener, the handshake produced no `HTCP`, and HBRI silently timed out on every attempt for that family. Fail-safe (secondary stayed stripped) but a silent misconfiguration trap, and it contradicted the `active()` / `cfg_defaults` comments that already require a "plain listener on BOTH families".

## Fix

Drop the TLS fallback - the side-channel port is the first PLAIN port for the family only. A family without a plain listener leaves the port nil -> `hbri_dual_stack` false -> `active()` false -> HBRI not advertised / not solicited (the secure default), instead of advertised-but-broken. Code now matches the existing comments.

## Tests

New `tests/unit/hbri_test.lua` (the module had no unit test): locks the `active()` activation gate - in particular "no plain port on a family -> `active()` false", the contract this fix relies on - plus the `eligible()` contract (placeholder discovery #291, opposite-family requirement, ADHBRI gate). Wired into both CI lua steps (Linux lua5.4 + Windows msys2 lua). 15 checks.

Smoke (plain listeners on both families): all HBRI tests still green - the plain-both-families path is unchanged.

Note: a dedicated smoke test for the TLS-only-family case would need a second hub instance with a TLS-only family (the harness runs a single shared hub), which is disproportionate for a fail-safe fallback removal; the unit test locks the consumer-side gate instead.