### PR TITLE
feat(usr_hubs): IP + CID in [USER HUBS] report (closes #308)

### DIFF
--- a/scripts/lang/usr_hubs.lang.de
+++ b/scripts/lang/usr_hubs.lang.de
@@ -17,10 +17,10 @@ Max Hubs: %s  |  bei dir: %s
 =================== USER HUBS CHECK ===
   ]],
 
-    report_msg = "[ USER HUBS ]--> User:  %s  |  wurde gebannt für:  %s  |  Grund: überschreiten des Users Hub Limits. Hubs:  %s  (Gesamt:  %s Hubs)  |  Erlaubt:  %s  (max.  %s  Hubs gesamt)",
+    report_msg = "[ USER HUBS ]--> User:  %s  |  IP:  %s  |  CID:  %s  |  wurde gebannt für:  %s  |  Grund: Überschreiten des User Hub Limits. Hubs:  %s  (Gesamt:  %s Hubs)  |  Erlaubt:  %s  (max.  %s  Hubs gesamt)",
     msg_reason = "Überschreiten des User Hub Limits",
 
-    report_msg_redirect = "[ USER HUBS ]--> User:  %s  |  wurde redirected  |  Grund: Überschreiten des User Hub Limits. Hubs:  %s  (Gesamt:  %s Hubs)  |  Erlaubt:  %s  (max.  %s  Hubs gesamt)",
+    report_msg_redirect = "[ USER HUBS ]--> User:  %s  |  IP:  %s  |  CID:  %s  |  wurde redirected  |  Grund: Überschreiten des User Hub Limits. Hubs:  %s  (Gesamt:  %s Hubs)  |  Erlaubt:  %s  (max.  %s  Hubs gesamt)",
     msg_redirect = "[ USER HUBS ]--> Du wurdest weitergeleitet weil: Überschreiten des User Hub Limits. Hubs: ",
 
     msg_years = " Jahre, ",

--- a/scripts/lang/usr_hubs.lang.en
+++ b/scripts/lang/usr_hubs.lang.en
@@ -17,10 +17,10 @@ Max hubs: %s  |  yours: %s
 =================== USER HUBS CHECK ===
   ]],
 
-    report_msg = "[ USER HUBS ]--> User:  %s  |  was banned for:  %s  |  reason: exceeded users hub limit. Hubs:  %s  (total:  %s hubs)  |  allowed:  %s  (max.  %s  hubs total)",
+    report_msg = "[ USER HUBS ]--> User:  %s  |  IP:  %s  |  CID:  %s  |  was banned for:  %s  |  reason: exceeded users hub limit. Hubs:  %s  (total:  %s hubs)  |  allowed:  %s  (max.  %s  hubs total)",
     msg_reason = "Exceeded users hub limit",
 
-    report_msg_redirect = "[ USER HUBS ]--> User:  %s  |  was redirected  |  reason: exceeded users hub limit. Hubs:  %s  (total:  %s hubs)  |  allowed:  %s  (max.  %s  hubs total)",
+    report_msg_redirect = "[ USER HUBS ]--> User:  %s  |  IP:  %s  |  CID:  %s  |  was redirected  |  reason: exceeded users hub limit. Hubs:  %s  (total:  %s hubs)  |  allowed:  %s  (max.  %s  hubs total)",
     msg_redirect = "[ USER HUBS ]--> You got redirected because: exceeded users hub limit. Hubs: ",
 
     msg_years = " years, ",

--- a/scripts/usr_hubs.lua
+++ b/scripts/usr_hubs.lua
@@ -4,6 +4,11 @@
 
         - this script checks the hub count of a user
 
+        v0.13: by Aybook (#308)
+            - include IP + CID in the [USER HUBS] report message so
+              operators can act on the IP / CID directly without
+              cross-referencing cmd_ban's internal table
+
         v0.12: by pulsar
             - show more detailed output msg
             - using permission table instead of godlevel
@@ -62,7 +67,7 @@
 --------------
 
 local scriptname = "usr_hubs"
-local scriptversion = "0.12"
+local scriptversion = "0.13"
 
 --// imports
 local scriptlang = cfg.get( "language" )
@@ -84,8 +89,8 @@ local usr_hubs_redirect = cfg.get( "usr_hubs_redirect" )
 
 --// msgs
 local msg_reason = lang.msg_reason or "Exceeded users hub limit"
-local report_msg = lang.report_msg or "[ USER HUBS ]--> User:  %s  |  was banned for:  %s  |  reason: exceeded users hub limit. Hubs:  %s  (total:  %s hubs)  |  allowed:  %s  (max.  %s  hubs total)"
-local report_msg_redirect = lang.report_msg_redirect or "[ USER HUBS ]--> User:  %s  |  was redirected  |  reason: exceeded users hub limit. Hubs:  %s  (total:  %s hubs)  |  allowed:  %s  (max.  %s  hubs total)"
+local report_msg = lang.report_msg or "[ USER HUBS ]--> User:  %s  |  IP:  %s  |  CID:  %s  |  was banned for:  %s  |  reason: exceeded users hub limit. Hubs:  %s  (total:  %s hubs)  |  allowed:  %s  (max.  %s  hubs total)"
+local report_msg_redirect = lang.report_msg_redirect or "[ USER HUBS ]--> User:  %s  |  IP:  %s  |  CID:  %s  |  was redirected  |  reason: exceeded users hub limit. Hubs:  %s  (total:  %s hubs)  |  allowed:  %s  (max.  %s  hubs total)"
 local msg_redirect = lang.msg_redirect or "[ USER HUBS ]--> You got redirected because: exceeded users hub limit. Hubs: "
 local msg_invalid = lang.msg_invalid or "Invalid hubcount"
 local msg_years = lang.msg_years or " years, "
@@ -116,6 +121,8 @@ Max hubs: %s  |  yours: %s
 
 local check = function( user )
     local user_nick = user:nick()
+    local user_ip = user:ip()
+    local user_cid = user:cid()
     local hn, hr, ho = user:hubs()
     -- Phase 8a F-INF-1b: a client BINF without the HN/HR/HO triplet
     -- returns nil from user:hubs(). Pre-fix, the arithmetic on the
@@ -137,7 +144,7 @@ local check = function( user )
             local redirect_msg = hub.escapeto( msg_redirect .. hubs )
             user:redirect( redirect_url, redirect_msg )
             --// report
-            local msg_out = utf.format( report_msg_redirect, user_nick, hubs, hm, hubs_allowed, hubs_max )
+            local msg_out = utf.format( report_msg_redirect, user_nick, user_ip, user_cid, hubs, hm, hubs_allowed, hubs_max )
             report.send( report_activate, report_hubbot, report_opchat, llevel, msg_out )
             return PROCESSED
         else
@@ -145,7 +152,7 @@ local check = function( user )
             user:reply( msg, hub.getbot() )
             ban.add( nil, user, bantime, msg_reason, "USER HUBS CHECK" )
             --// report
-            local msg_out = utf.format( report_msg, user_nick, msg_bantime, hubs, hm, hubs_allowed, hubs_max )
+            local msg_out = utf.format( report_msg, user_nick, user_ip, user_cid, msg_bantime, hubs, hm, hubs_allowed, hubs_max )
             report.send( report_activate, report_hubbot, report_opchat, llevel, msg_out )
             return PROCESSED
         end


### PR DESCRIPTION
## Summary

- `usr_hubs.lua` now includes `IP` and `CID` in the `[USER HUBS]`
  report message that lands in HubBot / OpChat when a user is
  banned / redirected for exceeding the hub-count limits.
- Mirrors the column layout `etc_onfailedauth.lua` already uses:
  `User: %s | IP: %s | CID: %s | ...`
- Operator-facing impact: forensics (subnet-pattern detection,
  permanent `+banip`, GeoIP correlation, hoster abuse reports)
  no longer require cross-referencing cmd_ban's internal table.

## Audit

Per CLAUDE.md §1a.1 (`grep the pattern across the repo`): among
`scripts/usr_*.lua` only `usr_hubs.lua` calls `report.send`. The
other `usr_*` plugins (slots, share, uptime, nick_length,
nick_prefix, desc_prefix, hide_share) kick/redirect silently
without opchat/hubbot output. Single-file scope confirmed.

## Drive-by note

`scripts/lang/usr_hubs.lang.de:20` had `Grund: überschreiten des
Users Hub Limits` (lowercase + spurious genitive-`s`) where line
23 already used `Grund: Überschreiten des User Hub Limits`. The
PR normalises line 20 to match. Mentioned explicitly so reviewers
don't squint at the diff (per CLAUDE.md §7).

## Backport

master only. No `release/3.1.x` backport - pure QoL / forensics
enhancement, no security impact, does not meet the §8 bar for
maintenance backport.

## Test plan

- [x] `lua54 -e 'loadfile(...)'` parse check on all three files
- [x] Render both lang files via `string.format` with realistic
      args (nick / IP / CID / bantime / hubs / ...) - all 8
      placeholders in `report_msg` and 7 in `report_msg_redirect`
      match the `utf.format` call sites
- [x] Independent two-pass code review via subagent
      (security / new bugs / breaking / consistency) - no blockers
- [x] Maintainer-side spot-check before merge
- [x] CI smoke pass (no usr_hubs-specific smoke test exists; the
      change does not touch any protocol path covered by the
      existing smoke suite)

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)