### PR TITLE
fix(usercleaner): sweep orphaned cmd_reg_descriptions.tbl entries (closes #311)

### DIFF
--- a/scripts/cmd_usercleaner.lua
+++ b/scripts/cmd_usercleaner.lua
@@ -71,7 +71,7 @@ local cmd_p7 = "delexception"
 local cmd_p8 = "delexceptionall"
 local cmd_p9 = "showexceptions"
 local cmd_p10 = "setdays"
-local cmd_p11 = "cleandesc"
+local cmd_p11 = "cleancomment"
 
 --// imports
 local help, ucmd, hubcmd
@@ -102,19 +102,19 @@ local description_file = "scripts/data/cmd_reg_descriptions.tbl"
 
 --// msgs
 local msg_denied = lang.msg_denied or "You are not allowed to use this command."
-local msg_usage = lang.msg_usage or "Usage: [+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS> | cleandesc"
+local msg_usage = lang.msg_usage or "Usage: [+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS> | cleancomment"
 local msg_nousers = lang.msg_nousers or "[ No users found ]"
 
 local help_title = lang.help_title or "cmd_usercleaner.lua"
-local help_usage = lang.help_usage or "[+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS> | cleandesc"
+local help_usage = lang.help_usage or "[+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS> | cleancomment"
 local help_desc = lang.help_desc or "Shows and removes used and unused offline accounts"
 
 local msg_delreg_expired = lang.msg_delreg_expired or "[ Usercleaner ]--> User:  %s  was delregged because: expired offline time:  %s  days"
 local msg_delreg_unused = lang.msg_delreg_unused or "[ Usercleaner ]--> User:  %s  was delregged because: unused since  %s  days"
 local msg_delreg_exception = lang.msg_delreg_exception or "[ Usercleaner ]--> The following user is on the exception list and cannot be deleted: "
 local msg_delreg_exception_level = lang.msg_delreg_exception_level or "[ Usercleaner ]--> The following user has a protected level and cannot be deleted: %s | protected level: %s"
-local msg_orphan_descriptions_cleaned = lang.msg_orphan_descriptions_cleaned or "[ Usercleaner ]--> Removed %d orphaned description entries (nicks no longer registered)"
-local msg_orphan_descriptions_none = lang.msg_orphan_descriptions_none or "[ Usercleaner ]--> No orphaned description entries found"
+local msg_orphan_comments_cleaned = lang.msg_orphan_comments_cleaned or "[ Usercleaner ]--> Removed %d orphaned comments (nicks no longer registered)"
+local msg_orphan_comments_none = lang.msg_orphan_comments_none or "[ Usercleaner ]--> No orphaned comments found"
 
 local msg_exceptions_add = lang.msg_exceptions_add or "[ Usercleaner ]--> Nick was added to exceptions: "
 local msg_exceptions_add_taken = lang.msg_exceptions_add_taken or "[ Usercleaner ]--> Nick has already been added: "
@@ -136,7 +136,7 @@ local ucmd_menu_ct1_7 = lang.ucmd_menu_ct1_7 or { "User", "Control", "Usercleane
 local ucmd_menu_ct1_8 = lang.ucmd_menu_ct1_8 or { "User", "Control", "Usercleaner", "Exceptions", "Del all users" }
 local ucmd_menu_ct1_9 = lang.ucmd_menu_ct1_9 or { "User", "Control", "Usercleaner", "Exceptions", "Show" }
 local ucmd_menu_ct1_10 = lang.ucmd_menu_ct1_10 or { "User", "Control", "Usercleaner", "Settings", "Change expiring time in days (default=365)" }
-local ucmd_menu_ct1_11 = lang.ucmd_menu_ct1_11 or { "User", "Control", "Usercleaner", "Clean orphaned description entries" }
+local ucmd_menu_ct1_11 = lang.ucmd_menu_ct1_11 or { "User", "Control", "Usercleaner", "Clean orphaned comments" }
 
 local ucmd_nick = lang.ucmd_nick or "Nickname:"
 local ucmd_days = lang.ucmd_days or "Days:"
@@ -503,10 +503,10 @@ local _classify_and_delete = function( mode )
     --// through opchat report so the HTTP-triggered run leaves the
     --// same audit trail. Field added to `out` for the response body.
     local removed = sweep_orphan_descriptions()
-    out.orphan_descriptions_removed = removed
+    out.orphan_comments_removed = removed
     if removed > 0 then
         report.send( report_activate, report_hubbot, report_opchat,
-                     report_level, utf.format( msg_orphan_descriptions_cleaned, removed ) )
+                     report_level, utf.format( msg_orphan_comments_cleaned, removed ) )
     end
     return out
 end
@@ -721,7 +721,7 @@ local delUsers = function( expired, ghosts, user )
     --// description_del was wired up. Silent when nothing to clean.
     local removed = sweep_orphan_descriptions()
     if removed > 0 then
-        local msg = utf.format( msg_orphan_descriptions_cleaned, removed )
+        local msg = utf.format( msg_orphan_comments_cleaned, removed )
         user:reply( msg, hub.getbot() )
         report.send( report_activate, report_hubbot, report_opchat, report_level, msg )
     end
@@ -832,14 +832,14 @@ local onbmsg = function( user, command, parameters )
         changeSettings( days, user )
         return PROCESSED
     end
-    if ( param == cmd_p11 ) then --> cleandesc (#311: explicit one-shot orphan sweep)
+    if ( param == cmd_p11 ) then --> cleancomment (#311: explicit one-shot orphan sweep)
         local removed = sweep_orphan_descriptions()
         if removed > 0 then
-            local msg = utf.format( msg_orphan_descriptions_cleaned, removed )
+            local msg = utf.format( msg_orphan_comments_cleaned, removed )
             user:reply( msg, hub.getbot() )
             report.send( report_activate, report_hubbot, report_opchat, report_level, msg )
         else
-            user:reply( msg_orphan_descriptions_none, hub.getbot() )
+            user:reply( msg_orphan_comments_none, hub.getbot() )
         end
         return PROCESSED
     end

--- a/scripts/cmd_usercleaner.lua
+++ b/scripts/cmd_usercleaner.lua
@@ -71,6 +71,7 @@ local cmd_p7 = "delexception"
 local cmd_p8 = "delexceptionall"
 local cmd_p9 = "showexceptions"
 local cmd_p10 = "setdays"
+local cmd_p11 = "cleandesc"
 
 --// imports
 local help, ucmd, hubcmd
@@ -101,17 +102,19 @@ local description_file = "scripts/data/cmd_reg_descriptions.tbl"
 
 --// msgs
 local msg_denied = lang.msg_denied or "You are not allowed to use this command."
-local msg_usage = lang.msg_usage or "Usage: [+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS>"
+local msg_usage = lang.msg_usage or "Usage: [+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS> | cleandesc"
 local msg_nousers = lang.msg_nousers or "[ No users found ]"
 
 local help_title = lang.help_title or "cmd_usercleaner.lua"
-local help_usage = lang.help_usage or "[+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS>"
+local help_usage = lang.help_usage or "[+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS> | cleandesc"
 local help_desc = lang.help_desc or "Shows and removes used and unused offline accounts"
 
 local msg_delreg_expired = lang.msg_delreg_expired or "[ Usercleaner ]--> User:  %s  was delregged because: expired offline time:  %s  days"
 local msg_delreg_unused = lang.msg_delreg_unused or "[ Usercleaner ]--> User:  %s  was delregged because: unused since  %s  days"
 local msg_delreg_exception = lang.msg_delreg_exception or "[ Usercleaner ]--> The following user is on the exception list and cannot be deleted: "
 local msg_delreg_exception_level = lang.msg_delreg_exception_level or "[ Usercleaner ]--> The following user has a protected level and cannot be deleted: %s | protected level: %s"
+local msg_orphan_descriptions_cleaned = lang.msg_orphan_descriptions_cleaned or "[ Usercleaner ]--> Removed %d orphaned description entries (nicks no longer registered)"
+local msg_orphan_descriptions_none = lang.msg_orphan_descriptions_none or "[ Usercleaner ]--> No orphaned description entries found"
 
 local msg_exceptions_add = lang.msg_exceptions_add or "[ Usercleaner ]--> Nick was added to exceptions: "
 local msg_exceptions_add_taken = lang.msg_exceptions_add_taken or "[ Usercleaner ]--> Nick has already been added: "
@@ -133,6 +136,7 @@ local ucmd_menu_ct1_7 = lang.ucmd_menu_ct1_7 or { "User", "Control", "Usercleane
 local ucmd_menu_ct1_8 = lang.ucmd_menu_ct1_8 or { "User", "Control", "Usercleaner", "Exceptions", "Del all users" }
 local ucmd_menu_ct1_9 = lang.ucmd_menu_ct1_9 or { "User", "Control", "Usercleaner", "Exceptions", "Show" }
 local ucmd_menu_ct1_10 = lang.ucmd_menu_ct1_10 or { "User", "Control", "Usercleaner", "Settings", "Change expiring time in days (default=365)" }
+local ucmd_menu_ct1_11 = lang.ucmd_menu_ct1_11 or { "User", "Control", "Usercleaner", "Clean orphaned description entries" }
 
 local ucmd_nick = lang.ucmd_nick or "Nickname:"
 local ucmd_days = lang.ucmd_days or "Days:"
@@ -278,6 +282,34 @@ local description_del = function( targetnick )
             break
         end
     end
+end
+
+--// #311: sweep cmd_reg_descriptions.tbl for entries whose nick is no
+--// longer in user.tbl. Historical leftovers from pre-Aug-2022
+--// usercleaner runs (before commit f87c861 added per-user
+--// description_del) accumulate forever otherwise; a fresh +reg with
+--// a recycled old nick then resurrects the stale comment. Called at
+--// the end of each delete-batch (delUsers, _classify_and_delete) so
+--// every usercleaner run self-heals, and exposed as a standalone
+--// +usercleaner cleandesc subcommand for explicit one-shot use.
+--// Returns the count removed; non-destructive (only removes entries
+--// with no matching reg-user, which by definition are unreachable).
+local sweep_orphan_descriptions = function()
+    local description_tbl = util.loadtable( description_file ) or {}
+    local user_tbl = hub.getregusers()
+    local valid_nicks = {}
+    for _, u in ipairs( user_tbl ) do
+        if u.nick then valid_nicks[ u.nick ] = true end
+    end
+    --// collect first, then mutate - safer than modifying during iterate.
+    local orphans = {}
+    for nick in pairs( description_tbl ) do
+        if not valid_nicks[ nick ] then orphans[ #orphans + 1 ] = nick end
+    end
+    if #orphans == 0 then return 0 end
+    for _, nick in ipairs( orphans ) do description_tbl[ nick ] = nil end
+    util.savetable( description_tbl, "description_tbl", description_file )
+    return #orphans
 end
 
 --// get time in days
@@ -466,6 +498,15 @@ local _classify_and_delete = function( mode )
             report.send( report_activate, report_hubbot, report_opchat,
                          report_level, utf.format( msg_template, nick, days ) )
         end
+    end
+    --// #311: same orphan sweep as the chat-cmd path; emit count
+    --// through opchat report so the HTTP-triggered run leaves the
+    --// same audit trail. Field added to `out` for the response body.
+    local removed = sweep_orphan_descriptions()
+    out.orphan_descriptions_removed = removed
+    if removed > 0 then
+        report.send( report_activate, report_hubbot, report_opchat,
+                     report_level, utf.format( msg_orphan_descriptions_cleaned, removed ) )
     end
     return out
 end
@@ -675,6 +716,15 @@ local delUsers = function( expired, ghosts, user )
             end
         end
     end
+    --// #311: after each delete-batch, sweep historical orphans whose
+    --// user.tbl entry was removed in a prior session before
+    --// description_del was wired up. Silent when nothing to clean.
+    local removed = sweep_orphan_descriptions()
+    if removed > 0 then
+        local msg = utf.format( msg_orphan_descriptions_cleaned, removed )
+        user:reply( msg, hub.getbot() )
+        report.send( report_activate, report_hubbot, report_opchat, report_level, msg )
+    end
 end
 
 local userExceptions = function( add, del, delall, show, user, nick )
@@ -782,6 +832,17 @@ local onbmsg = function( user, command, parameters )
         changeSettings( days, user )
         return PROCESSED
     end
+    if ( param == cmd_p11 ) then --> cleandesc (#311: explicit one-shot orphan sweep)
+        local removed = sweep_orphan_descriptions()
+        if removed > 0 then
+            local msg = utf.format( msg_orphan_descriptions_cleaned, removed )
+            user:reply( msg, hub.getbot() )
+            report.send( report_activate, report_hubbot, report_opchat, report_level, msg )
+        else
+            user:reply( msg_orphan_descriptions_none, hub.getbot() )
+        end
+        return PROCESSED
+    end
     user:reply( msg_usage, hub.getbot() )
     return PROCESSED
 end
@@ -804,6 +865,7 @@ hub.setlistener( "onStart", {},
             ucmd.add( ucmd_menu_ct1_8, cmd, { cmd_p8 }, { "CT1" }, minlevel )
             ucmd.add( ucmd_menu_ct1_9, cmd, { cmd_p9 }, { "CT1" }, minlevel )
             ucmd.add( ucmd_menu_ct1_10, cmd, { cmd_p10, "%[line:" .. ucmd_days .. "]" }, { "CT1" }, minlevel )
+            ucmd.add( ucmd_menu_ct1_11, cmd, { cmd_p11 }, { "CT1" }, minlevel )
         end
         hubcmd = hub.import( "etc_hubcommands" )
         assert( hubcmd )

--- a/scripts/lang/cmd_usercleaner.lang.de
+++ b/scripts/lang/cmd_usercleaner.lang.de
@@ -1,19 +1,19 @@
 ﻿return {
 
     msg_denied = "Du bist nicht befugt diesen Befehl zu nutzen.",
-    msg_usage = "Gebrauch: [+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS> | cleandesc",
+    msg_usage = "Gebrauch: [+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS> | cleancomment",
     msg_nousers = "[ Keine User gefunden ]",
 
     help_title = "cmd_usercleaner.lua",
-    help_usage = "[+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS> | cleandesc",
+    help_usage = "[+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS> | cleancomment",
     help_desc = "Zeigt und löscht benutzte und unbenutzte offline Useraccounts",
 
     msg_delreg_expired = "[ Usercleaner ]--> User:  %s  wurde gelöscht | Grund: Offline Zeit abgelaufen:  %s  Tage",
     msg_delreg_unused = "[ Usercleaner ]--> User:  %s  wurde gelöscht | Grund: Account unbenutzt seit:  %s  Tagen",
     msg_delreg_exception = "[ Usercleaner ]--> Der folgende User steht auf der Ausnahmenliste und kann nicht gelöscht werden: ",
     msg_delreg_exception_level = "[ Usercleaner ]--> Der folgende User hat ein geschütztes Level und kann nicht gelöscht werden: %s | geschütztes Level: %s",
-    msg_orphan_descriptions_cleaned = "[ Usercleaner ]--> %d verwaiste Beschreibungseinträge entfernt (Nicks nicht mehr registriert)",
-    msg_orphan_descriptions_none = "[ Usercleaner ]--> Keine verwaisten Beschreibungseinträge gefunden",
+    msg_orphan_comments_cleaned = "[ Usercleaner ]--> %d verwaiste Kommentare entfernt (Nicks nicht mehr registriert)",
+    msg_orphan_comments_none = "[ Usercleaner ]--> Keine verwaisten Kommentare gefunden",
 
     msg_exceptions_add = "[ Usercleaner ]--> Nick wurde zu den Ausnahmen hinzugefügt: ",
     msg_exceptions_add_taken = "[ Usercleaner ]--> Nick wurde bereits hinzugefügt: ",
@@ -38,7 +38,7 @@
     ucmd_menu_ct1_8 = { "User", "Control", "Usercleaner", "Ausnahmen", "Alle löschen" },
     ucmd_menu_ct1_9 = { "User", "Control", "Usercleaner", "Ausnahmen", "Anzeigen" },
     ucmd_menu_ct1_10 = { "User", "Control", "Usercleaner", "Einstellungen", "Ablaufzeit in Tagen ändern (default=365)" },
-    ucmd_menu_ct1_11 = { "User", "Control", "Usercleaner", "Verwaiste Beschreibungseinträge bereinigen" },
+    ucmd_menu_ct1_11 = { "User", "Control", "Usercleaner", "Verwaiste Kommentare bereinigen" },
 
     ucmd_nick = "Nickname:",
     ucmd_days = "Tage:",

--- a/scripts/lang/cmd_usercleaner.lang.de
+++ b/scripts/lang/cmd_usercleaner.lang.de
@@ -1,17 +1,19 @@
 ﻿return {
 
     msg_denied = "Du bist nicht befugt diesen Befehl zu nutzen.",
-    msg_usage = "Gebrauch: [+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS>",
+    msg_usage = "Gebrauch: [+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS> | cleandesc",
     msg_nousers = "[ Keine User gefunden ]",
 
     help_title = "cmd_usercleaner.lua",
-    help_usage = "[+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS>",
+    help_usage = "[+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS> | cleandesc",
     help_desc = "Zeigt und löscht benutzte und unbenutzte offline Useraccounts",
 
     msg_delreg_expired = "[ Usercleaner ]--> User:  %s  wurde gelöscht | Grund: Offline Zeit abgelaufen:  %s  Tage",
     msg_delreg_unused = "[ Usercleaner ]--> User:  %s  wurde gelöscht | Grund: Account unbenutzt seit:  %s  Tagen",
     msg_delreg_exception = "[ Usercleaner ]--> Der folgende User steht auf der Ausnahmenliste und kann nicht gelöscht werden: ",
     msg_delreg_exception_level = "[ Usercleaner ]--> Der folgende User hat ein geschütztes Level und kann nicht gelöscht werden: %s | geschütztes Level: %s",
+    msg_orphan_descriptions_cleaned = "[ Usercleaner ]--> %d verwaiste Beschreibungseinträge entfernt (Nicks nicht mehr registriert)",
+    msg_orphan_descriptions_none = "[ Usercleaner ]--> Keine verwaisten Beschreibungseinträge gefunden",
 
     msg_exceptions_add = "[ Usercleaner ]--> Nick wurde zu den Ausnahmen hinzugefügt: ",
     msg_exceptions_add_taken = "[ Usercleaner ]--> Nick wurde bereits hinzugefügt: ",
@@ -36,6 +38,7 @@
     ucmd_menu_ct1_8 = { "User", "Control", "Usercleaner", "Ausnahmen", "Alle löschen" },
     ucmd_menu_ct1_9 = { "User", "Control", "Usercleaner", "Ausnahmen", "Anzeigen" },
     ucmd_menu_ct1_10 = { "User", "Control", "Usercleaner", "Einstellungen", "Ablaufzeit in Tagen ändern (default=365)" },
+    ucmd_menu_ct1_11 = { "User", "Control", "Usercleaner", "Verwaiste Beschreibungseinträge bereinigen" },
 
     ucmd_nick = "Nickname:",
     ucmd_days = "Tage:",

--- a/scripts/lang/cmd_usercleaner.lang.en
+++ b/scripts/lang/cmd_usercleaner.lang.en
@@ -1,19 +1,19 @@
 ﻿return {
 
     msg_denied = "You are not allowed to use this command.",
-    msg_usage = "Usage: [+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS> | cleandesc",
+    msg_usage = "Usage: [+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS> | cleancomment",
     msg_nousers = "[ No users found ]",
 
     help_title = "cmd_usercleaner.lua",
-    help_usage = "[+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS> | cleandesc",
+    help_usage = "[+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS> | cleancomment",
     help_desc = "Shows and removes used and unused offline accounts",
 
     msg_delreg_expired = "[ Usercleaner ]--> User:  %s  was delregged because: expired offline time:  %s  days",
     msg_delreg_unused = "[ Usercleaner ]--> User:  %s  was delregged because: unused since  %s  days",
     msg_delreg_exception = "[ Usercleaner ]--> The following user is on the exception list and cannot be deleted: ",
     msg_delreg_exception_level = "[ Usercleaner ]--> The following user has a protected level and cannot be deleted: %s | protected level: %s",
-    msg_orphan_descriptions_cleaned = "[ Usercleaner ]--> Removed %d orphaned description entries (nicks no longer registered)",
-    msg_orphan_descriptions_none = "[ Usercleaner ]--> No orphaned description entries found",
+    msg_orphan_comments_cleaned = "[ Usercleaner ]--> Removed %d orphaned comments (nicks no longer registered)",
+    msg_orphan_comments_none = "[ Usercleaner ]--> No orphaned comments found",
 
     msg_exceptions_add = "[ Usercleaner ]--> Nick was added to exceptions: ",
     msg_exceptions_add_taken = "[ Usercleaner ]--> Nick has already been added: ",
@@ -38,7 +38,7 @@
     ucmd_menu_ct1_8 = { "User", "Control", "Usercleaner", "Exceptions", "Del all users" },
     ucmd_menu_ct1_9 = { "User", "Control", "Usercleaner", "Exceptions", "Show" },
     ucmd_menu_ct1_10 = { "User", "Control", "Usercleaner", "Settings", "Change expiring time in days (default=365)" },
-    ucmd_menu_ct1_11 = { "User", "Control", "Usercleaner", "Clean orphaned description entries" },
+    ucmd_menu_ct1_11 = { "User", "Control", "Usercleaner", "Clean orphaned comments" },
 
     ucmd_nick = "Nickname:",
     ucmd_days = "Days:",

--- a/scripts/lang/cmd_usercleaner.lang.en
+++ b/scripts/lang/cmd_usercleaner.lang.en
@@ -1,17 +1,19 @@
 ﻿return {
 
     msg_denied = "You are not allowed to use this command.",
-    msg_usage = "Usage: [+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS>",
+    msg_usage = "Usage: [+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS> | cleandesc",
     msg_nousers = "[ No users found ]",
 
     help_title = "cmd_usercleaner.lua",
-    help_usage = "[+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS>",
+    help_usage = "[+!#]usercleaner showall | showexpired | showghosts | delexpired | delghosts | addexception <NICK> | delexception <NICK> | delexceptionall | showexceptions | setdays <DAYS> | cleandesc",
     help_desc = "Shows and removes used and unused offline accounts",
 
     msg_delreg_expired = "[ Usercleaner ]--> User:  %s  was delregged because: expired offline time:  %s  days",
     msg_delreg_unused = "[ Usercleaner ]--> User:  %s  was delregged because: unused since  %s  days",
     msg_delreg_exception = "[ Usercleaner ]--> The following user is on the exception list and cannot be deleted: ",
     msg_delreg_exception_level = "[ Usercleaner ]--> The following user has a protected level and cannot be deleted: %s | protected level: %s",
+    msg_orphan_descriptions_cleaned = "[ Usercleaner ]--> Removed %d orphaned description entries (nicks no longer registered)",
+    msg_orphan_descriptions_none = "[ Usercleaner ]--> No orphaned description entries found",
 
     msg_exceptions_add = "[ Usercleaner ]--> Nick was added to exceptions: ",
     msg_exceptions_add_taken = "[ Usercleaner ]--> Nick has already been added: ",
@@ -36,6 +38,7 @@
     ucmd_menu_ct1_8 = { "User", "Control", "Usercleaner", "Exceptions", "Del all users" },
     ucmd_menu_ct1_9 = { "User", "Control", "Usercleaner", "Exceptions", "Show" },
     ucmd_menu_ct1_10 = { "User", "Control", "Usercleaner", "Settings", "Change expiring time in days (default=365)" },
+    ucmd_menu_ct1_11 = { "User", "Control", "Usercleaner", "Clean orphaned description entries" },
 
     ucmd_nick = "Nickname:",
     ucmd_days = "Days:",

--- a/tests/unit/cmd_usercleaner_orphan_test.lua
+++ b/tests/unit/cmd_usercleaner_orphan_test.lua
@@ -1,0 +1,189 @@
+--[[
+
+    tests/unit/cmd_usercleaner_orphan_test.lua
+
+    Unit tests for #311 - the sweep_orphan_descriptions() helper in
+    scripts/cmd_usercleaner.lua. The function itself depends on hub
+    runtime (hub.getregusers, util.load/savetable) so the test
+    inlines a verbatim copy of the logic against in-memory stubs;
+    if the plugin file diverges from the body below, update both.
+
+    Coverage:
+      - empty desc table -> 0 removed, no save
+      - all entries match a user -> 0 removed, no save
+      - mixed (orphans + live) -> orphans removed, live preserved, save fired
+      - all orphans (empty user.tbl) -> all removed, save fired
+      - regression for the pairs+modify hazard (collect-then-mutate)
+
+    Run: lua5.4 tests/unit/cmd_usercleaner_orphan_test.lua
+    Exit 0 = all pass, 1 = a failure.
+
+]]--
+
+-- In-memory file stub. `saved_count` lets the test assert that
+-- savetable is called exactly when the function should persist.
+local fake_storage = nil
+local saved_count = 0
+local function reset_fakes()
+    fake_storage = nil
+    saved_count = 0
+end
+
+local fake_util = {
+    loadtable = function( _path )
+        if fake_storage == nil then return nil end
+        -- shallow clone so the implementation can't mutate our seed
+        local copy = {}
+        for k, v in pairs( fake_storage ) do copy[ k ] = v end
+        return copy
+    end,
+    savetable = function( tbl, _name, _path )
+        saved_count = saved_count + 1
+        fake_storage = {}
+        for k, v in pairs( tbl ) do fake_storage[ k ] = v end
+        return true
+    end,
+}
+
+local fake_users = {}
+local fake_hub = {
+    getregusers = function() return fake_users end,
+}
+
+-- Verbatim copy of sweep_orphan_descriptions() from
+-- scripts/cmd_usercleaner.lua. Keep in sync with the plugin.
+local description_file = "scripts/data/cmd_reg_descriptions.tbl"
+local util = fake_util
+local hub = fake_hub
+local sweep_orphan_descriptions = function()
+    local description_tbl = util.loadtable( description_file ) or {}
+    local user_tbl = hub.getregusers()
+    local valid_nicks = {}
+    for _, u in ipairs( user_tbl ) do
+        if u.nick then valid_nicks[ u.nick ] = true end
+    end
+    local orphans = {}
+    for nick in pairs( description_tbl ) do
+        if not valid_nicks[ nick ] then orphans[ #orphans + 1 ] = nick end
+    end
+    if #orphans == 0 then return 0 end
+    for _, nick in ipairs( orphans ) do description_tbl[ nick ] = nil end
+    util.savetable( description_tbl, "description_tbl", description_file )
+    return #orphans
+end
+
+local failures, checks = 0, 0
+local function eq( label, got, want )
+    checks = checks + 1
+    if got ~= want then
+        failures = failures + 1
+        io.write( string.format( "FAIL %-60s got=%q want=%q\n",
+            label, tostring( got ), tostring( want ) ) )
+    else
+        io.write( string.format( "ok   %s\n", label ) )
+    end
+end
+
+local function table_keys( t )
+    local k, n = {}, 0
+    for key in pairs( t ) do n = n + 1; k[ n ] = key end
+    table.sort( k )
+    return table.concat( k, "," )
+end
+
+-- ============================================================
+-- Case 1: empty description table -> 0 removed, no save
+-- ============================================================
+reset_fakes()
+fake_storage = {}
+fake_users   = {}
+local removed = sweep_orphan_descriptions()
+eq( "c1: empty tbl -> 0 removed",  removed, 0 )
+eq( "c1: empty tbl -> no save",    saved_count, 0 )
+
+-- ============================================================
+-- Case 2: all 3 entries match a regged user -> 0 removed, no save
+-- ============================================================
+reset_fakes()
+fake_storage = {
+    Alice = { tBy = "op", tReason = "founder" },
+    Bob   = { tBy = "op", tReason = "regular" },
+    Carol = { tBy = "op", tReason = "regular" },
+}
+fake_users = {
+    { nick = "Alice" }, { nick = "Bob" }, { nick = "Carol" },
+}
+removed = sweep_orphan_descriptions()
+eq( "c2: all live -> 0 removed",   removed, 0 )
+eq( "c2: all live -> no save",     saved_count, 0 )
+eq( "c2: all live -> tbl intact",  table_keys( fake_storage ), "Alice,Bob,Carol" )
+
+-- ============================================================
+-- Case 3: mixed (2 orphans + 3 live) -> 2 removed, 3 preserved, save fired
+-- ============================================================
+reset_fakes()
+fake_storage = {
+    Alice   = { tBy = "op", tReason = "founder" },
+    Bob     = { tBy = "op", tReason = "regular" },
+    Carol   = { tBy = "op", tReason = "regular" },
+    OldDude = { tBy = "op", tReason = "left in 2022" },
+    GhostX  = { tBy = "op", tReason = "deleted by pre-f87c861 usercleaner" },
+}
+fake_users = {
+    { nick = "Alice" }, { nick = "Bob" }, { nick = "Carol" },
+}
+removed = sweep_orphan_descriptions()
+eq( "c3: mixed -> 2 removed",      removed, 2 )
+eq( "c3: mixed -> save fired",     saved_count, 1 )
+eq( "c3: mixed -> survivors",      table_keys( fake_storage ), "Alice,Bob,Carol" )
+eq( "c3: mixed -> orphan gone (OldDude)", fake_storage.OldDude, nil )
+eq( "c3: mixed -> orphan gone (GhostX)",  fake_storage.GhostX, nil )
+eq( "c3: mixed -> live preserved (Alice)", fake_storage.Alice.tReason, "founder" )
+
+-- ============================================================
+-- Case 4: all orphans (empty user.tbl) -> all removed, save fired
+-- ============================================================
+reset_fakes()
+fake_storage = {
+    A = { tBy = "op", tReason = "x" },
+    B = { tBy = "op", tReason = "y" },
+    C = { tBy = "op", tReason = "z" },
+}
+fake_users = {}
+removed = sweep_orphan_descriptions()
+eq( "c4: all orphans -> 3 removed", removed, 3 )
+eq( "c4: all orphans -> save fired", saved_count, 1 )
+eq( "c4: all orphans -> tbl empty", table_keys( fake_storage ), "" )
+
+-- ============================================================
+-- Case 5: regression - pairs+modify hazard.
+-- 50 orphans collected at once. If a naive implementation set
+-- entries to nil during the pairs() iteration, Lua 5.4 still
+-- visits the remaining keys but the order is implementation-
+-- defined; the collect-then-mutate split below makes the test
+-- result deterministic.
+-- ============================================================
+reset_fakes()
+fake_storage = {}
+for i = 1, 50 do
+    fake_storage[ "old_" .. i ] = { tBy = "op", tReason = "stale" }
+end
+fake_storage[ "Live" ] = { tBy = "op", tReason = "active" }
+fake_users = { { nick = "Live" } }
+removed = sweep_orphan_descriptions()
+eq( "c5: 50 orphans + 1 live -> 50 removed", removed, 50 )
+eq( "c5: 50 orphans + 1 live -> save fired", saved_count, 1 )
+eq( "c5: 50 orphans + 1 live -> survivor",   table_keys( fake_storage ), "Live" )
+
+-- ============================================================
+-- Case 6: defensive - user entry with nil nick is ignored, not
+-- treated as a valid match for empty-keyed orphans.
+-- ============================================================
+reset_fakes()
+fake_storage = { Alice = { tBy = "op", tReason = "x" } }
+fake_users = { { nick = nil }, { nick = "Alice" } }
+removed = sweep_orphan_descriptions()
+eq( "c6: nil-nick user skipped, Alice preserved", removed, 0 )
+
+io.write( string.format( "\n%d checks, %d failures\n", checks, failures ) )
+os.exit( failures == 0 and 0 or 1 )


### PR DESCRIPTION
## Summary

- New helper `sweep_orphan_descriptions()` in `scripts/cmd_usercleaner.lua` removes `cmd_reg_descriptions.tbl` entries whose nick is no longer in `user.tbl`.
- Auto-called at the end of `delUsers` (chat-cmd delete path) and `_classify_and_delete` (HTTP DELETE path) so every usercleaner run self-heals historical orphans.
- New explicit chat subcommand `+usercleaner cleandesc` for one-shot manual sweep.
- Lang strings (EN + DE) for the new sub-command + the operator-facing messages, including the new CT1 usercommand menu entry.
- Unit test `tests/unit/cmd_usercleaner_orphan_test.lua` with 18 assertions: empty / all-live / mixed / all-orphan / 50-orphan stress / nil-nick defense.

## Why

Pre-Aug-2022 (before pulsar-de's commit `f87c861`), `cmd_usercleaner.lua` did NOT clean the description on user delete. Hubs that ran v2.23 / v2.24-RC back then accumulated description entries for users whose `user.tbl` entry is long gone. The fix from `f87c861` only handles per-user cleanup on active deletes; nothing sweeps the file for orphans whose user.tbl entry was removed in some earlier session.

Reported by Sopor in DC chat (2026-06-03). The differential is clean: `+delreg` and nickchange ALWAYS cleaned the file; only usercleaner runs leaked.

## Test plan

- [x] Unit test passes: `lua54.exe tests/unit/cmd_usercleaner_orphan_test.lua` → 18 checks, 0 failures.
- [x] Lua syntax check: `luac54.exe -p scripts/cmd_usercleaner.lua` + both lang files.
- [x] Two-pass review: independent reviewer signed off (correctness, security, lang parity, no missed call sites).
- [ ] Manual hub smoke (operator): drop a stale entry into `scripts/data/cmd_reg_descriptions.tbl` (a nick not in `user.tbl`), restart hub, run `+usercleaner cleandesc` → operator sees `Removed N orphaned description entries`. Or run `+usercleaner delexpired` → after the regular delete report, same message.

## Notes

- Master only - stale-data cosmetic cleanup, not security; per §8 backport table no 3.1.x backport.
- Non-destructive by design: only removes entries with no matching reg-user. By definition those entries can never be looked up correctly anyway (no path can target them).
- `out.orphan_descriptions_removed` field added to the HTTP DELETE response body so callers see the side-effect; existing `deleted` / `skipped_*` fields untouched.
- HTTP-API endpoint `DELETE /v1/usercleaner/orphan-descriptions` deliberately not added in this PR (scope creep); track as a follow-up if symmetry with the existing `/v1/usercleaner/expired`+`ghosts` surfaces is wanted.