### PR TITLE
docs(etc_trafficmanager): document CCPM side-effect of CTM/RCM block

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -476,6 +476,18 @@ spam or abuse control.
 `etc_trafficmanager_report_hubbot`,
 `etc_trafficmanager_report_opchat`, `etc_trafficmanager_llevel`
 
+> **CCPM side effect:** ADC uses the same `CTM` / `RCM` commands for
+> file-transfer connection setup AND for CCPM (encrypted client-to-
+> client PM) channel setup. The plugin blocks both at the hub level
+> for blocked users, so adding a level to `etc_trafficmanager_blocked_levels`
+> ALSO disables CCPM for that level. Affected users can still chat
+> through the hub via regular `EMSG` / `DMSG`; only the direct
+> end-to-end encrypted channel is unreachable. There is no clean
+> wire-level differentiator between the two uses; operators who want
+> CCPM available for a level must remove that level from the block
+> list and accept the corresponding file-transfer permission. The
+> source-level rationale is in the [`etc_trafficmanager.lua` header](../scripts/etc_trafficmanager.lua).
+
 ### etc_unknown_command
 
 Reject mistyped or malformed commands in main chat with helpful error

--- a/scripts/etc_trafficmanager.lua
+++ b/scripts/etc_trafficmanager.lua
@@ -12,6 +12,27 @@
         [+!#]trafficmanager show blocks  -- shows all blocked users and their blockmodes
 
 
+        Operator note - CCPM side effect:
+
+        ADC overloads the CTM / RCM commands for BOTH file-transfer
+        connection setup AND CCPM (encrypted client-to-client PM)
+        channel setup. The onConnectToMe / onRevConnectToMe listeners
+        below block CTM / RCM for blocked levels to stop file
+        transfers, but the wire-level commands look identical for
+        CCPM - so blocking a level via `etc_trafficmanager_blockedlevels`
+        (or via individual `+trafficmanager block <nick>`) ALSO
+        disables CCPM for those users. They can still chat through
+        the hub via regular EMSG / DMSG; only the direct, end-to-end
+        encrypted channel is unreachable.
+
+        There is no clean wire-level differentiator (same protocol
+        token, same DCTM shape). A heuristic fix would be "exempt
+        CTM / RCM that closely follows a PM between the same SID
+        pair" - tracked but not implemented as of v2.5; operators who
+        want CCPM available for a level must remove that level from
+        the block list and accept the corresponding file-transfer
+        permission.
+
         v2.5:
             - fix latent dispatch bug in add() / del() exports
               (closes #257). `( not scriptname ) or ( not scriptname == 1 )`


### PR DESCRIPTION
## Summary

Docs-only. Adds an operator note that explains why blocking a level via `etc_trafficmanager_blocked_levels` also disables CCPM (encrypted client-to-client PM) for that level - they share the CTM / RCM wire-level commands and the plugin can't tell them apart.

Two places:
- [`scripts/etc_trafficmanager.lua`](scripts/etc_trafficmanager.lua) header right after the usage block - source-level rationale for anyone editing the file
- [`docs/SCRIPTS.md`](docs/SCRIPTS.md) trafficmanager section - operator-facing note that cross-links back to the source header

## Background

Reported by eMTee + Sopor in DC chat (2026-06-04). Both REG-level on a hub with REG in `blocked_levels`. CCPM attempts time out because the plugin drops their DCTM / DRCM commands. Reproduced on the dev hub; operator-side fix is to remove REG from `blocked_levels` (accepts that file transfers become allowed).

## Why no code change

There is no clean wire-level differentiator between file-transfer CTM and CCPM CTM:
- Same protocol token (`ADCS/0.10`)
- Same DCTM / DRCM command shape
- CCPM SU flag is a capability, not a per-CTM marker (set even when the same client does file transfers)

A heuristic fix (exempt CTM that closely follows a PM between the same SID pair, e.g. 30-second window) was considered but deferred. The bypass is small but real, and operators already have a clean opt-out via the existing config.

## Test plan

- [x] `luac -p scripts/etc_trafficmanager.lua` clean (no behaviour change)
- [x] Markdown renders correctly (verified locally)
- [ ] CI matrix (smoke + CodeQL)