### PR TITLE
release: prepare v3.1.11 - cherry-pick #320 hierarchy-check fix

### DIFF
--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,6 +1,6 @@
-# Luadch v3.1.10
+# Luadch v3.1.11
 
-**Maintenance patch release** on the `release/3.1.x` line. Two security / UX bugfixes cherry-picked from master. No breaking changes; no cfg / lang-file changes; drop-in upgrade from v3.1.9.
+**Maintenance patch release** on the `release/3.1.x` line. One privilege-escalation bugfix cherry-picked from master. No breaking changes; no cfg / lang-file changes; drop-in upgrade from v3.1.10.
 
 ## ⚠️ Before upgrading
 
@@ -12,44 +12,60 @@ tar -czf "luadch-backup-$(date +%F).tar.gz" cfg scripts certs secrets
 
 ## Why upgrade
 
-**If operators have set `kill_wrong_ips = false`** (NAT-weird deployments) - their hub was forwarding unverified primary-IP claims to other clients, opening the historical [DC++ DDoS-amplification vector](https://en.wikipedia.org/wiki/Direct_Connect_(protocol)#Direct_Connect_used_for_DDoS_attacks). This release closes that path.
+**If your hub has more than one operator-level account and only one hubowner**, the bug fixed here is exploitable: any account with `+ban` permission (typically op-level and above) could ban the hubowner while the hubowner was offline, locking them out on the next login attempt. With a single hubowner this becomes denial-of-administration on the hub - the hubowner cannot remove their own ban because they cannot log in. With multiple hubowner-level accounts the impact is reduced to a removable nuisance.
 
-**If operators see FAILED-AUTH spam** with reason `"User sent offending flag in INF: I4"` (HadesDCH reported this) - legitimate DC++ clients refreshing INF after NAT events were being killed in a loop. This release stops the kill and silent-strips the field instead.
-
-Default-config hubs (`kill_wrong_ips = true`, no INF-refresh storms) are not actively affected by either bug, but the upgrade is harmless and recommended.
+Default-config hubs are affected. The fix applies to every operator from level 60 upward (default `cmd_ban_permission` ladder).
 
 ## Bugfixes
 
-### [#214](https://github.com/luadch-ng/luadch/issues/214) Gap 2 - DDoS-amplification on `kill_wrong_ips = false` opt-out
+### [#320](https://github.com/luadch-ng/luadch/issues/320) (Kcchouette) - `cmd_ban` offline-by-nick path silently bypassed the hierarchy check
 
-`core/hub_dispatch.lua` `elseif infip_match ~= userip` branch: when `kill_wrong_ips = false` AND the BINF claim doesn't match the TCP-source IP, the wrong claim STAYED in `adccmd` and was broadcast to other clients - they would then direct CTM / RCM frames at the spoofed address (Maksis-confirmed DC++ DDoS-amp vector).
+`scripts/cmd_ban.lua` had two divergent target-resolution paths converging on `addban()`:
 
-**Fix:** the opt-out path now stamps the authenticated `userip` over the lie via `adccmd:setnp(userfam, userip)`. Opt-out intent (don't kill the user) preserved. Default `kill_wrong_ips = true` deployments unaffected. Side benefit: legitimate NAT-deployments now broadcast a routable IP, so other clients' CTMs succeed (pre-fix they targeted the wrong IP and failed).
+- **Online branch** resolves `target` to a user OBJECT (has `:level()` method), falls through to the existing check at line 594: `if permission[level] < target:level() then ... msg_god`
+- **Offline-by-nick branch** resolves `target` to a profile TABLE from `regnicks[]` (has `.level` field, no `:level()` method), then returns at `addban()` two lines BEFORE the check could run
 
-The companion Gap 1 (secondary-family unverified broadcast) is the upcoming HBRI implementation's responsibility - tracked on master.
+Effect: a level-60 operator could send `+ban nick hubowner_offline 60 reason`, the offline branch ran `addban()` directly without checking that the operator outranked the target, and the hubowner was banned. On their next login attempt the ban hit, kicking them with `ISTA 232 ... TL<reconnect-seconds>`.
 
-### [#222](https://github.com/luadch-ng/luadch/issues/222) (HadesDCH) - post-login INF with `I4` / `I6` killed legitimate users
+**Fix:** explicit hierarchy guard inside the offline-by-nick branch using `target.level`, mirroring the online-path semantics with the table-shape accessor:
 
-`scripts/hub_inf_manager.lua` `forbidden.flags_on_inf` contained `I4` / `I6` (originally added in #97 to prevent post-login IP-spoofing). Real DC++ clients refresh INF including `I4` on routine triggers (NAT rebind, ISP-IP change, plain refresh); pre-fix those legitimate refreshes triggered `ISTA 240` + `TL300` reconnect-block, producing FAILED-AUTH log spam and bouncing users in a loop.
+```lua
+elseif by == "nick" then
+    local _, regnicks, _ = hub.getregusers()
+    target = regnicks[ id ]
+    if not target then
+        user:reply( msg_off, hub.getbot() )
+        return PROCESSED
+    end
+    if permission[ level ] < ( target.level or 0 ) then    -- new
+        user:reply( msg_god, hub.getbot() )
+        return PROCESSED
+    end
+end
+```
 
-**Fix:** `flags_on_inf` split into `_kill` (`PD` / `ID` - identity spoofing, real attack signal = kill) and `_strip` (`I4` / `I6` - IP mutation attempt OR routine refresh = silent-strip). The strip path removes `I4` / `I6` from `cmd` via `cmd:deletenp()` before applying remaining fields. Anti-spoofing intent of #97 preserved: stored `_inf` IP is never mutated, broadcast doesn't carry the new claim. Other INF fields in the same update (DE, SS, etc.) still get applied normally. Plugin v0.06 → v0.07.
+cid / ip offline branches keep no profile lookup and stay unchecked by design (no hierarchy info available - the hub doesn't know whose IP a given IP is).
+
+Plugin v0.36 → v0.37. Cherry-picked from master ([PR #322](https://github.com/luadch-ng/luadch/pull/322), commit `30c8809`); the new HTTP-API-based regression smoke test stays master-only because the HTTP API ships on 3.2.x only - the fix logic is identical and reviewer-verified.
+
+A pattern sweep over the related command-and-profile plugins (`cmd_gag`, `cmd_setpass`, `cmd_upgrade`, `cmd_delreg`, `cmd_nickchange`, `cmd_redirect`, `cmd_disconnect`, `etc_trafficmanager`, `etc_msgmanager`) for the same online-vs-offline-hierarchy-check divergence came back clean - either properly guarded on both paths or online-only by design. cmd_ban was the only affected plugin in the family.
 
 ## Build / runtime
 
-No changes. Same Lua 5.4.7, same LuaSec 1.3.2, same LuaSocket 3.1.0, same build toolchain as v3.1.9.
+No changes. Same Lua 5.4.7, same LuaSec 1.3.2, same LuaSocket 3.1.0, same build toolchain as v3.1.10.
 
-The `linux-aarch64` artifact is built with the Bullseye-container pipeline introduced as the v3.1.9 in-place asset swap (glibc 2.31 baseline, works on Pi OS Bullseye / Bookworm / DietPi v9.x).
+The `linux-aarch64` artifact continues with the Bullseye-container pipeline (glibc 2.31 baseline, works on Pi OS Bullseye / Bookworm / DietPi v9.x).
 
 ## Upgrade
 
 ```sh
 # Linux x86_64 / aarch64
-wget https://github.com/luadch-ng/luadch/releases/download/v3.1.10/luadch-v3.1.10-linux-x86_64.tar.gz
-tar xzf luadch-v3.1.10-linux-x86_64.tar.gz
+wget https://github.com/luadch-ng/luadch/releases/download/v3.1.11/luadch-v3.1.11-linux-x86_64.tar.gz
+tar xzf luadch-v3.1.11-linux-x86_64.tar.gz
 # move your cfg/, scripts/data/, etc into the new tree, restart hub
 
 # Windows
-# Download luadch-v3.1.10-windows-x86_64.zip, extract, copy cfg+data over, restart.
+# Download luadch-v3.1.11-windows-x86_64.zip, extract, copy cfg+data over, restart.
 ```
 
 3.2.x is the active development line on `master`; security backports continue to land on `release/3.1.x` per [`CLAUDE.md` §8](https://github.com/luadch-ng/luadch/blob/master/CLAUDE.md#8-release-lines-and-support-policy).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The upstream project (`luadch/luadch`) is a separate codebase; its release
 history is at https://github.com/luadch/luadch/releases.
 
+## [v3.1.11] - 2026-06-07
+
+Maintenance patch release on the `release/3.1.x` line. One privilege-escalation bugfix cherry-picked from master. No breaking changes; no cfg / lang-file changes; drop-in upgrade from v3.1.10.
+
+### Bugfixes
+
+- [#320](https://github.com/luadch-ng/luadch/issues/320) (Kcchouette) - **`cmd_ban` offline-by-nick path silently bypassed the operator-to-target hierarchy check** (`cmd_ban_permission[level] < target:level()`) that fires on the online path. A lower-level operator could ban a higher-level offline registered user - including hubowner-level accounts, which would lock them out on their next login attempt. Root cause: the online branch resolves `target` to a user OBJECT (has `:level()` method), the offline branch resolves it to a profile TABLE from `regnicks[]` (has `.level` field), and the existing check site at `cmd_ban.lua:594` was only reachable from the online branch - the offline branch returned at `addban()` two lines earlier. Fix: explicit hierarchy guard inside the offline-by-nick branch using `target.level`, mirroring the online check semantics with the table-shape accessor. cid / ip offline branches keep no profile lookup and stay unchecked by design (no hierarchy info available). cmd_ban plugin bumped to v0.37. Cherry-picked from master ([PR #322](https://github.com/luadch-ng/luadch/pull/322), commit `30c8809`); the new HTTP-API-based regression smoke test stays master-only because the HTTP API ships on 3.2.x only - the fix logic is identical and reviewer-verified.
+
+### Notes
+
+- **No breaking changes, no cfg / lang-file edits required.** Drop-in upgrade from v3.1.10.
+- **All operators are urged to upgrade.** The bug is exploitable by anyone with `+ban` permission (typically operator-level and above), and the impact (offline ban of a hubowner-level account) can be a denial-of-administration on a single-hubowner deployment.
+
+[v3.1.11]: https://github.com/luadch-ng/luadch/releases/tag/v3.1.11
+
+
 ## [v3.1.10] - 2026-05-23
 
 Maintenance patch release on the `release/3.1.x` line. Two security / UX bugfixes cherry-picked from master. No breaking changes; no cfg / lang-file changes; drop-in upgrade from v3.1.9.

--- a/core/const.lua
+++ b/core/const.lua
@@ -11,7 +11,7 @@
 return {
 
     PROGRAM_NAME = "Luadch",
-    VERSION = "v3.1.10",
+    VERSION = "v3.1.11",
     COPYRIGHT = "by blastbeat and pulsar",
     FORK = "modernised fork by Aybo",
     CONFIG_PATH = "././cfg/",

--- a/scripts/cmd_ban.lua
+++ b/scripts/cmd_ban.lua
@@ -11,6 +11,18 @@
             - <time> and <reason> are optional
 
 
+        v0.37: by Aybo
+            - fix #320: enforce hierarchy check on the offline-by-nick
+              ban path. Pre-fix, the `permission[level] < target:level()`
+              guard on the online path was silently bypassed when the
+              target was an offline registered user (the offline branch
+              resolved the target via regnicks[] - a profile TABLE with
+              a `.level` field, not an object with a `:level()` method -
+              and returned at addban() before the check could run). A
+              low-level op could ban a higher-level offline user incl.
+              the hubowner. cid / ip offline branches have no profile
+              lookup and stay unchecked by design.
+
         v0.36: by pulsar
             - added "years" to util.formatseconds
                 - changed get_bantime()
@@ -169,7 +181,7 @@
 --------------
 
 local scriptname = "cmd_ban"
-local scriptversion = "0.36"
+local scriptversion = "0.37"
 
 local cmd = "ban"
 local cmd2 = "unban"
@@ -573,6 +585,21 @@ local onbmsg = function( user, command, parameters )
             target = regnicks[ id ]
             if not target then
                 user:reply( msg_off, hub.getbot() )
+                return PROCESSED
+            end
+            -- #320: offline hierarchy check. `target` here is the
+            -- registered-user profile TABLE from regnicks (has a
+            -- `.level` field), not an online user OBJECT (which has
+            -- a `:level()` method). The online-target hierarchy
+            -- check further below only fires when `target` is the
+            -- user object - on this offline-by-nick branch the code
+            -- returns at the addban() line below before it can run.
+            -- Without this check a low-level op can ban a higher-
+            -- level offline registered user (incl. hubowner). The
+            -- cid / ip offline branches have no profile lookup and
+            -- no hierarchy info, so they remain unchecked by design.
+            if permission[ level ] < ( target.level or 0 ) then
+                user:reply( msg_god, hub.getbot() )
                 return PROCESSED
             end
         end


### PR DESCRIPTION
## Summary

Backport of the master PR [#322](https://github.com/luadch-ng/luadch/pull/322) (commit `30c8809`) to the `release/3.1.x` line, packaged as the next maintenance release **v3.1.11**.

### What's in it

- `scripts/cmd_ban.lua` - the offline-by-nick hierarchy-check fix (cmd_ban v0.36 → v0.37)
- `core/const.lua` - `VERSION = v3.1.11`
- `CHANGELOG.md` - v3.1.11 section with the Bugfixes entry + reference link
- `.github/release-body.md` - v3.1.11 release notes (replaces v3.1.10's body)

### Why backport

[#320](https://github.com/luadch-ng/luadch/issues/320) is a privilege-escalation: any account with `+ban` permission (default ops at level 60+) could ban an offline registered user of arbitrarily higher level, including the hubowner. On a single-hubowner deployment this becomes denial-of-administration on the hub - the hubowner cannot remove their own ban because they cannot log in.

Per CLAUDE.md §8 backport criteria, this matches the *"plugin-state corruption: judgement call - if data loss is the failure mode, yes"* row (hub-owner lockout = administrative-loss failure mode), and is also a defensible read of the *"Critical CVE in hub-itself code"* row depending on how one classifies an in-plugin privilege check.

### Not a clean cherry-pick

The master PR also adds an HTTP-API-based smoke regression test (`test_320_offline_ban_hierarchy`). That test cannot run on 3.1.x because the HTTP API ships on 3.2.x only. The fix logic itself ports cleanly (the offline-branch shape is identical; only line numbers differ - 3.1.x sees the check site at `cmd_ban.lua:594`, master at `cmd_ban.lua:998`). Documented in the CHANGELOG entry and the release-body.

### Pattern sweep

Audited on master: `cmd_gag` / `cmd_setpass` / `cmd_upgrade` / `cmd_delreg` / `cmd_nickchange` / `cmd_redirect` / `cmd_disconnect` / `etc_trafficmanager` / `etc_msgmanager` for the same online-vs-offline-hierarchy-check divergence. All clean (6 properly guarded on both paths, 3 online-only by design). cmd_ban was the only affected plugin. Result carries over to 3.1.x because the affected code paths are byte-identical in the relevant range.

## Test plan

- [ ] CI smoke + analyze on `release/3.1.x` is green (no behaviour change for default-config hubs - default `cmd_ban_permission[100] = 100`, so hubowner-level ops continue to be able to ban any user)
- [ ] Manual: register two users (op=60, target=100 offline), op tries to +ban target → \`msg_god\` reply, no ban entry persisted

## Release follow-up (after merge)

1. Tag `v3.1.11` on the merge commit
2. Push the tag - the existing release workflow publishes the GitHub release with the new `.github/release-body.md` as the body and builds + uploads the linux-x86_64 / linux-aarch64 / windows-x86_64 artifacts

Closes #320 (3.1.x side).