### PR TITLE
fix(usr_uptime): drop always-zero years from per-month display (#328)

### DIFF
--- a/scripts/lang/usr_uptime.lang.de
+++ b/scripts/lang/usr_uptime.lang.de
@@ -12,7 +12,6 @@
     msg_usage = "[+!#]useruptime CT1 <FIRSTNICK> | CT2 <NICK>",
     msg_notfound = "User nicht gefunden.",
 
-    msg_years = " Jahre, ",
     msg_days = " Tage, ",
     msg_hours = " Stunden, ",
     msg_minutes = " Minuten, ",

--- a/scripts/lang/usr_uptime.lang.en
+++ b/scripts/lang/usr_uptime.lang.en
@@ -12,7 +12,6 @@
     msg_usage = "[+!#]useruptime CT1 <FIRSTNICK> | CT2 <NICK>",
     msg_notfound = "User not found.",
 
-    msg_years = " years, ",
     msg_days = " days, ",
     msg_hours = " hours, ",
     msg_minutes = " minutes, ",

--- a/scripts/usr_uptime.lua
+++ b/scripts/usr_uptime.lua
@@ -4,6 +4,18 @@
 
         usage: [+!#]useruptime [CT1 <FIRSTNICK> | CT2 <NICK>]
 
+        v0.11: by Aybo
+            - drop always-zero "years" from per-month display
+              (fix #328, reported by Sopor). A calendar month
+              holds <= 31 days = ~2.7M s, while formatseconds
+              only rolls a year at 365 days = ~31.5M s, so the
+              year column was pure noise. Switched to the
+              4-value (hubstart=true) form of formatseconds and
+              removed `y .. msg_years` from the rendered line.
+              The `msg_years` key is also dropped from this
+              plugin's lang files; 14 other plugins keep their
+              own `msg_years` for legitimate year-scale spans.
+
         v0.10: by Aybo
             - rewrite the per-month accounting (fix #127, original
               report upstream luadch/luadch#193 by Sopor).
@@ -77,7 +89,7 @@
 --------------
 
 local scriptname = "usr_uptime"
-local scriptversion = "0.10"
+local scriptversion = "0.11"
 
 local cmd = { "useruptime", "uu" }
 
@@ -105,7 +117,6 @@ local msg_denied = lang.msg_denied or "You are not allowed to use this command."
 local msg_usage = lang.msg_usage or "[+!#]useruptime CT1 <FIRSTNICK> | CT2 <NICK>"
 local msg_notfound = lang. msg_notfound or "User not found."
 
-local msg_years = lang.msg_years or " years, "
 local msg_days = lang.msg_days or " days, "
 local msg_hours = lang.msg_hours or " hours, "
 local msg_minutes = lang.msg_minutes or " minutes, "
@@ -240,8 +251,11 @@ local get_useruptime = function( firstnick )
                             -- weirdness for sessions crossing a month
                             -- boundary.
                             local complete = v.complete or 0
-                            local y, d, h, m, s = util.formatseconds( complete )
-                            local uptime = y .. msg_years .. d .. msg_days .. h .. msg_hours .. m .. msg_minutes .. s .. msg_seconds
+                            -- v0.11 fix #328: drop years (always 0 for a per-month
+                            -- counter, max 31 days < 365). hubstart=true gives the
+                            -- 4-value (d, h, m, s) form.
+                            local d, h, m, s = util.formatseconds( complete, true )
+                            local uptime = d .. msg_days .. h .. msg_hours .. m .. msg_minutes .. s .. msg_seconds
                             msg = msg .. "\t" .. year .. "\t" .. month_name[ month ] .. "\t" .. uptime .. "\n"
                         end
                     end


### PR DESCRIPTION
Closes #328. Reported by [REG]Sopor on the Luadch-NG Dev/Support hub.

## Summary
- Per-month uptime rows rendered as `0 years, X days, ...`. The `years` slot is mathematically always 0 because a calendar month tops out at 31 days = ~2.7M s, while `formatseconds` only rolls a year at 365 days = ~31.5M s.
- Switched the renderer to `formatseconds(complete, true)` (existing 4-return hub-uptime form), dropped `y .. msg_years` from the concat, and removed the now-unused `msg_years` key from this plugin's `lang.de` / `lang.en`. 14 other plugins keep their own `msg_years` for legitimate year-scale spans (`cmd_uptime`, `cmd_ban`, account age, etc.).
- Bumped script header to v0.11 with a brief changelog entry.

## Out of scope
Sopor also reports lower-than-expected day counts for Jan-April 2026 ("counting wrong... counts over to the next month"). Those rows are pre-#127 garbage data and explicitly documented as not retroactively recoverable in the v0.10 changelog (PR #131, merged 2026-05-11). From May 11 onward the per-tick accounting writes accurate numbers.

## Test plan
- [x] Verified `formatseconds(2678400, true)` returns `(31, 0, 0, 0)` (max-month case)
- [x] Verified `formatseconds(0, true)` returns `(0, 0, 0, 0)` (empty-month edge)
- [x] Verified the rendered string drops the leading `0 years, ` segment
- [x] Caller / consumer sweep: `get_useruptime` output is only sent as a `user:reply` chat message; no downstream string parser depends on the `years` prefix
- [x] Lang parity: `usr_uptime.lang.de` and `lang.en` updated symmetrically
- [x] Two-pass review (independent subagent + maintainer spot-check)
- [ ] Maintainer-side smoke pass