### PR TITLE
fix(smoke): wait for api_token.first after http-no-tokens mode-switch

### DIFF
--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -175,6 +175,26 @@ def wait_for_port(host: str, port: int, timeout: float):
     raise TimeoutError(f"port {host}:{port} did not open within {timeout}s; last error: {last_err}")
 
 
+def wait_for_file(path: Path, timeout: float):
+    """Poll filesystem until `path` exists, or timeout.
+
+    Used by mode-switch helpers that flip the hub into a state where
+    the hub itself emits a sentinel file as part of boot (e.g.
+    `cfg/api_token.first` when `http_port` is set + `http_api_tokens`
+    is empty - the #231 first-boot bootstrap). On Windows MinGW the
+    ADC port can bind before the HTTP-side bootstrap finishes
+    writing the sample-token file, so a setup that only does
+    `wait_for_port(ADC)` and then asserts the file is present races
+    on a slow runner. Symmetric with wait_for_port: setup ensures
+    the precondition; the test asserts behaviour."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return
+        time.sleep(0.1)
+    raise TimeoutError(f"file {path} did not appear within {timeout}s")
+
+
 def stop_hub(proc, log_file):
     if proc.poll() is None:
         log("stopping hub")
@@ -3116,6 +3136,14 @@ def _switch_to_http_no_tokens_mode(staging_dir: Path, current_proc, current_log_
     # the boot sequence (incl. the bootstrap_first_token write).
     # Without this, the test below might race the hub's startup.
     wait_for_port(HUB_HOST, TEST_PORT_PLAIN, 5.0)
+    # Also wait for the sample-token file. On Windows MinGW the
+    # ADC port can bind a tick BEFORE bootstrap_first_token has
+    # finished writing api_token.first; the original wait_for_port
+    # alone left a race that caused intermittent post-merge CI
+    # failures (every downstream HTTP test then failed with
+    # "[Errno 2] No such file or directory: cfg\\api_token.first").
+    sample_path = staging_dir / "cfg" / "api_token.first"
+    wait_for_file(sample_path, 5.0)
     return proc, log_file
 
 


### PR DESCRIPTION
## Summary

Closes a Windows-MinGW flake in the smoke harness. The \`_switch_to_http_no_tokens_mode\` helper waited only on the ADC port binding to confirm the hub finished booting; on Windows the ADC sockets sometimes bind a tick BEFORE \`bootstrap_first_token\` ([core/hub.lua](core/hub.lua)) has written \`cfg/api_token.first\`. The downstream test \"http_port set + tokens empty = no listener (#231)\" then race-fails with \"sample token file not present\" and every subsequent HTTP-API test cascades on the missing file.

## Observed pattern

Both PR #331 and PR #332 PASSED Windows pre-merge CI on the same code, then FAILED post-merge on master with two different flaky tests (#331 hit a long-poll timing flake, #332 hit this api_token race). Re-running each failed job went green - classic flake signature.

| PR | Pre-merge Win | Post-merge Win | Cause |
|---|---|---|---|
| #330 | ✓ | ✓ | (no flake) |
| #331 | ✓ | ✗ (long-poll timing) | (different flake) |
| #332 | ✓ | ✗ (api_token race) | **this PR fixes it** |

## Fix

Add \`wait_for_file(api_token.first, 5.0)\` right after the existing \`wait_for_port(ADC)\`. Symmetric with the existing setup pattern. New helper \`wait_for_file\` polls with the same deadline-with-raise shape as \`wait_for_port\`.

Semantic preserved: if the file doesn't appear within 5s the hub is genuinely broken and we still raise a \`TimeoutError\` - this is not muting real failures, just closing the race window.

## Out of scope

The OTHER post-merge Windows flake (#263 events long-poll \"returned too fast (1.06s); expected ~2s wait\") is a timer-precision issue and needs its own analysis / fix. Not bundled into this PR.

## Test plan

- [x] Local smoke run on Windows MinGW UCRT64 - the #231 test passes cleanly with the new wait.
- [x] \`python -c \"import ast; ast.parse(open('tests/smoke/run.py').read())\"\` - parse OK.
- [ ] CI run on this PR (Linux + Windows). Expected: both pass.

3.2.x only. No backport.