### PR TITLE
fix(http_events): use socket.gettime for long-poll deadline (#263)

### DIFF
--- a/core/http_events.lua
+++ b/core/http_events.lua
@@ -46,9 +46,11 @@ local tostring = use "tostring"
 
 local os = use "os"
 local table = use "table"
+local socket = use "socket"
 
 local os_date         = os.date
 local os_time         = os.time
+local socket_gettime  = socket.gettime
 local table_insert    = table.insert
 local table_remove    = table.remove
 
@@ -290,7 +292,14 @@ local register_waiter = function( handler, since_raw, types_str, wait_seconds, r
         since        = since,
         types_str    = types_str,
         types_filter = _parse_types_filter( types_str ),
-        deadline     = os_time( ) + secs,
+        -- socket.gettime() gives ms-resolution wall clock; os.time()
+        -- returns integer seconds, which on the deadline math meant a
+        -- request arriving at epoch T.99 with wait=2 got deadline =
+        -- floor(T.99)+2 = T+2 and resolved at the very next tick at
+        -- T+2 (elapsed = 1.01s, NOT the requested 2s). Closes the
+        -- "events PR-B long-poll: returned too fast" flake from
+        -- post-merge Windows CI (#332 master run, post #263 PR-B).
+        deadline     = socket_gettime( ) + secs,
         render_fn    = render_fn,
     }
 end
@@ -298,8 +307,10 @@ end
 -- PR-B: called from server.lua's timer loop ~once per second.
 -- Resolves any waiter whose deadline has elapsed with an empty
 -- events array (client picks up the cursor and immediately re-polls).
+-- Uses socket.gettime() to match register_waiter's ms-resolution
+-- deadline (see comment above).
 local tick = function( )
-    local now = os_time( )
+    local now = socket_gettime( )
     for i = #_waiters, 1, -1 do
         local w = _waiters[ i ]
         if w.deadline <= now then


### PR DESCRIPTION
## Summary

Closes a latent precision bug in the [#263](https://github.com/luadch-ng/luadch/issues/263) PR-B long-poll deadline path of [\`core/http_events.lua\`](core/http_events.lua). The deadline was computed with \`os.time()\` (integer seconds), so a request arriving at wall-clock epoch \`T.99\` with \`wait=2\` got \`deadline = floor(T.99)+2 = T+2\` and the very next tick at \`T+2\` resolved the waiter at **elapsed = 1.01s**, NOT the requested 2s.

This is NOT a Windows-only bug; the post-merge Windows CI just happened to land at a sub-second boundary. Linux is equally affected when the request times right.

## Fix

Swap both \`os.time()\` call sites in the deadline-related paths (\`register_waiter\` line ~293, \`tick\` line ~302) to \`socket.gettime()\`, which gives millisecond-precision wall clock. Same primitive [core/http_router.lua](core/http_router.lua) line 80 and [core/http_client.lua](core/http_client.lua) line 79 already use for their analogous deadline math.

\`_iso_now\` (line ~77) keeps \`os.time()\` because ISO-8601 timestamps are second-precision by convention and \`os.date\` wants an integer epoch.

Post-fix the deadline-driven resume lands in \`[2.0, ~3.0]\` seconds (tick still fires ~once/sec, so floor variance is bounded by tick resolution). The existing smoke test threshold \`1.5 < elapsed < 5.0\` is unchanged and still catches a return of the bug.

## Test plan

- [x] Static lint-load of \`core/http_events.lua\` via stub use shim - parses clean.
- [x] No other consumers of \`http_events\` deadline path - it's a private helper of \`register_waiter\` / \`tick\`.
- [x] The other \`os_time\` call (\`_iso_now\`) is intentionally NOT touched (ISO timestamps need integer epoch).
- [ ] CI smoke (Linux + Windows). Expected: both pass. The post-fix elapsed should land in \`[2.0, ~3.0]\` instead of the pre-fix \`[1.0, 2.0]\`.

3.2.x only. No backport.