### PR TITLE
fix(hub_dispatch): log TCP source IP on no-CID/PID/NICK reject

### DIFF
--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -443,12 +443,18 @@ _identify = {
         local inf_i4 = adccmd:getnp "I4"
         local inf_i6 = adccmd:getnp "I6"
         local hash = user.hash( )
+        local userip = user.ip( ) or ""
         if not ( cid and pid and nick ) then
             user:kill( "ISTA 220 " .. _i18n.no_cid_nick_found .. "\n", "TL-1" )
-            scripts_firelistener( "onFailedAuth", ( nick or _i18n.unknown ), ( inf_i4 or inf_i6 or _i18n.unknown ), ( cid or _i18n.unknown ), escapefrom( _i18n.no_cid_nick_found ) )
+            -- IP arg: log the authenticated TCP source rather than
+            -- `inf_i4 or inf_i6` (the client-claimed INF address). The
+            -- INF claim is unreliable here by construction - the BINF
+            -- is malformed - and operators correlate failed-auth lines
+            -- by source IP. Falls back to `unknown` only if the socket
+            -- has no peer (defensive; should not happen post-connect).
+            scripts_firelistener( "onFailedAuth", ( nick or _i18n.unknown ), ( userip ~= "" and userip or _i18n.unknown ), ( cid or _i18n.unknown ), escapefrom( _i18n.no_cid_nick_found ) )
             return true
         end
-        local userip = user.ip( ) or ""
         local userfam = ( userip:find( ":", 1, true ) and "I6" or "I4" )
         -- Field that the TCP source's family can authenticate. The
         -- other family (if advertised) is stripped below, post-stamp.


### PR DESCRIPTION
## Summary

The `ISTA 220 No CID/PID/NICK/IP found in your INF.` reject path fires when a client sends a BINF missing `PD` AND `ID` AND `NI` (three mandatory ADC fields). The `onFailedAuth` listener was receiving `inf_i4 or inf_i6 or _i18n.unknown` as the IP arg, which renders as `<UNKNOWN>` in operator logs whenever the malformed BINF also lacks `I4`/`I6` (typical for the same broken clients that omit the mandatory fields).

Hoist `user.ip()` above the reject and pass the authenticated TCP source as the listener's IP arg.

Reported by Sopor in chat - his `etc_userlogininfo` line was reading:

```
[ FAILED AUTHENTICATION ]--> User: <UNKNOWN>  |  IP: <UNKNOWN>  |  CID: <UNKNOWN>  |  Reason: No CID/PID/NICK/IP found in your INF.
```

with no way to correlate repeats. Post-fix the IP field carries the real TCP source.

## Why

- **Operator visibility**: lets operators correlate failed-auth lines by source IP - the only signal we still have when the client omits everything else.
- **Consistency**: this was the **sole outlier** among 7 `onFailedAuth` call sites in `_identify.BINF` - all 6 others already use `userip` (TCP source). Sibling paths like the `kill_wrong_ips` branch (line 472-475) have always used `userip` directly.
- **Mild security win**: the pre-patch code logged attacker-controlled raw INF strings as an "IP" in operator logs. The TCP source from `getpeername(2)` is kernel-authenticated and cannot be lied about.

## Behavior change

- Wire bytes unchanged. Hub still kicks with `ISTA 220` + `TL-1`.
- Listener IP arg semantics change from "client INF claim or unknown" to "kernel-authenticated TCP source or unknown".
- All downstream listener consumers reviewed - they stringify the IP arg without parsing it; no breakage.

## Scope

Master only. **No 3.1.x backport** per §8 - this is a log-quality / operator-visibility fix, not a CVE or crash. Operators on 3.1.x can apply a 2-line manual patch (see chat with Sopor).

## Test plan

- [x] Lua syntax check (`lua54.exe loadfile`) green
- [x] Two-pass review per §1a.6 (independent subagent + maintainer spot-check): no blockers, surfaces a consistency win and a mild log-injection mitigation
- [x] Smoke harness on push + PR (existing `test_binf_without_i4_or_i6_accepted` already covers the ISTA 220 path positively)
- [x] §1a.7 regression-test: skipped per `feedback_diff_is_self_evidence.md` - unpatched code provably passes `_i18n.unknown` when `inf_i4`/`inf_i6` are absent on the reject branch (which is the typical co-occurrence). The 2-line diff is the proof.

## Files

- `core/hub_dispatch.lua` - hoist `userip` above the CID/PID/NICK check, pass it to the listener.