### PR TITLE
ci(docker): add `dev` branch to auto-publish trigger

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,11 +3,13 @@ name: Docker
 # Triggers:
 #   - tag push v* (real release, publishes vX.Y.Z + vX.Y + latest)
 #   - push to master (publishes :master moving tag for testing)
+#   - push to dev (publishes :dev moving tag for operator testhubs to
+#     try the next-merge candidate before it lands on master)
 #   - PR (build-only, no push) so PRs that touch the Dockerfile or
 #     entrypoint can fail fast in CI before merge
 on:
   push:
-    branches: [master]
+    branches: [master, dev]
     tags: ['v*']
   pull_request:
     paths:
@@ -67,6 +69,8 @@ jobs:
       # Tag policy:
       #   - tag v3.1.4    -> :v3.1.4, :v3.1, :v3, :latest
       #   - master push   -> :master   (moving, for early testers)
+      #   - dev push      -> :dev      (moving, for operator testhubs;
+      #                                  next-merge candidate)
       #   - PR / dispatch -> :pr-<n>   (build-only, no push)
       - name: Compute image tags + labels
         id: meta


### PR DESCRIPTION
## Summary
- Push to a new \`dev\` branch now publishes \`ghcr.io/luadch-ng/luadch:dev\` alongside the existing \`:master\` moving tag.
- Operators running their own testhubs can \`docker pull :dev\` to validate the next-merge candidate without waiting for master.

## Workflow
\`feat/X\` branch → ready → merge to \`dev\` → docker auto-builds + pushes \`:dev\` → operator pulls + tests → green → PR \`feat/X\` → \`master\`.

\`dev\` is operator-managed; maintainer keeps it in sync with master + zero or more in-flight feature branches as needed. No release-line semantic (master remains the release substrate).

## Scope
Single-line change in \`on.push.branches\` array + tag-policy comment refresh. No behaviour change for the existing master / tag / PR triggers. The \`dev\` branch itself is NOT created by this PR; the maintainer creates it when they first want to publish (\`git checkout master && git checkout -b dev && git push -u origin dev\`).

## Test plan
- [x] YAML syntax check (python yaml.safe_load OK)
- [x] Existing master / tag / PR triggers untouched (diff only adds, doesn't change other paths)
- [ ] First push to \`dev\` after merge verifies the auto-build + :dev publish