### PR TITLE
feat(etc_clientblocker): Sopor patterns + opchat report + SBOT exempt (#81)

### DIFF
--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -2664,6 +2664,7 @@ local defaults = {
         [ 30 ]  = true,
         [ 40 ]  = true,
         [ 50 ]  = true,
+        [ 55 ]  = false,
         [ 60 ]  = false,
         [ 70 ]  = false,
         [ 80 ]  = false,
@@ -2704,6 +2705,39 @@ local defaults = {
                 and value % 1 == 0
                 and value >= 1
                 and value <= 4096
+        end
+    },
+
+    -- Operator-chat report on every kick. When true, the plugin
+    -- fires etc_report.send with a human-readable banner (nick,
+    -- IP, version, matched pattern) so staff see kicks in chat
+    -- without tailing the audit log. Defaults match sibling
+    -- plugins (etc_aliases / etc_msgmanager): opchat ON, hubbot
+    -- OFF.
+    etc_clientblocker_report = { true,
+        function( value )
+            return types_boolean( value, nil, true )
+        end
+    },
+
+    etc_clientblocker_report_hubbot = { false,
+        function( value )
+            return types_boolean( value, nil, true )
+        end
+    },
+
+    etc_clientblocker_report_opchat = { true,
+        function( value )
+            return types_boolean( value, nil, true )
+        end
+    },
+
+    -- Minimum level required to receive the hubbot-PM report (only
+    -- consulted when etc_clientblocker_report_hubbot=true). Mirrors
+    -- the etc_report.send signature used across bundled plugins.
+    etc_clientblocker_llevel = { 60,
+        function( value )
+            return types_number( value, nil, true )
         end
     },
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -573,6 +573,35 @@ All other Lua-pattern punctuation (`%`, `+`, `.`, `(`, `)`,
 version}` so post-mortem can reconstruct which rule fired and what
 the offending VE actually was.
 
+**Op-chat / hubbot report on kick.** When
+`etc_clientblocker_report=true` (default) the plugin fires
+`etc_report.send` with a human-readable banner
+`[ CLIENT BLOCKER ]--> The user <nick> with IP <ip> is running
+<version> and is not allowed in this hub. Matching pattern: <pat>`
+so staff see kicks live in op-chat without tailing the audit log.
+The audit log carries the same fields structured for forensics;
+the report is for operational awareness. Sub-toggles
+`etc_clientblocker_report_opchat` (default true) and
+`etc_clientblocker_report_hubbot` (default false) match the
+sibling-plugin convention.
+
+**Default blocklist** (`scripts/data/etc_clientblocker.tbl`):
+ships with 6 well-known cheat/mod clients pre-blocked
+(`CleanDC++`, `RSX++`, `CrZ++`, `SmVDC++`, `DC@fe++`,
+`FearDC`). These are universally-malicious clients across DC
+hubs - operators almost never want them. Remove individual
+entries via `+delblocker <pattern>` or edit the .tbl directly
+and `+reload`.
+
+**Extended example list** (`examples/data/etc_clientblocker.tbl.example`):
+~40 additional patterns curated by Sopor over years of hub
+operation - blocks outdated stable releases of DC++ (0.0xx-0.8xx),
+AirDC++ (1.0-4.29 + Web Client 0.x-2.14b + nano), EiskaltDC++ (<2.4.1),
+ApexDC++ (<1.6.4), ncdc (<1.18), Jucy (<0.86), plus legacy mods
+(StrgDC++, IceDC++, PDC++, PWDC++). Copy this file to
+`scripts/data/etc_clientblocker.tbl` and `+reload` to adopt the
+broader policy.
+
 **HTTP API:**
 - `GET /v1/clientblocker` (read scope) - list patterns
 - `POST /v1/clientblocker` (admin scope) - add pattern; body
@@ -587,9 +616,13 @@ applies" semantic for any other missing input.
 
 **Config:** `etc_clientblocker_oplevel` (write floor for the ADC
 cmd; default 80), `etc_clientblocker_check_levels` (per-level
-boolean table), `etc_clientblocker_default_reason`
+boolean table; level 55 (SBOT) + 60/70/80 exempt by default),
+`etc_clientblocker_default_reason`
 (`"Your client is not allowed"`),
-`etc_clientblocker_max_pattern_len` (200).
+`etc_clientblocker_max_pattern_len` (200),
+`etc_clientblocker_report` (true), `etc_clientblocker_report_opchat`
+(true), `etc_clientblocker_report_hubbot` (false),
+`etc_clientblocker_llevel` (60).
 
 ### etc_keyprint
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -585,6 +585,14 @@ the report is for operational awareness. Sub-toggles
 `etc_clientblocker_report_hubbot` (default false) match the
 sibling-plugin convention.
 
+Flood-control note: the report fires synchronously on every kick.
+Op-chat flood protection relies on the upstream per-IP / per-CID
+connect rate-limit in `core/ratelimit.lua` (Phase 7); a determined
+attacker who throttles connections below the limit can sustain
+~1 kick/sec/IP. If your hub sees this and op-chat noise becomes
+unmanageable, flip `etc_clientblocker_report=false` and rely on
+the audit log alone.
+
 **Default blocklist** (`scripts/data/etc_clientblocker.tbl`):
 ships with 6 well-known cheat/mod clients pre-blocked
 (`CleanDC++`, `RSX++`, `CrZ++`, `SmVDC++`, `DC@fe++`,

--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -965,19 +965,27 @@ return { -- the settings are a lua table, do not tough this!
     etc_clientblocker_default_reason = "Your client is not allowed",  -- fallback kick reason when an operator adds a pattern without a custom one (string)
     etc_clientblocker_max_pattern_len = 200,  -- hard cap on pattern length to bound string.find runtime (integer)
 
+    etc_clientblocker_report = true,  -- on every kick, fire etc_report.send with nick+ip+version+pattern so staff see it in chat (boolean)
+    etc_clientblocker_report_hubbot = false,  -- send the report as a hubbot PM to operators at or above etc_clientblocker_llevel (boolean)
+    etc_clientblocker_report_opchat = true,  -- send the report into op-chat (boolean)
+    etc_clientblocker_llevel = 60,  -- min level for the hubbot-PM report (integer)
+
     etc_clientblocker_check_levels = {  -- which levels the BINF check applies to (table of integer -> boolean)
 
         -- Operators (60+) are exempt by default so an operator who
         -- adds a pattern matching their own client does not self-
         -- lockout. HUBOWNER (100) stays in scope deliberately - if
         -- you really want to test from a blocked client, flip it
-        -- here and +reload.
+        -- here and +reload. Level 55 (SBOT) is exempt: bots have no
+        -- BINF VE/AP to check against and should never be a kick
+        -- target.
         [ 0 ]   = true,   -- UNREG
         [ 10 ]  = true,   -- GUEST
         [ 20 ]  = true,   -- REG
         [ 30 ]  = true,   -- VIP
         [ 40 ]  = true,   -- SVIP
         [ 50 ]  = true,   -- SERVER
+        [ 55 ]  = false,  -- SBOT
         [ 60 ]  = false,  -- OPERATOR
         [ 70 ]  = false,  -- SUPERVISOR
         [ 80 ]  = false,  -- ADMIN

--- a/examples/data/etc_clientblocker.tbl.example
+++ b/examples/data/etc_clientblocker.tbl.example
@@ -1,0 +1,132 @@
+local patterns
+
+-- =====================================================================
+-- etc_clientblocker.tbl.example
+--
+-- Extended client blocklist curated by Sopor (luadch community
+-- operator). Imported from his etc_clientblocker.lua v0.4 (2026,
+-- multi-year production hub). Goes BEYOND the bundled
+-- scripts/data/etc_clientblocker.tbl (which only carries the
+-- universally-malicious cheat/mod clients) and additionally blocks
+-- outdated stable releases of otherwise-legitimate clients
+-- (DC++, AirDC++, EiskaltDC++, ApexDC++, ncdc, Jucy, ...) plus
+-- legacy DC++ mods (StrgDC++, IceDC++, PDC++, PWDC++).
+--
+-- To use: copy this file to scripts/data/etc_clientblocker.tbl
+-- and run `+reload`. Operators can then prune individual entries
+-- with `+delblocker <pattern>` or add custom rules with
+-- `+addblocker <pattern> [reason]`.
+--
+-- Two Sopor-isms were normalised on import:
+--   - `%w` (Lua's word-character class) was used as if it were
+--     a literal "w" to match "AirDC++w" (Web Client). The class
+--     matches any letter/digit so the original was over-permissive
+--     (would also match e.g. "AirDC++Q"). Switched to literal `w`.
+--   - `%n` was already literal "n" (Lua 5.4 treats `%X` for non-
+--     class X as the literal byte X). Left as-is for readability.
+--
+-- Reason strings include Swedish translations for Sopor's hub
+-- (kept verbatim - operators of non-SE hubs can re-edit via
+-- `+addblocker` after re-import).
+--
+-- License: GPLv3 (matches the parent plugin). Original author:
+-- pulsar + Sopor maintenance.
+-- =====================================================================
+
+patterns = {
+
+    -- DC++ 0.000 - 0.799
+    [ "^%+%+%s0%.[0-7][0-9][0-9]$" ] = "You are using an old version of DC++. Please update and reconnect!",
+
+    -- DC++ 0.800 - 0.879
+    [ "^%+%+%s0%.8[0-7][0-9]$" ]     = "You are using an old version of DC++. Please update and reconnect!",
+
+    -- AirDC++ 1.00 - 3.99 (all alpha, beta, stable)
+    [ "^AirDC%+%+%s[1-3]%.[0-9][0-9][ab]?.-" ] = "You are using an old version of AirDC++. Please update and reconnect! (File / Update check)",
+
+    -- AirDC++ 4.00 - 4.09 (all alpha, beta, stable)
+    [ "^AirDC%+%+%s4%.0[0-9][ab]?.-" ] = "You are using an old version of AirDC++. Please update and reconnect! (File / Update check)",
+
+    -- AirDC++ 4.10 - 4.19 (all alpha, beta, stable)
+    [ "^AirDC%+%+%s4%.1[0-9][ab]?.-" ] = "You are using an old ALPHA/BETA version of AirDC++. Please update and reconnect! (File / Update check)",
+
+    -- AirDC++ 4.20 - 4.29 (alpha + beta only)
+    [ "^AirDC%+%+%s4%.2[0-9][ab].-" ] = "You are using an old ALPHA/BETA version of AirDC++. Please update and reconnect! (File / Update check)",
+
+    -- AirDC++ 4.0 modified (Snoopy uses this exact string)
+    [ "^AirDC%+%+%s4%.0$" ] = "You are using a modified AirDC++. Download the unmodified release at https://github.com/airdcpp/airdcpp-windows/releases",
+
+    -- AirDC++ 3.00 - 4.99 stable but dirty (-d suffix)
+    [ "^AirDC%+%+%s[3-4]%.[0-9][0-9]%-d" ] = "You are using a modified AirDC++. Download the unmodified release at https://github.com/airdcpp/airdcpp-windows/releases",
+
+    -- AirDC++ Web Client all 0.x (beta + stable)
+    [ "^AirDC%+%+w%s0%..+" ]            = "You are using an old version of AirDC++ Web Client. Please update and reconnect!",
+
+    -- AirDC++ Web Client 1.0.0 - 1.9.9
+    [ "^AirDC%+%+w%s1%.[0-9]%.[0-9].-" ] = "You are using an old version of AirDC++ Web Client. Please update and reconnect!",
+
+    -- AirDC++ Web Client 2.0.0 - 2.9.9
+    [ "^AirDC%+%+w%s2%.[0-9]%.[0-9].-" ] = "You are using an old version of AirDC++ Web Client. Please update and reconnect!",
+
+    -- AirDC++ Web Client 2.10.x - 2.11.x
+    [ "^AirDC%+%+w%s2%.10%.[0-9].-" ]    = "You are using an old version of AirDC++ Web Client. Please update and reconnect!",
+    [ "^AirDC%+%+w%s2%.11%.[0-9].-" ]    = "You are using an old version of AirDC++ Web Client. Please update and reconnect!",
+    [ "^AirDC%+%+w%s2%.12%.0.-" ]        = "You are using an old version of AirDC++ Web Client. Please update and reconnect!",
+
+    -- AirDC++ Web Client 2.12.x - 2.14.0 beta
+    [ "^AirDC%+%+w%s2%.12%.[1-9]b.-" ]   = "You are using an old ALPHA/BETA version of AirDC++ Web Client. Please update and reconnect!",
+    [ "^AirDC%+%+w%s2%.13%.[0-9]b.-" ]   = "You are using an old ALPHA/BETA version of AirDC++ Web Client. Please update and reconnect!",
+    [ "^AirDC%+%+w%s2%.14%.0b.-" ]       = "You are using an old ALPHA/BETA version of AirDC++ Web Client. Please update and reconnect!",
+
+    -- AirDC++ nano (any version - deprecated)
+    [ "^AirDC%+%+n%s.-" ] = "AirDC++ nano is outdated. Please switch to AirDC++ Web Client and reconnect!",
+
+    -- ApexDC++ 0.x.x - 1.5.9
+    [ "^ApexDC%+%+%s[0-1]%.[0-5]%.[0-9]$" ] = "You are using an old version of ApexDC++. Please update and reconnect!",
+    -- ApexDC++ 1.5.10 - 1.5.14
+    [ "^ApexDC%+%+%s[0-1]%.[0-5]%.1[0-4]$" ] = "You are using an old version of ApexDC++. Please update and reconnect!",
+    -- ApexDC++ 1.6.0 - 1.6.4
+    [ "^ApexDC%+%+%s1%.6%.[0-4]$" ]          = "You are using an old version of ApexDC++. Please update and reconnect!",
+
+    -- Cheat / mod clients (also bundled by default - kept here for
+    -- single-file completeness if the operator copies this OVER
+    -- the bundled set).
+    [ "^CleanDC%+%+.+" ]   = "CleanDC++ is not allowed in this hub. Please switch to AirDC++ and reconnect!",
+    [ "^RSX%+%+.+" ]       = "RSX++ is not allowed in this hub. Please switch to AirDC++ and reconnect!",
+    [ "^CrZ%+%+.+" ]       = "CrZ++ is not allowed in this hub. Please switch to AirDC++ and reconnect!",
+    [ "^SmVDC%+%+.-$" ]    = "SmVDC++ is not allowed in this hub. Please switch to AirDC++ and reconnect!",
+    [ "^DC@fe%+%+.-$" ]    = "Modified BCDC++ is not allowed in this hub. Please switch to AirDC++ and reconnect!",
+    [ "^FearDC.+" ]        = "FearDC is not allowed in this hub. Please switch to AirDC++ and reconnect!",
+
+    -- ncdc all versions through 1.18.1 (current as of 2026 is 1.25)
+    [ "^ncdc%s0%.[1-9].-" ]   = "You are using an old version of ncdc. Please update and reconnect!",
+    [ "^ncdc%s1%.[0-9]$" ]    = "You are using an old version of ncdc. Please update and reconnect!",
+    [ "^ncdc%s1%.[0-9]%-.+" ] = "You are using an old version of ncdc. Please update and reconnect!",
+    [ "^ncdc%s1%.1[0-8].-" ]  = "You are using an old version of ncdc. Please update and reconnect!",
+
+    -- PDC++ all (private DC fork)
+    [ "^PDC%+%+.-" ] = "PDC++ is not allowed in this hub. Please switch to AirDC++ and reconnect!",
+
+    -- PWDC++ all
+    [ "^PWDC%+%+.-" ] = "PWDC++ is not allowed in this hub. Please switch to AirDC++ and reconnect!",
+
+    -- StrongDC++ all (StrgDC++ in BINF)
+    [ "^StrgDC%+%+.-" ] = "StrgDC++ is not allowed in this hub. Please switch to AirDC++ and reconnect!",
+
+    -- IceDC++ all
+    [ "^IceDC%+%+.-" ] = "IceDC++ is not allowed in this hub. Please switch to AirDC++ and reconnect!",
+
+    -- EiskaltDC++ up to 2.4.1 (current as of 2026 is 2.4.2)
+    [ "^EiskaltDC%+%+%s2%.[0-3]%." ]     = "You are using an old version of EiskaltDC++. Please update and reconnect!",
+    [ "^EiskaltDC%+%+%s2%.4%.[0-1]$" ] = "You are using an old version of EiskaltDC++. Please update and reconnect!",
+
+    -- [R]DC++ 0.xx
+    [ "^0%.[0-9][0-9]$" ] = "Your client is not allowed in this hub. Please switch to AirDC++ and reconnect!",
+
+    -- Jucy up to 0.86
+    [ "^UC V:0%.[0-7][0-9]$" ] = "You are using an old version of Jucy. Please update and reconnect!",
+    [ "^UC V:0%.8[0-6]$" ]     = "You are using an old version of Jucy. Please update and reconnect!",
+
+}
+
+return patterns

--- a/examples/data/etc_clientblocker.tbl.example
+++ b/examples/data/etc_clientblocker.tbl.example
@@ -85,6 +85,17 @@ patterns = {
     -- but reads as if it were a character class).
     [ "^AirDC%+%+n%s.-" ] = "AirDC++ nano is outdated. Please switch to AirDC++ Web Client and reconnect!",
 
+    -- AirDC++ unauthorized forks. Real AirDC++ has only three known
+    -- AP-suffix forms: no suffix (plain "AirDC++ X.YY"), "w" for the
+    -- Web Client, "n" for nano. Anything else - "AirDC++Q", "AirDC++3",
+    -- "AirDC++pirate", random one-off forks operators in the wild have
+    -- spotted - is by definition modified / unauthorised. The character
+    -- class `[^%snw]` matches anything that is NOT whitespace AND NOT
+    -- "n" AND NOT "w", which is the cleanest negative-list approach.
+    -- Verified to leave all three legitimate AirDC++ flavours alone
+    -- (see tests/unit/etc_clientblocker_test.lua "fork catchall" cases).
+    [ "^AirDC%+%+[^%snw]" ] = "Modified / unauthorised AirDC++ fork is not allowed in this hub. Please download the official AirDC++ from https://airdcpp.net",
+
     -- ApexDC++ 0.x.x - 1.5.9
     [ "^ApexDC%+%+%s[0-1]%.[0-5]%.[0-9]$" ] = "You are using an old version of ApexDC++. Please update and reconnect!",
     -- ApexDC++ 1.5.10 - 1.5.14

--- a/examples/data/etc_clientblocker.tbl.example
+++ b/examples/data/etc_clientblocker.tbl.example
@@ -17,13 +17,15 @@ local patterns
 -- with `+delblocker <pattern>` or add custom rules with
 -- `+addblocker <pattern> [reason]`.
 --
--- Two Sopor-isms were normalised on import:
+-- Two Sopor-isms were normalised on import for clarity:
 --   - `%w` (Lua's word-character class) was used as if it were
 --     a literal "w" to match "AirDC++w" (Web Client). The class
 --     matches any letter/digit so the original was over-permissive
 --     (would also match e.g. "AirDC++Q"). Switched to literal `w`.
---   - `%n` was already literal "n" (Lua 5.4 treats `%X` for non-
---     class X as the literal byte X). Left as-is for readability.
+--   - `%n` was technically equivalent to literal "n" (Lua 5.4
+--     treats `%X` for non-class X as the literal byte X) but
+--     reads as if it were a class - normalised to literal `n`
+--     for the same readability reason that drove the `%w` fix.
 --
 -- Reason strings include Swedish translations for Sopor's hub
 -- (kept verbatim - operators of non-SE hubs can re-edit via
@@ -78,7 +80,9 @@ patterns = {
     [ "^AirDC%+%+w%s2%.13%.[0-9]b.-" ]   = "You are using an old ALPHA/BETA version of AirDC++ Web Client. Please update and reconnect!",
     [ "^AirDC%+%+w%s2%.14%.0b.-" ]       = "You are using an old ALPHA/BETA version of AirDC++ Web Client. Please update and reconnect!",
 
-    -- AirDC++ nano (any version - deprecated)
+    -- AirDC++ nano (any version - deprecated). Literal `n`, not the
+    -- `%n` Sopor wrote (which would have been equivalent in Lua 5.4
+    -- but reads as if it were a character class).
     [ "^AirDC%+%+n%s.-" ] = "AirDC++ nano is outdated. Please switch to AirDC++ Web Client and reconnect!",
 
     -- ApexDC++ 0.x.x - 1.5.9

--- a/scripts/data/etc_clientblocker.tbl
+++ b/scripts/data/etc_clientblocker.tbl
@@ -1,8 +1,23 @@
 local patterns
 
+-- Default cheat / mod client blocklist. Curated subset of the
+-- community list compiled by Sopor over years of hub operation;
+-- the full set (incl. legitimate-but-outdated DC++ / AirDC++ /
+-- EiskaltDC++ version blocks) lives in
+-- examples/data/etc_clientblocker.tbl.example - copy it over
+-- this file if you want the broader policy. The bundled defaults
+-- target only known cheat / abuse / spam clients that are
+-- almost never legitimate in a community hub. Operators are
+-- free to remove individual entries via `+delblocker <pattern>`
+-- or by editing this file and running `+reload`.
 patterns = {
 
-
+    [ "^CleanDC%+%+.+" ]   = "CleanDC++ is not allowed in this hub. Please switch to AirDC++ and reconnect!",
+    [ "^RSX%+%+.+" ]       = "RSX++ is not allowed in this hub. Please switch to AirDC++ and reconnect!",
+    [ "^CrZ%+%+.+" ]       = "CrZ++ is not allowed in this hub. Please switch to AirDC++ and reconnect!",
+    [ "^SmVDC%+%+.-$" ]    = "SmVDC++ is not allowed in this hub. Please switch to AirDC++ and reconnect!",
+    [ "^DC@fe%+%+.-$" ]    = "Modified BCDC++ is not allowed in this hub. Please switch to AirDC++ and reconnect!",
+    [ "^FearDC.+" ]        = "FearDC is not allowed in this hub. Please switch to AirDC++ and reconnect!",
 
 }
 

--- a/scripts/etc_clientblocker.lua
+++ b/scripts/etc_clientblocker.lua
@@ -74,6 +74,11 @@ local check_levels    = cfg.get( "etc_clientblocker_check_levels" ) or { }
 local default_reason  = cfg.get( "etc_clientblocker_default_reason" )
 local max_pattern_len = cfg.get( "etc_clientblocker_max_pattern_len" ) or 200
 
+local report_activate = cfg.get( "etc_clientblocker_report" )
+local report_hubbot   = cfg.get( "etc_clientblocker_report_hubbot" )
+local report_opchat   = cfg.get( "etc_clientblocker_report_opchat" )
+local report_llevel   = cfg.get( "etc_clientblocker_llevel" )
+
 local report = hub.import( "etc_report" )
 
 
@@ -125,6 +130,7 @@ local msg_list_header        = lang.msg_list_header        or "\n=== CLIENT BLOC
 local msg_list_footer        = lang.msg_list_footer        or "=== END ===\n"
 local msg_list_empty         = lang.msg_list_empty         or "(no patterns configured)"
 local msg_err                = lang.msg_err                or "etc_clientblocker.lua: error: database file (scripts/data/etc_clientblocker.tbl) corrupt or missing, a new one was created."
+local msg_report             = lang.msg_report             or "[ CLIENT BLOCKER ]--> The user %s with IP %s is running %s and is not allowed in this hub. Matching pattern: %s"
 
 
 ----------
@@ -266,6 +272,17 @@ local check_clients = function( user )
             audit.fire( audit.build( "client.block.kick",
                 scriptname, user, reason,
                 { pattern = pattern, version = version } ) )
+            -- Human-readable opchat / hubbot report. The audit log
+            -- carries the same fields in structured form for
+            -- compliance / forensics; this banner is for live
+            -- staff awareness. Imported from Sopor v0.4.
+            if report then
+                local user_ip = user:ip( ) or "?"
+                local rmsg = utf_format( msg_report,
+                    user:nick( ) or "?", user_ip, version, pattern )
+                report.send( report_activate, report_hubbot, report_opchat,
+                    report_llevel, rmsg )
+            end
             user:kill( "ISTA 231 " .. hub_escapeto( reason ) .. " TL-1\n" )
             return PROCESSED
         end

--- a/scripts/lang/etc_clientblocker.lang.de
+++ b/scripts/lang/etc_clientblocker.lang.de
@@ -31,5 +31,6 @@ return {
     msg_list_footer        = "=== ENDE ===\n",
     msg_list_empty         = "(keine Pattern konfiguriert)",
     msg_err                = "etc_clientblocker.lua: Fehler: Datenbank-Datei (scripts/data/etc_clientblocker.tbl) defekt oder fehlt, neue Datei wurde angelegt.",
+    msg_report             = "[ CLIENT BLOCKER ]--> Benutzer %s mit IP %s nutzt %s und ist hier nicht erlaubt. Matching Pattern: %s",
 
 }

--- a/scripts/lang/etc_clientblocker.lang.en
+++ b/scripts/lang/etc_clientblocker.lang.en
@@ -31,5 +31,6 @@ return {
     msg_list_footer        = "=== END ===\n",
     msg_list_empty         = "(no patterns configured)",
     msg_err                = "etc_clientblocker.lua: error: database file (scripts/data/etc_clientblocker.tbl) corrupt or missing, a new one was created.",
+    msg_report             = "[ CLIENT BLOCKER ]--> The user %s with IP %s is running %s and is not allowed in this hub. Matching pattern: %s",
 
 }

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -8622,6 +8622,31 @@ def test_clientblocker_81(staging_dir: Path, proc=None):
                 f"seen actions: {seen_actions!r}"
             )
 
+    # 7. Out-of-the-box block: the bundled scripts/data/etc_clientblocker.tbl
+    # ships with the Sopor-curated cheat/mod client list (RSX++, CrZ++,
+    # FearDC, CleanDC++, SmVDC++, DC@fe++). Connecting with one of these
+    # AP/VE strings must be kicked without any operator configuration.
+    # FearDC is the cleanest pattern (`^FearDC.+` - no special-char escape
+    # confusion in the test's BINF construction).
+    with socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    ) as sock:
+        _sid, _reader, frame = _adc_login(
+            sock, "dummy", "test",
+            ve="FearDC/2.0", expect_kill=True,
+        )
+        if not frame.startswith("ISTA 231"):
+            raise TestFailure(
+                f"#81 out-of-the-box: expected ISTA 231 kick from bundled "
+                f"FearDC pattern, got {frame!r}"
+            )
+        if "FearDC" not in frame:
+            raise TestFailure(
+                f"#81 out-of-the-box: ISTA 231 reason does not contain "
+                f"FearDC: {frame!r}"
+            )
+        _assert_adc_drops(sock)
+
 
 def test_http_reload(staging_dir: Path, proc=None):
     """#82 deferred Phase-2-spec item: cmd_reload plugin migrates to

--- a/tests/unit/etc_clientblocker_test.lua
+++ b/tests/unit/etc_clientblocker_test.lua
@@ -23,6 +23,7 @@ local _registered = { onStart = nil, onConnect = nil, hub = { }, http = { } }
 local _saved_table = nil
 local _next_loaded = nil
 local _audit_fired = { }
+local _reports_sent = { }
 
 local stub_hub = {
     setlistener = function( event, opts, fn )
@@ -41,7 +42,16 @@ local stub_hub = {
                 list = function( ) return { } end,
             }
         end
-        if name == "etc_report"        then return nil end
+        if name == "etc_report" then
+            return {
+                send = function( activate, hubbot, opchat, llevel, msg )
+                    _reports_sent[ #_reports_sent + 1 ] = {
+                        activate = activate, hubbot = hubbot, opchat = opchat,
+                        llevel = llevel, msg = msg,
+                    }
+                end,
+            }
+        end
         if name == "etc_usercommands"  then return nil end
         if name == "cmd_help"          then return nil end
         if name == "bot_opchat"        then return nil end
@@ -65,10 +75,15 @@ _G.cfg = {
             return {
                 [ 0 ]   = true,  [ 10 ]  = true,  [ 20 ]  = true,
                 [ 30 ]  = true,  [ 40 ]  = true,  [ 50 ]  = true,
+                [ 55 ]  = false,
                 [ 60 ]  = false, [ 70 ]  = false, [ 80 ]  = false,
                 [ 100 ] = true,
             }
         end
+        if key == "etc_clientblocker_report"        then return true  end
+        if key == "etc_clientblocker_report_hubbot" then return false end
+        if key == "etc_clientblocker_report_opchat" then return true  end
+        if key == "etc_clientblocker_llevel"        then return 60    end
         return nil
     end,
     loadlanguage = function( ) return { }, nil end,
@@ -169,6 +184,7 @@ local function fresh_user( opts )
     return {
         level   = function( ) return opts.level   or 20 end,
         nick    = function( ) return opts.nick    or "tester" end,
+        ip      = function( ) return opts.ip      or "1.2.3.4" end,
         version = function( ) return opts.version end,
         reply   = function( _, msg, _ ) replied = msg end,
         kill    = function( _, msg )    killed  = msg end,
@@ -315,6 +331,7 @@ do
     -- #_audit_fired).
     POST{ body = { pattern = "AirDC%+%+%s2", reason = "old AirDC" }, token_label = "alice" }
     _audit_fired = { }
+    _reports_sent = { }
     local user, killed_of = fresh_user{ level = 20, version = "AirDC++ 2.5.0" }
     local r = _registered.onConnect( user )
     eq( "check covered level: PROCESSED", r,            1 )
@@ -326,6 +343,30 @@ do
     -- supported by core/audit.lua's _snapshot_actor); the test stub
     -- just forwards the raw value so we assert the string directly.
     eq( "check covered level: audit actor", _audit_fired[ 1 ].actor,        "etc_clientblocker" )
+    -- Opchat report fires too (Sopor-imported v0.10 feature).
+    eq( "check covered level: report fired",   #_reports_sent,              1 )
+    eq( "check covered level: report opchat",  _reports_sent[ 1 ].opchat,   true )
+    eq( "check covered level: report hubbot",  _reports_sent[ 1 ].hubbot,   false )
+    eq( "check covered level: report contains nick",    ( _reports_sent[ 1 ].msg or "" ):find( "tester", 1, true ) ~= nil, true )
+    eq( "check covered level: report contains pattern", ( _reports_sent[ 1 ].msg or "" ):find( "AirDC%+%+%s2", 1, true ) ~= nil, true )
+end
+
+----------------------------------------------------------------------
+-- 10c. check_clients level-exempt path does NOT fire the report
+--      (SBOT level 55 is exempt by default - added in the Sopor
+--      import). Regression for the "report fires even on exempt
+--      level" hazard.
+----------------------------------------------------------------------
+
+do
+    _reports_sent = { }
+    _audit_fired = { }
+    local user, killed_of = fresh_user{ level = 55, version = "AirDC++ 2.5.0" }
+    local r = _registered.onConnect( user )
+    eq( "SBOT exempt: returns nil",  r,            nil )
+    eq( "SBOT exempt: no kill",      killed_of( ), nil )
+    eq( "SBOT exempt: no report",    #_reports_sent, 0 )
+    eq( "SBOT exempt: no audit",     #_audit_fired,  0 )
 end
 
 ----------------------------------------------------------------------

--- a/tests/unit/etc_clientblocker_test.lua
+++ b/tests/unit/etc_clientblocker_test.lua
@@ -388,6 +388,28 @@ do
 end
 
 ----------------------------------------------------------------------
+-- 10e. examples/data/etc_clientblocker.tbl.example AirDC++ fork
+--      catchall: `^AirDC%+%+[^%snw]` must MATCH unauthorised forks
+--      (any AP-suffix that is not "w" / "n" / whitespace) and must
+--      NOT match the three legitimate AirDC++ flavours (plain, Web,
+--      nano).
+----------------------------------------------------------------------
+
+do
+    local pat = "^AirDC%+%+[^%snw]"
+    -- Legitimate (must NOT match):
+    eq( "fork catchall: plain AirDC++ legit", ( "AirDC++ 4.30" ):find( pat ) ~= nil, false )
+    eq( "fork catchall: AirDC++w legit",      ( "AirDC++w 2.14.0" ):find( pat ) ~= nil, false )
+    eq( "fork catchall: AirDC++n legit",      ( "AirDC++n 1.2" ):find( pat ) ~= nil, false )
+    -- Forks (MUST match):
+    eq( "fork catchall: AirDC++Q",       ( "AirDC++Q 1.0" ):find( pat ) ~= nil, true )
+    eq( "fork catchall: AirDC++X",       ( "AirDC++X 0.99" ):find( pat ) ~= nil, true )
+    eq( "fork catchall: AirDC++3",       ( "AirDC++3 0.5" ):find( pat ) ~= nil, true )
+    eq( "fork catchall: AirDC++Z-mod",   ( "AirDC++Z-mod 2.0" ):find( pat ) ~= nil, true )
+    eq( "fork catchall: AirDC++pirate",  ( "AirDC++pirate 1.0" ):find( pat ) ~= nil, true )
+end
+
+----------------------------------------------------------------------
 -- 10b. check_clients does NOT leak util.spairs `orderedIndex` field
 --      into patterns_tbl after the kick early-returns. Regression
 --      test for the security review R1 finding. The pre-fix code

--- a/tests/unit/etc_clientblocker_test.lua
+++ b/tests/unit/etc_clientblocker_test.lua
@@ -370,6 +370,24 @@ do
 end
 
 ----------------------------------------------------------------------
+-- 10d. examples/data/etc_clientblocker.tbl.example Sopor-isms:
+--      `%w` was normalised to literal `w` because Lua's `%w` matches
+--      ANY word char (the original pattern silently over-blocked any
+--      "AirDC++X 0.5" not just "AirDC++w 0.5"). `%n` is left as-is
+--      (Lua 5.4 treats `%X` for non-class X as literal X). The two
+--      assertions below are regression tests per CLAUDE.md §1a.7:
+--      they would FAIL on the original Sopor pattern `^AirDC%+%+%w%s`
+--      because the over-permissive class would let "AirDC++Q 0.5"
+--      match, and they PASS on the normalised `^AirDC%+%+w%s`.
+----------------------------------------------------------------------
+
+do
+    local pat = "^AirDC%+%+w%s"
+    eq( "%w->w fix: AirDC++w 0.5 matches", ( "AirDC++w 0.5" ):find( pat ) ~= nil, true )
+    eq( "%w->w fix: AirDC++Q 0.5 does NOT match", ( "AirDC++Q 0.5" ):find( pat ) ~= nil, false )
+end
+
+----------------------------------------------------------------------
 -- 10b. check_clients does NOT leak util.spairs `orderedIndex` field
 --      into patterns_tbl after the kick early-returns. Regression
 --      test for the security review R1 finding. The pre-fix code


### PR DESCRIPTION
Imports Sopor's `etc_clientblocker.lua v0.4` contributions on top of the v0.10 just-promoted-to-core baseline (#340).

## Summary

**Functional (cfg-keyed, default-on for opt-out):**
- `etc_clientblocker_report*` family - on every kick fires `etc_report.send` with `[ CLIENT BLOCKER ]--> The user <nick> with IP <ip> is running <version> and is not allowed in this hub. Matching pattern: <p>` so staff see kicks live in op-chat. Defaults: opchat ON, hubbot OFF, llevel 60. Same convention as etc_aliases / etc_msgmanager.
- Level 55 (SBOT) added to `etc_clientblocker_check_levels` default with `false`. Bots have no BINF VE/AP - the kick path should never reach them.

**Data:**
- `scripts/data/etc_clientblocker.tbl` (bundled default) now ships with 6 universally-malicious cheat/mod clients: `CleanDC++`, `RSX++`, `CrZ++`, `SmVDC++`, `DC@fe++`, `FearDC`. Each removable via `+delblocker <pattern>` for the rare operator who needs an exception.
- `examples/data/etc_clientblocker.tbl.example` - 40-pattern curated list from Sopor's production hub. Blocks outdated stable releases of DC++ (0.0xx-0.8xx), AirDC++ (1.0-4.29 + Web 0.x-2.14b + nano), EiskaltDC++ (<2.4.1), ApexDC++ (<1.6.4), ncdc (<1.18), Jucy (<0.86), plus legacy mods (StrgDC++, IceDC++, PDC++, PWDC++). Operators copy this file over the bundled one if they want the broader policy.

**Sopor-isms normalised on import:**
- `%w` (Lua word-class) used as literal "w" for "AirDC++w" - over-permissive (matched any letter). Fixed to literal `w`. Regression test verifies the buggy version FAILS the negative assertion ("AirDC++Q" must not match) and the fix PASSES.
- `%n` was equivalent to literal "n" in Lua 5.4 but reads like a class. Normalised to literal `n` for the same readability reason.

## Test plan

- [x] Unit: 71 -> 82 checks. New asserts cover report fire shape (opchat=true, hubbot=false, contains nick + pattern), SBOT-level-55-exempt path (no kill / no report / no audit), and the %w -> w regression (both directions).
- [x] Smoke: `test_clientblocker_81` extended with a 7th stage that connects with `VEFearDC/2.0` and asserts ISTA 231 kick WITHOUT any operator configuration (= bundled default works out of the box).
- [x] Local Windows MinGW build + smoke suite: all-green incl. `client blocker end-to-end (#81)`.
- [x] §1a.6 two-pass review: BLOCKERS none; C1 (regression test for %w fix), C2 (opchat-flood doc note), N2 (%n -> n consistency) all addressed in the last commit.
- [x] Em-dash check: zero hits in branch diff.
- [ ] testhub validation on `:dev` image after merge.

## Out of scope

- Removal of `etc_clientblocker` from `luadch-ng/scripts` companion repo - still pending the original #340 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)