### PR TITLE
feat(cmd_disconnect): per-call TL override (closes #343)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -126,6 +126,11 @@ jobs:
       - name: Run etc_clientblocker unit test
         run: lua5.4 tests/unit/etc_clientblocker_test.lua
 
+      # #343 cmd_disconnect TL parser: optional TL<N> token between
+      # NICK and REASON. Pure helper, no hub state needed.
+      - name: Run cmd_disconnect TL parser unit test
+        run: lua5.4 tests/unit/cmd_disconnect_tl_test.lua
+
       - name: Configure
         run: cmake -B build -DCMAKE_BUILD_TYPE=Release
 
@@ -226,6 +231,10 @@ jobs:
       - name: Run etc_clientblocker unit test
         shell: msys2 {0}
         run: lua tests/unit/etc_clientblocker_test.lua
+
+      - name: Run cmd_disconnect TL parser unit test
+        shell: msys2 {0}
+        run: lua tests/unit/cmd_disconnect_tl_test.lua
 
       - name: Configure
         shell: msys2 {0}

--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -1197,6 +1197,22 @@ local defaults = {
         end
     },
 
+    -- Default ADC `TL` value (time-left in seconds) sent with the
+    -- disconnect kick. Tells the client when it may reconnect.
+    -- -1 = permanent (client should NOT auto-reconnect via this
+    -- nick); 0 = immediate retry allowed; N > 0 = wait N seconds.
+    -- Operators can override per-command via `+disconnect <NICK>
+    -- TL<N> <REASON>` (#343). Capped at 1 day - longer cooldowns
+    -- belong in `+ban`.
+    cmd_disconnect_default_tl = { 30,
+        function( value )
+            return types_number( value, nil, true )
+                and value % 1 == 0
+                and value >= -1
+                and value <= 86400
+        end
+    },
+
     ---------------------------------------------------------------------------------------------------------------------------------
     --// cmd_errors.lua settings
 

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -1045,10 +1045,12 @@ is disabled in `cfg.scripts`, the endpoint returns 404
 
 | Method | Path | Scope | Plugin | Status |
 |---|---|---|---|---|
-| DELETE | `/v1/users/{sid}` | admin | `cmd_disconnect` | **migrated (Phase 2 PR-1)** |
+| DELETE | `/v1/users/{sid}` | admin | `cmd_disconnect` | **migrated (Phase 2 PR-1)** [^http-disconnect-1] |
 | POST | `/v1/users/{sid}/redirect` | admin | `cmd_redirect` | **migrated (Phase 2 PR-2)** [^http-redirect-1] |
 | POST | `/v1/users/{sid}/gag` | admin | `cmd_gag` | **migrated (Phase 2 PR-3)** [^http-gag-1] |
 | DELETE | `/v1/users/{sid}/gag` | admin | `cmd_gag` | **migrated (Phase 2 PR-3)** [^http-gag-2] |
+
+[^http-disconnect-1]: Body `{reason: string optional (max 256), tl: integer optional (-1..86400, default `cmd_disconnect_default_tl`)}`. The `tl` field maps to the ADC `TL` time-left flag on the kick: -1 = client should not auto-reconnect, 0 = immediate retry allowed, N = client should wait N seconds. Schema validation rejects out-of-range values at the router layer; longer cooldowns belong in `+ban` / `POST /v1/bans`. Returns 200 with the §7.1.1 envelope plus `data: {reason, tl}` where `tl` is the effective value used (cfg default or operator override). Emits `user.kick` audit event with `meta: {tl}`. #343.
 
 [^http-redirect-1]: Body `{url: string?}`, URL scheme locked to `adc://` / `adcs://`. The ADC-side level-hierarchy guard (operator's `permission[level]` must be ≥ target's level) does NOT apply on the HTTP path: the bearer token's `admin` scope IS the authorisation gate. If the body has no `url` field, the cfg key `cmd_redirect_url` is used as the default. Body URL strings undergo control-byte sanitisation before reaching the `RD` field of the outbound IQUI; an admin operator with a leaked token can still redirect any user, by design - issue admin tokens accordingly.
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -109,13 +109,25 @@ prevent re-registration.
 
 ### cmd_disconnect
 
-Forcefully disconnect a user with optional reason message.
+Forcefully disconnect a user with optional reason message. Optional
+`TL<seconds>` token between nick and reason overrides the ADC
+time-left field (`-1` = permanent / don't auto-reconnect, `0` =
+immediate retry, `N` = wait N seconds); default comes from
+`cmd_disconnect_default_tl` (#343). Range -1..86400; longer
+cooldowns belong in `+ban`.
 
-**Commands:** `+disconnect <nick> <reason>`
+**Commands:** `+disconnect <nick> [TL<seconds>] <reason>`
+
+**HTTP:** `DELETE /v1/users/{sid}` with optional `body.tl: integer`
+in the same range.
+
+**Audit meta:** `{ tl = <effective_tl> }` so the trail records which
+TL value the kick used.
 
 **Config:** `cmd_disconnect_minlevel`, `cmd_disconnect_sendmainmsg`,
 `cmd_disconnect_report`, `cmd_disconnect_report_hubbot`,
-`cmd_disconnect_report_opchat`, `cmd_disconnect_llevel`
+`cmd_disconnect_report_opchat`, `cmd_disconnect_llevel`,
+`cmd_disconnect_default_tl`
 
 ### cmd_errors
 

--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -473,6 +473,7 @@ return { -- the settings are a lua table, do not tough this!
     cmd_disconnect_report_hubbot = false,  -- send report as hubbot msg? (boolean)
     cmd_disconnect_report_opchat = true,  -- send report as opchat feed? (boolean)
     cmd_disconnect_llevel = 60,  -- min level to get a report? (only for hubbot msg) (integer)
+    cmd_disconnect_default_tl = 30,  -- default ADC TL (seconds) sent with the kick; -1 = permanent, 0 = immediate retry, N = wait N seconds; per-cmd override via `+disconnect <NICK> TL<N> <REASON>` (#343) (integer)
 
     ---------------------------------------------------------------------------------------------------------------------------------
     --// cmd_ban.lua settings | this script adds a command to ban/unban users from hub

--- a/scripts/cmd_disconnect.lua
+++ b/scripts/cmd_disconnect.lua
@@ -127,16 +127,25 @@ local ucmd_menu2 = lang.ucmd_menu2 or { "Disconnect", "OK" }
 -- migrations - defence in depth around adclib::escape, which only
 -- handles ' ', '\n', '\\').
 -- Pure parser: extract optional TL<N> token from the raw
--- parameters string. Returns (tl, remaining_reason) where tl is
--- nil if the second token does not match the TL<N> shape (in
--- which case the entire parameters[after-nick] is the reason).
--- Returns (false, err_msg) when a TL<N> token IS present but
--- the N is malformed / out of bounds - we fail loud at parse
--- time rather than silently clamping. Exported via the public
--- return table for unit testing.
+-- parameters string. Returns (tl, remaining_reason) where:
+--   - tl == nil:   no TL token present, params is the full reason
+--   - tl == false: TL<N> was present but N is malformed / out of
+--                  bounds (caller surfaces msg_bad_tl)
+--   - tl == N:     valid override, reason is the remainder (may
+--                  be empty if operator typed only "TL<N>")
+-- Two patterns are matched:
+--   (a) "TL<N> <reason ...>" -> the standard case
+--   (b) "TL<N>" alone        -> reason becomes "", N still applies
+-- This avoids the surprising behaviour where "+disconnect Bob TL30"
+-- would treat the literal "TL30" as the reason. Exported via the
+-- public return table for unit testing.
 local function parse_tl_token( params_after_nick )
     if type( params_after_nick ) ~= "string" then return nil, params_after_nick or "" end
     local maybe_tl, rest = utf.match( params_after_nick, "^(TL%-?%d+)%s+(.*)$" )
+    if not maybe_tl then
+        maybe_tl = utf.match( params_after_nick, "^(TL%-?%d+)%s*$" )
+        rest = ""
+    end
     if not maybe_tl then
         return nil, params_after_nick
     end

--- a/scripts/cmd_disconnect.lua
+++ b/scripts/cmd_disconnect.lua
@@ -56,9 +56,16 @@
 --------------
 
 local scriptname = "cmd_disconnect"
-local scriptversion = "1.4"
+local scriptversion = "1.5"
 
 local cmd = "disconnect"
+
+-- #343: ADC TL bounds. -1 = permanent, 0 = immediate retry,
+-- positive seconds otherwise. The 1-day upper bound matches the
+-- cfg validator (longer cooldowns are abuse-of-tool; the right
+-- mechanism for those is +ban).
+local TL_MIN = -1
+local TL_MAX = 86400
 
 --// imports
 local help, ucmd, hubcmd
@@ -66,6 +73,7 @@ local scriptlang = cfg.get( "language" )
 local lang, err = cfg.loadlanguage( scriptlang, scriptname ); lang = lang or {}; err = err and hub.debug( err )
 local minlevel = cfg.get( "cmd_disconnect_minlevel" )
 local sendmainmsg = cfg.get( "cmd_disconnect_sendmainmsg" )
+local default_tl = cfg.get( "cmd_disconnect_default_tl" ) or 30
 local report = hub.import( "etc_report" )
 local report_activate = cfg.get( "cmd_disconnect_report" )
 local llevel = cfg.get( "cmd_disconnect_llevel" )
@@ -74,13 +82,14 @@ local report_opchat = cfg.get( "cmd_disconnect_report_opchat" )
 
 --// msgs
 local help_title = lang.help_title or "cmd_disconnect.lua"
-local help_usage = lang.help_usage or "[+!#]disconnect <NICK> <REASON>"
-local help_desc = lang.help_desc or "Disconnects a user"
+local help_usage = lang.help_usage or "[+!#]disconnect <NICK> [TL<SECONDS>] <REASON>"
+local help_desc = lang.help_desc or "Disconnects a user. Optional TL<SECONDS> sets the ADC time-left field: -1 = don't auto-reconnect, 0 = immediate retry, N = wait N seconds (default from cfg)."
 
 local user_msg = lang.user_msg or "[ DISCONNECT ]--> You were disconnected by: %s  |  reason: %s"
 local report_msg = lang.report_msg or "[ DISCONNECT ]--> User  %s  was disconnected by  %s  |  reason: %s"
 
-local msg_usage = lang.msg_usage or "Usage: [+!#]disconnect <NICK> <REASON>"
+local msg_usage = lang.msg_usage or "Usage: [+!#]disconnect <NICK> [TL<SECONDS>] <REASON>"
+local msg_bad_tl = lang.msg_bad_tl or "Invalid TL value. Must be an integer between -1 and 86400 (-1 = permanent, 0 = immediate, N = wait N seconds)."
 local msg_denied1 = lang.msg_denied1 or "You are not allowed to use this command."
 local msg_denied2 = lang.msg_denied2 or "You can't disconnect superior users."
 local msg_denied3 = lang.msg_denied3 or "You can't disconnect yourself."
@@ -117,21 +126,60 @@ local ucmd_menu2 = lang.ucmd_menu2 or { "Disconnect", "OK" }
 -- (single source of truth across the Phase 2 bundled-plugin
 -- migrations - defence in depth around adclib::escape, which only
 -- handles ' ', '\n', '\\').
-local do_disconnect = function( targetuser, reason, actor_label )
+-- Pure parser: extract optional TL<N> token from the raw
+-- parameters string. Returns (tl, remaining_reason) where tl is
+-- nil if the second token does not match the TL<N> shape (in
+-- which case the entire parameters[after-nick] is the reason).
+-- Returns (false, err_msg) when a TL<N> token IS present but
+-- the N is malformed / out of bounds - we fail loud at parse
+-- time rather than silently clamping. Exported via the public
+-- return table for unit testing.
+local function parse_tl_token( params_after_nick )
+    if type( params_after_nick ) ~= "string" then return nil, params_after_nick or "" end
+    local maybe_tl, rest = utf.match( params_after_nick, "^(TL%-?%d+)%s+(.*)$" )
+    if not maybe_tl then
+        return nil, params_after_nick
+    end
+    local n_str = maybe_tl:sub( 3 )    -- strip "TL" prefix
+    local n = tonumber( n_str )
+    if not n or n ~= math.floor( n ) or n < TL_MIN or n > TL_MAX then
+        return false, nil
+    end
+    return n, rest
+end
+
+local do_disconnect = function( targetuser, reason, actor_label, tl )
     local clean_reason = util.strip_control_bytes( reason )
     local clean_actor  = util.strip_control_bytes( actor_label )
     local targetuser_nick = targetuser:nick()
+    local effective_tl = tl
+    if type( effective_tl ) ~= "number"
+       or effective_tl ~= math.floor( effective_tl )
+       or effective_tl < TL_MIN or effective_tl > TL_MAX
+    then
+        effective_tl = default_tl
+    end
     local msg_target = utf.format( user_msg, clean_actor, clean_reason )
-    targetuser:kill( "ISTA 230 " .. hub.escapeto( msg_target ) .. "\n", "TL30" )
+    targetuser:kill( "ISTA 230 " .. hub.escapeto( msg_target ) .. "\n", "TL" .. effective_tl )
     local msg_report = utf.format( report_msg, targetuser_nick, clean_actor, clean_reason )
-    return msg_report
+    return msg_report, effective_tl
 end
 
 local onbmsg = function( user, adccmd, parameters )
     local user_level = user:level()
     local user_nick = user:nick()
     local target = utf.match( parameters, "^(%S+)" )
-    local reason = ( target and utf.match( parameters, "^%S+ (.*)" ) ) or ""
+    local rest = ( target and utf.match( parameters, "^%S+%s+(.*)$" ) ) or ""
+    -- #343: optional TL<N> token between NICK and REASON. parse_tl_token
+    -- returns (nil, rest) if no TL token, (false, nil) if a TL<N> is
+    -- present but malformed/out-of-bounds (loud usage error), or
+    -- (N, reason) on a valid TL override.
+    local tl, reason = parse_tl_token( rest )
+    if tl == false then
+        user:reply( msg_bad_tl, hub.getbot() )
+        return PROCESSED
+    end
+    reason = reason or ""
     local targetuser = hub.isnickonline( target )
     if not target then
         user:reply( msg_usage, hub.getbot() )
@@ -159,14 +207,14 @@ local onbmsg = function( user, adccmd, parameters )
         user:reply( msg_denied3, hub.getbot() )
         return PROCESSED
     end
-    local msg_report = do_disconnect( targetuser, reason, user_nick )
+    local msg_report, effective_tl = do_disconnect( targetuser, reason, user_nick, tl )
     -- Order preserved from v1.3: chat echo to the operator BEFORE
     -- the opchat report fires (the report can hit the same operator
     -- in opchat, and historically they saw their own kick echo first).
     if sendmainmsg then user:reply( msg_report, hub.getbot() ) end
     report.send( report_activate, report_hubbot, report_opchat, llevel, msg_report )
     audit.fire( audit.build( "user.kick", user, targetuser,
-        ( reason ~= "" and reason or nil ), nil ) )
+        ( reason ~= "" and reason or nil ), { tl = effective_tl } ) )
     return PROCESSED
 end
 
@@ -184,7 +232,11 @@ end
 local http_handler_disconnect = function( req, target )
     local reason = ( req.body and req.body.reason ) or ""
     local actor_label = req.token_label or "http-api"
-    local msg_report = do_disconnect( target, reason, actor_label )
+    -- #343: optional body.tl integer. Schema validation in the
+    -- router already enforces type + range; we accept nil here
+    -- as "use cfg default" via do_disconnect's own clamp logic.
+    local tl = req.body and req.body.tl
+    local msg_report, effective_tl = do_disconnect( target, reason, actor_label, tl )
     -- HTTP path has no operator-chat to echo into; fire the
     -- opchat report directly so an operator watching opchat sees
     -- a consistent line regardless of which surface drove the kick.
@@ -192,8 +244,8 @@ local http_handler_disconnect = function( req, target )
     audit.fire( audit.build( "user.kick",
         { nick = actor_label, sid = "<http>" },
         target,
-        ( reason ~= "" and reason or nil ), nil ) )
-    return { reason = reason }
+        ( reason ~= "" and reason or nil ), { tl = effective_tl } ) )
+    return { reason = reason, tl = effective_tl }
 end
 
 hub.setlistener( "onStart", {},
@@ -217,9 +269,10 @@ hub.setlistener( "onStart", {},
         util_http.http_register_user_action( scriptname,
             "DELETE", "/v1/users/{sid}", "disconnect",
             http_handler_disconnect, {
-                description = "disconnect (kick) an online user by SID; body { reason: string optional }",
+                description = "disconnect (kick) an online user by SID; body { reason: string optional, tl: integer optional (-1..86400, ADC time-left; -1 = permanent, 0 = immediate retry, N = wait N seconds; #343) }",
                 request_schema = {
                     reason = { type = "string", max_length = 256 },
+                    tl     = { type = "integer", min = -1, max = 86400 },
                 },
             }
         )
@@ -228,3 +281,11 @@ hub.setlistener( "onStart", {},
 )
 
 hub.debug( "** Loaded " .. scriptname .. " " .. scriptversion .." **" )
+
+
+-- Public surface: expose the pure parser for the unit test. The
+-- ADC + HTTP handlers use it internally; the test exercises the
+-- TL token shape contract.
+return {
+    parse_tl_token = parse_tl_token,
+}

--- a/scripts/lang/cmd_disconnect.lang.de
+++ b/scripts/lang/cmd_disconnect.lang.de
@@ -13,7 +13,7 @@
     msg_denied3 = "Du kannst dich nicht selbst disconnecten.",
     msg_denied4 = "Der User ist offline.",
     msg_bot = "Fehler: User ist ein Bot.",
-    msg_bad_tl = "Ungueltiger TL-Wert. Muss eine Ganzzahl zwischen -1 und 86400 sein (-1 = permanent, 0 = sofort, N = warte N Sekunden).",
+    msg_bad_tl = "Ungültiger TL-Wert. Muss eine Ganzzahl zwischen -1 und 86400 sein (-1 = permanent, 0 = sofort, N = warte N Sekunden).",
 
     ucmd_target = "Username",
     ucmd_reason = "Begründung",

--- a/scripts/lang/cmd_disconnect.lang.de
+++ b/scripts/lang/cmd_disconnect.lang.de
@@ -1,18 +1,19 @@
 ﻿return {
 
     help_title = "cmd_disconnect.lua",
-    help_usage = "[+!#]disconnect <NICK> <GRUND>",
-    help_desc = "Disconnected einen User",
+    help_usage = "[+!#]disconnect <NICK> [TL<SEKUNDEN>] <GRUND>",
+    help_desc = "Disconnected einen User. Optional TL<SEKUNDEN> setzt das ADC time-left Feld: -1 = nicht automatisch reconnect, 0 = sofort wieder, N = warte N Sekunden (Default aus cfg).",
 
     user_msg = "[ DISCONNECT ]--> Du wurdest disconnected von: %s  |  Grund: %s",
     report_msg = "[ DISCONNECT ]--> User  %s  wurde disconnected von  %s  |  Grund: %s",
 
-    msg_usage = "Gebrauch: [+!#]disconnect <NICK> <GRUND>",
+    msg_usage = "Gebrauch: [+!#]disconnect <NICK> [TL<SEKUNDEN>] <GRUND>",
     msg_denied1 = "Du bist nicht befugt diesen Befehl zu nutzen.",
     msg_denied2 = "Du kannst keinen disconnecten der ein höheres Level hat als du.",
     msg_denied3 = "Du kannst dich nicht selbst disconnecten.",
     msg_denied4 = "Der User ist offline.",
     msg_bot = "Fehler: User ist ein Bot.",
+    msg_bad_tl = "Ungueltiger TL-Wert. Muss eine Ganzzahl zwischen -1 und 86400 sein (-1 = permanent, 0 = sofort, N = warte N Sekunden).",
 
     ucmd_target = "Username",
     ucmd_reason = "Begründung",

--- a/scripts/lang/cmd_disconnect.lang.en
+++ b/scripts/lang/cmd_disconnect.lang.en
@@ -1,18 +1,19 @@
 ﻿return {
 
     help_title = "cmd_disconnect.lua",
-    help_usage = "[+!#]disconnect <NICK> <REASON>",
-    help_desc = "Disconnects a user",
+    help_usage = "[+!#]disconnect <NICK> [TL<SECONDS>] <REASON>",
+    help_desc = "Disconnects a user. Optional TL<SECONDS> sets the ADC time-left field: -1 = don't auto-reconnect, 0 = immediate retry, N = wait N seconds (default from cfg).",
 
     user_msg = "[ DISCONNECT ]--> You were disconnected by: %s  |  reason: %s",
     report_msg = "[ DISCONNECT ]--> User  %s  was disconnected by  %s  |  reason: %s",
 
-    msg_usage = "Usage: [+!#]disconnect <NICK> <REASON>",
+    msg_usage = "Usage: [+!#]disconnect <NICK> [TL<SECONDS>] <REASON>",
     msg_denied1 = "You are not allowed to use this command.",
     msg_denied2 = "You can't disconnect superior users.",
     msg_denied3 = "You can't disconnect yourself.",
     msg_denied4 = "User is offline.",
     msg_bot = "Error: User is a bot.",
+    msg_bad_tl = "Invalid TL value. Must be an integer between -1 and 86400 (-1 = permanent, 0 = immediate, N = wait N seconds).",
 
     ucmd_target = "Username",
     ucmd_reason = "Reason",

--- a/tests/unit/cmd_disconnect_tl_test.lua
+++ b/tests/unit/cmd_disconnect_tl_test.lua
@@ -196,16 +196,31 @@ do
 end
 
 ----------------------------------------------------------------------
--- 7. TL token with no rest after it -> NOT a valid TL+reason
---    (the pattern requires whitespace + rest; "TL30" alone has no
---    reason and is treated as the whole reason). This is a documented
---    quirk; operators should always specify a reason.
+-- 7. TL token with no reason after it -> tl applied, reason ""
+--    The original pattern required a trailing reason; the v0.10
+--    follow-up extended parse_tl_token to also accept "TL<N>"
+--    alone (reason becomes ""). Operators should still type a
+--    reason in practice, but the previous quirk (where "TL30"
+--    became the literal reason) was surprising. Per #343 review
+--    NIT 2.
 ----------------------------------------------------------------------
 
 do
     local tl, rest = parse( "TL30" )
-    eq( "TL30 alone (no rest): tl is nil", tl,   nil )
-    eq( "TL30 alone: rest unchanged",      rest, "TL30" )
+    eq( "TL30 alone: tl is 30",  tl,   30 )
+    eq( "TL30 alone: rest is ''", rest, "" )
+
+    tl, rest = parse( "TL-1" )
+    eq( "TL-1 alone: tl is -1",  tl,   -1 )
+    eq( "TL-1 alone: rest is ''", rest, "" )
+
+    tl, rest = parse( "TL30  " )
+    eq( "TL30 trailing-ws: tl is 30",  tl,   30 )
+    eq( "TL30 trailing-ws: rest is ''", rest, "" )
+
+    -- Out-of-bounds still rejected even without a reason.
+    tl, rest = parse( "TL999999" )
+    eq( "TL999999 alone: tl is false (oob)", tl, false )
 end
 
 ----------------------------------------------------------------------

--- a/tests/unit/cmd_disconnect_tl_test.lua
+++ b/tests/unit/cmd_disconnect_tl_test.lua
@@ -1,0 +1,216 @@
+--[[
+
+    tests/unit/cmd_disconnect_tl_test.lua
+
+    Unit test for #343 - the optional TL<N> token parser in
+    scripts/cmd_disconnect.lua.
+
+    Exercises parse_tl_token (the pure helper exported by the
+    plugin) against every realistic shape:
+      - no TL token (rest = full reason)
+      - TL<N> with valid N in -1..86400
+      - TL<N> with N out of bounds -> (false, nil) for loud reject
+      - TL prefix on a non-numeric tail -> NOT a TL token, treated
+        as part of the reason
+      - empty / whitespace input
+
+    Run: lua5.4 tests/unit/cmd_disconnect_tl_test.lua
+
+]]--
+
+----------------------------------------------------------------------
+-- stub layer: sandbox globals the plugin reads at file scope
+----------------------------------------------------------------------
+
+local _registered = { onStart = nil, http = { } }
+
+_G.hub = {
+    setlistener = function( event, opts, fn ) _registered[ event ] = fn end,
+    debug    = function( ) end,
+    getbot   = function( ) return "stub-bot" end,
+    import   = function( name )
+        if name == "etc_report" then return { send = function( ) end } end
+        return nil
+    end,
+    escapefrom = function( s ) return s end,
+    escapeto   = function( s ) return s end,
+}
+_G.cfg = {
+    get = function( key )
+        if key == "language" then return "en" end
+        if key == "cmd_disconnect_minlevel" then return 60 end
+        if key == "cmd_disconnect_sendmainmsg" then return false end
+        if key == "cmd_disconnect_default_tl" then return 30 end
+        if key == "cmd_disconnect_report" then return true end
+        if key == "cmd_disconnect_llevel" then return 60 end
+        if key == "cmd_disconnect_report_hubbot" then return false end
+        if key == "cmd_disconnect_report_opchat" then return true end
+        return nil
+    end,
+    loadlanguage = function( ) return { }, nil end,
+}
+_G.util = {
+    strip_control_bytes = function( s ) return s end,
+}
+_G.utf = {
+    match  = string.match,
+    format = string.format,
+}
+_G.audit = {
+    build = function( ) return { } end,
+    fire  = function( ) end,
+}
+_G.util_http = {
+    http_register_user_action = function( name, method, path, action, fn, meta )
+        _registered.http[ method .. " " .. path ] = fn
+    end,
+}
+_G.PROCESSED = 1
+
+----------------------------------------------------------------------
+-- minimal test framework
+----------------------------------------------------------------------
+
+local failures, checks = 0, 0
+local function eq( label, got, want )
+    checks = checks + 1
+    if got ~= want then
+        failures = failures + 1
+        io.write( string.format( "FAIL %-65s got=%q want=%q\n", label, tostring( got ), tostring( want ) ) )
+    else
+        io.write( string.format( "ok   %s\n", label ) )
+    end
+end
+
+----------------------------------------------------------------------
+-- load plugin + extract parse_tl_token
+----------------------------------------------------------------------
+
+local plugin = assert( loadfile( "scripts/cmd_disconnect.lua" ) )( )
+assert( plugin and type( plugin.parse_tl_token ) == "function",
+        "plugin must export parse_tl_token" )
+local parse = plugin.parse_tl_token
+
+----------------------------------------------------------------------
+-- 1. No TL token (the plain-reason case)
+----------------------------------------------------------------------
+
+do
+    local tl, rest = parse( "spamming the hub" )
+    eq( "no TL: tl is nil",    tl,   nil )
+    eq( "no TL: rest is full", rest, "spamming the hub" )
+end
+
+----------------------------------------------------------------------
+-- 2. TL<N> with valid N in -1..86400
+----------------------------------------------------------------------
+
+do
+    local tl, rest = parse( "TL30 short cooldown" )
+    eq( "TL30: tl",   tl,   30 )
+    eq( "TL30: rest", rest, "short cooldown" )
+
+    tl, rest = parse( "TL0 immediate retry allowed" )
+    eq( "TL0: tl",   tl,   0 )
+    eq( "TL0: rest", rest, "immediate retry allowed" )
+
+    tl, rest = parse( "TL-1 never auto-reconnect" )
+    eq( "TL-1: tl",   tl,   -1 )
+    eq( "TL-1: rest", rest, "never auto-reconnect" )
+
+    tl, rest = parse( "TL3600 one hour cooldown" )
+    eq( "TL3600: tl",   tl,   3600 )
+    eq( "TL3600: rest", rest, "one hour cooldown" )
+
+    tl, rest = parse( "TL86400 one day cap" )
+    eq( "TL86400 (max): tl",   tl,   86400 )
+    eq( "TL86400 (max): rest", rest, "one day cap" )
+end
+
+----------------------------------------------------------------------
+-- 3. TL<N> out of bounds -> (false, nil)
+----------------------------------------------------------------------
+
+do
+    local tl, rest = parse( "TL-2 below min" )
+    eq( "TL-2: tl is false (out-of-bounds)", tl,   false )
+    eq( "TL-2: rest is nil",                 rest, nil )
+
+    tl, rest = parse( "TL86401 above max" )
+    eq( "TL86401: tl is false",   tl,   false )
+    eq( "TL86401: rest is nil",   rest, nil )
+
+    tl, rest = parse( "TL999999 way above" )
+    eq( "TL999999: tl is false", tl, false )
+end
+
+----------------------------------------------------------------------
+-- 4. TL prefix on non-numeric tail -> NOT a TL token (treated as reason)
+----------------------------------------------------------------------
+
+do
+    local tl, rest = parse( "TLabc not a tl token" )
+    eq( "TLabc: tl is nil",        tl,   nil )
+    eq( "TLabc: rest unchanged",   rest, "TLabc not a tl token" )
+
+    tl, rest = parse( "TL30abc not a tl token" )
+    eq( "TL30abc: tl is nil",      tl,   nil )
+    eq( "TL30abc: rest unchanged", rest, "TL30abc not a tl token" )
+
+    tl, rest = parse( "TL not a tl token" )
+    eq( "TL alone: tl is nil",      tl,   nil )
+    eq( "TL alone: rest unchanged", rest, "TL not a tl token" )
+end
+
+----------------------------------------------------------------------
+-- 5. Reason that HAPPENS to contain TL later -> still no TL token
+--    (TL must be the FIRST whitespace-token)
+----------------------------------------------------------------------
+
+do
+    local tl, rest = parse( "spamming hub including TL30 reference" )
+    eq( "trailing TL: tl is nil", tl, nil )
+    eq( "trailing TL: rest unchanged",
+        rest, "spamming hub including TL30 reference" )
+end
+
+----------------------------------------------------------------------
+-- 6. Empty / whitespace / nil inputs
+----------------------------------------------------------------------
+
+do
+    local tl, rest = parse( "" )
+    eq( "empty: tl is nil",  tl,   nil )
+    eq( "empty: rest is ''", rest, "" )
+
+    tl, rest = parse( nil )
+    eq( "nil: tl is nil",  tl,   nil )
+    eq( "nil: rest is ''", rest, "" )
+
+    tl, rest = parse( 42 )
+    eq( "number: tl is nil",  tl, nil )
+
+    tl, rest = parse( "   " )
+    eq( "whitespace only: tl is nil", tl,   nil )
+    eq( "whitespace only: rest unchanged", rest, "   " )
+end
+
+----------------------------------------------------------------------
+-- 7. TL token with no rest after it -> NOT a valid TL+reason
+--    (the pattern requires whitespace + rest; "TL30" alone has no
+--    reason and is treated as the whole reason). This is a documented
+--    quirk; operators should always specify a reason.
+----------------------------------------------------------------------
+
+do
+    local tl, rest = parse( "TL30" )
+    eq( "TL30 alone (no rest): tl is nil", tl,   nil )
+    eq( "TL30 alone: rest unchanged",      rest, "TL30" )
+end
+
+----------------------------------------------------------------------
+-- summary
+----------------------------------------------------------------------
+
+io.write( string.format( "\n%d checks, %d failures\n", checks, failures ) )
+os.exit( failures > 0 and 1 or 0 )


### PR DESCRIPTION
Closes #343 (Sopor's request). Lets operators override the default `TL30` on `+disconnect` for cases like \"kick + don't auto-reconnect\" (`TL-1`) or longer cooldowns.

## ADC syntax

\`\`\`
+disconnect <NICK> [TL<SECONDS>] <REASON>
\`\`\`

Examples:

\`\`\`
+disconnect Bob spamming                  → TL30 (cfg default)
+disconnect Bob TL-1 spamming the hub     → permanent kick
+disconnect Bob TL300 5min cooldown       → wait 5 minutes
+disconnect Bob TL30                       → reason="" + TL30
\`\`\`

Parser peeks at the 2nd whitespace-token; if `^TL(-?\d+)$` AND the N is in -1..86400, it's the TL value. Out-of-bounds N fails LOUD via `msg_bad_tl`. Backward-compatible: existing `+disconnect <NICK> <REASON>` (no TL token) unchanged.

## HTTP API

`DELETE /v1/users/{sid}` body gains optional `tl: integer (-1..86400)`. Schema validation at the router rejects out-of-range before the handler fires. Response data echoes the effective `tl` used (cfg default or operator override).

## Audit

`user.kick` events now carry `meta = { tl = <effective_tl> }` so the trail records which TL was applied.

## Configuration

New cfg key `cmd_disconnect_default_tl` (default 30, range -1..86400). Operator can change the hub-wide default. Cap is 1 day; longer cooldowns belong in `+ban`.

## Tests

- New `tests/unit/cmd_disconnect_tl_test.lua` (39 checks): exercises every parser branch (no-TL, valid TL, out-of-bounds, TL-prefix-but-not-numeric, trailing-TL-in-reason, empty/whitespace/nil inputs, TL-alone-without-reason)
- Wired into both smoke.yml Linux + Windows jobs

## §1a.6 two-pass review

Independent subagent + maintainer-side pass found 0 BLOCKERs / 0 CONCERNs / 2 NITs - both addressed in the last commit (3abcf1d):
- NIT 1: lang.de `Ungueltiger` → `Ungültiger` (consistency with existing umlauts)
- NIT 2: `+disconnect Bob TL30` (TL-only) now applies TL=30 with empty reason instead of treating literal \"TL30\" as the reason text

Em-dashes: 0 in branch diff (one `≥` symbol is context-only in an unrelated existing footnote).

## Test plan

- [x] 39 unit checks pass on lua5.4
- [x] Local Windows MinGW build + full smoke suite green
- [x] §1a.6 two-pass review, all NITs addressed
- [ ] testhub validation after `:dev` rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)