### PR TITLE
feat(cfg): make etc_clientblocker API-toggleable (#81 / #261)

### DIFF
--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -1413,7 +1413,7 @@ return { -- the settings are a lua table, do not tough this!
 
         "usr_nick_length.lua",
         "hub_inf_manager.lua",
-        "etc_clientblocker.lua",  -- #81 client AP/VE blocklist. Must sit AFTER hub_inf_manager so structural BINF rejects (forbidden flags / identity spoofing) happen first; client-policy kicks then run on already-validated INFs.
+        { "etc_clientblocker.lua", enabled = true },  -- #81 client AP/VE blocklist. API-toggleable (#261). Must sit AFTER hub_inf_manager so structural BINF rejects (forbidden flags / identity spoofing) happen first; client-policy kicks then run on already-validated INFs.
         { "hub_runtime.lua", enabled = true },  -- using report import; API-toggleable (#261)
         { "bot_regchat.lua", enabled = true },  -- API-toggleable (#261)
         { "bot_session_chat.lua", enabled = true },  -- API-toggleable (#261)


### PR DESCRIPTION
Trivial 1-line follow-up to #341. Wraps the `etc_clientblocker.lua` cfg.scripts entry in the `{ \"name\", enabled = true }` table form so it surfaces in `GET /v1/plugins` and is toggleable via `PUT /v1/plugins/etc_clientblocker/enabled` per the #261 plugin-management API.

## Why

The plugin was bundled with the un-wrapped string entry which made it always-loaded with no API control surface. Matches the convention used by 11 other plugins in the same cfg.scripts array (etc_motd, etc_banner, etc_chatlog, etc_records, etc_prometheus, hub_runtime, bot_regchat, bot_session_chat, etc_userlogininfo, etc_dhtblocker, etc_regserver_announce).

## Effect

- Default `enabled = true` preserves current behaviour
- Operators can disable the filter without removing the cfg entry: `PUT /v1/plugins/etc_clientblocker/enabled { \"enabled\": false }` + reload
- Listener-chain placement unchanged: still after `hub_inf_manager` per #81 invariant

## Test plan

- [x] cfg.tbl loads
- [x] Local Windows MinGW smoke suite green incl. `HTTP API plugins (#261)` which exercises the toggle endpoint
- [x] No em-dashes in diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)