### PR TITLE
feat(secrets): sensitive-key registry + env-var-first cfg lookup (Part of #78)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -126,6 +126,13 @@ jobs:
       - name: Run etc_clientblocker unit test
         run: lua5.4 tests/unit/etc_clientblocker_test.lua
 
+      # #78 Precursor 0c: core/secrets.lua sensitive-key registry +
+      # env-var-first cfg lookup. Stubbed cfg + os.getenv; verifies
+      # registry semantics, _derive_env_name shape, and the env-vs-
+      # cfg precedence + empty-string-as-unset semantics.
+      - name: Run secrets unit test
+        run: lua5.4 tests/unit/secrets_test.lua
+
       - name: Configure
         run: cmake -B build -DCMAKE_BUILD_TYPE=Release
 
@@ -226,6 +233,10 @@ jobs:
       - name: Run etc_clientblocker unit test
         shell: msys2 {0}
         run: lua tests/unit/etc_clientblocker_test.lua
+
+      - name: Run secrets unit test
+        shell: msys2 {0}
+        run: lua tests/unit/secrets_test.lua
 
       - name: Configure
         shell: msys2 {0}

--- a/core/http_router.lua
+++ b/core/http_router.lua
@@ -1334,15 +1334,13 @@ local function plugins_toggle_handler( req )
     } }
 end
 
--- #262: cfg keys whose value MUST NOT leak through the HTTP API,
--- masked as the string "<redacted>" on GET and rejected with 403
--- on PUT. Sensitive credentials (bearer tokens) and file paths
--- that protect the at-rest encryption master key go here. Adding
--- a new sensitive key in the future = one-line append.
-local _config_denylist = {
-    http_api_tokens = true,
-    master_key_path = true,
-}
+-- #262 / Precursor 0c of #78 arc: cfg keys whose value MUST NOT
+-- leak through the HTTP API are masked as the string "<redacted>"
+-- on GET and rejected with 403 on PUT. The registry lives in
+-- core/secrets.lua (single source of truth across +showcfg, GET
+-- /v1/config, audit-body redaction). Future plugins register their
+-- own sensitive keys at onStart via `secrets.register(cfg_key)` -
+-- no edit to this file required.
 
 -- #262: apply-status classification - which keys take effect
 -- immediately on cfg.set vs need POST /v1/reload vs need a full
@@ -1403,7 +1401,7 @@ local _config_restart_required = {
     ssl_ports_ipv6   = true,
     http_port        = true,
     hub_listen       = true,
-    master_key_path  = true,    -- also in denylist; PUT 403 before this is reached
+    master_key_path  = true,    -- also in secrets registry; PUT 403 before this is reached
     log_path         = true,    -- log file handles opened at startup
     -- TLS context is constructed once when the SSL listener binds.
     -- Changing ssl_params / use_ssl after startup has no effect
@@ -1419,17 +1417,19 @@ local _classify_apply_status = function( key )
 end
 
 -- #262 GET /v1/config: read-scoped. Returns the full cfg snapshot
--- (every key registered in cfg_defaults.lua) with denylisted keys
--- masked as "<redacted>".
+-- (every key registered in cfg_defaults.lua) with sensitive keys
+-- masked as "<redacted>". The sensitive-key list lives in
+-- core/secrets.lua (Precursor 0c of #78 arc).
 local function config_get_handler( req )
     local cfg_mod = use "cfg"
     if type( cfg_mod.list_keys ) ~= "function" then
         return { status = 500, error = { code = "E_INTERNAL",
             message = "cfg.list_keys not available" } }
     end
+    local secrets_mod = use "secrets"
     local snapshot = { }
     for _, key in ipairs( cfg_mod.list_keys( ) ) do
-        if _config_denylist[ key ] then
+        if secrets_mod.is_secret_key( key ) then
             snapshot[ key ] = "<redacted>"
         else
             snapshot[ key ] = cfg_mod.get( key )
@@ -1449,9 +1449,10 @@ local function config_put_handler( req )
         return { status = 400, error = { code = "E_BAD_INPUT",
             message = "missing {key} path variable" } }
     end
-    if _config_denylist[ key ] then
+    local secrets_mod = use "secrets"
+    if secrets_mod.is_secret_key( key ) then
         return { status = 403, error = { code = "E_FORBIDDEN",
-            message = "cfg key '" .. key .. "' is sensitive (in API denylist); " ..
+            message = "cfg key '" .. key .. "' is sensitive (in secrets registry); " ..
                 "rotate / relocate via direct cfg.tbl edit + hub restart" } }
     end
     local cfg_mod = use "cfg"
@@ -1605,7 +1606,7 @@ register_core_endpoints = function( )
     -- #262 config management endpoints.
     register( "GET", "/v1/config", "read", config_get_handler, {
         plugin = "core",
-        description = "full cfg snapshot; sensitive keys (http_api_tokens, master_key_path) masked as <redacted>",
+        description = "full cfg snapshot; keys in the secrets registry (see core/secrets.lua) masked as <redacted>",
     } )
     register( "PUT", "/v1/config/{key}", "admin", config_put_handler, {
         plugin = "core",

--- a/core/init.lua
+++ b/core/init.lua
@@ -80,6 +80,13 @@ _core = {    -- luadch core, order is important
     -- secret.init() from cfg.init() after _settings is loaded so
     -- the cfg-side path override works on first boot.
     "cfg",
+    -- core/secrets.lua (Precursor 0c of #78 arc): sensitive-key
+    -- registry + env-var-first cfg lookup. Loaded AFTER cfg so the
+    -- init() baseline registrations and the lookup fallback can
+    -- consult cfg.get; loaded BEFORE everything that holds
+    -- sensitive cfg keys (http_router /v1/config redaction, future
+    -- etc_geoip / etc_proxydetect plugins).
+    "secrets",
     "out",
     -- cert_bootstrap MUST come after cfg + out (it reads cfg.get and
     -- writes via out.put) and BEFORE hub (hub.init() binds the TLS

--- a/core/scripts.lua
+++ b/core/scripts.lua
@@ -239,6 +239,12 @@ local SANDBOX_GLOBALS = {
     -- luadch core modules (always present in _G after init.lua)
     "cfg", "util", "util_http", "http_filter", "http_events", "http_client", "adc", "adclib", "signal", "out",
     "audit",
+    -- core/secrets.lua (#78 Precursor 0c): sensitive-key registry
+    -- + env-var-first cfg lookup. Future API-keyed plugins
+    -- (etc_geoip MaxMind license, etc_proxydetect provider keys,
+    -- webhook tokens) call `secrets.lookup(cfg_key)` so Docker
+    -- operators can set keys via env vars instead of cfg.tbl.
+    "secrets",
     "unicode",
     -- read-only program constants (PROGRAM_NAME / VERSION / FORK /
     -- COPYRIGHT / CONFIG_PATH). Static strings, no capability; lets

--- a/core/secrets.lua
+++ b/core/secrets.lua
@@ -1,0 +1,128 @@
+--[[
+
+    core/secrets.lua - sensitive-key registry + env-var-first lookup.
+
+    Two responsibilities, both pre-requisites for the unified
+    blocklist arc (#78 Precursor 0c) - Phase D (etc_geoip) needs a
+    MaxMind license-key lookup that survives both Docker (env var)
+    and bare-metal (cfg.tbl) deployments; Phase F (etc_proxydetect)
+    needs the same shape for proxycheck.io / VPNAPI.io / IPQS API
+    keys. The redaction registry is also used today by
+    GET /v1/config (#262) which previously hardcoded its denylist.
+
+    1. Registry of cfg keys that are "secrets" (API tokens, license
+       keys, encryption-master-key paths). Consumers consult
+       `is_secret_key(cfg_key)` before displaying / logging /
+       exporting a cfg value. Single source of truth - GET /v1/config
+       redaction, future +showcfg, audit-body redaction all consult
+       this module instead of carrying their own denylist copies.
+
+    2. Env-var-first lookup helper (`lookup`): for API-keyed plugins
+       and any cfg key that should travel via Docker env section
+       instead of cfg.tbl. Checks `LUADCH_<UPPER_CFG_KEY>` env var
+       first; falls back to cfg.get on miss. Empty string in either
+       location counts as "unset" so an empty env var does NOT mask
+       a populated cfg value.
+
+    Lazy-binds cfg via `use "cfg"` at call time so module load order
+    in init.lua is straightforward (cfg -> secrets -> rest of core).
+
+    Baseline registry (pre-loaded by init()):
+      - http_api_tokens (HTTP API auth tokens; existed pre-arc)
+      - master_key_path (cfg_secret encryption key path; existed pre-arc)
+
+    Plugins / other modules register additional keys at onStart /
+    init time:
+
+        local secrets = use "secrets"
+        secrets.register( "etc_geoip_license_key" )
+
+    Re-registration is idempotent. No unregister() - sensitive keys
+    stay sensitive for the process lifetime.
+
+]]--
+
+local type        = type
+local pairs       = pairs
+local tostring    = tostring
+local string      = string
+local table       = table
+local os          = os
+local use         = use
+
+local _registry = { }
+
+local _env_prefix = "LUADCH_"
+
+local _derive_env_name = function( cfg_key )
+    if type( cfg_key ) ~= "string" or cfg_key == "" then return nil end
+    -- cfg keys in this repo are [a-z0-9_]+ (per cfg_defaults.lua
+    -- convention); a plain upper() suffices and the POSIX / Windows
+    -- env-var name charset accepts all of [A-Z0-9_]. Fail-loud on
+    -- any future cfg key that contains chars outside that set
+    -- rather than silently producing an unreliable env-var name
+    -- (e.g. `LUADCH_FOO-BAR` reads differ across shells).
+    if cfg_key:find( "[^%a%d_]" ) then return nil end
+    return _env_prefix .. string.upper( cfg_key )
+end
+
+local register = function( cfg_key )
+    if type( cfg_key ) ~= "string" or cfg_key == "" then return false end
+    _registry[ cfg_key ] = true
+    return true
+end
+
+local is_secret_key = function( cfg_key )
+    return _registry[ cfg_key ] == true
+end
+
+local lookup = function( cfg_key )
+    if type( cfg_key ) ~= "string" or cfg_key == "" then return nil end
+
+    -- 1. Env var first (Docker-friendly).
+    local env_name = _derive_env_name( cfg_key )
+    if env_name then
+        local v = os.getenv( env_name )
+        if type( v ) == "string" and v ~= "" then
+            return v
+        end
+    end
+
+    -- 2. cfg.tbl fallback (bare-metal friendly; chmod 600 by Phase
+    -- 7c hardening).
+    local cfg_mod = use "cfg"
+    if cfg_mod and type( cfg_mod.get ) == "function" then
+        local v = cfg_mod.get( cfg_key )
+        if type( v ) == "string" and v ~= "" then
+            return v
+        end
+    end
+
+    return nil
+end
+
+local list_secret_keys = function( )
+    local out = { }
+    for k in pairs( _registry ) do
+        out[ #out + 1 ] = k
+    end
+    table.sort( out )
+    return out
+end
+
+local init = function( )
+    -- Baseline registry - sensitive keys that existed before this
+    -- module landed. Migrated from the hardcoded denylist at
+    -- core/http_router.lua _config_denylist (#262 / #272).
+    register( "http_api_tokens" )
+    register( "master_key_path" )
+end
+
+return {
+    register         = register,
+    is_secret_key    = is_secret_key,
+    lookup           = lookup,
+    list_secret_keys = list_secret_keys,
+    _derive_env_name = _derive_env_name,    -- exposed for tests
+    init             = init,
+}

--- a/core/secrets.lua
+++ b/core/secrets.lua
@@ -42,13 +42,17 @@
 
 ]]--
 
-local type        = type
-local pairs       = pairs
-local tostring    = tostring
-local string      = string
-local table       = table
-local os          = os
-local use         = use
+local use = use
+
+-- Core modules run under init.lua's restricted env (only `use` is
+-- in scope). Everything else - stdlib functions, libraries - must
+-- be pulled in via `use`. Same pattern as core/util.lua + core/audit.lua.
+local type        = use "type"
+local pairs       = use "pairs"
+local tostring    = use "tostring"
+local string      = use "string"
+local table       = use "table"
+local os          = use "os"
 
 local _registry = { }
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -373,6 +373,80 @@ snapshots, `_normalize_str` for flat-table input). INF-derived
 strings are F-INF-2-clamped at parse time too, so this is
 defense-in-depth.
 
+### cfg-level secrets, env-var fallback, and HTTP API redaction
+
+Some cfg keys hold authentication material (HTTP API bearer tokens,
+future plugin API keys) or paths that protect at-rest encryption.
+These are tracked in a SINGLE registry at
+[`core/secrets.lua`](../core/secrets.lua) - the same module that
+`GET /v1/config` redaction consults and that plugin secrets-lookup
+helpers go through.
+
+**Registry semantics.** A cfg key registered via
+`secrets.register(cfg_key)` is treated as sensitive for the
+process lifetime:
+
+- `GET /v1/config` masks its value as `"<redacted>"`.
+- `PUT /v1/config/{key}` returns `403 E_FORBIDDEN` (rotate via
+  direct `cfg.tbl` edit + restart).
+- Future `+showcfg` / `+config show` cmds (when added) will
+  consult the same registry.
+
+Baseline registrations are seeded by `secrets.init()`:
+
+- `http_api_tokens` (HTTP API auth tokens, existed pre-arc).
+- `master_key_path` (cfg_secret encryption key path, existed
+  pre-arc).
+
+Plugins register their own sensitive keys at `onStart`:
+
+```lua
+local secrets = use "secrets"
+secrets.register( "etc_geoip_license_key" )
+secrets.register( "etc_proxydetect_api_key" )
+```
+
+`register()` is exposed to every plugin via `SANDBOX_GLOBALS` and
+takes effect for the process lifetime - the same trust assumption
+as §2 applies. A hostile plugin can hide a live cfg key from
+`GET /v1/config` by registering it, but the sandbox already grants
+worse capabilities (file I/O, network, hub state). The registry is
+defense-in-depth alongside the per-key chmod baseline above, not a
+plugin-trust boundary.
+
+**Env-var-first lookup.** Plugins that need an API key call
+`secrets.lookup(cfg_key)` instead of `cfg.get(cfg_key)`. The helper
+checks `LUADCH_<UPPER_CFG_KEY>` (e.g. `LUADCH_ETC_GEOIP_LICENSE_KEY`)
+first, then falls back to `cfg.get`. Empty strings in either
+location are treated as unset, so an accidentally blank env var
+does NOT mask a populated cfg value.
+
+Use cases:
+
+| Deployment | Where the key lives | Why |
+|---|---|---|
+| Docker / docker-compose | `environment:` section of the service | Survives container restarts; never written to disk; trivial rotation via `docker compose up -d` after a value change |
+| Bare-metal (Linux / Windows) | `cfg/cfg.tbl` (chmod 600 / icacls applied per the recipes above) | Stable across reboots; no env var to forget |
+| CI / staging | `LUADCH_*` env var injected by the orchestrator | Separation between code-config (cfg.tbl in repo or volume) and secrets (injected per environment) |
+
+Mixed deployments are allowed - any individual key can travel via
+env, via cfg, or both (env wins).
+
+**Why env-var-first and not encrypted-cfg.** The hub-itself already
+encrypts `cfg/user.tbl` (Phase 7c F-AUTH-1) but `cfg.tbl` itself is
+plain on disk with chmod 600. Encrypting individual cfg keys
+introduces an at-rest-secrets-management problem that the existing
+master-key path already solves at the user.tbl scope. The env-var
+fallback gives Docker operators a path that does not touch disk at
+all (env vars live in `/proc/<pid>/environ`, readable only by the
+process owner), and bare-metal operators a path that mirrors how
+they already manage `cfg.tbl` (chmod 600 + backup separation).
+
+**Process-environ leak surface.** `os.getenv` reads from the
+process environment, which Linux exposes via `/proc/<pid>/environ`
+to the process owner. Run the hub under its own dedicated user;
+the per-OS hardening recipes above already cover this.
+
 ---
 
 ## 5. Network-level defenses

--- a/tests/unit/secrets_test.lua
+++ b/tests/unit/secrets_test.lua
@@ -19,15 +19,22 @@
 ]]--
 
 ----------------------------------------------------------------------
--- `use` shim. secrets.lua only needs cfg via use("cfg") inside
--- lookup() at call time, plus the module captures `os` / standard
--- libs at module load via local bindings.
+-- `use` shim. secrets.lua follows the core-module pattern: every
+-- stdlib / library it touches comes via use("X") under init.lua's
+-- restricted env. The shim hands back the real stdlib values for
+-- type / pairs / tostring / string / table / os; cfg is mocked.
 ----------------------------------------------------------------------
 
 local _cfg_store = { }
 
-local mocks = {
-    cfg = {
+local _real = {
+    type     = type,
+    pairs    = pairs,
+    tostring = tostring,
+    string   = string,
+    table    = table,
+    os       = os,
+    cfg      = {
         get = function( key )
             return _cfg_store[ key ]
         end,
@@ -35,7 +42,7 @@ local mocks = {
 }
 
 _G.use = function( name )
-    local m = mocks[ name ]
+    local m = _real[ name ]
     if m == nil then
         error( "secrets_test shim missing dep: use \"" .. tostring( name ) .. "\"" )
     end

--- a/tests/unit/secrets_test.lua
+++ b/tests/unit/secrets_test.lua
@@ -1,0 +1,245 @@
+--[[
+
+    tests/unit/secrets_test.lua
+
+    Unit tests for core/secrets.lua (#78 Precursor 0c). Covers:
+      - registry: register / is_secret_key / list_secret_keys
+      - baseline registrations after init()
+      - _derive_env_name shape (prefix + uppercase)
+      - lookup: env-var precedence over cfg.get
+      - lookup: cfg.get fallback when env var unset / empty
+      - lookup: empty cfg returns nil (not the empty string)
+      - lookup: nil / non-string input -> nil
+      - re-registration is idempotent
+      - register rejects non-string / empty input
+
+    Run:  C:\lua-5.4.8_Win64_bin\lua54.exe tests/unit/secrets_test.lua
+    Exit 0 = all pass, 1 = a failure.
+
+]]--
+
+----------------------------------------------------------------------
+-- `use` shim. secrets.lua only needs cfg via use("cfg") inside
+-- lookup() at call time, plus the module captures `os` / standard
+-- libs at module load via local bindings.
+----------------------------------------------------------------------
+
+local _cfg_store = { }
+
+local mocks = {
+    cfg = {
+        get = function( key )
+            return _cfg_store[ key ]
+        end,
+    },
+}
+
+_G.use = function( name )
+    local m = mocks[ name ]
+    if m == nil then
+        error( "secrets_test shim missing dep: use \"" .. tostring( name ) .. "\"" )
+    end
+    return m
+end
+
+local secrets = assert( loadfile( "core/secrets.lua" ) )( )
+
+----------------------------------------------------------------------
+-- Tiny test harness.
+----------------------------------------------------------------------
+
+local _passes, _fails = 0, 0
+
+local function assert_eq( what, got, expected )
+    if got == expected then
+        _passes = _passes + 1
+    else
+        _fails = _fails + 1
+        io.stderr:write( string.format(
+            "FAIL: %s\n  got: %s\n  expected: %s\n",
+            what, tostring( got ), tostring( expected )
+        ) )
+    end
+end
+
+local function assert_true( what, got )
+    assert_eq( what, not not got, true )
+end
+
+local function assert_false( what, got )
+    assert_eq( what, not got, true )
+end
+
+----------------------------------------------------------------------
+-- _derive_env_name
+----------------------------------------------------------------------
+
+assert_eq( "_derive_env_name: simple cfg key",
+    secrets._derive_env_name( "etc_geoip_license_key" ),
+    "LUADCH_ETC_GEOIP_LICENSE_KEY" )
+
+assert_eq( "_derive_env_name: short key",
+    secrets._derive_env_name( "api_token" ),
+    "LUADCH_API_TOKEN" )
+
+assert_eq( "_derive_env_name: nil input -> nil",
+    secrets._derive_env_name( nil ), nil )
+
+assert_eq( "_derive_env_name: empty string -> nil",
+    secrets._derive_env_name( "" ), nil )
+
+assert_eq( "_derive_env_name: non-string -> nil",
+    secrets._derive_env_name( 42 ), nil )
+
+-- Fail-loud guard: any cfg key with chars outside [A-Za-z0-9_] gets
+-- nil rather than an unreliable env-var name. POSIX shells accept
+-- only [A-Z0-9_] in env-var names; producing `LUADCH_FOO-BAR`
+-- silently would create shell-dependent lookup behaviour.
+assert_eq( "_derive_env_name: dash rejected",
+    secrets._derive_env_name( "foo-bar" ), nil )
+
+assert_eq( "_derive_env_name: dot rejected",
+    secrets._derive_env_name( "foo.bar" ), nil )
+
+assert_eq( "_derive_env_name: space rejected",
+    secrets._derive_env_name( "foo bar" ), nil )
+
+assert_eq( "_derive_env_name: slash rejected",
+    secrets._derive_env_name( "foo/bar" ), nil )
+
+----------------------------------------------------------------------
+-- register / is_secret_key / list_secret_keys (fresh registry)
+----------------------------------------------------------------------
+
+assert_false( "is_secret_key: unknown key pre-init",
+    secrets.is_secret_key( "etc_geoip_license_key" ) )
+
+assert_true( "register: returns true on success",
+    secrets.register( "etc_geoip_license_key" ) )
+
+assert_true( "is_secret_key: registered key -> true",
+    secrets.is_secret_key( "etc_geoip_license_key" ) )
+
+assert_false( "is_secret_key: still-unknown key -> false",
+    secrets.is_secret_key( "etc_proxydetect_api_key" ) )
+
+assert_true( "register: re-registration is idempotent",
+    secrets.register( "etc_geoip_license_key" ) )
+
+assert_false( "register: nil input rejected",
+    secrets.register( nil ) )
+
+assert_false( "register: empty string rejected",
+    secrets.register( "" ) )
+
+assert_false( "register: non-string rejected",
+    secrets.register( 42 ) )
+
+local list = secrets.list_secret_keys( )
+assert_eq( "list_secret_keys: count = 1 after one register",
+    #list, 1 )
+assert_eq( "list_secret_keys: contains registered key",
+    list[ 1 ], "etc_geoip_license_key" )
+
+----------------------------------------------------------------------
+-- init() seeds the baseline registry
+----------------------------------------------------------------------
+
+secrets.init( )
+
+assert_true( "init: http_api_tokens registered",
+    secrets.is_secret_key( "http_api_tokens" ) )
+
+assert_true( "init: master_key_path registered",
+    secrets.is_secret_key( "master_key_path" ) )
+
+local list_after = secrets.list_secret_keys( )
+assert_true( "list_secret_keys: returns sorted array",
+    list_after[ 1 ] <= list_after[ #list_after ] )
+
+----------------------------------------------------------------------
+-- lookup: env-var precedence (mock os.getenv via _G replacement)
+----------------------------------------------------------------------
+
+-- Stash + replace os.getenv with a controllable mock. The module
+-- captured `os` at load time via `local os = os`, so we mutate the
+-- shared `os` table's `getenv` field instead of rebinding the local.
+local _real_getenv = os.getenv
+local _env = { }
+os.getenv = function( name ) return _env[ name ] end
+
+-- Case 1: env var set + cfg unset -> env wins
+_env[ "LUADCH_TESTKEY_ALPHA" ] = "from-env"
+_cfg_store[ "testkey_alpha" ] = nil
+assert_eq( "lookup: env-var precedence over unset cfg",
+    secrets.lookup( "testkey_alpha" ),
+    "from-env" )
+
+-- Case 2: env var set + cfg also set -> env still wins
+_env[ "LUADCH_TESTKEY_BETA" ] = "from-env"
+_cfg_store[ "testkey_beta" ] = "from-cfg"
+assert_eq( "lookup: env wins over populated cfg",
+    secrets.lookup( "testkey_beta" ),
+    "from-env" )
+
+-- Case 3: env unset + cfg set -> cfg fallback
+_env[ "LUADCH_TESTKEY_GAMMA" ] = nil
+_cfg_store[ "testkey_gamma" ] = "from-cfg"
+assert_eq( "lookup: cfg fallback when env unset",
+    secrets.lookup( "testkey_gamma" ),
+    "from-cfg" )
+
+-- Case 4: env set to empty + cfg set -> cfg wins (empty env != set)
+_env[ "LUADCH_TESTKEY_DELTA" ] = ""
+_cfg_store[ "testkey_delta" ] = "from-cfg"
+assert_eq( "lookup: empty env does NOT mask populated cfg",
+    secrets.lookup( "testkey_delta" ),
+    "from-cfg" )
+
+-- Case 5: both unset -> nil
+_env[ "LUADCH_TESTKEY_EPSILON" ] = nil
+_cfg_store[ "testkey_epsilon" ] = nil
+assert_eq( "lookup: both unset -> nil",
+    secrets.lookup( "testkey_epsilon" ),
+    nil )
+
+-- Case 6: cfg has empty string -> nil (treated as unset)
+_env[ "LUADCH_TESTKEY_ZETA" ] = nil
+_cfg_store[ "testkey_zeta" ] = ""
+assert_eq( "lookup: cfg empty string treated as unset",
+    secrets.lookup( "testkey_zeta" ),
+    nil )
+
+-- Case 7: cfg has non-string value (e.g. table) -> nil
+_env[ "LUADCH_TESTKEY_ETA" ] = nil
+_cfg_store[ "testkey_eta" ] = { "not", "a", "string" }
+assert_eq( "lookup: cfg non-string treated as unset",
+    secrets.lookup( "testkey_eta" ),
+    nil )
+
+-- Case 8: lookup() with bad input
+assert_eq( "lookup: nil input -> nil",
+    secrets.lookup( nil ), nil )
+
+assert_eq( "lookup: empty string input -> nil",
+    secrets.lookup( "" ), nil )
+
+assert_eq( "lookup: non-string input -> nil",
+    secrets.lookup( 42 ), nil )
+
+-- Restore os.getenv
+os.getenv = _real_getenv
+
+----------------------------------------------------------------------
+-- Result
+----------------------------------------------------------------------
+
+if _fails > 0 then
+    io.stderr:write( string.format(
+        "\nFAIL: %d/%d checks failed\n",
+        _fails, _passes + _fails
+    ) )
+    os.exit( 1 )
+end
+
+print( string.format( "OK: %d checks passed", _passes ) )


### PR DESCRIPTION
Precursor 0c of the unified-blocklist arc (#78). Introduces `core/secrets.lua` as the single source of truth for cfg keys that hold authentication material, and refactors the hardcoded `_config_denylist` in `core/http_router.lua` (#262 / PR #272) to consult it.

Part of #78.

## Why now

Phase D (etc_geoip MaxMind license) and Phase F (etc_proxydetect provider API keys) both need:
- A way for operators to ship API keys via Docker `environment:` OR cfg.tbl (mixed deployments allowed).
- A registry that ensures the new keys are redacted on `GET /v1/config` and rejected on `PUT /v1/config/{key}` without each plugin re-implementing redaction.

This Precursor lands the shared infrastructure once so Phase D + F can register their cfg keys in one line each.

## What changed

**New: `core/secrets.lua` (~120 LoC).** Single module with two orthogonal responsibilities:

1. **Registry** - `register(cfg_key)` / `is_secret_key(cfg_key)` / `list_secret_keys()`. Baseline seeded by `init()` with `http_api_tokens` + `master_key_path` (the two keys from the prior hardcoded denylist; behaviour preserved exactly).
2. **Lookup** - `lookup(cfg_key)` checks `LUADCH_<UPPER_CFG_KEY>` env var first, falls back to `cfg.get`. Empty strings in either location are treated as unset so a blank env var does NOT mask a populated cfg value.

**Refactor: `core/http_router.lua`.** Removed the local `_config_denylist = {http_api_tokens=true, master_key_path=true}` literal at line 1342. The two consumers (`GET /v1/config` redaction + `PUT /v1/config/{key}` 403 gate) now call `secrets.is_secret_key(key)` via `use "secrets"`. Future plugins can register additional sensitive keys without touching this file.

**Wiring:**
- `core/init.lua`: `"secrets"` added to `_core` array between `cfg` and `out`.
- `core/scripts.lua`: `"secrets"` added to `SANDBOX_GLOBALS` so plugins can `use "secrets"`.
- `docs/SECURITY.md`: new subsection under §4 documenting registry semantics, env-var-first lookup, deployment matrix (Docker / bare-metal / CI), and the plugin trust contract for `register()` exposure.
- `.github/workflows/smoke.yml`: 32-check unit test wired into both Linux and Windows jobs.

## Testing

- **Local lua54.exe** per [`feedback-run-unit-tests-locally`]: `tests/unit/secrets_test.lua` passes 32/32 checks.
- **Coverage**: `_derive_env_name` shape (incl. fail-loud rejection of `-`/`.`/space/`/` in cfg keys), registry semantics (register / is_secret_key / list / idempotency / bad input rejection), baseline registry after `init()`, lookup precedence matrix (env-only / both / cfg-only / empty-env-with-cfg / both-unset / cfg-empty / cfg-non-string / bad input).
- **Existing tests**: `http_router_test.lua` still passes (63 checks) after the refactor.

## Pre-merge §1a.6 review

Subagent review pass: 0 blockers, 0 concerns, 4 nits - all addressed before push:
- Stale "denylist" terminology fixed in surviving comment (`http_router.lua:1404`).
- `/v1/config` route description generalised to point at the registry instead of hardcoding the baseline two keys.
- SECURITY.md adds a paragraph on the plugin trust contract for `register()` exposure (sandbox is defense-in-depth, not a security boundary).
- `_derive_env_name` fail-loud guard on cfg keys with non-`[A-Za-z0-9_]` chars (POSIX env-var name charset).

## Test plan

- [x] Local Lua unit test pass (32/32) on lua54.exe
- [ ] CI: Smoke Linux + Smoke Windows + Docker + CodeQL all green
- [ ] Testhub `:dev` Docker validation: hub starts with `LUADCH_HTTP_API_TOKENS` env var set, `+reload` works, `GET /v1/config` redacts `http_api_tokens` and `master_key_path`
- [ ] Post-merge: feat branch deleted, master tag deferred to Phase A start

## Scope

This is a precursor, deliberately small. Phase A of the #78 arc (the actual blocklist primitives) comes next. The registry + lookup API land here so Phase D / F can use them directly when they ship.