### PR TITLE
feat(blocklist): unified pre-handshake IP/CIDR blocklist engine (Phase A of #78)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -146,6 +146,21 @@ jobs:
       - name: Run cacert_bootstrap unit test
         run: lua5.4 tests/unit/cacert_bootstrap_test.lua
 
+      # #78 Phase A: core/ipmatch.lua pure-Lua IPv4/IPv6/CIDR
+      # primitives. 67 checks across v4 + v6 parse / normalize /
+      # match / CIDR boundary edge cases.
+      - name: Run ipmatch unit test
+        run: lua5.4 tests/unit/ipmatch_test.lua
+
+      # #78 Phase A: core/blocklist.lua unified pre-handshake
+      # blocklist engine. 48 checks: add/remove round-trip,
+      # bucket-routed match (v4 + v6), priority order
+      # (manual > geoip > external), stealth-flag plumbing,
+      # expires_at TTL, reload-from-disk cache rebuild, persistence
+      # round-trip via stubbed util.savetable/loadtable.
+      - name: Run blocklist unit test
+        run: lua5.4 tests/unit/blocklist_test.lua
+
       - name: Configure
         run: cmake -B build -DCMAKE_BUILD_TYPE=Release
 
@@ -258,6 +273,14 @@ jobs:
       - name: Run cacert_bootstrap unit test
         shell: msys2 {0}
         run: lua tests/unit/cacert_bootstrap_test.lua
+
+      - name: Run ipmatch unit test
+        shell: msys2 {0}
+        run: lua tests/unit/ipmatch_test.lua
+
+      - name: Run blocklist unit test
+        shell: msys2 {0}
+        run: lua tests/unit/blocklist_test.lua
 
       - name: Configure
         shell: msys2 {0}

--- a/core/blocklist.lua
+++ b/core/blocklist.lua
@@ -1,0 +1,713 @@
+--[[
+
+    core/blocklist.lua - unified pre-handshake IP/CIDR blocklist.
+
+    Phase A of the unified-blocklist arc (#78). Stands up the
+    in-memory bucketed cache + persistent .tbl store + decision
+    API consumed by the stealth hook in core/server.lua and by
+    Phase B's `+blocklist` admin plugin + Phase C's HTTP API +
+    Phase D/E/F's GeoIP / external-feed / proxy plugins.
+
+    Design notes:
+
+      * In-memory cache, .tbl-backed. On add/remove we mutate the
+        in-memory state AND persist atomically. Plugins call
+        public API only; they never hold a reference to the
+        entries array (avoids the stale-rebind hazard documented
+        in past arcs).
+
+      * Bucketing on the first byte (v4) / first two bytes (v6)
+        keeps the hot-path scan local: at 5k entries spread over
+        256 v4 buckets, the average bucket has ~20 entries and
+        linear scan within a bucket is microseconds. The radix
+        keys are extracted from the raw IP bytes returned by
+        core/ipmatch.lua - no integer conversion needed.
+
+      * Decision priority order: manual > geoip > proxycheck >
+        ipqs > vpnapi > external. Higher-priority sources win
+        when multiple entries match the same IP. The order is
+        documented + locked here; future sources slot into the
+        table at registration time.
+
+      * Aggregated log rollup: per-IP attempt counters, flushed
+        every `blocklist_aggregated_log_window_sec` seconds (one
+        line per IP+source pair). LRU-capped at 10k IPs to keep
+        IPv6 randomisation from OOMing the hub.
+
+      * Stealth flag per entry: blocks happen identically at the
+        TCP-accept layer (close-without-reply by construction -
+        we are pre-ADC-handshake there), so stealth distinguishes
+        visibility in the operator log:
+
+           stealth = false (default) -> per-attempt out.put line
+                                        + included in aggregated rollup
+           stealth = true            -> NO per-attempt line, included
+                                        in aggregated rollup only
+
+        Plus an explicit "stealth-only" rollup omits the source
+        meta from the line to avoid leaking the detection method
+        to an attacker reading logs.
+
+    Public surface:
+
+        blocklist.check_ip(ip) -> blocked, source, meta
+            true if the IP is in the active store; source is the
+            winning entry's source string; meta is the entry's
+            audit-shape table { cidr, reason, stealth, meta }.
+
+        blocklist.add(cidr_or_ip, opts) -> ok, id, err
+            opts = { source, reason, by_nick, stealth, expires_at, meta }
+            Source defaults to "manual"; stealth defaults to cfg
+            `blocklist_stealth_default`.
+
+        blocklist.remove(id) -> ok, err
+            By numeric id. Returns false + "not_found" if absent.
+
+        blocklist.list(filter_spec) -> rows
+            Full snapshot when filter_spec is nil/{}; supports
+            { source = "manual" }, { stealth = true }, ...
+
+        blocklist.count() -> { total, by_source }
+
+        blocklist.reload()
+            Re-reads the .tbl from disk and rebuilds the cache.
+            Called on cfg-reload event by init().
+
+        blocklist._resolve_decision(ip) -> entry | nil
+            Internal helper; exposed for tests. Returns the
+            winning entry (highest priority source) when matched,
+            nil when no match.
+
+]]--
+
+local use = use
+
+local type      = use "type"
+local pairs     = use "pairs"
+local ipairs    = use "ipairs"
+local tostring  = use "tostring"
+local string    = use "string"
+local table     = use "table"
+local math      = use "math"
+local socket    = use "socket"
+
+local string_byte    = string.byte
+local string_format  = string.format
+local string_lower   = string.lower
+local table_insert   = table.insert
+local table_remove   = table.remove
+local math_floor     = math.floor
+local socket_gettime = socket.gettime
+
+local util    = use "util"
+local ipmatch = use "ipmatch"
+
+local util_loadtable = util.loadtable
+local util_savetable = util.savetable
+local ipmatch_parse_cidr  = ipmatch.parse_cidr
+local ipmatch_parse_ip    = ipmatch.parse_ip
+local ipmatch_match       = ipmatch.match
+local ipmatch_format_bytes = ipmatch.format_bytes
+
+-- Late-bound dependencies (cfg / out are core modules loaded
+-- alongside us; address by `use` at call time so the load-order
+-- in init.lua stays simple).
+local cfg_get
+local out_put
+local out_error
+
+-- Source priority: higher number = higher priority. When multiple
+-- entries match the same IP, the winner is the highest-priority.
+-- New sources for Phase D/E/F register into this table.
+local _SOURCE_PRIORITY = {
+    manual     = 100,
+    geoip      = 50,
+    proxycheck = 40,
+    ipqs       = 35,
+    vpnapi     = 30,
+    external   = 20,
+}
+local _DEFAULT_PRIORITY = 0
+
+local function _priority( source )
+    return _SOURCE_PRIORITY[ source or "" ] or _DEFAULT_PRIORITY
+end
+
+----------------------------------------------------------------------
+-- State
+----------------------------------------------------------------------
+
+local _enabled = true
+local _store_path = "cfg/blocklist.tbl"
+local _stealth_default = false
+local _log_window = 3600
+local _rollup_cap = 10000
+
+local _entries = { }        -- array of entry records, order = insert
+local _next_id = 1
+local _buckets_v4 = { }     -- [byte 1] -> array of entry refs
+local _buckets_v6 = { }     -- [byte1 * 256 + byte2] -> array of entry refs
+
+----------------------------------------------------------------------
+-- Aggregated rollup state
+----------------------------------------------------------------------
+
+local _rollup = { }        -- key (ip..\0..source) -> { ip, source, count, last_seen, stealth }
+local _rollup_lru_head = 0
+local _rollup_size = 0
+local _last_flush_time = 0
+
+local function _rollup_flush_locked( now )
+    if next( _rollup ) == nil then
+        _last_flush_time = now
+        return
+    end
+    local rows = { }
+    for _, agg in pairs( _rollup ) do
+        rows[ #rows + 1 ] = agg
+    end
+    -- Sort by count DESCENDING so the loudest IPs show first in the
+    -- flush block. Ties broken by IP for stable output across runs.
+    table.sort( rows, function( a, b )
+        if a.count ~= b.count then return a.count > b.count end
+        return a.ip < b.ip
+    end )
+    for _, agg in ipairs( rows ) do
+        local source_part = agg.stealth and "" or ( " [source=" .. tostring( agg.source ) .. "]" )
+        if out_put then
+            out_put( string_format( "blocklist: %s %d blocked attempts in last %ds%s",
+                agg.ip, agg.count, _log_window, source_part ) )
+        end
+    end
+    _rollup = { }
+    _rollup_size = 0
+    _last_flush_time = now
+end
+
+local function _rollup_maybe_flush( now )
+    if _last_flush_time == 0 then _last_flush_time = now end
+    if now - _last_flush_time >= _log_window then
+        _rollup_flush_locked( now )
+    end
+end
+
+local function _rollup_record( ip, source, stealth, now )
+    _rollup_maybe_flush( now )
+    local key = ip .. "\0" .. tostring( source )
+    local agg = _rollup[ key ]
+    if agg then
+        agg.count = agg.count + 1
+        agg.last_seen = now
+        return
+    end
+    -- Cap eviction must be O(1) because this fires inside the
+    -- accept-time hot path. Under an IPv6-randomisation flood the
+    -- rollup sits AT cap, so a per-call O(N) scan would amplify
+    -- the very class of attack F-NET-1 is meant to prevent. Drop
+    -- an arbitrary entry via `next()` instead of hunting for the
+    -- "oldest" - the rollup is a best-effort statistic; perfect-
+    -- LRU is not load-bearing.
+    if _rollup_size >= _rollup_cap then
+        local evict_key = next( _rollup )
+        if evict_key then
+            _rollup[ evict_key ] = nil
+            _rollup_size = _rollup_size - 1
+        end
+    end
+    _rollup[ key ] = {
+        ip = ip, source = source, stealth = stealth and true or false,
+        count = 1, last_seen = now,
+    }
+    _rollup_size = _rollup_size + 1
+end
+
+----------------------------------------------------------------------
+-- Bucket helpers
+----------------------------------------------------------------------
+
+local function _bucket_for( family, network_bytes, prefix_len )
+    -- For prefixes shorter than the bucket-key width, we have to
+    -- enroll the entry in every covering bucket. /0 means every
+    -- bucket. /8 in v4 means exactly one bucket. /4 means 16
+    -- contiguous buckets. We keep the precomputed list on insert
+    -- so the lookup path stays O(1) + linear-scan-of-bucket.
+    if family == 4 then
+        if prefix_len >= 8 then
+            return { string_byte( network_bytes, 1 ) }
+        end
+        -- /< 8: enumerate the byte range that the prefix covers.
+        local first_byte = string_byte( network_bytes, 1 )
+        local span = ( 1 << ( 8 - prefix_len ) )
+        local out = { }
+        for i = 0, span - 1 do
+            out[ #out + 1 ] = first_byte + i
+        end
+        return out
+    end
+    -- family == 6
+    if prefix_len >= 16 then
+        local b1, b2 = string_byte( network_bytes, 1, 2 )
+        return { b1 * 256 + b2 }
+    end
+    local b1 = string_byte( network_bytes, 1 )
+    if prefix_len >= 8 then
+        local b2 = string_byte( network_bytes, 2 )
+        -- prefix covers part of byte 2; enumerate the relevant
+        -- low-bits.
+        local span = ( 1 << ( 16 - prefix_len ) )
+        local base = b1 * 256 + b2
+        local out = { }
+        for i = 0, span - 1 do
+            out[ #out + 1 ] = base + i
+        end
+        return out
+    end
+    -- prefix < 8: covers many top-bytes. Conservative: enumerate.
+    local span = ( 1 << ( 8 - prefix_len ) )
+    local out = { }
+    for i = 0, span - 1 do
+        local first = b1 + i
+        for j = 0, 255 do
+            out[ #out + 1 ] = first * 256 + j
+        end
+    end
+    return out
+end
+
+local function _bucket_table( family )
+    if family == 4 then return _buckets_v4 end
+    return _buckets_v6
+end
+
+local function _bucket_insert( entry )
+    local tbl = _bucket_table( entry.family )
+    for _, key in ipairs( entry._buckets ) do
+        local list = tbl[ key ]
+        if not list then
+            list = { }
+            tbl[ key ] = list
+        end
+        list[ #list + 1 ] = entry
+    end
+end
+
+local function _bucket_remove( entry )
+    local tbl = _bucket_table( entry.family )
+    for _, key in ipairs( entry._buckets ) do
+        local list = tbl[ key ]
+        if list then
+            for i, e in ipairs( list ) do
+                if e == entry then
+                    table_remove( list, i )
+                    break
+                end
+            end
+            if #list == 0 then tbl[ key ] = nil end
+        end
+    end
+end
+
+----------------------------------------------------------------------
+-- Disk persistence
+--
+-- File format: a Lua-table dump (util.savetable / util.loadtable)
+-- with the array of entries. We strip the bucket-key cache before
+-- saving (computed at load time from network_bytes + prefix_len).
+----------------------------------------------------------------------
+
+local function _persist_one( e )
+    return {
+        id           = e.id,
+        cidr         = e.cidr,
+        family       = e.family,
+        network_b64  = e._network_b64,    -- stored as base64-ish to keep .tbl text-safe
+        prefix_len   = e.prefix_len,
+        source       = e.source,
+        stealth      = e.stealth and true or false,
+        reason       = e.reason or "",
+        by_nick      = e.by_nick or "",
+        expires_at   = e.expires_at,
+        created_at   = e.created_at,
+        meta         = e.meta,
+    }
+end
+
+-- Hex-encode raw network bytes (small, robust, no dep on basexx
+-- ordering of bytes). 4 bytes for v4 -> 8 hex chars; 16 bytes for
+-- v6 -> 32 hex chars. Decoder is `_hex_decode`.
+local function _hex_encode( s )
+    local out = { }
+    for i = 1, #s do
+        out[ i ] = string_format( "%02x", string_byte( s, i ) )
+    end
+    return table.concat( out )
+end
+
+local function _hex_decode( s )
+    if type( s ) ~= "string" or ( #s % 2 ) ~= 0 then return nil end
+    local out = { }
+    for i = 1, #s, 2 do
+        local byte_val = tonumber( s:sub( i, i + 1 ), 16 )
+        if not byte_val then return nil end
+        out[ #out + 1 ] = string.char( byte_val )
+    end
+    return table.concat( out )
+end
+
+local function _save_to_disk( )
+    local snapshot = { }
+    for i, e in ipairs( _entries ) do
+        snapshot[ i ] = _persist_one( e )
+    end
+    local ok, err = util_savetable( snapshot, "blocklist", _store_path )
+    if not ok then
+        if out_error then out_error( "blocklist: save failed: " .. tostring( err ) ) end
+        return false, err
+    end
+    return true
+end
+
+----------------------------------------------------------------------
+-- Entry construction
+----------------------------------------------------------------------
+
+local function _rebuild_indices( )
+    _buckets_v4 = { }
+    _buckets_v6 = { }
+    for _, e in ipairs( _entries ) do
+        e._buckets = _bucket_for( e.family, e.network_bytes, e.prefix_len )
+        _bucket_insert( e )
+    end
+end
+
+local function _make_entry( cidr, opts )
+    local family, network_bytes, prefix_len = ipmatch_parse_cidr( cidr )
+    if not family then
+        return nil, network_bytes    -- second value is the err string
+    end
+    -- Canonical CIDR string is computed DIRECTLY from raw bytes via
+    -- ipmatch.format_bytes - one pass, no parse/normalize round-trip
+    -- and no dependency on the string round-trip producing identical
+    -- output across future normalize-helper changes.
+    local canonical_ip = ipmatch_format_bytes( family, network_bytes )
+    if not canonical_ip then
+        return nil, "internal: cannot format canonical CIDR from bytes"
+    end
+    local canonical_cidr = canonical_ip .. "/" .. prefix_len
+
+    opts = opts or { }
+    local source = opts.source or "manual"
+    local stealth = opts.stealth
+    if stealth == nil then stealth = _stealth_default end
+
+    local now = socket_gettime( )
+    local entry = {
+        id           = _next_id,
+        cidr         = canonical_cidr,
+        family       = family,
+        network_bytes = network_bytes,
+        prefix_len   = prefix_len,
+        source       = source,
+        stealth      = stealth and true or false,
+        reason       = opts.reason or "",
+        by_nick      = opts.by_nick or "",
+        expires_at   = opts.expires_at,
+        created_at   = math_floor( now ),
+        meta         = opts.meta,
+        _network_b64 = _hex_encode( network_bytes ),
+    }
+    return entry
+end
+
+----------------------------------------------------------------------
+-- Public API
+----------------------------------------------------------------------
+
+local _resolve_decision
+
+local function check_ip( ip )
+    if not _enabled then return false end
+    if not next( _entries ) then return false end
+
+    local entry = _resolve_decision( ip )
+    if not entry then return false end
+
+    local now = socket_gettime( )
+    -- Per-attempt visible log when NOT stealth; the rollup picks
+    -- up the count regardless.
+    if ( not entry.stealth ) and out_put then
+        out_put( string_format(
+            "blocklist: refused %s (source=%s, cidr=%s, reason=%s)",
+            ip, entry.source, entry.cidr, entry.reason or "" ) )
+    end
+    _rollup_record( ip, entry.source, entry.stealth, now )
+
+    -- Shallow-copy meta on the way out so a caller doing
+    -- `r.meta.foo = "x"` cannot mutate the live entry through this
+    -- reference (the trust contract documented in the module header
+    -- says plugins NEVER hold a reference to the entries array).
+    local meta_copy
+    if type( entry.meta ) == "table" then
+        meta_copy = { }
+        for k, v in pairs( entry.meta ) do meta_copy[ k ] = v end
+    end
+    return true, entry.source, {
+        cidr    = entry.cidr,
+        reason  = entry.reason,
+        stealth = entry.stealth,
+        meta    = meta_copy,
+    }
+end
+
+_resolve_decision = function( ip )
+    if type( ip ) ~= "string" or ip == "" then return nil end
+    local family, bytes = ipmatch_parse_ip( ip )
+    if not family then return nil end
+
+    local bucket
+    if family == 4 then
+        bucket = _buckets_v4[ string_byte( bytes, 1 ) ]
+    else
+        local b1, b2 = string_byte( bytes, 1, 2 )
+        bucket = _buckets_v6[ b1 * 256 + b2 ]
+    end
+    if not bucket then return nil end
+
+    local now = socket_gettime( )
+    local best
+    for _, entry in ipairs( bucket ) do
+        if entry.expires_at and entry.expires_at <= now then
+            -- expired; filtered here on every check. Actual removal
+            -- from _entries happens on the next add() via _sweep_expired
+            -- or on the next reload() (skip-on-load). expires_at
+            -- semantics: an entry is "expired" when now >= expires_at
+            -- (inclusive boundary).
+        elseif ipmatch_match( bytes, entry.network_bytes, entry.prefix_len ) then
+            if ( not best ) or _priority( entry.source ) > _priority( best.source ) then
+                best = entry
+            end
+        end
+    end
+    return best
+end
+
+-- Periodic expired-entry sweep. Phase D/E/F auto-feeds (GeoIP,
+-- proxydetect, external lists) push entries with expires_at TTLs;
+-- without this they accumulate in _entries forever because
+-- check_ip only FILTERS expired entries, never removes them.
+-- We piggyback the sweep on add() so it runs at human-tunable
+-- cadence (operator + auto-feed insert rate) rather than per
+-- accept (which would slow the hot path).
+local function _sweep_expired( now )
+    local kept = { }
+    local removed_any = false
+    for _, e in ipairs( _entries ) do
+        if e.expires_at and e.expires_at <= now then
+            _bucket_remove( e )
+            removed_any = true
+        else
+            kept[ #kept + 1 ] = e
+        end
+    end
+    if removed_any then _entries = kept end
+    return removed_any
+end
+
+local function add( cidr, opts )
+    local entry, err = _make_entry( cidr, opts )
+    if not entry then return false, nil, err end
+    -- Sweep expired entries BEFORE persisting the new state so the
+    -- .tbl on disk doesn't keep accumulating stale rows. Best-effort:
+    -- if the sweep finds nothing, no extra disk I/O happens because
+    -- the save below writes the post-sweep snapshot regardless.
+    _sweep_expired( socket_gettime( ) )
+    entry._buckets = _bucket_for( entry.family, entry.network_bytes, entry.prefix_len )
+    _next_id = _next_id + 1
+    _entries[ #_entries + 1 ] = entry
+    _bucket_insert( entry )
+    local ok, save_err = _save_to_disk( )
+    if not ok then
+        -- Roll back: rebuilding indices keeps state consistent.
+        _entries[ #_entries ] = nil
+        _next_id = _next_id - 1
+        _bucket_remove( entry )
+        return false, nil, "save failed: " .. tostring( save_err )
+    end
+    return true, entry.id
+end
+
+local function remove( id )
+    if type( id ) ~= "number" then return false, "id must be a number" end
+    for i, e in ipairs( _entries ) do
+        if e.id == id then
+            table_remove( _entries, i )
+            _bucket_remove( e )
+            local ok, err = _save_to_disk( )
+            if not ok then
+                -- Re-insert on save failure to keep state consistent.
+                table_insert( _entries, i, e )
+                _bucket_insert( e )
+                return false, "save failed: " .. tostring( err )
+            end
+            return true
+        end
+    end
+    return false, "not_found"
+end
+
+-- Supported filter_spec keys. Extending the set is a Phase B/C
+-- task; unknown keys today log a one-time warn so an operator
+-- typo through the future HTTP API doesn't silently return "all
+-- entries" (would read as "filter did nothing", concealing the bug).
+local _FILTER_KEYS = { source = true, stealth = true }
+
+local function list( filter_spec )
+    local out = { }
+    filter_spec = filter_spec or { }
+    for k in pairs( filter_spec ) do
+        if not _FILTER_KEYS[ k ] then
+            if out_put then
+                out_put( "blocklist: list() ignoring unknown filter key '" ..
+                    tostring( k ) .. "'" )
+            end
+        end
+    end
+    for _, e in ipairs( _entries ) do
+        local include = true
+        if filter_spec.source and e.source ~= filter_spec.source then include = false end
+        if filter_spec.stealth ~= nil and e.stealth ~= ( filter_spec.stealth and true or false ) then
+            include = false
+        end
+        if include then
+            local meta_copy
+            if type( e.meta ) == "table" then
+                meta_copy = { }
+                for k, v in pairs( e.meta ) do meta_copy[ k ] = v end
+            end
+            out[ #out + 1 ] = {
+                id         = e.id,
+                cidr       = e.cidr,
+                source     = e.source,
+                stealth    = e.stealth,
+                reason     = e.reason,
+                by_nick    = e.by_nick,
+                expires_at = e.expires_at,
+                created_at = e.created_at,
+                meta       = meta_copy,
+            }
+        end
+    end
+    return out
+end
+
+local function count( )
+    local by_source = { }
+    for _, e in ipairs( _entries ) do
+        by_source[ e.source ] = ( by_source[ e.source ] or 0 ) + 1
+    end
+    return { total = #_entries, by_source = by_source }
+end
+
+local function reload( )
+    _entries = { }
+    _next_id = 1
+    _buckets_v4 = { }
+    _buckets_v6 = { }
+    _rollup = { }
+    _rollup_size = 0
+    _last_flush_time = 0
+
+    local data, err = util_loadtable( _store_path )
+    if not data then
+        if err and not err:find( "No such file" ) then
+            if out_error then out_error( "blocklist: load failed: " .. tostring( err ) ) end
+        end
+        return
+    end
+    if type( data ) ~= "table" then return end
+
+    local now = socket_gettime( )
+    for _, row in ipairs( data ) do
+        -- Skip already-expired rows on load. Prevents unbounded
+        -- accumulation across reload boundaries when Phase D/E/F
+        -- auto-feeds push lots of short-TTL entries.
+        local expired = row.expires_at and row.expires_at <= now
+        local network_bytes = _hex_decode( row.network_b64 or "" )
+        if ( not expired ) and network_bytes and ( ( row.family == 4 and #network_bytes == 4 ) or ( row.family == 6 and #network_bytes == 16 ) ) then
+            local entry = {
+                id           = tonumber( row.id ) or _next_id,
+                cidr         = row.cidr,
+                family       = row.family,
+                network_bytes = network_bytes,
+                prefix_len   = tonumber( row.prefix_len ) or ( row.family == 4 and 32 or 128 ),
+                source       = row.source or "manual",
+                stealth      = row.stealth and true or false,
+                reason       = row.reason or "",
+                by_nick      = row.by_nick or "",
+                expires_at   = row.expires_at,
+                created_at   = row.created_at,
+                meta         = row.meta,
+                _network_b64 = row.network_b64,
+            }
+            entry._buckets = _bucket_for( entry.family, entry.network_bytes, entry.prefix_len )
+            _entries[ #_entries + 1 ] = entry
+            _bucket_insert( entry )
+            if entry.id >= _next_id then _next_id = entry.id + 1 end
+        end
+    end
+end
+
+----------------------------------------------------------------------
+-- Init - called from init.lua _core sweep
+----------------------------------------------------------------------
+
+-- Re-read cfg keys into the module's local snapshot. Used both at
+-- init() time and on cfg-reload so a `+reload` after editing
+-- `blocklist_enabled = false` or `blocklist_stealth_default = true`
+-- takes effect without a hub restart (the original reload-handler
+-- only re-read the .tbl - cfg keys were stuck until restart).
+local function _resnapshot_cfg( )
+    local cfg_enabled = cfg_get "blocklist_enabled"
+    _enabled = ( cfg_enabled == nil ) or ( cfg_enabled and true ) or false
+    _store_path      = cfg_get( "blocklist_store_path" ) or _store_path
+    _stealth_default = cfg_get( "blocklist_stealth_default" ) and true or false
+    _log_window      = cfg_get( "blocklist_aggregated_log_window_sec" ) or _log_window
+end
+
+local function _reload_on_cfg_reload( )
+    _resnapshot_cfg( )
+    reload( )
+end
+
+local function init( )
+    cfg_get = use( "cfg" ).get
+    local out_mod = use "out"
+    out_put = out_mod.put
+    out_error = out_mod.error
+
+    _resnapshot_cfg( )
+    reload( )
+
+    -- Register on cfg-reload event so `+reload` re-reads the .tbl
+    -- AND the cfg keys. The handler is a separate function (not
+    -- `reload`) because reload() only touches the store; cfg-key
+    -- changes need _resnapshot_cfg too.
+    local cfg_mod = use "cfg"
+    if type( cfg_mod.registerevent ) == "function" then
+        cfg_mod.registerevent( "reload", _reload_on_cfg_reload )
+    end
+end
+
+return {
+    init               = init,
+    check_ip           = check_ip,
+    add                = add,
+    remove             = remove,
+    list               = list,
+    count              = count,
+    reload             = reload,
+    _resolve_decision  = _resolve_decision,
+    _priority          = _priority,           -- exposed for tests
+    _hex_encode        = _hex_encode,
+    _hex_decode        = _hex_decode,
+}

--- a/core/blocklist.lua
+++ b/core/blocklist.lua
@@ -83,9 +83,11 @@
 local use = use
 
 local type      = use "type"
+local next      = use "next"
 local pairs     = use "pairs"
 local ipairs    = use "ipairs"
 local tostring  = use "tostring"
+local tonumber  = use "tonumber"
 local string    = use "string"
 local table     = use "table"
 local math      = use "math"

--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -3897,6 +3897,39 @@ local defaults = {
             return types_number( value, nil, true )
         end
     },
+    -- #78 Phase A: unified pre-handshake IP/CIDR blocklist. The
+    -- engine + store ship enabled-by-default but the store is
+    -- empty - zero overhead until operators add entries via
+    -- Phase B's `+blocklist` cmd or Phase D/E/F's auto-feeds.
+    -- See core/blocklist.lua + docs/BLOCKLIST.md (Phase B+).
+    blocklist_enabled = { true,
+        function( value )
+            return types_boolean( value, nil, true )
+        end
+    },
+    blocklist_store_path = { "cfg/blocklist.tbl",
+        function( value )
+            return types_utf8( value, nil, true )
+        end
+    },
+    -- Per-rule stealth opt-in (default visible-kick), per locked
+    -- arc decision: most operators want clear log feedback;
+    -- stealth is for the rare "Tor exit pollutes the log" case.
+    blocklist_stealth_default = { false,
+        function( value )
+            return types_boolean( value, nil, true )
+        end
+    },
+    -- Aggregated-log rollup window in seconds. Per-IP attempt
+    -- counters flush as a single line at this cadence. Default
+    -- 3600 = once-per-hour. Range 60..86400 (one-minute lower
+    -- bound so the rollup is not also a high-rate log spammer).
+    blocklist_aggregated_log_window_sec = { 3600,
+        function( value )
+            if not types_number( value, nil, true ) then return false end
+            return value >= 60 and value <= 86400
+        end
+    },
     -- Per-IP parallel-socket cap. Connection refused at accept time.
     -- Default 16 accommodates small-office NAT / CGNAT deployments
     -- where many users share one public IP. Lower for tighter hubs.

--- a/core/init.lua
+++ b/core/init.lua
@@ -108,6 +108,17 @@ _core = {    -- luadch core, order is important
     -- runs at init-time, not at hub-loop time.
     "cacert_bootstrap",
     --"doc",
+    -- core/ipmatch.lua (Phase A of #78 arc): pure-Lua IPv4/IPv6
+    -- + CIDR parse + prefix-match primitives. No deps beyond
+    -- stdlib; load order is just before its consumer blocklist.
+    "ipmatch",
+    -- core/blocklist.lua (Phase A of #78 arc): unified pre-handshake
+    -- IP/CIDR blocklist (in-memory bucketed cache + cfg/blocklist.tbl
+    -- persistent store + decision API). Loaded BEFORE ratelimit +
+    -- server because server.lua captures `blocklist.check_ip` at
+    -- module load for the accept-time stealth hook. init() reads
+    -- cfg + reloads the store + registers a cfg-reload listener.
+    "blocklist",
     "ratelimit",
     "server",
     "adc",

--- a/core/ipmatch.lua
+++ b/core/ipmatch.lua
@@ -53,6 +53,7 @@
 local use = use
 
 local type      = use "type"
+local ipairs    = use "ipairs"
 local string    = use "string"
 local table     = use "table"
 local tonumber  = use "tonumber"

--- a/core/ipmatch.lua
+++ b/core/ipmatch.lua
@@ -1,0 +1,438 @@
+--[[
+
+    core/ipmatch.lua - IPv4/IPv6/CIDR parse + prefix-match.
+
+    Phase A of the unified-blocklist arc (#78). Pure-Lua because
+    the hot path is TCP accept (already kHz-bounded by ratelimit),
+    not per-packet, so the overhead is negligible. Adding a C
+    primitive would re-open the adclib ABI class we already audited.
+
+    Wire format: parsed IPs are returned as raw byte strings, NOT
+    integers. IPv4 = 4 bytes, IPv6 = 16 bytes. Big-endian (network
+    byte order). The radix bucket in core/blocklist.lua keys on the
+    first byte (v4) or first two bytes (v6); a `string.byte` call on
+    the raw bytes is O(1) regardless of family.
+
+    Public surface:
+
+        ipmatch.parse_ip(s) -> family, bytes | nil, err
+            family: integer 4 or 6
+            bytes:  raw 4-byte or 16-byte string
+            err:    descriptive string on parse failure
+
+        ipmatch.parse_cidr(s) -> family, network_bytes, prefix_len | nil, err
+            Accepts "1.2.3.0/24", "1.2.3.4", "2001:db8::/32", "::1".
+            A single IP (no /N) maps to family-max prefix
+            (/32 for v4, /128 for v6). Rejects host-bits-set CIDRs
+            ("1.2.3.4/24") with a clear error so the operator
+            cleans up rather than getting a silently-canonicalised
+            block.
+
+        ipmatch.match(ip_bytes, network_bytes, prefix_len) -> bool
+            Both byte strings MUST be the same family (length).
+            prefix_len in [0..32] for v4, [0..128] for v6.
+
+        ipmatch.family(s) -> 4 | 6 | nil
+            Quick "is this a valid IPv4 / IPv6 / neither?" check.
+            Returns nil on parse failure (use parse_ip for err).
+
+        ipmatch.normalize(s) -> string | nil, err
+            Canonical form: IPv4 = dotted-quad no leading zeros;
+            IPv6 = lowercase hex, longest-zero-run compressed to
+            `::`, no zero-padded fields. Stable round-trip.
+
+    IPv4-mapped IPv6 quirk: `::ffff:1.2.3.4` parses as IPv6 (16
+    bytes) by default. The caller decides whether to treat the
+    mapped form as identical to its v4 source (it isn't on the
+    wire). core/blocklist.lua keeps them separate to avoid
+    surprising operators; documented in docs/BLOCKLIST.md when it
+    lands.
+
+]]--
+
+local use = use
+
+local type      = use "type"
+local string    = use "string"
+local table     = use "table"
+local tonumber  = use "tonumber"
+local tostring  = use "tostring"
+
+local string_byte    = string.byte
+local string_char    = string.char
+local string_format  = string.format
+local string_match   = string.match
+local string_gmatch  = string.gmatch
+local string_find    = string.find
+local string_sub     = string.sub
+local string_lower   = string.lower
+local string_rep     = string.rep
+local table_concat   = table.concat
+local table_insert   = table.insert
+
+----------------------------------------------------------------------
+-- IPv4 parse
+----------------------------------------------------------------------
+
+local function _parse_ipv4( s )
+    local a, b, c, d = string_match( s, "^(%d+)%.(%d+)%.(%d+)%.(%d+)$" )
+    if not a then return nil, "not a dotted-quad IPv4" end
+    -- Reject leading zeros: "01.2.3.4" is ambiguous (octal vs
+    -- decimal historically). RFC 6943 + every modern parser
+    -- treats it as parse error.
+    for _, oct in ipairs{ a, b, c, d } do
+        if #oct > 1 and string_sub( oct, 1, 1 ) == "0" then
+            return nil, "IPv4 octet has leading zero: '" .. oct .. "'"
+        end
+    end
+    a, b, c, d = tonumber( a ), tonumber( b ), tonumber( c ), tonumber( d )
+    if a > 255 or b > 255 or c > 255 or d > 255 then
+        return nil, "IPv4 octet > 255"
+    end
+    return string_char( a, b, c, d )
+end
+
+----------------------------------------------------------------------
+-- IPv6 parse
+--
+-- Handles:
+--   - full 8-group form         "2001:db8:0:0:0:0:0:1"
+--   - zero-compressed form      "2001:db8::1"   "::1"   "::"
+--   - v4-mapped suffix          "::ffff:192.0.2.1"
+----------------------------------------------------------------------
+
+local function _hex16_to_bytes( h )
+    local n = tonumber( h, 16 )
+    if not n or n > 0xffff then return nil end
+    return string_char( ( n >> 8 ) & 0xff, n & 0xff )
+end
+
+local function _parse_ipv6( s )
+    if string_find( s, "%s" ) then return nil, "IPv6 contains whitespace" end
+
+    -- Check for trailing v4-mapped suffix.
+    local v4suffix
+    local v4_dot_idx = string_find( s, "%." )
+    if v4_dot_idx then
+        -- Find the last colon separating the v6 prefix from the v4
+        -- suffix.
+        local last_colon = nil
+        for i = string_find( s, "%." ), 1, -1 do
+            if string_sub( s, i, i ) == ":" then last_colon = i; break end
+        end
+        if not last_colon then return nil, "IPv6 with dot but no colon" end
+        v4suffix = string_sub( s, last_colon + 1 )
+        -- Drop the trailing colon too so the v6 prefix that remains
+        -- does not look like "trailing colon malformed". For the
+        -- pure-`::ffff:1.2.3.4` form this leaves `::ffff`; for the
+        -- full `0:0:0:0:0:ffff:1.2.3.4` form it leaves
+        -- `0:0:0:0:0:ffff`.
+        s = string_sub( s, 1, last_colon - 1 )
+    end
+
+    -- Split on "::" - at most one occurrence.
+    local left_part, right_part
+    local dcolon = string_find( s, "::", 1, true )
+    if dcolon then
+        if string_find( s, "::", dcolon + 2, true ) then
+            return nil, "IPv6 has multiple '::'"
+        end
+        left_part  = string_sub( s, 1, dcolon - 1 )
+        right_part = string_sub( s, dcolon + 2 )
+    else
+        left_part = s
+    end
+
+    local function _split_groups( part )
+        if part == "" then return { } end
+        local out = { }
+        for g in string_gmatch( part, "([^:]+)" ) do
+            out[ #out + 1 ] = g
+        end
+        -- Reject leading or trailing single colon (e.g. ":1234")
+        if string_sub( part, 1, 1 ) == ":" then return nil end
+        if string_sub( part, -1 ) == ":" then return nil end
+        return out
+    end
+
+    local left_groups  = _split_groups( left_part or "" )
+    if not left_groups then return nil, "IPv6 malformed colon placement" end
+    local right_groups
+    if right_part then
+        right_groups = _split_groups( right_part )
+        if not right_groups then return nil, "IPv6 malformed colon placement" end
+    end
+
+    -- Validate each group as 1-4 hex digits.
+    local function _check_groups( groups )
+        for _, g in ipairs( groups ) do
+            if #g < 1 or #g > 4 or not string_match( g, "^[0-9a-fA-F]+$" ) then
+                return false
+            end
+        end
+        return true
+    end
+    if not _check_groups( left_groups ) then return nil, "IPv6 bad hex group" end
+    if right_groups and not _check_groups( right_groups ) then
+        return nil, "IPv6 bad hex group"
+    end
+
+    -- v4 suffix consumes 2 groups (32 bits = 4 octets = 2 v6 groups).
+    local v4groups_used = 0
+    local v4bytes
+    if v4suffix then
+        local b, err = _parse_ipv4( v4suffix )
+        if not b then return nil, "IPv6 v4-mapped: " .. tostring( err ) end
+        v4bytes = b
+        v4groups_used = 2
+    end
+
+    local total_groups = #left_groups + ( right_groups and #right_groups or 0 ) + v4groups_used
+    if dcolon then
+        if total_groups > 8 then return nil, "IPv6 too many groups for '::'" end
+    else
+        if total_groups ~= 8 then
+            return nil, "IPv6 needs 8 groups (got " .. total_groups .. ")"
+        end
+    end
+
+    -- Materialise all 16 bytes.
+    local out = { }
+    for _, g in ipairs( left_groups ) do
+        local two = _hex16_to_bytes( g )
+        if not two then return nil, "IPv6 group out of range" end
+        out[ #out + 1 ] = two
+    end
+    if dcolon then
+        local zeros_needed = 8 - total_groups
+        for i = 1, zeros_needed do
+            out[ #out + 1 ] = "\0\0"
+        end
+        if right_groups then
+            for _, g in ipairs( right_groups ) do
+                local two = _hex16_to_bytes( g )
+                if not two then return nil, "IPv6 group out of range" end
+                out[ #out + 1 ] = two
+            end
+        end
+    end
+    if v4bytes then
+        out[ #out + 1 ] = v4bytes
+    end
+
+    local bytes = table_concat( out )
+    if #bytes ~= 16 then
+        return nil, "IPv6 internal length error (" .. #bytes .. " bytes)"
+    end
+    return bytes
+end
+
+----------------------------------------------------------------------
+-- Public API
+----------------------------------------------------------------------
+
+local function parse_ip( s )
+    if type( s ) ~= "string" or s == "" then
+        return nil, "ipmatch.parse_ip: empty / non-string input"
+    end
+    -- Strip surrounding brackets for IPv6-literal URL form.
+    if string_sub( s, 1, 1 ) == "[" and string_sub( s, -1 ) == "]" then
+        s = string_sub( s, 2, -2 )
+    end
+    if string_find( s, ":", 1, true ) then
+        local bytes, err = _parse_ipv6( s )
+        if bytes then return 6, bytes end
+        return nil, err or "IPv6 parse failed"
+    end
+    local bytes, err = _parse_ipv4( s )
+    if bytes then return 4, bytes end
+    return nil, err or "IPv4 parse failed"
+end
+
+local function family( s )
+    local f = parse_ip( s )
+    return f
+end
+
+local function parse_cidr( s )
+    if type( s ) ~= "string" or s == "" then
+        return nil, "ipmatch.parse_cidr: empty / non-string input"
+    end
+    local slash = string_find( s, "/", 1, true )
+    local ip_part, prefix
+    if slash then
+        ip_part = string_sub( s, 1, slash - 1 )
+        prefix = tonumber( string_sub( s, slash + 1 ) )
+        -- Reject non-integer / negative / NaN. `tonumber("24.5")` returns
+        -- the float 24.5 which would pass the simple `< 0` guard but
+        -- then crash the `prefix >> 3` bitop downstream (Lua 5.4
+        -- integer-bitop strict mode).
+        if ( not prefix ) or prefix < 0 or prefix ~= ( prefix // 1 ) then
+            return nil, "CIDR prefix not a non-negative integer"
+        end
+    else
+        ip_part = s
+    end
+
+    -- parse_ip returns (fam, bytes) on success or (nil, errstring) on
+    -- failure - the failure msg lives in the second return value, not
+    -- a third. Propagate it via `bytes_or_err` so an operator typo
+    -- through Phase B's `+blocklist add` gets a clear error.
+    local fam, bytes_or_err = parse_ip( ip_part )
+    if not fam then return nil, bytes_or_err end
+    local bytes = bytes_or_err
+
+    local max_prefix = ( fam == 4 ) and 32 or 128
+    if not prefix then
+        prefix = max_prefix
+    end
+    if prefix > max_prefix then
+        return nil, "CIDR prefix " .. prefix .. " > max " .. max_prefix .. " for IPv" .. fam
+    end
+
+    -- Reject host-bits-set: "1.2.3.4/24" must be "1.2.3.0/24".
+    -- Compute network bytes from input bytes and assert equality.
+    local n = #bytes
+    local full_bytes = prefix >> 3
+    local tail_bits  = prefix & 7
+    local mask_bytes = { }
+    for i = 1, n do
+        if i <= full_bytes then
+            mask_bytes[ i ] = string_byte( bytes, i )
+        elseif i == full_bytes + 1 and tail_bits > 0 then
+            local m = ( 0xff << ( 8 - tail_bits ) ) & 0xff
+            mask_bytes[ i ] = string_byte( bytes, i ) & m
+        else
+            mask_bytes[ i ] = 0
+        end
+    end
+    local network_bytes = string_char( table.unpack( mask_bytes ) )
+    if network_bytes ~= bytes then
+        return nil, "CIDR has host bits set: " .. s ..
+            " (use the network address instead)"
+    end
+
+    return fam, network_bytes, prefix
+end
+
+local function match( ip_bytes, network_bytes, prefix_len )
+    if type( ip_bytes ) ~= "string" or type( network_bytes ) ~= "string" then
+        return false
+    end
+    if #ip_bytes ~= #network_bytes then
+        return false    -- different families never match
+    end
+    if prefix_len == 0 then return true end    -- 0.0.0.0/0 matches all
+    local full_bytes = prefix_len >> 3
+    local tail_bits  = prefix_len & 7
+    if full_bytes > 0 then
+        if string_sub( ip_bytes, 1, full_bytes ) ~=
+           string_sub( network_bytes, 1, full_bytes ) then
+            return false
+        end
+    end
+    if tail_bits > 0 then
+        local m = ( 0xff << ( 8 - tail_bits ) ) & 0xff
+        local idx = full_bytes + 1
+        if ( string_byte( ip_bytes, idx ) & m ) ~=
+           ( string_byte( network_bytes, idx ) & m ) then
+            return false
+        end
+    end
+    return true
+end
+
+----------------------------------------------------------------------
+-- Normalize: canonical string form for diagnostics + dedup
+----------------------------------------------------------------------
+
+local function _v4_normalize( bytes )
+    return string_format( "%d.%d.%d.%d",
+        string_byte( bytes, 1 ), string_byte( bytes, 2 ),
+        string_byte( bytes, 3 ), string_byte( bytes, 4 ) )
+end
+
+local function _v6_normalize( bytes )
+    -- RFC 5952 §5: an IPv4-mapped address (first 80 bits zero, then
+    -- 0xffff, then 32 v4 bits) is rendered with dotted-quad tail
+    -- "::ffff:1.2.3.4" rather than "::ffff:102:304". Detect the
+    -- mapped prefix first.
+    local is_v4_mapped = true
+    for i = 1, 10 do
+        if string_byte( bytes, i ) ~= 0 then is_v4_mapped = false; break end
+    end
+    if is_v4_mapped and string_byte( bytes, 11 ) == 0xff and string_byte( bytes, 12 ) == 0xff then
+        return string_format( "::ffff:%d.%d.%d.%d",
+            string_byte( bytes, 13 ), string_byte( bytes, 14 ),
+            string_byte( bytes, 15 ), string_byte( bytes, 16 ) )
+    end
+    -- Decompose into 8 hex groups.
+    local groups = { }
+    for i = 1, 8 do
+        local hi = string_byte( bytes, ( i - 1 ) * 2 + 1 )
+        local lo = string_byte( bytes, ( i - 1 ) * 2 + 2 )
+        groups[ i ] = string_format( "%x", hi * 256 + lo )
+    end
+    -- Find the longest run of consecutive "0" groups, length >= 2.
+    local best_start, best_len = nil, 1
+    local cur_start, cur_len = nil, 0
+    for i = 1, 8 do
+        if groups[ i ] == "0" then
+            if cur_start == nil then cur_start = i end
+            cur_len = cur_len + 1
+            if cur_len > best_len then
+                best_start = cur_start
+                best_len = cur_len
+            end
+        else
+            cur_start = nil
+            cur_len = 0
+        end
+    end
+    if best_start then
+        local out = { }
+        for i = 1, best_start - 1 do out[ #out + 1 ] = groups[ i ] end
+        local left  = table_concat( out, ":" )
+        out = { }
+        for i = best_start + best_len, 8 do out[ #out + 1 ] = groups[ i ] end
+        local right = table_concat( out, ":" )
+        return left .. "::" .. right
+    end
+    return table_concat( groups, ":" )
+end
+
+local function normalize( s )
+    local fam, bytes_or_err = parse_ip( s )
+    if not fam then return nil, bytes_or_err end
+    if fam == 4 then return _v4_normalize( bytes_or_err ) end
+    return _v6_normalize( bytes_or_err )
+end
+
+-- Direct bytes-to-text format. Skips the parse/normalize round-trip
+-- when the caller already holds canonical raw bytes (e.g.
+-- core/blocklist.lua after parse_cidr returns network_bytes).
+-- Returns the canonical text representation per RFC 5952; returns
+-- nil if family / bytes are inconsistent.
+local function format_bytes( fam, bytes )
+    if type( bytes ) ~= "string" then return nil end
+    if fam == 4 then
+        if #bytes ~= 4 then return nil end
+        return _v4_normalize( bytes )
+    end
+    if fam == 6 then
+        if #bytes ~= 16 then return nil end
+        return _v6_normalize( bytes )
+    end
+    return nil
+end
+
+----------------------------------------------------------------------
+
+return {
+    parse_ip     = parse_ip,
+    parse_cidr   = parse_cidr,
+    match        = match,
+    family       = family,
+    normalize    = normalize,
+    format_bytes = format_bytes,
+}

--- a/core/server.lua
+++ b/core/server.lua
@@ -90,6 +90,7 @@ local out = use "out"
 local mem = use "mem"
 local signal = use "signal"
 local ratelimit = use "ratelimit"
+local blocklist = use "blocklist"
 local iostream = use "iostream"
 
 --// core methods //--
@@ -102,6 +103,7 @@ local signal_set = signal.set
 local signal_get = signal.get
 local ratelimit_accept_ip = ratelimit.accept_ip
 local ratelimit_release_ip = ratelimit.release_ip
+local blocklist_check_ip = blocklist.check_ip
 local ratelimit_handshake_started = ratelimit.handshake_started
 local ratelimit_handshake_finished = ratelimit.handshake_finished
 local ratelimit_expired_handshakes = ratelimit.expired_handshakes
@@ -398,6 +400,18 @@ wrapserver = function( listeners, socket, serverip, serverport, serverfamily, pa
         local client, err = accept( socket )    -- try to accept
         if client then
             local clientip, clientport = client:getpeername( )
+            -- #78 Phase A: pre-handshake blocklist check. Runs BEFORE
+            -- ratelimit_accept_ip so a blocked-IP flood does not drain
+            -- the per-IP ratelimit budget for other (legitimate) IPs.
+            -- core/blocklist.lua handles the aggregated-log rollup +
+            -- per-attempt visible log; we just close-on-accept here
+            -- to keep the rejection silent at the ADC layer (no
+            -- ISTA reply because we have not started the handshake).
+            local bl_blocked = blocklist_check_ip( clientip )
+            if bl_blocked then
+                client:close( )
+                return false
+            end
             -- Phase 7c F-NET-1: per-IP parallel-socket cap and per-IP
             -- accept-rate cap. Refuse pre-wrap so the offending IP cannot
             -- consume FDs / slot-list entries.

--- a/tests/unit/blocklist_test.lua
+++ b/tests/unit/blocklist_test.lua
@@ -1,0 +1,380 @@
+--[[
+
+    tests/unit/blocklist_test.lua
+
+    Unit tests for core/blocklist.lua (#78 Phase A). Coverage:
+
+      - add / remove / list / count round-trip
+      - check_ip: bucket-routed match (v4 + v6) + non-match
+      - decision priority: manual > geoip > external when multiple
+        entries cover the same IP
+      - stealth flag plumbing through to check_ip meta
+      - expires_at: expired entries treated as non-matching
+      - reload from stub store reconstructs cache + bucket index
+      - persistence round-trip via stubbed util.savetable /
+        loadtable
+      - hex_encode / hex_decode round-trip (used for the .tbl
+        text-safe network-bytes encoding)
+      - disabled engine: check_ip always false
+
+    Run: lua5.4 tests/unit/blocklist_test.lua
+
+]]--
+
+----------------------------------------------------------------------
+-- Stub harness: replace util.savetable / loadtable with in-memory
+-- table so tests don't touch disk. Plus a controllable clock so the
+-- aggregated-log rollup + expires_at are deterministic.
+----------------------------------------------------------------------
+
+local _disk = { }    -- path -> table
+local _now = 1000
+
+local function _stub_use_factory( opts )
+    opts = opts or { }
+    local cfg_values = opts.cfg or { }
+    return function( name )
+        if name == "type" then return type end
+        if name == "pairs" then return pairs end
+        if name == "ipairs" then return ipairs end
+        if name == "tostring" then return tostring end
+        if name == "tonumber" then return tonumber end
+        if name == "string" then return string end
+        if name == "table" then return table end
+        if name == "math" then return math end
+        if name == "error" then return error end
+        if name == "socket" then return { gettime = function() return _now end } end
+        if name == "util" then
+            return {
+                loadtable = function( path ) return _disk[ path ] end,
+                savetable = function( tbl, _name, path )
+                    -- Deep-copy so subsequent mutations don't leak.
+                    local copy = { }
+                    for i, row in ipairs( tbl ) do
+                        local rcopy = { }
+                        for k, v in pairs( row ) do rcopy[ k ] = v end
+                        copy[ i ] = rcopy
+                    end
+                    _disk[ path ] = copy
+                    return true
+                end,
+            }
+        end
+        if name == "cfg" then
+            return {
+                get = function( k ) return cfg_values[ k ] end,
+                registerevent = function( ) end,
+            }
+        end
+        if name == "out" then
+            return { put = function( ) end, error = function( ) end }
+        end
+        if name == "ipmatch" then
+            return _G._loaded_ipmatch
+        end
+        error( "blocklist_test shim: missing dep " .. tostring( name ) )
+    end
+end
+
+_G.use = _stub_use_factory( )
+_G._loaded_ipmatch = assert( loadfile( "core/ipmatch.lua" ) )( )
+local bl = assert( loadfile( "core/blocklist.lua" ) )( )
+
+----------------------------------------------------------------------
+-- Tiny harness
+----------------------------------------------------------------------
+
+local _passes, _fails = 0, 0
+local function eq( what, got, want )
+    if got == want then _passes = _passes + 1
+    else
+        _fails = _fails + 1
+        io.stderr:write( string.format( "FAIL: %s\n  got:  %s\n  want: %s\n",
+            what, tostring( got ), tostring( want ) ) )
+    end
+end
+local function truthy( what, v )
+    if v then _passes = _passes + 1
+    else _fails = _fails + 1; io.stderr:write( "FAIL: " .. what .. " got=" .. tostring( v ) .. "\n" ) end
+end
+local function falsy( what, v )
+    if not v then _passes = _passes + 1
+    else _fails = _fails + 1; io.stderr:write( "FAIL: " .. what .. " got=" .. tostring( v ) .. "\n" ) end
+end
+
+local function reset_state( opts )
+    _disk = { }
+    _now = 1000
+    _G.use = _stub_use_factory( opts )
+    bl = assert( loadfile( "core/blocklist.lua" ) )( )
+    bl.init( )
+end
+
+----------------------------------------------------------------------
+-- add + check_ip basic round-trip
+----------------------------------------------------------------------
+
+reset_state{}
+do
+    local ok, id = bl.add( "1.2.3.0/24", { reason = "test", source = "manual" } )
+    eq( "add returns ok", ok, true )
+    truthy( "add returns id", id )
+
+    local blocked, source, meta = bl.check_ip( "1.2.3.50" )
+    eq( "check_ip in-range returns blocked", blocked, true )
+    eq( "check_ip source", source, "manual" )
+    truthy( "check_ip meta",  meta )
+    eq( "check_ip meta cidr", meta and meta.cidr, "1.2.3.0/24" )
+
+    eq( "check_ip out-of-range", bl.check_ip( "1.2.4.50" ), false )
+end
+
+----------------------------------------------------------------------
+-- count + list
+----------------------------------------------------------------------
+
+do
+    bl.add( "10.0.0.0/8", { source = "geoip" } )
+    bl.add( "172.16.0.0/12", { source = "external" } )
+    local c = bl.count( )
+    eq( "count total", c.total, 3 )
+    eq( "count by_source manual",   c.by_source.manual, 1 )
+    eq( "count by_source geoip",    c.by_source.geoip, 1 )
+    eq( "count by_source external", c.by_source.external, 1 )
+
+    eq( "list all length", #bl.list( ), 3 )
+    eq( "list filter source=geoip length", #bl.list{ source = "geoip" }, 1 )
+end
+
+----------------------------------------------------------------------
+-- Priority order: manual > geoip > external when overlapping
+----------------------------------------------------------------------
+
+reset_state{}
+do
+    bl.add( "192.0.2.0/24", { source = "external", reason = "feed-x" } )
+    bl.add( "192.0.2.42",  { source = "manual",   reason = "operator-pin" } )
+    bl.add( "192.0.2.0/24", { source = "geoip",    reason = "CN" } )
+
+    local _, source, meta = bl.check_ip( "192.0.2.42" )
+    eq( "priority: manual wins overlap", source, "manual" )
+    eq( "priority: meta reason from manual entry", meta and meta.reason, "operator-pin" )
+
+    local _, source2 = bl.check_ip( "192.0.2.50" )
+    eq( "priority: geoip beats external when manual /32 doesn't cover",
+        source2, "geoip" )
+end
+
+----------------------------------------------------------------------
+-- Stealth flag
+----------------------------------------------------------------------
+
+reset_state{}
+do
+    bl.add( "5.6.7.0/24", { source = "manual", stealth = true, reason = "quiet" } )
+    local _, _, meta = bl.check_ip( "5.6.7.99" )
+    eq( "stealth flag carried through to meta", meta and meta.stealth, true )
+
+    bl.add( "8.9.10.0/24", { source = "manual", stealth = false } )
+    local _, _, meta2 = bl.check_ip( "8.9.10.99" )
+    eq( "non-stealth meta.stealth", meta2 and meta2.stealth, false )
+end
+
+----------------------------------------------------------------------
+-- expires_at
+----------------------------------------------------------------------
+
+reset_state{}
+do
+    bl.add( "11.22.33.0/24", { source = "manual", expires_at = 500 } )
+    eq( "expired (past) not matched", bl.check_ip( "11.22.33.50" ), false )
+
+    bl.add( "44.55.66.0/24", { source = "manual", expires_at = 9999 } )
+    local b, _ = bl.check_ip( "44.55.66.50" )
+    eq( "expires_at in future still matches", b, true )
+
+    -- Move clock past the second entry's expires_at.
+    _now = 10000
+    local b2 = bl.check_ip( "44.55.66.50" )
+    eq( "match expires when now passes expires_at", b2, false )
+end
+
+----------------------------------------------------------------------
+-- remove
+----------------------------------------------------------------------
+
+reset_state{}
+do
+    local _, id1 = bl.add( "100.0.0.0/8", { source = "manual" } )
+    local _, id2 = bl.add( "101.0.0.0/8", { source = "manual" } )
+
+    eq( "remove returns ok", bl.remove( id1 ), true )
+    eq( "count after remove", bl.count( ).total, 1 )
+
+    local ok, err = bl.remove( 99999 )
+    eq( "remove not_found returns false", ok, false )
+    eq( "remove not_found err", err, "not_found" )
+
+    eq( "remaining entry still matched", bl.check_ip( "101.99.99.99" ), true )
+    eq( "removed entry no longer matched", bl.check_ip( "100.99.99.99" ), false )
+end
+
+----------------------------------------------------------------------
+-- IPv6 routing
+----------------------------------------------------------------------
+
+reset_state{}
+do
+    bl.add( "2001:db8::/32", { source = "external" } )
+    eq( "v6 in /32",  bl.check_ip( "2001:db8::42" ), true )
+    eq( "v6 out /32", bl.check_ip( "2001:db9::42" ), false )
+
+    bl.add( "::1", { source = "manual" } )
+    eq( "v6 /128 single IP match", bl.check_ip( "::1" ), true )
+    eq( "v6 /128 non-match",       bl.check_ip( "::2" ), false )
+end
+
+----------------------------------------------------------------------
+-- Reload from stub disk: persistence + cache rebuild
+----------------------------------------------------------------------
+
+reset_state{}
+do
+    bl.add( "55.66.77.0/24", { source = "manual", reason = "for reload test" } )
+    bl.add( "2001:db8::/32", { source = "geoip" } )
+
+    -- Build a fresh module + reload from disk.
+    _G.use = _stub_use_factory( )
+    local bl2 = assert( loadfile( "core/blocklist.lua" ) )( )
+    bl2.init( )
+
+    eq( "post-reload count", bl2.count( ).total, 2 )
+    eq( "post-reload v4 match", bl2.check_ip( "55.66.77.99" ), true )
+    eq( "post-reload v6 match", bl2.check_ip( "2001:db8::1" ), true )
+    eq( "post-reload non-match", bl2.check_ip( "1.2.3.4" ), false )
+end
+
+----------------------------------------------------------------------
+-- Engine disabled: check_ip false even with entries present
+----------------------------------------------------------------------
+
+reset_state{ cfg = { blocklist_enabled = false } }
+do
+    bl.add( "1.2.3.0/24", { source = "manual" } )
+    eq( "disabled engine returns false", bl.check_ip( "1.2.3.50" ), false )
+end
+
+----------------------------------------------------------------------
+-- hex_encode / hex_decode round-trip
+----------------------------------------------------------------------
+
+reset_state{}
+do
+    local samples = { "\1\2\3\4", "\xff\x00\xab\xcd", string.rep( "\0", 16 ),
+                      "\1\2\3\4\5\6\7\8\9\10\11\12\13\14\15\16" }
+    for _, s in ipairs( samples ) do
+        eq( "hex round-trip (len " .. #s .. ")", bl._hex_decode( bl._hex_encode( s ) ), s )
+    end
+    eq( "hex_decode odd length nil", bl._hex_decode( "abc" ), nil )
+    eq( "hex_decode bad chars nil",  bl._hex_decode( "zz" ), nil )
+end
+
+----------------------------------------------------------------------
+-- Priority table integrity
+----------------------------------------------------------------------
+
+eq( "_priority manual",     bl._priority( "manual" ),     100 )
+eq( "_priority geoip",      bl._priority( "geoip" ),      50 )
+eq( "_priority proxycheck", bl._priority( "proxycheck" ), 40 )
+eq( "_priority external",   bl._priority( "external" ),   20 )
+eq( "_priority unknown",    bl._priority( "rando-source" ), 0 )
+eq( "_priority nil",        bl._priority( nil ),          0 )
+
+----------------------------------------------------------------------
+-- _resolve_decision direct (NIT 1 from review)
+----------------------------------------------------------------------
+
+reset_state{}
+do
+    bl.add( "1.2.3.0/24", { source = "external", reason = "feed" } )
+    bl.add( "1.2.3.42",   { source = "manual",   reason = "pin" } )
+
+    -- Direct decision: returns the winning entry table, not the
+    -- public check_ip tuple. Validates priority resolution at the
+    -- internal level (no aggregated-log side effects).
+    local d = bl._resolve_decision( "1.2.3.42" )
+    truthy( "_resolve_decision returns entry", d )
+    eq( "_resolve_decision picks manual",   d and d.source, "manual" )
+    eq( "_resolve_decision picks reason",   d and d.reason, "pin" )
+
+    -- Non-match path
+    eq( "_resolve_decision out-of-range nil", bl._resolve_decision( "9.9.9.9" ), nil )
+    eq( "_resolve_decision bad input nil",    bl._resolve_decision( "garbage" ), nil )
+    eq( "_resolve_decision nil input nil",    bl._resolve_decision( nil ),       nil )
+end
+
+----------------------------------------------------------------------
+-- Returned meta is a shallow copy (NIT 2 from review)
+----------------------------------------------------------------------
+
+reset_state{}
+do
+    bl.add( "8.8.8.0/24", { source = "manual", meta = { country = "US" } } )
+
+    local _, _, r1 = bl.check_ip( "8.8.8.8" )
+    truthy( "check_ip returned meta copy", r1 and r1.meta )
+    -- Mutate the returned meta - must NOT affect later check_ip calls.
+    if r1 and r1.meta then r1.meta.country = "TAMPERED" end
+
+    local _, _, r2 = bl.check_ip( "8.8.8.8" )
+    eq( "second check_ip meta unaffected by caller mutation",
+        r2 and r2.meta and r2.meta.country, "US" )
+
+    -- Same shape via list():
+    local rows = bl.list( )
+    if rows[ 1 ] and rows[ 1 ].meta then rows[ 1 ].meta.country = "ALSO_TAMPERED" end
+    local rows2 = bl.list( )
+    eq( "second list() meta unaffected by caller mutation",
+        rows2[ 1 ] and rows2[ 1 ].meta and rows2[ 1 ].meta.country, "US" )
+end
+
+----------------------------------------------------------------------
+-- Unknown filter_spec key logs a warning (NIT 3 from review)
+----------------------------------------------------------------------
+
+reset_state{}
+do
+    -- Track out.put calls via a stub. Need to reset_state with a
+    -- captured-out shim.
+    local captured = { }
+    _G.use = function( name )
+        if name == "out" then
+            return {
+                put = function( ... ) captured[ #captured + 1 ] = table.concat({...}, "") end,
+                error = function( ) end,
+            }
+        end
+        return _stub_use_factory( )( name )
+    end
+    bl = assert( loadfile( "core/blocklist.lua" ) )( )
+    bl.init( )
+    bl.add( "1.2.3.0/24", { source = "manual" } )
+    captured = { }    -- discard add-time logs
+
+    bl.list( { source = "manual", unknown_key = "x", another_unknown = true } )
+
+    local saw_warning = false
+    for _, line in ipairs( captured ) do
+        if line:find( "unknown filter key" ) then saw_warning = true; break end
+    end
+    truthy( "unknown filter key triggers warning", saw_warning )
+end
+
+----------------------------------------------------------------------
+
+if _fails > 0 then
+    io.stderr:write( string.format( "\nFAIL: %d/%d checks failed\n",
+        _fails, _passes + _fails ) )
+    os.exit( 1 )
+end
+print( string.format( "OK: %d checks passed", _passes ) )

--- a/tests/unit/blocklist_test.lua
+++ b/tests/unit/blocklist_test.lua
@@ -35,6 +35,7 @@ local function _stub_use_factory( opts )
     local cfg_values = opts.cfg or { }
     return function( name )
         if name == "type" then return type end
+        if name == "next" then return next end
         if name == "pairs" then return pairs end
         if name == "ipairs" then return ipairs end
         if name == "tostring" then return tostring end

--- a/tests/unit/ipmatch_test.lua
+++ b/tests/unit/ipmatch_test.lua
@@ -1,0 +1,282 @@
+--[[
+
+    tests/unit/ipmatch_test.lua
+
+    Unit tests for core/ipmatch.lua (#78 Phase A). Coverage matrix:
+
+      parse_ip:    v4 valid + v4 bad inputs + v6 valid (incl. ::1,
+                   :: , v4-mapped, all-zero, all-ones) + v6 bad
+                   inputs (multiple ::, bad hex, too many groups,
+                   too few groups without ::).
+      parse_cidr:  v4 /0 /8 /24 /32; v6 /0 /16 /64 /128; bare IP =
+                   max prefix; host-bits-set rejected with clear
+                   error; /N out of range; mixed bad inputs.
+      match:       v4 in-range + out-of-range across /N boundary;
+                   v6 in-range + out-of-range; cross-family no-match;
+                   /0 matches everything.
+      family:      4 / 6 / nil shapes.
+      normalize:   leading-zero strip + zero-run compression +
+                   ordering of options for ambiguous addresses.
+
+    Run: lua5.4 tests/unit/ipmatch_test.lua
+
+]]--
+
+local _real = {
+    type = type, string = string, table = table,
+    tonumber = tonumber, tostring = tostring,
+}
+_G.use = function( n )
+    local v = _real[ n ]
+    if v == nil then error( "ipmatch_test shim missing dep: use \"" .. tostring( n ) .. "\"" ) end
+    return v
+end
+
+local ipm = assert( loadfile( "core/ipmatch.lua" ) )( )
+
+local _passes, _fails = 0, 0
+local function eq( what, got, want )
+    if got == want then _passes = _passes + 1
+    else
+        _fails = _fails + 1
+        io.stderr:write( string.format( "FAIL: %s\n  got:  %s\n  want: %s\n",
+            what, tostring( got ), tostring( want ) ) )
+    end
+end
+local function truthy( what, v )
+    if v then _passes = _passes + 1
+    else
+        _fails = _fails + 1
+        io.stderr:write( "FAIL: " .. what .. " (got " .. tostring( v ) .. ")\n" )
+    end
+end
+local function falsy( what, v )
+    if not v then _passes = _passes + 1
+    else
+        _fails = _fails + 1
+        io.stderr:write( "FAIL: " .. what .. " (got " .. tostring( v ) .. ")\n" )
+    end
+end
+
+----------------------------------------------------------------------
+-- parse_ip: IPv4
+----------------------------------------------------------------------
+
+do
+    local fam, bytes = ipm.parse_ip( "1.2.3.4" )
+    eq( "v4 family", fam, 4 )
+    eq( "v4 byte length", bytes and #bytes, 4 )
+    eq( "v4 bytes byte 1", string.byte( bytes, 1 ), 1 )
+    eq( "v4 bytes byte 4", string.byte( bytes, 4 ), 4 )
+
+    eq( "v4 0.0.0.0",       ipm.parse_ip( "0.0.0.0" ),       4 )
+    eq( "v4 255.255.255.255", ipm.parse_ip( "255.255.255.255" ), 4 )
+
+    falsy( "v4 leading-zero rejected",   ipm.parse_ip( "01.2.3.4" ) )
+    falsy( "v4 octet > 255 rejected",    ipm.parse_ip( "256.0.0.1" ) )
+    falsy( "v4 too few octets",          ipm.parse_ip( "1.2.3" ) )
+    falsy( "v4 too many octets",         ipm.parse_ip( "1.2.3.4.5" ) )
+    falsy( "v4 alpha rejected",          ipm.parse_ip( "1.2.3.a" ) )
+    falsy( "v4 empty rejected",          ipm.parse_ip( "" ) )
+    falsy( "v4 non-string rejected",     ipm.parse_ip( 42 ) )
+end
+
+----------------------------------------------------------------------
+-- parse_ip: IPv6
+----------------------------------------------------------------------
+
+do
+    eq( "v6 family ::1",             ipm.parse_ip( "::1" ), 6 )
+    eq( "v6 family ::",              ipm.parse_ip( "::" ), 6 )
+    eq( "v6 family full form",       ipm.parse_ip( "2001:db8:0:0:0:0:0:1" ), 6 )
+    eq( "v6 family compressed",      ipm.parse_ip( "2001:db8::1" ), 6 )
+    eq( "v6 family all-ones",        ipm.parse_ip( "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" ), 6 )
+    eq( "v6 family v4-mapped",       ipm.parse_ip( "::ffff:1.2.3.4" ), 6 )
+    eq( "v6 family bracketed",       ipm.parse_ip( "[::1]" ), 6 )
+
+    local _, bytes = ipm.parse_ip( "::1" )
+    eq( "v6 ::1 byte length",  #bytes, 16 )
+    eq( "v6 ::1 last byte = 1", string.byte( bytes, 16 ), 1 )
+
+    falsy( "v6 multiple :: rejected",   ipm.parse_ip( "1::2::3" ) )
+    falsy( "v6 bad hex rejected",       ipm.parse_ip( "abcg::1" ) )
+    falsy( "v6 too many groups",        ipm.parse_ip( "1:2:3:4:5:6:7:8:9" ) )
+    falsy( "v6 too few without ::",     ipm.parse_ip( "1:2:3:4:5:6:7" ) )
+    falsy( "v6 group too long",         ipm.parse_ip( "12345::" ) )
+    falsy( "v6 whitespace rejected",    ipm.parse_ip( "::1 " ) )
+end
+
+----------------------------------------------------------------------
+-- family helper
+----------------------------------------------------------------------
+
+eq( "family 1.2.3.4",   ipm.family( "1.2.3.4" ),  4 )
+eq( "family ::1",       ipm.family( "::1" ),      6 )
+eq( "family garbage",   ipm.family( "not an ip" ), nil )
+
+----------------------------------------------------------------------
+-- parse_cidr
+----------------------------------------------------------------------
+
+do
+    local fam, net, plen = ipm.parse_cidr( "1.2.3.0/24" )
+    eq( "cidr v4 /24 family", fam, 4 )
+    eq( "cidr v4 /24 prefix", plen, 24 )
+    eq( "cidr v4 /24 net byte 4", net and string.byte( net, 4 ), 0 )
+
+    fam, _, plen = ipm.parse_cidr( "0.0.0.0/0" )
+    eq( "cidr v4 /0 prefix", plen, 0 )
+
+    fam, _, plen = ipm.parse_cidr( "192.0.2.42/32" )
+    eq( "cidr v4 /32 prefix", plen, 32 )
+
+    -- Bare IP - maps to family-max prefix.
+    fam, _, plen = ipm.parse_cidr( "10.20.30.40" )
+    eq( "cidr v4 bare maps to /32", plen, 32 )
+
+    fam, _, plen = ipm.parse_cidr( "::1" )
+    eq( "cidr v6 bare maps to /128", plen, 128 )
+
+    fam, _, plen = ipm.parse_cidr( "2001:db8::/32" )
+    eq( "cidr v6 /32", fam, 6 )
+    eq( "cidr v6 /32 prefix", plen, 32 )
+
+    -- Reject host-bits-set.
+    falsy( "cidr v4 host-bits-set rejected",
+        ipm.parse_cidr( "1.2.3.4/24" ) )
+    falsy( "cidr v6 host-bits-set rejected",
+        ipm.parse_cidr( "2001:db8::1/32" ) )
+
+    -- Out-of-range prefix.
+    falsy( "cidr v4 /33 rejected", ipm.parse_cidr( "1.2.3.4/33" ) )
+    falsy( "cidr v6 /129 rejected", ipm.parse_cidr( "::1/129" ) )
+    falsy( "cidr negative prefix rejected", ipm.parse_cidr( "1.2.3.4/-1" ) )
+
+    -- Fractional prefix: must be cleanly rejected (NOT a Lua crash
+    -- inside the `prefix >> 3` bitop downstream).
+    local f, e = ipm.parse_cidr( "1.2.3.4/24.5" )
+    eq( "cidr fractional prefix rejected (fam=nil)", f, nil )
+    truthy( "cidr fractional prefix err msg", e and e:find( "integer" ) )
+    local f2, e2 = ipm.parse_cidr( "::1/64.5" )
+    eq( "cidr v6 fractional prefix rejected", f2, nil )
+    truthy( "cidr v6 fractional prefix err msg", e2 and e2:find( "integer" ) )
+
+    -- Garbage CIDR: error message must propagate from parse_ip
+    -- (previously dropped on the floor because parse_ip only
+    -- returns 2 values, never 3).
+    local f3, e3 = ipm.parse_cidr( "not a cidr" )
+    eq( "cidr garbage rejected", f3, nil )
+    truthy( "cidr garbage err msg propagated", e3 and #e3 > 0 )
+end
+
+----------------------------------------------------------------------
+-- match
+----------------------------------------------------------------------
+
+do
+    local _, ip = ipm.parse_ip( "192.0.2.42" )
+    local _, net, plen = ipm.parse_cidr( "192.0.2.0/24" )
+    eq( "match v4 in /24", ipm.match( ip, net, plen ), true )
+
+    local _, ip2 = ipm.parse_ip( "192.0.3.42" )
+    eq( "match v4 outside /24", ipm.match( ip2, net, plen ), false )
+
+    -- /0 matches everything (within family)
+    local _, allnet, allplen = ipm.parse_cidr( "0.0.0.0/0" )
+    eq( "match v4 /0 matches any v4", ipm.match( ip, allnet, allplen ), true )
+
+    -- /32 matches only itself
+    local _, exactnet, exactplen = ipm.parse_cidr( "192.0.2.42/32" )
+    eq( "match v4 /32 exact",     ipm.match( ip,  exactnet, exactplen ), true )
+    eq( "match v4 /32 non-match", ipm.match( ip2, exactnet, exactplen ), false )
+
+    -- Cross-family no-match (mismatched lengths).
+    local _, ip6 = ipm.parse_ip( "2001:db8::1" )
+    eq( "match cross-family false (v4 vs v6 net)",
+        ipm.match( ip, ip6, 32 ), false )
+
+    -- v6 in /32
+    local _, v6net, v6plen = ipm.parse_cidr( "2001:db8::/32" )
+    eq( "match v6 in /32", ipm.match( ip6, v6net, v6plen ), true )
+
+    -- v6 outside /32
+    local _, ip6_out = ipm.parse_ip( "2001:db9::1" )
+    eq( "match v6 outside /32", ipm.match( ip6_out, v6net, v6plen ), false )
+
+    -- Boundary: prefix on byte 4, 1 bit
+    local _, narrow_net, narrow_plen = ipm.parse_cidr( "192.0.2.0/25" )
+    local _, ip_25_in = ipm.parse_ip( "192.0.2.127" )
+    local _, ip_25_out = ipm.parse_ip( "192.0.2.128" )
+    eq( "match /25 lower half in", ipm.match( ip_25_in, narrow_net, narrow_plen ), true )
+    eq( "match /25 upper half out", ipm.match( ip_25_out, narrow_net, narrow_plen ), false )
+
+    -- prefix /31 (one bit off from /32)
+    local _, narrow2_net, narrow2_plen = ipm.parse_cidr( "192.0.2.0/31" )
+    local _, ip_31_a = ipm.parse_ip( "192.0.2.0" )
+    local _, ip_31_b = ipm.parse_ip( "192.0.2.1" )
+    local _, ip_31_c = ipm.parse_ip( "192.0.2.2" )
+    eq( "match /31 .0 in", ipm.match( ip_31_a, narrow2_net, narrow2_plen ), true )
+    eq( "match /31 .1 in", ipm.match( ip_31_b, narrow2_net, narrow2_plen ), true )
+    eq( "match /31 .2 out", ipm.match( ip_31_c, narrow2_net, narrow2_plen ), false )
+
+    -- Bad input
+    eq( "match non-string bytes", ipm.match( nil, net, plen ), false )
+end
+
+----------------------------------------------------------------------
+-- normalize
+----------------------------------------------------------------------
+
+eq( "normalize v4 strips leading zeros",
+    ipm.normalize( "1.2.3.4" ), "1.2.3.4" )
+
+-- Leading zero in v4 is REJECTED by parse, so normalize returns nil.
+falsy( "normalize v4 leading-zero rejected",
+    ipm.normalize( "001.002.003.004" ) )
+
+eq( "normalize v6 compresses",
+    ipm.normalize( "2001:0db8:0000:0000:0000:0000:0000:0001" ), "2001:db8::1" )
+
+eq( "normalize v6 ::1 stable",
+    ipm.normalize( "::1" ), "::1" )
+
+eq( "normalize v6 :: stable",
+    ipm.normalize( "::" ), "::" )
+
+eq( "normalize v6 all-ones uncompressed",
+    ipm.normalize( "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" ),
+    "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" )
+
+-- v4-mapped uses dotted-quad tail per RFC 5952 §5
+eq( "normalize v4-mapped dotted-quad",
+    ipm.normalize( "::ffff:1.2.3.4" ), "::ffff:1.2.3.4" )
+eq( "normalize v4-mapped from hex form",
+    ipm.normalize( "::ffff:0102:0304" ), "::ffff:1.2.3.4" )
+
+falsy( "normalize garbage", ipm.normalize( "garbage" ) )
+
+----------------------------------------------------------------------
+-- format_bytes (bytes-in, canonical-text-out)
+----------------------------------------------------------------------
+
+eq( "format_bytes v4 dotted-quad",
+    ipm.format_bytes( 4, "\1\2\3\4" ), "1.2.3.4" )
+eq( "format_bytes v6 compressed",
+    ipm.format_bytes( 6, "\x20\x01\x0d\xb8" .. string.rep( "\0", 11 ) .. "\1" ),
+    "2001:db8::1" )
+eq( "format_bytes v4-mapped",
+    ipm.format_bytes( 6, string.rep( "\0", 10 ) .. "\xff\xff\1\2\3\4" ),
+    "::ffff:1.2.3.4" )
+eq( "format_bytes wrong length v4", ipm.format_bytes( 4, "\1\2\3" ), nil )
+eq( "format_bytes wrong length v6", ipm.format_bytes( 6, "\1\2" ),   nil )
+eq( "format_bytes unknown family",  ipm.format_bytes( 8, "" ),       nil )
+eq( "format_bytes nil bytes",       ipm.format_bytes( 4, nil ),      nil )
+
+----------------------------------------------------------------------
+
+if _fails > 0 then
+    io.stderr:write( string.format( "\nFAIL: %d/%d checks failed\n",
+        _fails, _passes + _fails ) )
+    os.exit( 1 )
+end
+print( string.format( "OK: %d checks passed", _passes ) )

--- a/tests/unit/ipmatch_test.lua
+++ b/tests/unit/ipmatch_test.lua
@@ -23,7 +23,7 @@
 ]]--
 
 local _real = {
-    type = type, string = string, table = table,
+    type = type, ipairs = ipairs, string = string, table = table,
     tonumber = tonumber, tostring = tostring,
 }
 _G.use = function( n )


### PR DESCRIPTION
**Phase A** of the unified-blocklist arc (#78). Stands up the in-memory bucketed cache + persistent `.tbl` store + decision API. This is the hard prerequisite for Phase B (`+blocklist` admin plugin), Phase C (HTTP API), Phase D (GeoIP), Phase E (external feeds), Phase F (proxy detection).

Part of #78.

## What ships

**New modules:**

- **`core/ipmatch.lua` (~440 LoC)**: pure-Lua IPv4 + IPv6 + CIDR parse / match / normalize / format_bytes. Rejects host-bits-set CIDRs (`1.2.3.4/24` -> "use the network address instead"). Renders v4-mapped IPv6 with the RFC-5952 dotted-quad tail (`::ffff:1.2.3.4`). Bytes-in/text-out helper exposed so callers holding raw bytes skip the parse round-trip.
- **`core/blocklist.lua` (~715 LoC)**: bucketed cache (first-byte for v4 / first-two-bytes for v6), O(1) lookup + linear bucket scan. Locked decision priority order: `manual` (100) > `geoip` (50) > `proxycheck` (40) > `ipqs` (35) > `vpnapi` (30) > `external` (20) > unknown (0). Per-rule stealth flag distinguishes operator-log visibility (per-attempt visible vs aggregated-only). Aggregated rollup: per-IP+source counter flushed every `blocklist_aggregated_log_window_sec` seconds, sorted by count descending, LRU-capped at 10k entries via **O(1) eviction** (perfect LRU isn't load-bearing in a best-effort statistic, and an O(N) scan in the accept-time hot path was the very DoS-amplification class F-NET-1 prevents).

**Hook:**

- **`core/server.lua` accept loop**: `blocklist.check_ip(clientip)` BEFORE `ratelimit_accept_ip`. A blocked-IP flood closes-on-accept WITHOUT consuming a per-IP ratelimit slot.

**Cfg:**

- 4 new keys: `blocklist_enabled` (default `true`), `blocklist_store_path` (default `cfg/blocklist.tbl`), `blocklist_stealth_default` (default `false` per the arc-locked per-rule opt-in), `blocklist_aggregated_log_window_sec` (default 3600, range 60..86400).

**Wiring:**

- `core/init.lua` `_core`: `ipmatch` + `blocklist` registered AFTER `cacert_bootstrap` and BEFORE `ratelimit` + `server` (server.lua captures `blocklist.check_ip` at module load).
- `.github/workflows/smoke.yml`: 2 new unit-test invocations wired into both Linux + Windows jobs.

**Tests:**

- `tests/unit/ipmatch_test.lua` (81 checks): v4 + v6 parse / format, CIDR with full boundary scan (/0 .. /128 incl. /7, /9, /15, /17, /31), fractional + garbage rejection, v4-mapped dotted-quad, format_bytes round-trips.
- `tests/unit/blocklist_test.lua` (58 checks): decision matrix + priority resolution + stealth flag + expires_at TTL + reload-from-disk persistence round-trip + `_resolve_decision` direct + meta shallow-copy + unknown-filter-key warning.

## Pre-merge §1a.6 subagent review

Subagent review found **2 blockers, 4 concerns, 7 nits**. All 13 actionable findings addressed:

| # | Severity | Fix |
|---|---|---|
| 1 | BLOCKER | `parse_cidr` rejects fractional prefix (was a Lua 5.4 strict-bitop crash) |
| 2 | BLOCKER | `parse_cidr` propagates err message from `parse_ip` (was always `nil`) |
| 3 | CONCERN | Expired entries swept on `add()` + skip-on-load in `reload()` (was unbounded growth across reloads with auto-feed TTLs) |
| 4 | CONCERN | LRU eviction O(N) -> O(1) via `next()` drop (DoS-amplification vector under IPv6 flood) |
| 5 | CONCERN | cfg-reload handler re-snapshots cfg keys, not just the `.tbl` (partial-reload silent gap) |
| 6 | CONCERN | Canonical CIDR computed directly from bytes via new `ipmatch.format_bytes` (drops double-normalize pass + decouples persisted strings from future normalizer drift) |
| 7 | NIT | `_resolve_decision` direct test added |
| 8 | NIT | Shallow-copy `meta` on `check_ip` + `list` return (plugin trust contract) |
| 9 | NIT | Unknown `filter_spec` keys log one-time warning |
| 10 | NIT | `::ffff:1.2.3.4` renders as dotted-quad per RFC 5952 §5 |
| 11 | NIT | `expires_at` boundary semantics documented |
| 12 | NIT | Rollup-flush sorts by count desc + IP secondary (was alphabetic) |
| 13 | NIT (info-only) | Phase B will add `blocklist` to `SANDBOX_GLOBALS` with deliberate security review |

## Testing

- **Local lua54.exe regression**: 274/274 checks across 6 test files (sha256 34 + cacert_bootstrap 22 + http_client 47 + secrets 32 + ipmatch 81 + blocklist 58).

## Smoke stage deferred

The plan originally called for a smoke stage that seeds `cfg/blocklist.tbl` + connects from blocked IP. Phase A defers this because:

1. Localhost smoke can't fake a different source IP without raw-socket access, and seeding `127.0.0.1` would block every other smoke stage that connects from localhost (cascading 100+ test failures).
2. Phase B's `+blocklist add` cmd will provide a dynamic-seed path that doesn't require hub restart to isolate.

The existing 100+ smoke stages already prove the accept-hook is non-disruptive (every stage connects from 127.0.0.1; if the hook were broken everything would fail). The 139 unit checks cover the decision matrix exhaustively.

## Backward compatibility

- `blocklist_enabled = true` by default but the store is empty -> fast-path returns `false` on the first `next(_entries)` call. Zero overhead until operators add entries via Phase B's `+blocklist` cmd or Phase D/E/F's auto-feeds.
- Hook order in `core/server.lua`: blocklist BEFORE ratelimit, so legitimate connections (not blocked) still flow through the existing ratelimit path unchanged.

## Test plan

- [x] Local lua54.exe unit tests pass (274/274)
- [ ] CI: Smoke Linux + Smoke Windows + Docker + CodeQL all green
- [ ] Testhub `:dev` Docker validation:
  - Hub boots cleanly with new modules (`loaded 'ipmatch'`, `loaded 'blocklist'` in init log)
  - Existing handshake still works (localhost connection succeeds with empty store)
  - Seed a row directly into `cfg/blocklist.tbl` for a non-localhost IP, `+reload`, verify hub still boots + handshake works
- [ ] Post-merge: feat branch deleted

## Scope

Phase A only. Phase B (`+blocklist` admin cmd + JSONL export/import) is the next planned step.