### PR TITLE
fix(blocklist): silence checkfile log on first-boot fresh install (#78)

### DIFF
--- a/core/blocklist.lua
+++ b/core/blocklist.lua
@@ -91,6 +91,7 @@ local tonumber  = use "tonumber"
 local string    = use "string"
 local table     = use "table"
 local math      = use "math"
+local io        = use "io"
 local socket    = use "socket"
 
 local string_byte    = string.byte
@@ -99,6 +100,7 @@ local string_lower   = string.lower
 local table_insert   = table.insert
 local table_remove   = table.remove
 local math_floor     = math.floor
+local io_open        = io.open
 local socket_gettime = socket.gettime
 
 local util    = use "util"
@@ -618,6 +620,16 @@ local function reload( )
     _rollup = { }
     _rollup_size = 0
     _last_flush_time = 0
+
+    -- Peek for file existence BEFORE util.loadtable so we avoid the
+    -- noisy `util.lua: function 'checkfile': error in cfg/blocklist.tbl:
+    -- No such file or directory` log line on a fresh install. The
+    -- empty-store branch IS the correct first-boot state; nothing to
+    -- seed (no bundled defaults). Operator-facing .tbl appears on the
+    -- first `+blocklist add` once Phase B lands.
+    local probe = io_open( _store_path, "r" )
+    if not probe then return end
+    probe:close( )
 
     local data, err = util_loadtable( _store_path )
     if not data then

--- a/tests/unit/blocklist_test.lua
+++ b/tests/unit/blocklist_test.lua
@@ -70,6 +70,20 @@ local function _stub_use_factory( opts )
         if name == "out" then
             return { put = function( ) end, error = function( ) end }
         end
+        if name == "io" then
+            -- Existence probe stub: io.open(path,"r") succeeds iff the
+            -- stubbed `_disk` knows the path. Matches the real-hub
+            -- behaviour that on first boot the file is missing and
+            -- reload() must skip the load-from-disk branch quietly.
+            return {
+                open = function( path, _mode )
+                    if _disk[ path ] ~= nil then
+                        return { close = function( ) end }
+                    end
+                    return nil, "No such file or directory"
+                end,
+            }
+        end
         if name == "ipmatch" then
             return _G._loaded_ipmatch
         end
@@ -253,6 +267,36 @@ do
     eq( "post-reload v4 match", bl2.check_ip( "55.66.77.99" ), true )
     eq( "post-reload v6 match", bl2.check_ip( "2001:db8::1" ), true )
     eq( "post-reload non-match", bl2.check_ip( "1.2.3.4" ), false )
+end
+
+----------------------------------------------------------------------
+-- Fresh-install: reload() with no .tbl on disk is silent + clean
+-- (regression for the "util.lua: function 'checkfile': error in
+-- cfg/blocklist.tbl: No such file or directory" testhub finding).
+-- The io-stub returns nil for any path the _disk has never seen, so
+-- this exercises the same branch as a literal first-boot.
+----------------------------------------------------------------------
+
+reset_state{}
+do
+    local err_count = 0
+    -- Override the out stub so we can count error invocations during
+    -- this reload-from-empty scenario.
+    _G.use = function( name )
+        if name == "out" then
+            return {
+                put   = function( ) end,
+                error = function( ) err_count = err_count + 1 end,
+            }
+        end
+        return _stub_use_factory( )( name )
+    end
+    local bl_fresh = assert( loadfile( "core/blocklist.lua" ) )( )
+    bl_fresh.init( )
+    eq( "fresh-install reload emits no out.error",  err_count, 0 )
+    eq( "fresh-install reload leaves zero entries", bl_fresh.count( ).total, 0 )
+    -- Restore the standard stub for subsequent tests.
+    _G.use = _stub_use_factory( )
 end
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Phase A blocklist (PR #358) emits one stray `util.lua: function 'checkfile': error in cfg/blocklist.tbl: No such file or directory (checkfile)` log line on every fresh-install boot.
- Hub runs fine and the empty-store branch in `reload()` already covered the case; the line is just noise from `util.checkfile` logging via `out.error` BEFORE returning nil.
- Fix: peek the store path via `io.open` BEFORE calling `util.loadtable`. If missing, return early from `reload()`. No bundled defaults to seed (blocklist starts empty); the .tbl appears on the first `+blocklist add` in Phase B.

Found on Aybo testhub immediately after PR #358 merge.

## Test plan

- [x] `lua54.exe tests/unit/blocklist_test.lua` -> 60/60 (was 58/58, +2 for regression test)
- [x] `lua54.exe tests/unit/ipmatch_test.lua` -> 81/81 (unchanged)
- [x] Regression test counts `out.error` invocations on a fresh-install reload; expects zero. FAILS on unpatched code via the existing checkfile-log path, PASSES patched.
- [ ] Testhub :dev validation - confirm no checkfile error in log on fresh container

Part of #78.