### PR TITLE
fix(blocklist): move store to scripts/data/etc_blocklist.tbl (Part of #78)

### DIFF
--- a/core/blocklist.lua
+++ b/core/blocklist.lua
@@ -142,7 +142,7 @@ end
 ----------------------------------------------------------------------
 
 local _enabled = true
-local _store_path = "cfg/blocklist.tbl"
+local _store_path = "scripts/data/etc_blocklist.tbl"
 local _stealth_default = false
 local _log_window = 3600
 local _rollup_cap = 10000
@@ -631,7 +631,7 @@ local function reload( )
     _last_flush_time = 0
 
     -- Peek for file existence BEFORE util.loadtable so we avoid the
-    -- noisy `util.lua: function 'checkfile': error in cfg/blocklist.tbl:
+    -- noisy `util.lua: function 'checkfile': error in scripts/data/etc_blocklist.tbl:
     -- No such file or directory` log line on a fresh install. The
     -- empty-store branch IS the correct first-boot state; nothing to
     -- seed (no bundled defaults). Operator-facing .tbl appears on the

--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -3907,7 +3907,7 @@ local defaults = {
             return types_boolean( value, nil, true )
         end
     },
-    blocklist_store_path = { "cfg/blocklist.tbl",
+    blocklist_store_path = { "scripts/data/etc_blocklist.tbl",
         function( value )
             return types_utf8( value, nil, true )
         end

--- a/core/init.lua
+++ b/core/init.lua
@@ -113,7 +113,7 @@ _core = {    -- luadch core, order is important
     -- stdlib; load order is just before its consumer blocklist.
     "ipmatch",
     -- core/blocklist.lua (Phase A of #78 arc): unified pre-handshake
-    -- IP/CIDR blocklist (in-memory bucketed cache + cfg/blocklist.tbl
+    -- IP/CIDR blocklist (in-memory bucketed cache + scripts/data/etc_blocklist.tbl
     -- persistent store + decision API). Loaded BEFORE ratelimit +
     -- server because server.lua captures `blocklist.check_ip` at
     -- module load for the accept-time stealth hook. init() reads

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -580,10 +580,14 @@ land in the hub log on the
 `blocklist_aggregated_log_window_sec` cadence (default 3600s).
 
 **Storage and reload.** The engine writes
-`cfg/blocklist.tbl` on every successful add / remove. The file
-appears on the first successful `+blocklist add` (no empty stub
-on fresh install). `+reload` re-snapshots the cfg keys
-(`blocklist_enabled`, `blocklist_stealth_default`,
+`scripts/data/etc_blocklist.tbl` on every successful add /
+remove. The file appears on the first successful `+blocklist
+add` (no empty stub on fresh install). The path is configurable
+via `blocklist_store_path` cfg key; `scripts/data/` matches the
+convention used by sibling plugins (`cmd_ban_bans.tbl`,
+`etc_clientblocker.tbl`, `etc_blacklist.tbl`) so operators find
+all plugin-owned state in one place. `+reload` re-snapshots the
+cfg keys (`blocklist_enabled`, `blocklist_stealth_default`,
 `blocklist_aggregated_log_window_sec`) and re-reads the .tbl.
 
 **Tradeoffs.** This plugin only ships the admin CLI; the HTTP
@@ -603,6 +607,13 @@ at `examples/cfg/cfg.tbl` shows the placement. The new cfg
 keys (`etc_blocklist_oplevel`, `etc_blocklist_import_min_level`,
 etc.) all have safe defaults via `core/cfg_defaults.lua` so
 omitting them from `cfg.tbl` is fine.
+
+Operators who ran the very first Phase-B build (`v0.01`) and
+already have data at the old `cfg/blocklist.tbl` path from that
+window: move the file to `scripts/data/etc_blocklist.tbl` (or
+set `blocklist_store_path = "cfg/blocklist.tbl"` in `cfg.tbl`
+to pin the old location). No auto-migration is provided; the
+old-path window was small.
 
 ### etc_clientblocker
 


### PR DESCRIPTION
## Summary

Aybo testhub follow-up on PR #360: the blocklist engine's persistent store lived at `cfg/blocklist.tbl`, out of line with every other stateful bundled plugin (all under `scripts/data/`).

Move the default `blocklist_store_path` to `scripts/data/etc_blocklist.tbl` so operators find all plugin-owned data in one canonical place.

## Path stays cfg-overridable

Operators pinning to the old path can set:
```
blocklist_store_path = \"cfg/blocklist.tbl\",
```
in `cfg.tbl` and keep pre-existing data intact. No auto-migration - the v0.01 window was small.

## Test plan

- [x] Local unit tests: 60/67/81 (blocklist / etc_blocklist / ipmatch)
- [x] `luac54.exe -p core/blocklist.lua` -> syntax OK
- [x] CI smoke green
- [x] Testhub: after merge + pull, `+blocklist add 1.2.3.0/24`, `docker compose exec luadch ls scripts/data/etc_blocklist.tbl` -> file present

Part of #78.