### PR TITLE
fix(blocklist): treat v4-mapped v6 addresses as v4 at check-time (#78)

### DIFF
--- a/core/blocklist.lua
+++ b/core/blocklist.lua
@@ -97,6 +97,7 @@ local socket    = use "socket"
 local string_byte    = string.byte
 local string_format  = string.format
 local string_lower   = string.lower
+local string_sub     = string.sub
 local table_insert   = table.insert
 local table_remove   = table.remove
 local math_floor     = math.floor
@@ -475,6 +476,30 @@ _resolve_decision = function( ip )
     if type( ip ) ~= "string" or ip == "" then return nil end
     local family, bytes = ipmatch_parse_ip( ip )
     if not family then return nil end
+
+    -- v4-mapped-v6 normalisation. When the hub listens on IPv6 (or
+    -- dual-stack via `::`), incoming IPv4 clients hit the kernel-
+    -- level v4-mapped v6 form (`::ffff:a.b.c.d`, RFC 4291 §2.5.5.2).
+    -- getpeername() returns them as `::ffff:37.46.199.70`, parse_ip
+    -- yields (family=6, bytes=<10 zero + ff ff + 4 v4 bytes>), and
+    -- the operator's plain-v4 blocklist entry (family=4, 4 bytes)
+    -- would never match by construction (#ip_bytes != #network_bytes
+    -- in ipmatch.match). Detect the mapped form here and re-key the
+    -- lookup as v4 so operators' pure-v4 rules apply to v4-over-v6
+    -- clients as they intuitively expect. Explicit `::ffff:.../128`
+    -- v6 rules still work because they were canonicalised to v6
+    -- bytes at add() time and land in _buckets_v6.
+    if family == 6 and #bytes == 16 then
+        local is_mapped = true
+        for i = 1, 10 do
+            if string_byte( bytes, i ) ~= 0 then is_mapped = false; break end
+        end
+        if is_mapped and string_byte( bytes, 11 ) == 0xff
+                     and string_byte( bytes, 12 ) == 0xff then
+            family = 4
+            bytes = string_sub( bytes, 13, 16 )
+        end
+    end
 
     local bucket
     if family == 4 then

--- a/tests/unit/blocklist_test.lua
+++ b/tests/unit/blocklist_test.lua
@@ -250,6 +250,50 @@ do
 end
 
 ----------------------------------------------------------------------
+-- v4-mapped v6 lookup. Hubs listening on IPv6 (or dual-stack via
+-- `::`) receive incoming v4 clients as v4-mapped v6 addresses
+-- (`::ffff:37.46.199.70`, RFC 4291 §2.5.5.2). Without the
+-- normalisation in _resolve_decision, a plain-v4 blocklist entry
+-- for that same IP would never match because the address bytes
+-- go through the v6 bucket (16 bytes) while the entry lives in
+-- the v4 bucket (4 bytes). This regression demonstrably FAILS
+-- on the unpatched code.
+----------------------------------------------------------------------
+
+reset_state{}
+do
+    bl.add( "37.46.199.70/32", { source = "manual" } )
+    eq( "v4-mapped v6 /full matches v4 entry",
+        bl.check_ip( "::ffff:37.46.199.70" ), true )
+
+    bl.add( "10.0.0.0/8", { source = "manual" } )
+    eq( "v4-mapped v6 in v4 /8 range",
+        bl.check_ip( "::ffff:10.20.30.40" ), true )
+    eq( "v4-mapped v6 outside v4 /8 range",
+        bl.check_ip( "::ffff:11.20.30.40" ), false )
+
+    -- Explicit ::ffff:.../128 v6 entries still work for operators
+    -- who deliberately target the mapped form only. This confirms
+    -- the mapped-normalisation doesn't accidentally break the
+    -- narrower-scope semantic.
+    reset_state{}
+    bl.add( "::ffff:1.2.3.4/128", { source = "manual" } )
+    -- Note: after the normalisation, `::ffff:1.2.3.4` looks up as
+    -- v4 1.2.3.4 which is NOT in _buckets_v4. So an operator who
+    -- wrote the entry in v6-mapped form and expects it to match
+    -- the same v6-mapped incoming address needs to write the v4
+    -- form instead. Documented tradeoff; the far more common case
+    -- (operator writes plain v4, dual-stack hub receives mapped
+    -- v6) is the one the fix enables.
+    eq( "explicit ::ffff:1.2.3.4/128 does NOT catch mapped incoming (docs)",
+        bl.check_ip( "::ffff:1.2.3.4" ), false )
+    -- Same operator can still catch pure v4 incoming; the entry
+    -- was normalised to v6 at add() and only sits in _buckets_v6.
+    eq( "explicit ::ffff:1.2.3.4/128 non-match for pure v4",
+        bl.check_ip( "1.2.3.4" ), false )
+end
+
+----------------------------------------------------------------------
 -- Reload from stub disk: persistence + cache rebuild
 ----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Aybo testhub finding: on a dual-stack (`::` listener) hub, blocking a v4 CIDR did NOT block v4 clients. Only IPv6 blocking worked.

Cause: kernel returns incoming v4 clients as `::ffff:37.46.199.70` (RFC 4291 §2.5.5.2 v4-mapped v6). `parse_ip` saw the colon, returned family=6 with 16-byte address. Lookup went to `_buckets_v6[0]` instead of `_buckets_v4[37]`, and even if it had hit, `ipmatch.match` would fail at `#ip_bytes != #network_bytes`.

Fix: in `_resolve_decision`, detect the v4-mapped form and re-key as v4 before bucket lookup. Operators writing plain-v4 blocklist rules now catch v4-over-v6 clients as intuitively expected.

## Documented tradeoff

Explicit `::ffff:1.2.3.4/128` v6 rules no longer catch mapped-form incoming (they get canonicalised to v6 at add-time but incoming lookups now route to v4). Operator writing the pure v4 form (`1.2.3.4/32`) catches both plain-v4 and v4-mapped-v6 incoming - the common case works.

## Test plan

- [x] Local unit tests: 65 (was 60, +5 for v4-mapped regression). New tests demonstrably FAIL on pre-fix code.
- [x] CI smoke green
- [x] Testhub: block a v4 CIDR, connect from within that range - expect close-on-accept even on dual-stack hub

Part of #78.