### PR TITLE
docs: fix cross-doc drift (PLUGIN_API path, tests CI claim, README connect addr)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,11 @@ cmake --install build
 cd build/install/luadch && ./luadch
 ```
 
-Then connect with an ADC client (e.g. AirDC++) to `adc://127.0.0.1:5000`,
-log in as `dummy` / `test`, and read [CONFIGURATION.md](docs/CONFIGURATION.md)
-for first-run steps. Windows users: see the Windows section of
+Fresh installs are TLS-only (the cert is auto-generated on first boot).
+Connect with an ADC client (e.g. AirDC++) to `adcs://127.0.0.1:5001`, log
+in as `dummy` / `test`, and read [CONFIGURATION.md](docs/CONFIGURATION.md)
+for first-run steps (including keyprint pinning and enabling a plain
+`adc://` port if you want one). Windows users: see the Windows section of
 [BUILDING.md](docs/BUILDING.md).
 
 ## License

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -193,13 +193,39 @@ file matching the `language` cfg key. Loading happens via
 [`cfg.loadlanguage()`](../core/cfg.lua) and the plugin reads keys
 via the returned table.
 
+Worked example. The `.lang.en` file returns a table:
+
+```lua
+-- scripts/lang/etc_my_plugin.lang.en
+return {
+    ["etc_my_plugin_msg_done"] = "Done.",
+    ["etc_my_plugin_err_denied"] = "You are not allowed to do that.",
+}
+```
+
+The plugin loads it once at scope top and reads each key with an
+in-source fallback (the pattern every bundled plugin uses, e.g.
+`scripts/etc_aliases.lua`):
+
+```lua
+local scriptname = "etc_my_plugin"
+local scriptlang = cfg.get( "language" )                  -- the active language, e.g. "en"
+local lang       = cfg.loadlanguage( scriptlang, scriptname ) or { }
+local msg_done   = lang.etc_my_plugin_msg_done or "Done."  -- fallback if the key is missing
+```
+
+Ship every operator-visible string this way in BOTH `.lang.en` and
+`.lang.de` (all-or-nothing), and keep DC jargon (Hub, Slot, Share, OP,
+Kick, Ban, Nick, PM) in English in both files.
+
 ### 3.6 Plugin state persistence
 
 Plugins that need to persist data across hub restarts write
-[`util.savetable`](#52-util) calls to files under `cfg/` (mutable
-operator state) or alongside the plugin under `scripts/<name>.tbl`
-(plugin-private state). The `cfg/` location travels with operator
-backups; `scripts/` does not.
+[`util.savetable`](#52-util) calls to `scripts/data/<name>.tbl`
+(plugin-private state - the repo-wide convention, matching `cmd_ban`,
+`etc_clientblocker`, `etc_blocklist`). Operator-facing artifacts
+(exports, backups a human is meant to copy) go under `cfg/`, which
+travels with operator config backups.
 
 ---
 
@@ -724,7 +750,7 @@ report.send( true, true, true, 60, "something happened" )
 ### 7.5 Plugin state file
 
 ```lua
-local state_path = "scripts/etc_my_plugin.tbl"
+local state_path = "scripts/data/etc_my_plugin.tbl"
 
 -- Load at startup
 local state = util.loadtable( state_path ) or { counter = 0 }
@@ -837,6 +863,29 @@ these, the user must reconnect.
 from any external source (file, network, OS environment), validate
 before passing to ADC-frame-bound APIs - the hub assumes UTF-8 and
 will not gracefully degrade.
+
+### 10.8 Never export a mutable table reference across `+reload`
+
+`hub.import` shallow-copies your plugin's export table, so a consumer
+that captured a direct reference to one of your tables keeps pointing at
+the OLD table the moment you rebind the local - which happens on every
+`+reload`/`onStart` reinit and on in-place resets like `bans = { }`. The
+consumer then reads stale/empty state with no error. This bit two
+plugins ([#238](https://github.com/luadch-ng/luadch/issues/238),
+[#239](https://github.com/luadch-ng/luadch/issues/239)).
+
+Two safe patterns:
+
+```lua
+-- (a) mutate in place - never rebind the local the consumer captured
+for k in pairs( state ) do state[ k ] = nil end   -- clear, don't reassign
+
+-- (b) export a getter, so callers always read the live table
+return { get_state = function( ) return state end }   -- not `state = state`
+```
+
+See the [`scripts/etc_aliases.lua`](../scripts/etc_aliases.lua) header
+for a worked reference.
 
 ---
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,13 +1,15 @@
 # luadch tests
 
-Smoke tests that prove a freshly-built hub starts, binds its ports,
-speaks ADC over plain and TLS, and loads all bundled plugins without
-errors.
+Two test layers: a protocol-level **smoke** harness that proves a
+freshly-built hub starts, binds its ports, speaks ADC over plain and TLS,
+and loads all bundled plugins without errors; and a pure-Lua **unit**
+suite for modules that can be exercised standalone.
 
-The suite is part of the **Phase 6** modernisation work
-(see [`docs/phases/`](../docs/phases/) and CLAUDE.md §5). It exists to
-catch regressions when we refactor `core/cfg.lua`, `core/hub.lua`, and
-the path-anchoring logic later in Phase 6.
+The smoke harness started as Phase 6 modernisation work and is now the
+permanent regression floor: it runs on every push and PR, and both layers
+run in CI on Linux AND Windows (`.github/workflows/smoke.yml`). Authoring
+guidance (unit-harness contract, the regression-fail-pre-fix recipe, smoke
+gotchas) lives in [`../docs/DEVELOPMENT.md`](../docs/DEVELOPMENT.md) §4.
 
 ## Layout
 
@@ -33,7 +35,7 @@ tests/
 - **Hub binds plain + TLS ports.** The hub successfully starts and
   accepts TCP connections on both the plain and TLS test ports within
   the start timeout. Implicit coverage: `core/init.lua` runs to
-  completion, the listener setup in `core/hub.lua` works, all 66
+  completion, the listener setup in `core/hub.lua` works, all
   bundled scripts load (a script error during start would either
   prevent listener registration or surface in the log).
 - **Plain ADC handshake.** The harness opens a TCP socket to the
@@ -97,25 +99,26 @@ does not matter there.
 
 ## Unit tests (`tests/unit/`)
 
-Pure-byte core modules with no socket/global dependencies can be
-loaded standalone by stubbing the `use "X"` sandbox shim. Currently:
+Pure-Lua modules (and plugins) with no socket dependency are exercised
+standalone by stubbing the `use "X"` sandbox shim, `loadfile`-ing the
+module from the repo root, and counting assertions with a tiny
+`eq`/`truthy` harness. Each `tests/unit/<name>_test.lua` runs on its own:
 
 ```sh
 # any Lua 5.4 interpreter, from repo root:
-lua tests/unit/iostream_test.lua
+lua tests/unit/iostream_test.lua      # exit 0 = all pass, 1 = a failure
 ```
 
-Exit `0` = all pass, `1` = a failure. `iostream_test.lua` is the
-durable regression for the Phase 8 framing pipeline (S1 framer parity
-+ S2 passthrough / composition / `prepend` ordering).
+**These run in CI on BOTH platforms.** `.github/workflows/smoke.yml` runs
+the whole `tests/unit/*_test.lua` set on the Linux leg (`lua5.4`) and the
+Windows leg (msys2 `lua`) before the build+smoke step. When you add a unit
+test you MUST add a step for it to both legs, or it is silent
+non-coverage. (The one exception is `adclib_unescape_test.lua`, which
+needs the built C module and so runs on the Linux leg only, after install,
+with `LD_LIBRARY_PATH=.`.)
 
-**Not yet wired into CI:** `.github/workflows/smoke.yml` is Python and
-the CMake build does not emit a standalone `lua` interpreter. The
-*neutral* path is already CI-guarded transitively (a 1-stage pipeline
-is byte-identical to the S1 framer, so the S1 protocol smoke tests
-would break on a framing regression). Wiring this file into CI is an
-explicit gate before Phase 8 S4 - see
-[`docs/phases/PHASE_8_IO.md`](../docs/phases/PHASE_8_IO.md).
+The unit-test authoring contract + the regression-fail-pre-fix recipe are
+in [`../docs/DEVELOPMENT.md`](../docs/DEVELOPMENT.md) §4.
 
 ## Limitations
 


### PR DESCRIPTION
Corrections to docs that drifted from the code, found while verifying `CLAUDE.md` for the refresh PR. **Pairs with #366** - merge that first so the two `../docs/DEVELOPMENT.md` links in `tests/README.md` resolve on `dev`.

## Fixes

**docs/PLUGIN_API.md**
- §3.6 + §7.5: plugin state path corrected `scripts/<name>.tbl` -> `scripts/data/<name>.tbl` (the actual repo convention - `cmd_ban`, `etc_clientblocker`, `etc_blocklist`). This was the one hard contradiction: every plugin + every other doc use `scripts/data/`.
- §3.5: added a worked i18n example with the **verified** two-arg signature `cfg.loadlanguage( cfg.get("language"), scriptname )` then `lang.key or fallback` (the single-arg form I first drafted was wrong - checked against `etc_aliases`).
- §10.8 (new pitfall): the getter-vs-export reload idiom (#238/#239).

**tests/README.md**
- removed the false "**not yet wired into CI**" claim - the whole `tests/unit/*_test.lua` set runs on both smoke.yml legs (Linux `lua5.4` + Windows msys2 `lua`); `adclib_unescape` is the Linux-only C-module exception.
- dropped the hardcoded "66 bundled scripts"; generalised the unit section from one example to the harness contract; reframed the Phase-6 wording as the permanent regression floor.

**README.md**
- quick-start said connect `adc://127.0.0.1:5000`; fresh installs are TLS-only on 5001 (already stated in README's own New Features section).

## Deliberately not changed

`core/cert_bootstrap.lua`'s `certs/make_cert` comment is **correct** from the operator/install-tree view (`cmake --install` copies `examples/certs` -> `certs/`); only the repo source path is `examples/certs/`. A review flag on it was a false positive - re-derived, not blindly applied.

Verified `scripts/data`, both CI legs, the `loadlanguage` signature, and the getter idiom against the code before writing. No code changes.
