### PR TITLE
fix(hub_dispatch): kill_wrong_ips=false path errors with undeclared var (v3.1.12)

### DIFF
--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,6 +1,6 @@
-# Luadch v3.1.11
+# Luadch v3.1.12
 
-**Maintenance patch release** on the `release/3.1.x` line. One privilege-escalation bugfix cherry-picked from master. No breaking changes; no cfg / lang-file changes; drop-in upgrade from v3.1.10.
+**Maintenance patch release** on the `release/3.1.x` line. One bugfix for a backport slip introduced in v3.1.10. No breaking changes; no cfg / lang-file changes; drop-in upgrade from v3.1.11.
 
 ## ⚠️ Before upgrading
 
@@ -12,47 +12,34 @@ tar -czf "luadch-backup-$(date +%F).tar.gz" cfg scripts certs secrets
 
 ## Why upgrade
 
-**If your hub has more than one operator-level account and only one hubowner**, the bug fixed here is exploitable: any account with `+ban` permission (typically op-level and above) could ban the hubowner while the hubowner was offline, locking them out on the next login attempt. With a single hubowner this becomes denial-of-administration on the hub - the hubowner cannot remove their own ban because they cannot log in. With multiple hubowner-level accounts the impact is reduced to a removable nuisance.
-
-Default-config hubs are affected. The fix applies to every operator from level 60 upward (default `cmd_ban_permission` ladder).
+**Only deployments that explicitly set `kill_wrong_ips = false`** are affected (the 3.1.x default is `true`). Operators run that opt-out specifically to admit NAT / CGNAT users whose client advertises a different IP than the one they connect from - and this bug defeats exactly that opt-out: instead of stamping the real IP and letting the user in, the hub raised a Lua error in `incoming` and the affected user could not complete login. If you set `kill_wrong_ips = false` (or plan to), upgrade. If you run the default, you are not affected and can upgrade at leisure.
 
 ## Bugfixes
 
-### [#320](https://github.com/luadch-ng/luadch/issues/320) (Kcchouette) - `cmd_ban` offline-by-nick path silently bypassed the hierarchy check
+### [#393](https://github.com/luadch-ng/luadch/issues/393) (Sopor) - `kill_wrong_ips = false` path errored with `attempt to read undeclared var: 'userfam'`
 
-`scripts/cmd_ban.lua` had two divergent target-resolution paths converging on `addban()`:
+The symptom, once an operator set `kill_wrong_ips = false` and a mismatched-IP user connected:
 
-- **Online branch** resolves `target` to a user OBJECT (has `:level()` method), falls through to the existing check at line 594: `if permission[level] < target:level() then ... msg_god`
-- **Offline-by-nick branch** resolves `target` to a profile TABLE from `regnicks[]` (has `.level` field, no `:level()` method), then returns at `addban()` two lines BEFORE the check could run
-
-Effect: a level-60 operator could send `+ban nick hubowner_offline 60 reason`, the offline branch ran `addban()` directly without checking that the operator outranked the target, and the hubowner was banned. On their next login attempt the ban hit, kicking them with `ISTA 232 ... TL<reconnect-seconds>`.
-
-**Fix:** explicit hierarchy guard inside the offline-by-nick branch using `target.level`, mirroring the online-path semantics with the table-shape accessor:
-
-```lua
-elseif by == "nick" then
-    local _, regnicks, _ = hub.getregusers()
-    target = regnicks[ id ]
-    if not target then
-        user:reply( msg_off, hub.getbot() )
-        return PROCESSED
-    end
-    if permission[ level ] < ( target.level or 0 ) then    -- new
-        user:reply( msg_god, hub.getbot() )
-        return PROCESSED
-    end
-end
+```
+hub.lua: function 'incoming': lua error: ././core/hub_dispatch.lua:356: attempt to read undeclared var: 'userfam'
 ```
 
-cid / ip offline branches keep no profile lookup and stay unchecked by design (no hierarchy info available - the hub doesn't know whose IP a given IP is).
+The [#214](https://github.com/luadch-ng/luadch/issues/214) Gap 2 fix (shipped to 3.1.x in v3.1.10) stamps the authenticated TCP-source IP over a mismatched INF claim so the wrong IP is never broadcast. The v3.1.10 cherry-pick wrote that stamp as `adccmd:setnp( userfam, userip )` - but `userfam` is the **master** branch's variable name. The 3.1.x `incoming` function calls its address-family variable `ipver` (declared at the top of the function, used correctly by the first `setnp` on the no-IP path ~15 lines above). Under luadch's restricted core environment, reading the undeclared `userfam` raises an error - so for every user whose claimed INF IP differed from their real TCP-source IP while `kill_wrong_ips = false` was set, the stamp branch threw and the user (typically the very NAT/CGNAT client the opt-out exists to admit) could not log in.
 
-Plugin v0.36 → v0.37. Cherry-picked from master ([PR #322](https://github.com/luadch-ng/luadch/pull/322), commit `30c8809`); the new HTTP-API-based regression smoke test stays master-only because the HTTP API ships on 3.2.x only - the fix logic is identical and reviewer-verified.
+**Fix:** use the in-scope `ipver` at that call site, matching the sibling `setnp`:
 
-A pattern sweep over the related command-and-profile plugins (`cmd_gag`, `cmd_setpass`, `cmd_upgrade`, `cmd_delreg`, `cmd_nickchange`, `cmd_redirect`, `cmd_disconnect`, `etc_trafficmanager`, `etc_msgmanager`) for the same online-vs-offline-hierarchy-check divergence came back clean - either properly guarded on both paths or online-only by design. cmd_ban was the only affected plugin in the family.
+```lua
+-               adccmd:setnp( userfam, userip )
++               adccmd:setnp( ipver, userip )
+```
+
+Default `kill_wrong_ips = true` deployments are unaffected - they take the kill branch and never reach the stamp branch. Master is unaffected; it uses `userfam` consistently throughout its renamed `incoming`. This was a partial-rename slip in the v3.1.10 backport only, so the fix is applied directly on `release/3.1.x` (nothing to cherry-pick from master).
+
+The `kill_wrong_ips = false` stamp path had no smoke coverage, which is how the slip shipped in v3.1.10; a behavioural regression test needs a `kill_wrong_ips = false` hub config and is tracked as a follow-up.
 
 ## Build / runtime
 
-No changes. Same Lua 5.4.7, same LuaSec 1.3.2, same LuaSocket 3.1.0, same build toolchain as v3.1.10.
+No changes. Same Lua 5.4, same LuaSec 1.3.2, same LuaSocket 3.1.0, same build toolchain as v3.1.11.
 
 The `linux-aarch64` artifact continues with the Bullseye-container pipeline (glibc 2.31 baseline, works on Pi OS Bullseye / Bookworm / DietPi v9.x).
 
@@ -60,12 +47,12 @@ The `linux-aarch64` artifact continues with the Bullseye-container pipeline (gli
 
 ```sh
 # Linux x86_64 / aarch64
-wget https://github.com/luadch-ng/luadch/releases/download/v3.1.11/luadch-v3.1.11-linux-x86_64.tar.gz
-tar xzf luadch-v3.1.11-linux-x86_64.tar.gz
+wget https://github.com/luadch-ng/luadch/releases/download/v3.1.12/luadch-v3.1.12-linux-x86_64.tar.gz
+tar xzf luadch-v3.1.12-linux-x86_64.tar.gz
 # move your cfg/, scripts/data/, etc into the new tree, restart hub
 
 # Windows
-# Download luadch-v3.1.11-windows-x86_64.zip, extract, copy cfg+data over, restart.
+# Download luadch-v3.1.12-windows-x86_64.zip, extract, copy cfg+data over, restart.
 ```
 
 3.2.x is the active development line on `master`; security backports continue to land on `release/3.1.x` per [`CLAUDE.md` §8](https://github.com/luadch-ng/luadch/blob/master/CLAUDE.md#8-release-lines-and-support-policy).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The upstream project (`luadch/luadch`) is a separate codebase; its release
 history is at https://github.com/luadch/luadch/releases.
 
+## [v3.1.12] - 2026-07-10
+
+Maintenance patch release on the `release/3.1.x` line. One bugfix for a backport slip introduced in v3.1.10. No breaking changes; no cfg / lang-file changes; drop-in upgrade from v3.1.11.
+
+### Bugfixes
+
+- [#393](https://github.com/luadch-ng/luadch/issues/393) (Sopor) - **the `kill_wrong_ips = false` opt-out raised `attempt to read undeclared var: 'userfam'` in `incoming` and never stamped the real IP.** The [#214](https://github.com/luadch-ng/luadch/issues/214) Gap 2 backport in v3.1.10 stamps the verified IP over a mismatched claim via `adccmd:setnp( userfam, userip )` - but `userfam` is the *master* line's variable name; the 3.1.x `incoming` function calls its address-family variable `ipver` (declared at the top of the function, used correctly by the first `setnp` on the no-IP path ~15 lines above). Under the restricted core env the undeclared `userfam` read raised a Lua error in `hub.lua: function 'incoming'` for every user whose claimed INF IP differed from their authenticated TCP-source IP while `kill_wrong_ips = false` was set - so the NAT/CGNAT opt-out never stamped the real IP and the affected user (typically the very NAT/CGNAT client the opt-out exists to admit) could not complete login. Fix: use the in-scope `ipver` at that call site, matching the sibling `setnp`. Default `kill_wrong_ips = true` deployments are unaffected (they take the kill branch, never the stamp branch). Master is unaffected - it uses `userfam` consistently throughout its (renamed) `incoming`; this was a partial-rename slip in the v3.1.10 cherry-pick only, so the fix is applied directly on `release/3.1.x` (nothing to cherry-pick from master). The one-token fix is self-evident (the unpatched `userfam` is undeclared in the entire function and can only error; `ipver` is the family variable used identically on the no-IP path). The kill_wrong_ips=false stamp path had no smoke coverage, which is how the slip shipped in v3.1.10; a behavioural regression test needs a kill_wrong_ips=false hub config and is tracked as a follow-up.
+
+### Notes
+
+- **No breaking changes, no cfg / lang-file edits required.** Drop-in upgrade from v3.1.11.
+- **Affects only deployments that set `kill_wrong_ips = false`** (not the default `true`). Those operators - typically running the opt-out specifically to admit NAT / CGNAT users - should upgrade: the bug defeats exactly that opt-out.
+
+[v3.1.12]: https://github.com/luadch-ng/luadch/releases/tag/v3.1.12
+
+
 ## [v3.1.11] - 2026-06-07
 
 Maintenance patch release on the `release/3.1.x` line. One privilege-escalation bugfix cherry-picked from master. No breaking changes; no cfg / lang-file changes; drop-in upgrade from v3.1.10.

--- a/core/const.lua
+++ b/core/const.lua
@@ -11,7 +11,7 @@
 return {
 
     PROGRAM_NAME = "Luadch",
-    VERSION = "v3.1.11",
+    VERSION = "v3.1.12",
     COPYRIGHT = "by blastbeat and pulsar",
     FORK = "modernised fork by Aybo",
     CONFIG_PATH = "././cfg/",

--- a/core/hub_dispatch.lua
+++ b/core/hub_dispatch.lua
@@ -353,7 +353,16 @@ _identify = {
                 -- address (DDoS-amplification, see issue body). Stamp
                 -- the authenticated TCP-source IP over the lie so the
                 -- broadcast INF carries `userip`, not the claim.
-                adccmd:setnp( userfam, userip )
+                -- v3.1.12: this branch used the master-line variable
+                -- name `userfam`, which does not exist in the 3.1.x
+                -- scope (this function's family variable is `ipver`,
+                -- see line ~341). Under the restricted core env the
+                -- undeclared read raised "attempt to read undeclared
+                -- var: 'userfam'" in `incoming` for every mismatched-IP
+                -- user with kill_wrong_ips=false, so the opt-out never
+                -- stamped the real IP. Partial-rename backport slip;
+                -- master is unaffected (uses `userfam` throughout).
+                adccmd:setnp( ipver, userip )
             end
         end
         if cid ~= adclib_hash( pid ) then


### PR DESCRIPTION
Closes #393. Direct fix on `release/3.1.x` - master is unaffected, so there is nothing to cherry-pick.

## Bug (reported by Sopor)

```
hub.lua: function 'incoming': lua error: ././core/hub_dispatch.lua:356: attempt to read undeclared var: 'userfam'
```

The [#214](https://github.com/luadch-ng/luadch/issues/214) Gap 2 backport in **v3.1.10** stamps the verified IP over a mismatched claim via `adccmd:setnp( userfam, userip )`. But `userfam` is the **master** function's variable name; the 3.1.x `incoming` names its address-family variable `ipver` (declared at the top, used correctly by the first `setnp` on the no-IP path ~15 lines above). Under the restricted core env the undeclared `userfam` read raises the error for every user whose claimed INF IP differs from their authenticated TCP-source IP while `kill_wrong_ips = false` is set - so the NAT/CGNAT opt-out never stamps the real IP and the affected user (the very client the opt-out exists to admit) cannot complete login.

## Fix

One token: `adccmd:setnp( userfam, userip )` -> `adccmd:setnp( ipver, userip )`, matching the sibling `setnp` on the no-IP path. Comment added explaining the slip. Version bump `v3.1.11 -> v3.1.12`. CHANGELOG v3.1.12 section.

## Scope / testing

- Default `kill_wrong_ips = true` deployments are **unaffected** (they take the kill branch, never the stamp branch). Only operators who explicitly set `kill_wrong_ips = false` (to admit NAT/CGNAT users) hit it.
- Master is unaffected - it uses `userfam` consistently throughout its renamed `incoming`.
- The fix is **self-evident** (diff-is-self-evidence): the unpatched `userfam` is undeclared in the entire function and can only error; `ipver` is the in-scope family variable used identically on the sibling path. `grep -c userfam core/hub_dispatch.lua` is 0 in code (3 remaining hits are the explanatory comment); file compiles under Lua 5.4.8.
- **Coverage gap noted:** the `kill_wrong_ips=false` stamp path had no smoke test, which is how the v3.1.10 slip shipped. A behavioural regression needs a `kill_wrong_ips=false` hub config - tracked as a follow-up.

Cuts as **v3.1.12** once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
