### PR TITLE
docs: currency refresh - status_push secret key + v3.1.12 release marker + secret-register-timing rule

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -443,6 +443,7 @@ Plugins register their own sensitive keys at `onStart`:
 local secrets = use "secrets"
 secrets.register( "etc_geoip_license_key" )
 secrets.register( "etc_proxydetect_api_key" )
+secrets.register( "etc_status_push_token" )   -- heartbeat bearer token
 ```
 
 `register()` is exposed to every plugin via `SANDBOX_GLOBALS` and


### PR DESCRIPTION
Doc-currency follow-ups after this session (etc_status_push #395 + the v3.1.12 patch). Docs-only, no code.

- **`docs/SECURITY.md`** §3: add `etc_status_push_token` to the illustrative registered-secret-keys list.
- **`docs/DEVELOPMENT.md`** §3: strengthen the plugin-secret rule with the #395 review lesson - call `secrets.register` at the TOP of `onStart`, before any `activate`/`enabled` early-return, so a cfg.tbl-stored key is redacted even while the plugin is loaded-but-inactive. Adds `etc_status_push` as a precedent.
- **`CLAUDE.md`**: bump the "latest release" markers `v3.1.9` -> `v3.1.12` (§2, §6, and the §7 doc-rule example).

3.2.x only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)