### PR TITLE
docs: currency refresh - v3.1.12 release marker + secret-register-timing rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ luadch is a DC++ **ADC** hub server written in Lua with a thin C launcher
 
 - **Current source version:** `v3.2.0-dev` on `master`, `PROGRAM_NAME = "Luadch-NG"`
   (see `core/const.lua`). The 3.1.x maintenance line keeps `PROGRAM_NAME = "Luadch"`.
-- **Latest release:** `v3.1.9` (2026-05-13, on `release/3.1.x`)
+- **Latest release:** `v3.1.12` (2026-07-10, on `release/3.1.x`)
 - **Status:** the Phase 1-7 modernisation programme is content-complete; work is now
   3.2.x feature development (Phase 8+) plus 3.1.x security-only maintenance (see §8).
 - **Open issues:** check `gh issue list --repo luadch-ng/luadch` (never trust a
@@ -275,7 +275,7 @@ contract, preflight): see [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) §3 and
   **this file**, not in memory, because they belong with the code. Durable
   engineering patterns belong in [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) so
   they reach every assistant and contributor, not just one memory owner.
-- **Releases** — this fork's latest release is `v3.1.9` (see §2 and §8); UPSTREAM
+- **Releases** — this fork's latest release is `v3.1.12` (see §2 and §8); UPSTREAM
   `luadch/luadch` last released v2.23 back in 2022-04-02 (see Upstream policy below).
 
 ### Upstream policy
@@ -325,7 +325,7 @@ open a fresh issue here that references the upstream one in its body.
   source of truth (`wc -l`, `gh issue list`, CI) instead. Two exemptions, because
   they do NOT drift: (a) frozen historical facts about a CLOSED phase (e.g. "24
   findings / 22 closed" in the §5 table); (b) release/version/"verified-on"
-  markers (e.g. "latest release v3.1.9", the deps-table verified date). A live
+  markers (e.g. "latest release v3.1.12", the deps-table verified date). A live
   status line (like §5 "In flight") must name the tracker as its source of truth.
 
 ### Tooling gotchas (these have already burned us)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -139,13 +139,17 @@ The conventions below are either not in it or are easy to get wrong:
 - **API keys / secrets: env-var-first via `core/secrets.lua`.** Read a key with
   `secrets.lookup("cfg_key")` (checks `LUADCH_CFG_KEY` env first, then `cfg.tbl`)
   and call `secrets.register("cfg_key")` in `onStart` so `GET /v1/config` redacts
-  it. Two gotchas: redaction is active only once the plugin is *loaded* (a key
-  sat in `cfg.tbl` before the plugin is enabled in `cfg.scripts` is NOT redacted,
-  and `/v1/config` is `read`-scoped) - so document "prefer the env var" (never
-  dumped); and there is no `+showcfg` command today, only `GET /v1/config`
-  redacts, so do not claim otherwise. Send the key in a request HEADER, never a
-  URL query param (`http_client` logs the URL on failure, never the headers).
-  Precedent: `etc_blocklist_feeds` (AbuseIPDB key).
+  it. Three gotchas: (1) redaction is active only once the plugin is *loaded* (a
+  key sat in `cfg.tbl` before the plugin is enabled in `cfg.scripts` is NOT
+  redacted, and `/v1/config` is `read`-scoped) - so document "prefer the env var"
+  (never dumped); (2) call `secrets.register` at the TOP of `onStart`, BEFORE any
+  `activate` / `enabled` early-return - registering it after the gate leaves a
+  cfg.tbl-stored key un-redacted while the plugin is loaded-but-inactive (the
+  `#395` review catch; `lookup` can stay at the point of use); (3) there is no
+  `+showcfg` command today, only `GET /v1/config` redacts, so do not claim
+  otherwise. Send the key in a request HEADER, never a URL query param
+  (`http_client` logs the URL on failure, never the headers). Precedents:
+  `etc_blocklist_feeds` (AbuseIPDB key), `etc_status_push` (heartbeat bearer token).
 - **`scriptversion` bump on any semantic change** (behaviour, cfg keys, wire
   surface) - the companion `luadch-ng/scripts` repo syncs by version.
 - **Config defaults + validator go in `core/cfg_defaults.lua`.** Add the key


### PR DESCRIPTION
The CLAUDE.md + DEVELOPMENT.md half of the doc-currency batch that missed #396's merge window (that squash landed only the SECURITY.md line). Docs-only.

- **CLAUDE.md**: bump the "latest release" markers `v3.1.9` -> `v3.1.12` (§2, §6, §7 doc-rule example).
- **DEVELOPMENT.md** §3: strengthen the plugin-secret rule - call `secrets.register` at the TOP of onStart, before any activate/enabled early-return, so a cfg.tbl-stored key is redacted even while the plugin is loaded-but-inactive (#395 review lesson). etc_status_push added as a precedent.

3.2.x only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)