### PR TITLE
fix(server): remote hub-crash on peer reset after accept (v3.1.13 backport, #401)

### DIFF
--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,6 +1,6 @@
-# Luadch v3.1.12
+# Luadch v3.1.13
 
-**Maintenance patch release** on the `release/3.1.x` line. One bugfix for a backport slip introduced in v3.1.10. No breaking changes; no cfg / lang-file changes; drop-in upgrade from v3.1.11.
+**Security maintenance patch** on the `release/3.1.x` line. One fix: a remote, unauthenticated hub-crash. No breaking changes; no cfg / lang-file changes; drop-in upgrade from v3.1.12.
 
 ## ⚠️ Before upgrading
 
@@ -12,34 +12,49 @@ tar -czf "luadch-backup-$(date +%F).tar.gz" cfg scripts certs secrets
 
 ## Why upgrade
 
-**Only deployments that explicitly set `kill_wrong_ips = false`** are affected (the 3.1.x default is `true`). Operators run that opt-out specifically to admit NAT / CGNAT users whose client advertises a different IP than the one they connect from - and this bug defeats exactly that opt-out: instead of stamping the real IP and letting the user in, the hub raised a Lua error in `incoming` and the affected user could not complete login. If you set `kill_wrong_ips = false` (or plan to), upgrade. If you run the default, you are not affected and can upgrade at leisure.
+**Every operator should upgrade.** This is a remote, unauthenticated denial of service that takes the **whole hub** down - all users dropped, no reconnections possible until you manually restart the process. It is trivially triggerable (a single TCP connect followed by an immediate reset) and reproducible against any hub regardless of configuration.
 
 ## Bugfixes
 
-### [#393](https://github.com/luadch-ng/luadch/issues/393) (Sopor) - `kill_wrong_ips = false` path errored with `attempt to read undeclared var: 'userfam'`
+### [#401](https://github.com/luadch-ng/luadch/issues/401) (Sopor) - remote hub-crash on a peer reset right after accept
 
-The symptom, once an operator set `kill_wrong_ips = false` and a mismatched-IP user connected:
+The symptom in the error log, immediately followed by the hub dropping every user:
 
 ```
-hub.lua: function 'incoming': lua error: ././core/hub_dispatch.lua:356: attempt to read undeclared var: 'userfam'
+././core/ratelimit.lua:176: attempt to concatenate a nil value (local 'ip')
+*** TLS error: Connection closed
 ```
 
-The [#214](https://github.com/luadch-ng/luadch/issues/214) Gap 2 fix (shipped to 3.1.x in v3.1.10) stamps the authenticated TCP-source IP over a mismatched INF claim so the wrong IP is never broadcast. The v3.1.10 cherry-pick wrote that stamp as `adccmd:setnp( userfam, userip )` - but `userfam` is the **master** branch's variable name. The 3.1.x `incoming` function calls its address-family variable `ipver` (declared at the top of the function, used correctly by the first `setnp` on the no-IP path ~15 lines above). Under luadch's restricted core environment, reading the undeclared `userfam` raises an error - so for every user whose claimed INF IP differed from their real TCP-source IP while `kill_wrong_ips = false` was set, the stamp branch threw and the user (typically the very NAT/CGNAT client the opt-out exists to admit) could not log in.
+`core/server.lua`'s accept path reads the connecting client's IP via `client:getpeername()` and hands it to the per-IP rate-limit guard. When a peer resets the TCP connection in the split second between `accept()` and `getpeername()` (connect + immediate RST - anyone can do it), `getpeername()` returns `nil`. That `nil` reached `ratelimit.accept_ip`, which builds its token-bucket key as `"ip:" .. ip` - raising `attempt to concatenate a nil value (local 'ip')`. The error was **uncaught inside the listener's accept loop**, so the hub stopped accepting connections and dropped everyone online.
 
-**Fix:** use the in-scope `ipver` at that call site, matching the sibling `setnp`:
+`ratelimit.release_ip` already guarded a `nil` IP; `accept_ip` did not - the asymmetry that made this reachable.
+
+**Fix (defence in depth):**
 
 ```lua
--               adccmd:setnp( userfam, userip )
-+               adccmd:setnp( ipver, userip )
+-- core/server.lua, accept path
+ local clientip, clientport = client:getpeername( )
++if not clientip then
++    -- peer reset between accept() and getpeername(); socket is dead,
++    -- and we cannot rate-limit an unknown IP. Drop it before the guard.
++    client:close( )
++    return false
++end
 ```
 
-Default `kill_wrong_ips = true` deployments are unaffected - they take the kill branch and never reach the stamp branch. Master is unaffected; it uses `userfam` consistently throughout its renamed `incoming`. This was a partial-rename slip in the v3.1.10 backport only, so the fix is applied directly on `release/3.1.x` (nothing to cherry-pick from master).
+```lua
+-- core/ratelimit.lua, accept_ip
+ if not _activate then return true end
++if not ip then return true end   -- mirror release_ip's nil guard
+```
 
-The `kill_wrong_ips = false` stamp path had no smoke coverage, which is how the slip shipped in v3.1.10; a behavioural regression test needs a `kill_wrong_ips = false` hub config and is tracked as a follow-up.
+`core/server.lua` now closes a just-accepted socket whose peer address cannot be read *before* the rate-limit guard runs, and `accept_ip` guards `nil` directly.
+
+The 3.2.x line (`master`) additionally guards `core/blocklist.lua`, which does not exist on 3.1.x, and carries a regression unit test (`tests/unit/ratelimit_test.lua`) that reproduces the exact crash and provably fails pre-fix. The 3.1.x fix is the same server + ratelimit guard, reviewer-verified, and validated by running that same test against this line's `ratelimit.lua`.
 
 ## Build / runtime
 
-No changes. Same Lua 5.4, same LuaSec 1.3.2, same LuaSocket 3.1.0, same build toolchain as v3.1.11.
+No changes. Same Lua 5.4, same LuaSec 1.3.2, same LuaSocket 3.1.0, same build toolchain as v3.1.12.
 
 The `linux-aarch64` artifact continues with the Bullseye-container pipeline (glibc 2.31 baseline, works on Pi OS Bullseye / Bookworm / DietPi v9.x).
 
@@ -47,12 +62,12 @@ The `linux-aarch64` artifact continues with the Bullseye-container pipeline (gli
 
 ```sh
 # Linux x86_64 / aarch64
-wget https://github.com/luadch-ng/luadch/releases/download/v3.1.12/luadch-v3.1.12-linux-x86_64.tar.gz
-tar xzf luadch-v3.1.12-linux-x86_64.tar.gz
+wget https://github.com/luadch-ng/luadch/releases/download/v3.1.13/luadch-v3.1.13-linux-x86_64.tar.gz
+tar xzf luadch-v3.1.13-linux-x86_64.tar.gz
 # move your cfg/, scripts/data/, etc into the new tree, restart hub
 
 # Windows
-# Download luadch-v3.1.12-windows-x86_64.zip, extract, copy cfg+data over, restart.
+# Download luadch-v3.1.13-windows-x86_64.zip, extract, copy cfg+data over, restart.
 ```
 
 3.2.x is the active development line on `master`; security backports continue to land on `release/3.1.x` per [`CLAUDE.md` §8](https://github.com/luadch-ng/luadch/blob/master/CLAUDE.md#8-release-lines-and-support-policy).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The upstream project (`luadch/luadch`) is a separate codebase; its release
 history is at https://github.com/luadch/luadch/releases.
 
+## [v3.1.13] - 2026-07-11
+
+Maintenance patch release on the `release/3.1.x` line. One security bugfix: a remotely-triggerable hub-crash. No breaking changes; no cfg / lang-file changes; drop-in upgrade from v3.1.12.
+
+### Bugfixes
+
+- [#401](https://github.com/luadch-ng/luadch/issues/401) (Sopor) - **remote hub-crash: a peer that reset its connection right after the TCP accept took the whole hub down.** `core/server.lua`'s accept path reads the client IP via `client:getpeername()` and hands it to the per-IP rate-limit guard. When the peer resets the connection between `accept()` and `getpeername()` (trivially remote-triggerable - connect + immediate RST), `getpeername()` returns `nil`, and `ratelimit.accept_ip(nil)` raised `attempt to concatenate a nil value (local 'ip')` at `core/ratelimit.lua:176` while building its token-bucket key `"ip:" .. ip`. The raise was **uncaught inside the listener's accept loop**, so the hub stopped accepting connections and dropped every online user - a remote, unauthenticated denial of service (Sopor hit this on 3.1.11 after 10+ years, matching the `TLS error: Connection closed` two seconds after the ratelimit error). `ratelimit.release_ip` already guarded `nil`; `accept_ip` did not - the asymmetry that made it reachable. Fix (defence in depth): `core/server.lua` now closes a just-accepted socket whose peer address cannot be read *before* the rate-limit guard runs, and `ratelimit.accept_ip` guards `nil` (mirroring `release_ip`). The 3.2.x master fix ([PR #402](https://github.com/luadch-ng/luadch/pull/402), commit `54ac292`) additionally guards `core/blocklist.lua`, which does not exist on the 3.1.x line; the regression test (`tests/unit/ratelimit_test.lua`, reproduces the exact nil-concat crash, provably fails pre-fix) lives on the 3.2.x line because 3.1.x has no unit-test harness - the fix logic here is identical and reviewer-verified, and was validated by running that same test against the 3.1.x `ratelimit.lua`.
+
+### Notes
+
+- **No breaking changes, no cfg / lang-file edits required.** Drop-in upgrade from v3.1.12.
+- **All operators should upgrade.** The crash is a remote, unauthenticated denial of service (connect + immediate reset), reproducible against any hub regardless of config, and takes the whole hub down - every user dropped, no reconnects until a manual restart.
+
+[v3.1.13]: https://github.com/luadch-ng/luadch/releases/tag/v3.1.13
+
+
 ## [v3.1.12] - 2026-07-10
 
 Maintenance patch release on the `release/3.1.x` line. One bugfix for a backport slip introduced in v3.1.10. No breaking changes; no cfg / lang-file changes; drop-in upgrade from v3.1.11.

--- a/core/const.lua
+++ b/core/const.lua
@@ -11,7 +11,7 @@
 return {
 
     PROGRAM_NAME = "Luadch",
-    VERSION = "v3.1.12",
+    VERSION = "v3.1.13",
     COPYRIGHT = "by blastbeat and pulsar",
     FORK = "modernised fork by Aybo",
     CONFIG_PATH = "././cfg/",

--- a/core/ratelimit.lua
+++ b/core/ratelimit.lua
@@ -163,6 +163,11 @@ end
 
 accept_ip = function( ip )
     if not _activate then return true end
+    -- Defence in depth: server.lua drops a nil peer IP before calling
+    -- us, but never let a nil crash the accept loop here (mirror
+    -- release_ip's guard below). A peer we cannot identify cannot be
+    -- per-IP limited; allow and let the caller close the dead socket.
+    if not ip then return true end
     -- Sticky F-AUTH-3 IP block from prior bad-auth abuse.
     if _ip_blocked( ip ) then
         return false, "IP locked out due to repeated auth failures: " .. tostring( ip )

--- a/core/server.lua
+++ b/core/server.lua
@@ -368,6 +368,18 @@ wrapserver = function( listeners, socket, serverip, serverport, pattern, sslctx,
         local client, err = accept( socket )    -- try to accept
         if client then
             local clientip, clientport = client:getpeername( )
+            -- A peer that reset the connection between accept() and here
+            -- leaves getpeername() returning nil (remote-triggerable).
+            -- We cannot rate-limit an unknown IP and the socket is
+            -- already dead; drop it before ratelimit_accept_ip rather
+            -- than passing nil in - a nil there raised inside the accept
+            -- loop and took the whole listener down (no new connections
+            -- could be accepted; Sopor, 3.1.11).
+            if not clientip then
+                out_put( "server.lua: function 'wrapserver': accepted socket with no peer address (reset before getpeername), closing" )
+                client:close( )
+                return false
+            end
             -- Phase 7c F-NET-1: per-IP parallel-socket cap and per-IP
             -- accept-rate cap. Refuse pre-wrap so the offending IP cannot
             -- consume FDs / slot-list entries.


### PR DESCRIPTION
Security backport of [#401](https://github.com/luadch-ng/luadch/issues/401)
to the 3.1.x line -> **v3.1.13**. Master fix landed in
[#402](https://github.com/luadch-ng/luadch/pull/402) (commit `54ac292`).

Remote, unauthenticated hub-crash: a peer that resets its TCP connection
between `accept()` and `getpeername()` feeds a nil IP into
`ratelimit.accept_ip`, which raised `attempt to concatenate a nil value
(local 'ip')` at `core/ratelimit.lua:176` uncaught inside the accept
loop - the hub stopped serving and dropped every user. Reported by Sopor
on 3.1.11.

**Adapted for 3.1.x** (no `core/blocklist.lua` on this line):
- `core/server.lua`: drop a just-accepted socket whose peer address
  can't be read, before the rate-limit guard.
- `core/ratelimit.lua` `accept_ip`: `if not ip then return true end`
  (mirror `release_ip`).
- `core/const.lua`: v3.1.12 -> v3.1.13.
- CHANGELOG + `.github/release-body.md` for v3.1.13.

The regression unit test (`tests/unit/ratelimit_test.lua`) stays on the
3.2.x line (3.1.x has no unit-test harness), but was run against this
line's patched `ratelimit.lua` to verify: 10 checks pass, provably fails
pre-fix. 3.1.x smoke (this PR's CI) boots the hub to confirm no boot
regression.

Ref #401. Merge -> then tag `v3.1.13`.
