### PR TITLE
docs: currency post webhook-live + geoip reload-throttle pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,11 +248,16 @@ cross-host to a signed CDN URL), boot-time runtime-dir self-heal
 (`core/ensuredirs.lua` + a `makedir` C primitive #382, #384) with a daemon
 `umask(027)` hardening, and an `etc_blocklist_feeds` reload-throttle (#386).
 
-**Current era: feature plugins + bug-issue triage.** Recent dev: push/pull
-status export (`etc_status_push` #395), the inbound webhook receiver
-(`etc_webhook` #398, the first `scope="none"` plugin route), plus a run of
-Sopor-reported fixes (v3.1.13 ratelimit hub-crash #401, `usr_uptime`
-undercount #405, BLOM smoke de-flake #408). Alongside, the
+**Current era: feature plugins + bug-issue triage.** Shipped to master
+(3.2.x, still no `v3.2.0` tag): push/pull status export (`etc_status_push`
+#395), the inbound webhook receiver (`etc_webhook` #398, the first
+`scope="none"` plugin route - live against a Discourse forum + a GitHub org),
+plus Sopor-reported fixes (v3.1.13 ratelimit hub-crash #401, `usr_uptime`
+undercount #405, BLOM smoke de-flake #408). A recurring pattern this era:
+a **periodic-fetch plugin must persist its next-fetch deadline across
+`+reload`**, or every reload re-hits a rate-limited provider - fixed twice
+(`etc_blocklist_feeds` #386, `etc_geoip` auto-update #414); general rule in
+[`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) §3. Alongside, the
 `gh issue list --label bug` backlog is worked one at a time (each: deep-dive
 from source per §1a.3/4, since many are old-version reports asking "fixed in
 3.x?"). GitFlow A per fix; batch dev->master as a MERGE commit (never squash

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -138,6 +138,25 @@ The conventions below are either not in it or are easy to get wrong:
   #238 / #239. Fix: either mutate the table in place (never rebind the local),
   or export a **getter function** `function() return state end` so callers
   always read the live table. See the `scripts/etc_aliases.lua` header.
+- **A periodic outbound fetch must persist its next-fetch deadline across
+  `+reload`.** A plugin that polls an external endpoint on an `onTimer`
+  deadline (`if now >= next_fetch then ...; next_fetch = now + interval`)
+  holds `next_fetch` in a RAM-only file-local. `onStart` fires on every
+  `+reload` (a full Lua restart), so re-seeding `next_fetch = now + <small>`
+  there means every reload re-fetches shortly after boot - an operator
+  reloading several times a day hammers a rate-limited provider (a feed
+  gets the hub's IP firewalled; MaxMind / AbuseIPDB have daily quotas).
+  Fix: persist the last-fetch epoch to `scripts/data/<plugin>.tbl` - write
+  it when a request actually goes out, **including on failure** (a
+  429/500/timeout still hit the provider, so those are exactly who a
+  reload-loop must not re-hit) - and in `onStart` schedule
+  `next_fetch = min(last_fetch + interval, now + interval)`, or a staggered
+  `now + <small>` only if never-fetched / overdue (the `min` caps a bogus
+  future timestamp from clock skew / a corrupt state file). Note the state
+  file loses no protection on reload - the fetched data (feed entries, the
+  `.mmdb`) survives independently. Same class of bug fixed twice:
+  `etc_blocklist_feeds` (#386) and `etc_geoip` auto-update (#414); when you
+  add a third periodic fetcher, do this from the start.
 - **i18n: all-or-nothing, en + de.** If a plugin uses `cfg.loadlanguage`, every
   operator-visible string goes through it, and both `scripts/lang/<name>.lang.en`
   and `.lang.de` ship. Keep DC jargon (Hub, Slot, Share, OP, Kick, Ban, Nick,


### PR DESCRIPTION
Doc-currency for this session's work (already on master).

- **docs/DEVELOPMENT.md §3** - new plugin-authoring pattern: a periodic outbound fetch must persist its next-fetch deadline across `+reload`, or every reload re-hits a rate-limited provider. The same class of bug was fixed twice (`etc_blocklist_feeds` #386, `etc_geoip` auto-update #414) yet the rule wasn't written down - now it is, so a third periodic fetcher does it from the start. Includes the mark-on-failure + min()-cap details.
- **CLAUDE.md §5** - current-era note: `etc_webhook` (#398) is now on master and live (Discourse forum + GitHub org); reference the reload-throttle pattern.

Docs only. 3.2.x only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)