### PR TITLE
fix(luasocket): raise Windows FD_SETSIZE 64->1024 (v3.1.14) - backport #416

### DIFF
--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,6 +1,6 @@
-# Luadch v3.1.13
+# Luadch v3.1.14
 
-**Security maintenance patch** on the `release/3.1.x` line. One fix: a remote, unauthenticated hub-crash. No breaking changes; no cfg / lang-file changes; drop-in upgrade from v3.1.12.
+**Maintenance patch** on the `release/3.1.x` line. One fix: a **Windows-only** hub-crash once the hub holds ~64 concurrent sockets. No breaking changes; no cfg / lang-file changes; drop-in upgrade from v3.1.13. **Linux operators are unaffected** (no functional change).
 
 ## ⚠️ Before upgrading
 
@@ -12,62 +12,52 @@ tar -czf "luadch-backup-$(date +%F).tar.gz" cfg scripts certs secrets
 
 ## Why upgrade
 
-**Every operator should upgrade.** This is a remote, unauthenticated denial of service that takes the **whole hub** down - all users dropped, no reconnections possible until you manually restart the process. It is trivially triggerable (a single TCP connect followed by an immediate reset) and reproducible against any hub regardless of configuration.
+**Windows operators should upgrade**, especially busier hubs. Before this fix, a Windows hub crashed with `bad argument #1 to 'socket_select' (too many sockets)` and dropped every user once it held about **64 concurrent sockets** - a ceiling a moderately busy hub reaches organically (it can also be pushed there by a distributed connect flood; a single IP stays capped by `ratelimit_perip_max_conns`). Reported on Windows Server 2008 R2 running 3.1.13, but it affects any Windows version.
+
+**Linux is unaffected** - its glibc select ceiling is already 1024, so this release makes no functional change on Linux beyond one informational boot-log line.
 
 ## Bugfixes
 
-### [#401](https://github.com/luadch-ng/luadch/issues/401) (Sopor) - remote hub-crash on a peer reset right after accept
+### [#416](https://github.com/luadch-ng/luadch/issues/416) (Sopor) - Windows hub-crash at ~64 concurrent sockets
 
-The symptom in the error log, immediately followed by the hub dropping every user:
+The symptom in the log, immediately followed by the hub dropping every user:
 
 ```
-././core/ratelimit.lua:176: attempt to concatenate a nil value (local 'ip')
-*** TLS error: Connection closed
+/core/server.lua:...: bad argument #1 to 'socket_select' (too many sockets)
 ```
 
-`core/server.lua`'s accept path reads the connecting client's IP via `client:getpeername()` and hands it to the per-IP rate-limit guard. When a peer resets the TCP connection in the split second between `accept()` and `getpeername()` (connect + immediate RST - anyone can do it), `getpeername()` returns `nil`. That `nil` reached `ratelimit.accept_ip`, which builds its token-bucket key as `"ip:" .. ip` - raising `attempt to concatenate a nil value (local 'ip')`. The error was **uncaught inside the listener's accept loop**, so the hub stopped accepting connections and dropped everyone online.
+The hub event loop (`core/server.lua`'s `tick()`) calls `socket.select` over **every** connected socket at once. On Windows, luasocket's `select.c` hard-caps that at `FD_SETSIZE`:
 
-`ratelimit.release_ip` already guarded a `nil` IP; `accept_ip` did not - the asymmetry that made this reachable.
-
-**Fix (defence in depth):**
-
-```lua
--- core/server.lua, accept path
- local clientip, clientport = client:getpeername( )
-+if not clientip then
-+    -- peer reset between accept() and getpeername(); socket is dead,
-+    -- and we cannot rate-limit an unknown IP. Drop it before the guard.
-+    client:close( )
-+    return false
-+end
+```c
+#ifdef _WIN32
+    if (n >= FD_SETSIZE)
+        luaL_argerror(L, tab, "too many sockets");
 ```
 
-```lua
--- core/ratelimit.lua, accept_ip
- if not _activate then return true end
-+if not ip then return true end   -- mirror release_ip's nil guard
-```
+The bundled Windows build never defined `FD_SETSIZE`, so it inherited the Winsock default of **64** (`luasocket/CMakeLists.txt` set only `WINVER`). Once the hub held ~64 sockets (logged-in users + v4/v6 listeners + HBRI + HTTP), the unguarded `select` raised and the main loop died.
 
-`core/server.lua` now closes a just-accepted socket whose peer address cannot be read *before* the rate-limit guard runs, and `accept_ip` guards `nil` directly.
+**Fix:** define `FD_SETSIZE=1024` for the Windows luasocket build (`socket` module + `luasocket_static`) - parity with the Linux glibc `fd_set`. On Windows `fd_set` is a `SOCKET` array sized by this macro, so raising it genuinely enlarges the set. This is **Windows-only**: on Linux, glibc's `fd_set` is a fixed 1024-bit buffer that redefining `FD_SETSIZE` would overflow.
 
-The 3.2.x line (`master`) additionally guards `core/blocklist.lua`, which does not exist on 3.1.x, and carries a regression unit test (`tests/unit/ratelimit_test.lua`) that reproduces the exact crash and provably fails pre-fix. The 3.1.x fix is the same server + ratelimit guard, reviewer-verified, and validated by running that same test against this line's `ratelimit.lua`.
+Watching **more than ~1024** concurrent sockets needs replacing `select()` with `poll()` on both platforms, tracked in [#310](https://github.com/luadch-ng/luadch/issues/310) on the 3.2.x line. `max_users` (default 3000) counts logged-in users, not sockets, and is not reached on either platform before this ~1024 socket ceiling.
+
+The hub now logs its compile-time select capacity (`socket._SETSIZE`) once at boot (`hub.loop`, to `event.log`) so you can confirm the raised cap. The identical fix is on the 3.2.x line (`master`, PR [#417](https://github.com/luadch-ng/luadch/pull/417)) with a smoke regression that provably fails pre-fix on the Windows CI leg.
 
 ## Build / runtime
 
-No changes. Same Lua 5.4, same LuaSec 1.3.2, same LuaSocket 3.1.0, same build toolchain as v3.1.12.
+No toolchain changes. Same Lua 5.4.8, same LuaSec 1.3.2, same LuaSocket 3.1.0, same build toolchain as v3.1.13. The Windows build simply compiles luasocket with `-DFD_SETSIZE=1024`.
 
 The `linux-aarch64` artifact continues with the Bullseye-container pipeline (glibc 2.31 baseline, works on Pi OS Bullseye / Bookworm / DietPi v9.x).
 
 ## Upgrade
 
 ```sh
-# Linux x86_64 / aarch64
-wget https://github.com/luadch-ng/luadch/releases/download/v3.1.13/luadch-v3.1.13-linux-x86_64.tar.gz
-tar xzf luadch-v3.1.13-linux-x86_64.tar.gz
-# move your cfg/, scripts/data/, etc into the new tree, restart hub
+# Windows (the platform this fix targets)
+# Download luadch-v3.1.14-windows-x86_64.zip, extract, copy cfg+data over, restart.
 
-# Windows
-# Download luadch-v3.1.13-windows-x86_64.zip, extract, copy cfg+data over, restart.
+# Linux x86_64 / aarch64 (no functional change; upgrade at leisure)
+wget https://github.com/luadch-ng/luadch/releases/download/v3.1.14/luadch-v3.1.14-linux-x86_64.tar.gz
+tar xzf luadch-v3.1.14-linux-x86_64.tar.gz
+# move your cfg/, scripts/data/, etc into the new tree, restart hub
 ```
 
 3.2.x is the active development line on `master`; security backports continue to land on `release/3.1.x` per [`CLAUDE.md` §8](https://github.com/luadch-ng/luadch/blob/master/CLAUDE.md#8-release-lines-and-support-policy).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The upstream project (`luadch/luadch`) is a separate codebase; its release
 history is at https://github.com/luadch/luadch/releases.
 
+## [v3.1.14] - 2026-07-13
+
+Maintenance patch release on the `release/3.1.x` line. One bugfix: a Windows-only hub-crash once the hub holds ~64 concurrent sockets. No breaking changes; no cfg / lang-file changes; drop-in upgrade from v3.1.13. Linux operators are unaffected (no functional change - the boot log gains one informational line).
+
+### Bugfixes
+
+- [#416](https://github.com/luadch-ng/luadch/issues/416) (Sopor) - **Windows: the hub crashed once it held ~64 concurrent sockets** with `/core/server.lua:...: bad argument #1 to 'socket_select' (too many sockets)`. The event loop's `tick()` calls `socket.select` over every connected socket at once; on Windows luasocket's `select.c` hard-caps that at `FD_SETSIZE`, and the bundled build inherited the Winsock default of **64** (`luasocket/CMakeLists.txt` set only `WINVER`, never `FD_SETSIZE`). Once a hub held ~64 sockets (users + v4/v6 listeners + HBRI + HTTP) the unguarded `select` in `tick()` raised and the main loop died, dropping every user. Reported on Windows Server 2008 R2 running 3.1.13, but it affects any Windows version. Fix: define `FD_SETSIZE=1024` for the Windows luasocket build (`socket` module + `luasocket_static`), i.e. parity with the Linux glibc `fd_set`. Windows-only by design: on Linux redefining `FD_SETSIZE` cannot enlarge glibc's fixed 1024-bit `fd_set` (the >1024 case there needs the `select`->`poll` port tracked in [#310](https://github.com/luadch-ng/luadch/issues/310), 3.2.x). The hub now logs the compile-time select capacity (`socket._SETSIZE`) once at boot from `hub.loop` so operators can confirm the raised cap. The 3.2.x line (`master`, PR [#417](https://github.com/luadch-ng/luadch/pull/417)) carries the identical fix plus a smoke regression that provably fails pre-fix on the Windows CI leg; 3.1.x's smoke harness does not enable `log_events`, so the test lives on 3.2.x - the code here is identical and reviewer-verified, and was validated green on master's Windows smoke.
+
+### Notes
+
+- **No breaking changes, no cfg / lang-file edits required.** Drop-in upgrade from v3.1.13.
+- **Windows operators should upgrade**, especially busier hubs - the crash triggers organically once ~64 concurrent connections are held (or via a distributed connect flood; a single IP is capped at `ratelimit_perip_max_conns`). **Linux is unaffected** - its glibc select cap is already 1024, so this release makes no functional change there.
+
+[v3.1.14]: https://github.com/luadch-ng/luadch/releases/tag/v3.1.14
+
+
 ## [v3.1.13] - 2026-07-11
 
 Maintenance patch release on the `release/3.1.x` line. One security bugfix: a remotely-triggerable hub-crash. No breaking changes; no cfg / lang-file changes; drop-in upgrade from v3.1.12.

--- a/core/const.lua
+++ b/core/const.lua
@@ -11,7 +11,7 @@
 return {
 
     PROGRAM_NAME = "Luadch",
-    VERSION = "v3.1.13",
+    VERSION = "v3.1.14",
     COPYRIGHT = "by blastbeat and pulsar",
     FORK = "modernised fork by Aybo",
     CONFIG_PATH = "././cfg/",

--- a/core/hub.lua
+++ b/core/hub.lua
@@ -1499,6 +1499,15 @@ end
 loop = function()
     signal_set( "external_exit_request", false )
     signal_set( "hub", "run" )
+    -- One-time boot line: the compile-time select() capacity (luasocket
+    -- FD_SETSIZE). server.tick() selects over every connected socket at once,
+    -- so once the hub holds this many sockets socket.select raises "too many
+    -- sockets" and this loop dies. On Windows this is the Winsock default 64
+    -- unless the luasocket build raises it (luasocket/CMakeLists.txt, #416);
+    -- on Linux glibc it is 1024. Logged (event.log) so operators can diagnose
+    -- that class of crash; watching more sockets needs the select->poll port
+    -- (#310).
+    out_put( "hub.lua: select() capacity (FD_SETSIZE): ", ( use "socket" )._SETSIZE, " sockets" )
     while signal_get "hub" == "run" do
         server.tick()
         if not signal_get( "external_exit_request" ) then

--- a/luasocket/CMakeLists.txt
+++ b/luasocket/CMakeLists.txt
@@ -59,7 +59,18 @@ add_library(socket MODULE
 )
 target_compile_definitions(socket PRIVATE LUASOCKET_NODEBUG LUASOCKET_INET_PTON)
 if(WIN32)
-    target_compile_definitions(socket PRIVATE WINVER=0x0501)
+    # FD_SETSIZE (Winsock default 64) is the hard cap on how many sockets a
+    # single select() call can watch: select.c raises "too many sockets" at
+    # n >= FD_SETSIZE. The hub event loop (core/server.lua tick()) selects
+    # over EVERY connected socket at once, so the default 64 crashes the hub
+    # once it holds ~64 sockets (users + v4/v6 listeners + HBRI + HTTP).
+    # Raise to 1024 = parity with the Linux glibc fd_set. On Windows fd_set
+    # is a SOCKET array sized by this macro, so bumping it genuinely enlarges
+    # the set; the -D lands before <winsock2.h> (which defines FD_SETSIZE
+    # only #ifndef). WINDOWS-ONLY: on Linux, glibc's fd_set is a fixed 1024-
+    # bit buffer, so redefining FD_SETSIZE would overflow it - the >1024 case
+    # there needs the select->poll port (#310). See luadch-ng/luadch#416.
+    target_compile_definitions(socket PRIVATE WINVER=0x0501 FD_SETSIZE=1024)
     target_link_libraries(socket PRIVATE ws2_32)
 endif()
 target_include_directories(socket PRIVATE ${LSOCKET_SRC})
@@ -95,7 +106,12 @@ endif()
 add_library(luasocket_static STATIC ${LSOCKET_STATIC_SOURCES})
 target_compile_definitions(luasocket_static PRIVATE LUASOCKET_NODEBUG LUASOCKET_INET_PTON)
 if(WIN32)
-    target_compile_definitions(luasocket_static PRIVATE WINVER=0x0501)
+    # Keep luasocket_static's FD_SETSIZE in sync with the `socket` module
+    # (see above) for consistency. This is future-proofing, NOT an ABI
+    # requirement: luasec links this static lib but no fd_set crosses that
+    # boundary (ssl.c only calls socket_waitfd, which builds a single-fd set
+    # that is correct at any FD_SETSIZE). luadch-ng/luadch#416.
+    target_compile_definitions(luasocket_static PRIVATE WINVER=0x0501 FD_SETSIZE=1024)
 endif()
 target_include_directories(luasocket_static PUBLIC ${LSOCKET_SRC})
 target_link_libraries(luasocket_static PUBLIC lua)


### PR DESCRIPTION
Backport of #416 (Windows FD_SETSIZE hub-crash) to `release/3.1.x`, preparing **v3.1.14**. Reported by Sopor on 3.1.13.

Master-first per [`CLAUDE.md` §8](https://github.com/luadch-ng/luadch/blob/master/CLAUDE.md#8-release-lines-and-support-policy): the identical fix is on `master` (f9111a4, PR #417, CI green incl. Windows smoke).

## Fix

On Windows the hub crashed once it held ~64 concurrent sockets: `tick()` runs `socket.select` over every connected socket, and luasocket's `select.c` raises "too many sockets" at `n >= FD_SETSIZE` - the bundled build inherited the Winsock default 64. Define `FD_SETSIZE=1024` for the Windows luasocket build (`socket` + `luasocket_static`) = Linux glibc parity. Windows-only (Linux `fd_set` is fixed 1024; >1024 needs the `select`->`poll` port #310, 3.2.x).

`hub.loop` logs the compile-time cap once at boot so operators can confirm it. This runtime line is exercised by the 3.1.x Windows smoke (the hub must boot for the battery to run).

## Scope (minimal patch, matches the v3.1.13 shape)

- `luasocket/CMakeLists.txt` - the `FD_SETSIZE=1024` define (the fix). Identical to master.
- `core/hub.lua` - boot-log line. Identical to master.
- `core/const.lua` - `VERSION` -> `v3.1.14`.
- `CHANGELOG.md` + `.github/release-body.md` - v3.1.14 release notes (Windows-only framing; Linux unaffected).

The smoke **regression** test is NOT backported: 3.1.x's `run.py` does not enable `log_events`, so the event.log assertion cannot fire here. Same call the v3.1.13 backport made for its unit test. The code is identical to master, where the regression provably fails pre-fix on the Windows CI leg.

## Release gate

- CI here builds + smokes on Linux **and** Windows; green proves the `-DFD_SETSIZE=1024` build works and the boot-log line does not break startup.
- On merge: tag `v3.1.14` on `release/3.1.x` -> `release.yml` builds all three artifacts from `release-body.md`.

Related: #416 (tracker), #417 (3.2.x fix), #310 (select->poll port for >1024).
