### PR TITLE
docs: record the removal-side use-trap and how to prove a core removal

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -86,6 +86,34 @@ comments before inserting - they document real ordering dependencies (e.g.
 Not every module belongs in `_core`: some are pulled in on demand via `use`
 from another module (e.g. `cfg_secret`, whose `init()` needs `cfg` to be up).
 
+**The same rule runs backwards, and that direction is easy to miss.** `use` is
+`_global[name] or loadscript(name)`, so a `use "X"` for a module that is *not
+loaded yet* is what pulls X in. **Deleting such a line moves X's load** - it is
+not a no-op just because the local was unused. Before removing any
+`local X = use "Y"`, check Y's position in `_core` against the module you are
+editing: if Y comes first, the call was only reading an already-populated
+`_global` entry and the removal is free. If it does not, find out who else pulls
+Y in and when (#447 PR 5: removing `cfg`'s unused `types_*` aliases orphaned its
+`use "types"`, and `cfg` sits at `_core` 5 while `types` is 28 - safe only
+because `cfg.lua` loads `cfg_defaults` itself, which does `use "types"` ~50 lines
+further into the same load). Stdlib names (`table`, `debug`, `os`, ...) resolve
+from `_G` and never reach `loadscript`, so those are always free.
+
+### Verifying a removal in a core module
+
+`luac -p` proves syntax, not scope. The failure mode that matters here - a
+deleted `local` whose assignment or read is still there - is syntactically
+perfect and dies at hub load under the restricted env. Two checks catch it:
+
+- **Bytecode scan (categorical).** Under the restricted env any reference to a
+  name with no `local` in scope compiles to an `_ENV` access. So:
+  `luac -p -l -l core/<file>.lua | grep '_ENV "<name>"'`. A `GETTABUP` means a
+  dangling read or a captured closure; a `SETTABUP` means a stray global write.
+  Zero hits is proof, not evidence. Validate the scan first by grepping for a
+  name you *know* is global in that file, so a silent zero cannot fool you.
+- **Boot the hub.** The only end-to-end check. `luac -p` and the unit tests both
+  pass on code that cannot load.
+
 ### Rules
 
 - **Passive at load.** A core module must only define functions and return its


### PR DESCRIPTION
Docs-only, from the [#447](https://github.com/luadch-ng/luadch/issues/447) cleanup arc. 28 lines added to `docs/DEVELOPMENT.md` §2.

## Why

`DEVELOPMENT.md` documented the `use` load-order rule in **one direction only**:

> A module that does `use "X"` at load time must appear after `X` in the array.

The arc kept walking into the inverse, which was written down nowhere:

**Deleting a `local X = use "Y"` is not free.** `use` is `_global[name] or loadscript(name)`, so for a module not yet loaded, that call *is* what pulls Y in. Removing an unused local can move a module's load.

PR 5 hit the real case: removing `cfg`'s unused `types_*` aliases orphaned its `use "types"` - and `cfg` sits at `_core` 5 while `types` is 28. Safe only because `cfg.lua` loads `cfg_defaults` itself, which does `use "types"` ~50 lines further into the same load. That took a source dive to establish, twice, because nothing recorded the rule.

## And how to prove a removal

`luac -p` proves syntax, not scope. The failure that matters - a deleted `local` whose assignment or read survives - is **syntactically perfect and dies at hub load** under the restricted env. Worth writing down precisely because "tests green" is not evidence: the unit suite passes on code that cannot load.

- **Bytecode scan, categorical:** `luac -p -l -l core/<file>.lua | grep '_ENV "<name>"'`. `GETTABUP` = dangling read or captured closure; `SETTABUP` = stray global write. Zero hits is proof. (A reviewer on [#454](https://github.com/luadch-ng/luadch/pull/454) brought this - it beats any comment-stripping heuristic.)
- **Boot the hub.** The only end-to-end check.
- Validate the scan against a name you *know* is global in that file first. A grep pattern's silent zero fooled this arc **three times**: a phrase broken across a line, `[a-z_]+` skipping `sha256`, and `local function foo` parsing as a local named `function`.

Part of #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)