### PR TITLE
docs: refresh stale docs after the post-#447 batch + nick-prefix arc

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -404,8 +404,9 @@ jobs:
       # #275 COV-2 holistic review follow-up: the Lua-side unit tests
       # MUST run on Windows too. Linux-only coverage masks divergences
       # in the MinGW UCRT64 Lua 5.4 build (locale-dependent string
-      # ops, integer-width / pattern-class edge cases). Same five
-      # tests as the Linux job, same order.
+      # ops, integer-width / pattern-class edge cases). Same set as the
+      # Linux job (minus the two C-module tests, which are Linux-only),
+      # same order.
       - name: Run iostream unit test
         shell: msys2 {0}
         run: lua5.4 tests/unit/iostream_test.lua

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ The repo bundles all runtime dependencies as source - there is no external packa
 manager. This is intentional (the project ships as a self-contained build) but means
 dependency updates are manual.
 
-### Bundled dependencies (verified 2026-07-05; a dependency bump MUST update this table)
+### Bundled dependencies (verified 2026-07-21; a dependency bump MUST update this table)
 
 | Component   | Bundled version | Path           | Notes                                |
 |-------------|-----------------|----------------|--------------------------------------|
@@ -254,15 +254,18 @@ the index. Do not re-plan closed phases.
 ### Phase 8+ - feature development (current era)
 
 Each Phase-8+ item gets its own tracker issue, scope, and §1a.6 review gate.
-The strict "one phase at a time" discipline (§1b) still applies. Active
-engineering journals: [`PHASE_8_IO.md`](docs/phases/PHASE_8_IO.md) (IO/framing
-rework), [`PHASE_8A.md`](docs/phases/PHASE_8A.md) (ADC input-validation
-audit), [`PHASE_8B_DUAL_STACK.md`](docs/phases/PHASE_8B_DUAL_STACK.md)
-(dual-stack + HBRI).
+The strict "one phase at a time" discipline (§1b) still applies. The Phase-8
+engineering journals ([`PHASE_8_IO.md`](docs/phases/PHASE_8_IO.md) IO/framing
+rework, [`PHASE_8A.md`](docs/phases/PHASE_8A.md) ADC input-validation audit,
+[`PHASE_8B_DUAL_STACK.md`](docs/phases/PHASE_8B_DUAL_STACK.md) dual-stack +
+HBRI) are **historical** - those arcs shipped; read them for the narrative,
+not for open work.
 
 Shipped feature arcs so far (closed trackers, details in the issues): HTTP
 API #82, audit log #84, real HBRI #214, registered-users API family #236,
-subsystem managers #249, client blocker #81, aliases #327.
+subsystem managers #249, client blocker #81, aliases #327, unified blocklist
++ in-hub GeoIP #78/#79/#352, global whitelist/allowlist (#78 deferred item),
+status-push heartbeat #395, inbound webhook receiver #398.
 
 **Unified blocklist arc [#78](https://github.com/luadch-ng/luadch/issues/78)
 COMPLETE + on master (2026-07-10); #78 + #79 + #352 closed.** All precursors
@@ -274,62 +277,51 @@ cross-host to a signed CDN URL), boot-time runtime-dir self-heal
 (`core/ensuredirs.lua` + a `makedir` C primitive #382, #384) with a daemon
 `umask(027)` hardening, and an `etc_blocklist_feeds` reload-throttle (#386).
 
-**Current era: feature plugins + bug-issue triage.** Shipped to master
-(3.2.x, still no `v3.2.0` tag): push/pull status export (`etc_status_push`
-#395), the inbound webhook receiver (`etc_webhook` #398, the first
-`scope="none"` plugin route - live against a Discourse forum + a GitHub org),
-plus Sopor-reported fixes (v3.1.13 ratelimit hub-crash #401, `usr_uptime`
-undercount #405, BLOM smoke de-flake #408; **v3.1.14** Windows `FD_SETSIZE`
-64->1024 hub-crash #416, Sopor - the Windows luasocket build inherited the
-Winsock-default 64-socket `select()` cap; the Linux `>1024` sibling of that
-crash was the `select`->`poll` port, done in #310/#436). Shipped to master
-2026-07-13 (#419/#420/#423 all closed): the
-ADC parser now discards messages with unknown escape sequences per ADC 3.1
-(#419) + hub-bot INF `EM` escaping (#423), and an `etc_webhook` body-field
-`conditions` filter (#420 - fixed a live double-announce by filtering on a
-JSON body field like a GitHub release `action=released` or a Discourse
-opening post, not just the event header).
+**Current state (3.2.x on `master`, still no `v3.2.0` tag).** The items that
+used to sit here as "in flight on `dev`" have all merged. Recently shipped to
+master (frozen history - the live delta is always
+`git log --oneline origin/master..origin/dev`, never a list written here):
 
-**On `dev`, pending testhub validation then a dev->master MERGE** (exact
-delta: `git log --oneline origin/master..origin/dev` - do not trust a list
-written here): the `select`->`poll` event-loop port (#310 / PR #436) which
-removes the ~1024 concurrent-socket ceiling on POSIX and leaves Windows on
-`select`; `core/sysinfo.lua`'s `Get-CimInstance` -> `Get-WmiObject` fallback
-(#432) so old-Windows hubowners (Server 2008 R2 / Win7 = PowerShell 2.0,
-which has no `Get-CimInstance`) get real `+hubinfo` OS/CPU/RAM instead of
-`<UNKNOWN>` (Sopor; the pre-refactor 3.1.x plugin also CRASHED on the
-nil-concat - shipped a v0.30 `cmd_hubinfo` drop-in per §8); a `release.yml`
-zlib-dev fix (#441 - `find_package(ZLIB REQUIRED)` is unconditional but no
-release leg installed the dev package, so the first `v3.2.0` tag would have
-failed the aarch64 build at configure); a repo-wide plugin lang-key guard
-(#442); `CONTRIBUTING.md` documenting the dev-branch policy (#440); and
-three external cleanups from @Kcchouette (#437/#438/#439). Many hubowners
-run ancient Windows (the UCRT release build also needs KB2999226 there -
-the Universal C Runtime). A
-recurring pattern this era:
-a **periodic-fetch plugin must persist its next-fetch deadline across
-`+reload`**, or every reload re-hits a rate-limited provider - fixed twice
-(`etc_blocklist_feeds` #386, `etc_geoip` auto-update #414); general rule in
-[`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) §3. Alongside, the
-`gh issue list --label bug` backlog is worked one at a time (each: deep-dive
-from source per §1a.3/4, since many are old-version reports asking "fixed in
-3.x?"). GitFlow A per fix; batch dev->master as a MERGE commit (never squash
-- see §8 branch hygiene).
+- **`select`->`poll` event-loop port (#310)** - lifts the ~1024 concurrent-
+  socket ceiling on POSIX (the Linux sibling of Sopor's Windows 64-socket
+  `FD_SETSIZE` crash #416); Windows stays on `select`. `hub/hub.c` raises the
+  fd soft limit to hard at boot.
+- **#78 global whitelist / allowlist** - `core/whitelist.lua` consulted by
+  every IP-blocking path so trusted infra (hublist pingers etc.) is exempt
+  from the AUTOMATED blockers (GeoIP / proxydetect / feeds / hub-limit) but
+  NOT from a deliberate manual `+ban` / `+blocklist` (**Model A**: a manual
+  block wins). Engine + `etc_whitelist` + pinger seed + per-plugin guards +
+  HTTP `/v1/whitelist`. NOT extended to `usr_share` / `usr_slots` /
+  `usr_nick_*`.
+- **single-instance lock + port-hijack fix (#433/#434)**, `sysinfo`
+  old-Windows `Get-WmiObject` fallback (#432), `CONTRIBUTING.md` (#440), a
+  repo-wide plugin lang-key guard (#442), a `release.yml` zlib-dev fix (#441),
+  external cleanups from @Kcchouette (#437/#438/#439).
+- **`etc_status_push` #395** (push heartbeat) + **`etc_webhook` #398** (inbound
+  HMAC receiver, first `scope="none"` route) + the ADC unknown-escape discard
+  #419 / hub-bot `EM` escaping #423 / webhook `conditions` filter #420.
+- **the #447 dead-code audit**, then a post-#447 correctness/i18n batch:
+  `cmd_ban` permanent ban (#444 keyword + #475 right-click menu entry),
+  `hub_runtime` store moved out of shipped `core/` (#445), `etc_records`
+  defensive load (#465), exhaustive PLUGIN_API §8 (#457),
+  `etc_cmdlog` / `cmd_userinfo` / blocklist+whitelist i18n + alignment
+  (#460 / #459 / #456).
+- **nick-prefix resolution arc (#473/#474/#477)** - `usr_nick_prefix` re-keys
+  the hub nick table to the PREFIXED nick, so ten operator commands
+  (+ `bot_session_chat`) that resolved an online user by a TYPED base nick
+  silently took the offline path (`+ban` stored but no kick; others no-op).
+  They now fall back to `user:firstnick()` - the `etc_trafficmanager` /
+  upstream-`luadch/luadch#240` idiom; `bot_session_chat` re-keys its whole
+  member/owner identity model to firstnick.
 
-**On `dev`: the #78 allowlist (global whitelist) - 4-PR arc A-D MERGED
-(PRs #427/#431/#429/#430), pending testhub -> dev->master.** The allowlist deferred from the
-unified-blocklist arc. A `core/whitelist.lua` engine consulted by every
-IP-blocking path so trusted infrastructure (hublist pingers etc.) is exempt
-from the AUTOMATED blockers (GeoIP / proxydetect / feeds / hub-limit) - but
-NOT from a deliberate manual `+ban` / `+blocklist` (Model A: a manual block
-wins). Phase A (engine + `blocklist.check_ip` precedence +
-`whitelist.is_whitelisted` sandbox global), B (`+whitelist` plugin +
-bundled hublist-pinger seed, `etc_whitelist`), C (per-plugin guards in
-etc_geoip / etc_proxydetect / usr_hubs - where the log goes quiet), D (HTTP
-`/v1/whitelist`). NOT extended to the share / slots / nick-policy plugins
-(`usr_share` / `usr_slots` / `usr_nick_*`). Source of truth: the
-whitelist-arc PRs (deferred item of
-[#78](https://github.com/luadch-ng/luadch/issues/78)).
+`dev` and `master` track closely; open work is the feature-arc backlog -
+`gh issue list --repo luadch-ng/luadch` (no open bugs). Durable pattern from
+this era: a **periodic-fetch plugin must persist its next-fetch deadline
+across `+reload`**, or every reload re-hits a rate-limited provider - fixed
+twice (`etc_blocklist_feeds` #386, `etc_geoip` #414); general rule in
+[`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) §3. Workflow: GitFlow A per fix
+(deep-dive from source per §1a.3/4); batch dev->master as a MERGE commit
+(never squash - §8 branch hygiene).
 
 **HTTP-endpoint authoring** (which helper for which endpoint shape, envelope
 contract, preflight): see [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) §3 and

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ promoted to `master`, so pull requests go against **`dev`** - see
 - **Atomic plugin saves** ([#133](https://github.com/luadch-ng/luadch/issues/133)) - `util.savearray` / `util.savetable` use tmp + rename so a hub crash mid-write leaves the `.tbl` intact
 - **Docker plugin + language autosync** ([#118](https://github.com/luadch-ng/luadch/pull/118)) - container restarts pull in new bundled scripts and lang files without overwriting operator customisations
 
+### 3.2.x feature era (Phase 8+, on `master`)
+
+- **HTTP / JSON API** ([#82](https://github.com/luadch-ng/luadch/issues/82)) - token-authed REST surface for users, bans, registered users, config, logs, and a live `/v1/events` stream; see [`docs/HTTP_API.md`](docs/HTTP_API.md)
+- **Audit log** ([#84](https://github.com/luadch-ng/luadch/issues/84)) - structured JSONL `onAudit` records across ~20 plugins, exposed via `etc_auditlog` + the HTTP event stream
+- **Unified pre-handshake blocklist + in-hub GeoIP** ([#78](https://github.com/luadch-ng/luadch/issues/78) / [#79](https://github.com/luadch-ng/luadch/issues/79)) - CIDR/IPv6 blocklist with provenance, stealth mode, external feeds (Tor / Spamhaus / AbuseIPDB), MaxMind GeoLite2 country/ASN, and live proxy/VPN detection ([#352](https://github.com/luadch-ng/luadch/issues/352)); operator guide in [`docs/BLOCKLIST.md`](docs/BLOCKLIST.md)
+- **Global allowlist / whitelist** (#78 allowlist) - trusted infrastructure (hublist pingers etc.) exempt from the *automated* blockers, never from a manual ban
+- **Client blocker** ([#81](https://github.com/luadch-ng/luadch/issues/81)) - version-range client filtering
+- **Real dual-stack HBRI** ([#214](https://github.com/luadch-ng/luadch/issues/214)) - secondary-IP verification for IPv4+IPv6 clients
+- **Inbound webhook receiver + status-push heartbeat** ([#398](https://github.com/luadch-ng/luadch/issues/398) / [#395](https://github.com/luadch-ng/luadch/issues/395)) - HMAC-authed inbound webhooks (Discourse / GitHub) and an outbound status heartbeat
+- **`select`->`poll` event loop** ([#310](https://github.com/luadch-ng/luadch/issues/310)) - lifts the ~1024 concurrent-socket ceiling on POSIX
+- **ADC command aliases** ([#327](https://github.com/luadch-ng/luadch/issues/327)) - operator-defined `+alias`es
+
 See [`docs/SECURITY.md`](docs/SECURITY.md) for the full threat model
 and operator guidance.
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -49,9 +49,14 @@ cmake --install build
 
 ```sh
 cd build/install/luadch
-./luadch              # plain ADC on port 5000
-./certs/make_cert.sh  # once, for TLS on port 5001
+./luadch              # TLS-only by default: adcs://<host>:5001
 ```
+
+Fresh installs are **TLS-only** (`ssl_ports = {5001}`, `tcp_ports = {}`);
+the TLS certificate is **auto-generated on first boot** by
+`core/cert_bootstrap.lua` (#77) - no cert step needed.
+`certs/make_cert.{sh,bat}` exist only for manual regeneration. Plain
+`adc://` requires explicitly enabling `tcp_ports` in `cfg/cfg.tbl`.
 
 ---
 
@@ -140,11 +145,12 @@ cmake --install build
 
 ```cmd
 cd build\install\luadch
-Luadch.exe                 :: plain ADC on port 5000
-certs\make_cert.bat        :: once, for TLS on port 5001
+Luadch.exe                 :: TLS-only by default: adcs://<host>:5001
 ```
 
-The OpenSSL DLLs are bundled into the install tree automatically.
+The TLS certificate is auto-generated on first boot (#77);
+`certs\make_cert.bat` is only for manual regeneration. The OpenSSL DLLs are
+bundled into the install tree automatically.
 
 ---
 
@@ -208,14 +214,17 @@ Pi 4 / Pi 5 / Apple Silicon Linux / AWS Graviton, etc.). Verify with
 
 ## First-time login
 
-Whichever platform you built on:
+Whichever platform you built on (TLS-only by default; the certificate is
+auto-generated on first boot, #77):
 
 ```
 Nick:     dummy
 Password: test
-Address:  adc://127.0.0.1:5000     (plain)
-          adcs://127.0.0.1:5001    (TLS, after the cert script)
+Address:  adcs://127.0.0.1:5001    (TLS; production clients should pin the
+                                    keyprint: adcs://host:5001/?kp=SHA256/...)
 ```
+
+Plain `adc://` requires explicitly enabling `tcp_ports` in `cfg/cfg.tbl`.
 
 After login: `+reg <yournick> 100`, `+delreg dummy`, `+reload`. The dummy
 default account is hubowner — **delete it as soon as you have your own**.

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -1123,6 +1123,9 @@ is disabled in `cfg.scripts`, the endpoint returns 404
 | GET | `/v1/whitelist/counts` | read | `etc_whitelist` (= ADC `+whitelist count`) - **landed (#78 allowlist Phase D)** [^http-whitelist-2] |
 | POST | `/v1/whitelist` | admin | `etc_whitelist` (= ADC `+whitelist add`) - **landed (#78 allowlist Phase D)** [^http-whitelist-3] |
 | DELETE | `/v1/whitelist/{id}` | admin | `etc_whitelist` (= ADC `+whitelist del`) - **landed (#78 allowlist Phase D)** [^http-whitelist-4] |
+| GET | `/v1/geoip` | read | `etc_geoip` - GeoIP policy + MMDB status (country/ASN DB freshness) |
+| GET | `/v1/proxydetect` | read | `etc_proxydetect` - proxy/VPN detection provider + cache status |
+| GET | `/v1/blocklist/feeds` | read | `etc_blocklist_feeds` - per-feed refresh status (last pull, entry counts, errors) |
 
 [^http-ban-1]: Returns `{ok:true, data:{bans:[entry, ...]}}`. Each entry carries `id` (1-based index into the live bans array - the same `{id}` accepted by DELETE), `nick`, `cid`, `hash`, `ip`, `reason`, `by_nick`, `by_level`, `ban_seconds`, `ban_start` (epoch seconds, hub clock), `permanent` (bool - a permanent ban never expires; #444), `remaining_seconds` (can be negative for not-yet-pruned-expired entries; pruning happens on `onConnect` of the banned user, not on a timer), and `expires_at` (ISO 8601 UTC, omitted when `remaining_seconds <= 0`). **For a permanent ban** (`permanent:true`) `ban_seconds` is `0` and BOTH `remaining_seconds` and `expires_at` are omitted - a consumer distinguishes "permanent" from "expired-not-yet-pruned" by the `permanent` flag, not by the absent expiry. The `id` is NOT a stable surrogate key - it shifts every time a ban is removed (the underlying `bans` array is reindexed by `table.remove`). Operators / tooling MUST re-list before issuing a follow-up DELETE.
 

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -277,6 +277,7 @@ claimed.
 |---|---|---|
 | `onStart` | `function()` | Plugin loaded at hub startup or `+restartscripts` |
 | `onExit` | `function()` | Plugin unloaded at hub shutdown or `+restartscripts` |
+| `onShutdown` | `function()` | Hub is shutting down (fired once, distinct from `onExit`'s per-plugin unload) |
 | `onError` | `function( msg )` | Lua error in another listener (do not raise here - infinite loop) |
 | `onTimer` | `function()` | Fires roughly once per second |
 | `onConnect` | `function( user )` | User passed identify state, before login completes |
@@ -294,6 +295,7 @@ claimed.
 | `onSearchResult` | `function( user, targetuser, adccmd )` | Incoming DRES / FRES search result |
 | `onReg` | `function( nick )` | A user was successfully registered. `nick` is the firstnick |
 | `onDelreg` | `function( nick )` | A user was successfully delregistered. `nick` is the firstnick |
+| `onAudit` | `function( event )` | An audit record was emitted (via `audit.fire`); `event` is the structured audit object. Backs `etc_auditlog` + the HTTP `/v1/events` stream (#84) |
 | `onFailedAuth` | `function( nick, ip, cid, reason )` | Authentication failed at any stage during login |
 
 > **Rate-limit interaction:** per-user rate limits fire before the
@@ -359,10 +361,13 @@ local regs, regs_by_nick, regs_by_cid = hub.getregusers()
 ```
 
 > `hub.getusers()` returns three tables of decreasing strictness.
-> The first table is documented as "no-bot, normal state" but
-> currently contains bots due to [#179](https://github.com/luadch-ng/luadch/issues/179).
-> Plugins should defensively filter via `if not user:isbot() then`
-> until that issue is fixed.
+> The first (`_nobot_normalstatesids`) is **normal-state humans only** -
+> bots are inserted into the second/third tables only, never the first
+> (a single-assignment `for _, u in pairs( hub.getusers() )` therefore
+> iterates humans-only). Use it for per-human iteration; reach for the
+> second/third table when you deliberately need bots or in-handshake
+> connections. ([#179](https://github.com/luadch-ng/luadch/issues/179),
+> which had bots leaking into the first table, is fixed.)
 
 #### Escaping
 
@@ -866,12 +871,16 @@ returning `PROCESSED` blocks plugins later in the list. For
 "catch-all" plugins like `etc_unknown_command.lua`, place them at
 the tail of `cfg.scripts`.
 
-### 10.5 Bots in user iteration
+### 10.5 Picking the right `getusers()` table
 
-`hub.getusers()`'s first return is documented as "no-bot, normal
-state" but currently contains bots due to a known
-[issue](https://github.com/luadch-ng/luadch/issues/179). Filter
-defensively with `if not user:isbot() then` for any per-human iteration.
+`hub.getusers()` returns three tables (see §5.1). The first
+(`_nobot_normalstatesids`) is normal-state **humans only** - bots go into
+the second/third tables, never the first - so a single-assignment
+`for _, u in pairs( hub.getusers() )` iterates humans-only. Use the second
+table when you deliberately need bots too. (The old
+[#179](https://github.com/luadch-ng/luadch/issues/179) bot-leak into the
+first table is fixed; the `if not user:isbot() then` guard is no longer
+needed for the first table, only harmless.)
 
 ### 10.6 Forbidden post-login INF fields
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,10 +23,10 @@ tests/
                   CIDs and password challenge responses for the login
                   flow tests. Self-tests on import.
   unit/
-    iostream_test.lua  Pure-Lua unit test for core/iostream.lua
-                  (Phase 8 framing pipeline). Stubs the `use` sandbox
-                  shim, loads the module standalone, asserts the
-                  stage/pipeline contract. Exit 0/1.
+    *_test.lua    Pure-Lua unit tests (one per module/plugin) - stub the
+                  `use` sandbox shim / plugin globals, load the target
+                  standalone, assert its contract. Exit 0/1. Run
+                  `ls tests/unit/*.lua` for the current set.
   README.md       (this file)
 ```
 
@@ -51,9 +51,8 @@ tests/
   matching `CID = Tiger(PID)`, GPA salt receipt, HPAS response
   computed as `Tiger(password || salt)`. Asserts the hub transitions
   the client to NORMAL state by emitting our own BINF echo. Exercises
-  `createuser`'s user object end-to-end (the user object factory is
-  the largest single function in `core/hub.lua` and a top target for
-  the Phase 6d refactor), the BINF parser, salt generation, and
+  `createuser`'s user object end-to-end (the user object factory in
+  `core/hub_user_object.lua`), the BINF parser, salt generation, and
   password verification.
 - **TLS ADC full login (dummy/test).** Same login flow over TLS.
 - **`+cmd` routing (post-login `+help`).** After a successful login,
@@ -111,11 +110,13 @@ lua tests/unit/iostream_test.lua      # exit 0 = all pass, 1 = a failure
 
 **These run in CI on BOTH platforms.** `.github/workflows/smoke.yml` runs
 the whole `tests/unit/*_test.lua` set on the Linux leg (`lua5.4`) and the
-Windows leg (msys2 `lua`) before the build+smoke step. When you add a unit
-test you MUST add a step for it to both legs, or it is silent
-non-coverage. (The one exception is `adclib_unescape_test.lua`, which
-needs the built C module and so runs on the Linux leg only, after install,
-with `LD_LIBRARY_PATH=.`.)
+Windows leg (msys2 `lua5.4`, the versioned `lua54` package - the unversioned
+`lua` rolled to Lua 5.5 and broke the suite, #388) before the build+smoke
+step. When you add a unit test you MUST add a step for it to both legs, or
+it is silent non-coverage. (The exceptions are the C-module tests -
+`adclib_unescape_test.lua` and `zlib_stream_test.lua` - which need the built
+C module and so run on the Linux leg only, after install, with
+`LD_LIBRARY_PATH=.`.)
 
 The unit-test authoring contract + the regression-fail-pre-fix recipe are
 in [`../docs/DEVELOPMENT.md`](../docs/DEVELOPMENT.md) §4.


### PR DESCRIPTION
Housekeeping doc-refresh. A 3-agent staleness audit (each verified against code/git/gh) found the docs had drifted after the large post-#447 batch + nick-prefix resolution arc landed on master. **Docs-only, no code change.**

## Fixes (most-harmful first)

| File | What was stale | Fix |
|---|---|---|
| **CLAUDE.md §5** | The whole "current era" block described work as "in flight on dev pending merge" (whitelist arc, `select`->`poll` #310, #432/#440/#441/#442, #437-439) that is **all on master**; the post-#447 batch + nick-prefix arc were missing | Rewrote to a compact "recently shipped (frozen)" summary + `git log`/`gh issue list` as the live source of truth; demoted PHASE_8_* journals to historical; bumped §2 deps "verified" date |
| **BUILDING.md** | First-run told operators `adc://...:5000` (plain) + run `make_cert` | TLS-only `adcs://...:5001`, cert auto-generated on first boot (#77) |
| **tests/README.md** | Windows leg "msys2 `lua`" (should be `lua5.4`, #388); one C-module exception (now two); "Phase 6d refactor" framing; layout implied one unit test | all corrected |
| **PLUGIN_API.md** | §4.4 event table missing `onShutdown` + `onAudit`; stale "#179 first getusers table contains bots" claim | added the two events; #179 is fixed, first table is humans-only |
| **HTTP_API.md** | §10 catalog missing 3 live read endpoints | added `GET /v1/geoip`, `/v1/proxydetect`, `/v1/blocklist/feeds` |
| **README.md** | "New Features" frozen pre-Phase-8 | added a "3.2.x feature era" block |
| **smoke.yml** | "Same five tests" comment | ~45 now |

## Verification
Each finding was established from source by the audit agents; the applied diff was then re-verified by an independent review pass (issue attributions vs `git log origin/master`, `onShutdown`/`onAudit` fire sites, getusers bot-free, the 3 endpoints registered at `read` scope, TLS-only defaults, no em-dashes, no dead links, no new point-in-time rot). `PLUGIN_API.md` §8 seam-only roster was audited and confirmed **already correct** (12) - not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)