### PR TITLE
feat(backup): automatic-backup engine + scheduler plugin (PR-A of #480)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -221,6 +221,12 @@ jobs:
       - name: Run backup engine unit test
         run: lua5.4 tests/unit/backup_test.lua
 
+      # scripts/etc_backup.lua (#480 PR-A) schedule math: daily-at HH:MM
+      # (today-vs-tomorrow slot), interval-from-anchor, overdue-fires-now,
+      # invalid HH:MM falls back to the interval. Loaded with stubbed globals.
+      - name: Run etc_backup schedule unit test
+        run: lua5.4 tests/unit/etc_backup_schedule_test.lua
+
       # #78 Precursor 0d: core/cacert_bootstrap.lua reconcile_bundle
       # decision-matrix (source-missing / installed / no-op / warned /
       # auto-updated branches). Uses OS temp dir for file fixtures.
@@ -545,6 +551,10 @@ jobs:
       - name: Run backup engine unit test
         shell: msys2 {0}
         run: lua5.4 tests/unit/backup_test.lua
+
+      - name: Run etc_backup schedule unit test
+        shell: msys2 {0}
+        run: lua5.4 tests/unit/etc_backup_schedule_test.lua
 
       - name: Run cacert_bootstrap unit test
         shell: msys2 {0}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -214,6 +214,13 @@ jobs:
       - name: Run backup_archive unit test
         run: lua5.4 tests/unit/backup_archive_test.lua
 
+      # core/backup.lua (#480 PR-A) engine: collection spec (which files +
+      # modes + master.key toggle + .tbl/.tmp filter), rotation victim
+      # selection, cfg/secrets config interpretation. Pure seams; the full
+      # read/pack/write path is covered by the backup smoke test.
+      - name: Run backup engine unit test
+        run: lua5.4 tests/unit/backup_test.lua
+
       # #78 Precursor 0d: core/cacert_bootstrap.lua reconcile_bundle
       # decision-matrix (source-missing / installed / no-op / warned /
       # auto-updated branches). Uses OS temp dir for file fixtures.
@@ -534,6 +541,10 @@ jobs:
       - name: Run backup_archive unit test
         shell: msys2 {0}
         run: lua5.4 tests/unit/backup_archive_test.lua
+
+      - name: Run backup engine unit test
+        shell: msys2 {0}
+        run: lua5.4 tests/unit/backup_test.lua
 
       - name: Run cacert_bootstrap unit test
         shell: msys2 {0}

--- a/adclib/adclib.cpp
+++ b/adclib/adclib.cpp
@@ -728,6 +728,10 @@ int pbkdf2_sha256(lua_State* L)
     size_t pw_len, salt_len;
     const char* pw   = luaL_checklstring(L, 1, &pw_len);
     const char* salt = luaL_checklstring(L, 2, &salt_len);
+    if (pw_len > INT_MAX || salt_len > INT_MAX)
+    {
+        return luaL_error(L, "pbkdf2_sha256: password/salt too large");
+    }
     lua_Integer iters = luaL_checkinteger(L, 3);
     lua_Integer dklen = luaL_checkinteger(L, 4);
     if (iters < 1 || iters > 100000000)

--- a/adclib/adclib.cpp
+++ b/adclib/adclib.cpp
@@ -711,6 +711,44 @@ int unescape(lua_State* L)
     return 1;
 }
 
+/*
+ * pbkdf2_sha256(password, salt, iterations, dklen) -> derived key (raw bytes)
+ *
+ * PBKDF2-HMAC-SHA256 via OpenSSL. The pure-Lua PBKDF2 in
+ * core/backup_archive.lua is correct but ~tens of seconds at 200k
+ * iterations - far too slow for the single-threaded hub, which would freeze
+ * for the whole backup. This C path derives the SAME key (PBKDF2 is
+ * deterministic) in ~1ms, so the backup passphrase keeps a strong iteration
+ * count without stalling the loop. The Lua impl stays as the standalone /
+ * self-test fallback and cross-checks against this one at load.
+ */
+int pbkdf2_sha256(lua_State* L)
+{
+    ERR_clear_error();
+    size_t pw_len, salt_len;
+    const char* pw   = luaL_checklstring(L, 1, &pw_len);
+    const char* salt = luaL_checklstring(L, 2, &salt_len);
+    lua_Integer iters = luaL_checkinteger(L, 3);
+    lua_Integer dklen = luaL_checkinteger(L, 4);
+    if (iters < 1 || iters > 100000000)
+    {
+        return luaL_error(L, "pbkdf2_sha256: iterations out of range (1..100000000)");
+    }
+    if (dklen < 1 || dklen > 1024)
+    {
+        return luaL_error(L, "pbkdf2_sha256: dklen out of range (1..1024)");
+    }
+    unsigned char out[1024];
+    if (PKCS5_PBKDF2_HMAC(pw, (int)pw_len,
+                          (const unsigned char *)salt, (int)salt_len,
+                          (int)iters, EVP_sha256(), (int)dklen, out) != 1)
+    {
+        return luaL_error(L, "pbkdf2_sha256: PKCS5_PBKDF2_HMAC failed");
+    }
+    lua_pushlstring(L, (const char *)out, (size_t)dklen);
+    return 1;
+}
+
 static const luaL_Reg adclib[] = {
     {"hash", hash_pid},
     {"hashpas", hash_pas},
@@ -722,6 +760,7 @@ static const luaL_Reg adclib[] = {
     {"random_bytes", random_bytes},
     {"aes_gcm_seal", aes_gcm_seal},
     {"aes_gcm_open", aes_gcm_open},
+    {"pbkdf2_sha256", pbkdf2_sha256},
     {"gen_self_signed_cert", gen_self_signed_cert},
     {"cert_fingerprint_sha256", cert_fingerprint_sha256},
     {"constant_time_eq", constant_time_eq},

--- a/core/backup.lua
+++ b/core/backup.lua
@@ -57,10 +57,12 @@ local table       = use "table"
 local table_sort  = table.sort
 
 local os        = use "os"
-local os_time   = os.time
-local os_date   = os.date
-local os_rename = os.rename
-local os_remove = os.remove
+local os_time    = os.time
+local os_date    = os.date
+local os_rename  = os.rename
+local os_remove  = os.remove
+local os_getenv  = os.getenv
+local os_execute = os.execute
 
 local io        = use "io"
 local io_open   = io.open
@@ -100,7 +102,7 @@ local MASTERKEY_ENTRY  = "__masterkey__"
 local BACKUP_PREFIX     = "luadch-backup-"
 local BACKUP_SUFFIX     = ".ldbk"
 local SIDECAR_SUFFIX    = ".sha256"
-local DEFAULT_DIR       = "backups"
+local DEFAULT_DIR       = "cfg/backups"
 local DEFAULT_KEEP      = 7
 
 ----------------------------------// CONFIG SNAPSHOT //--
@@ -247,6 +249,16 @@ local function _write_atomic( path, content )
     return false, rerr or "rename failed"
 end
 
+-- POSIX chmod 600 on the sealed artifact - it bundles the (encrypted)
+-- master.key / user.tbl / serverkey, so keep it owner-only even though the
+-- AES-256-GCM sealing already protects the contents (the daemon umask leaves
+-- new files group-readable). Best-effort, no-op on Windows. Mirrors
+-- cfg_secret's helper.
+local function _chmod_600( path )
+    if os_getenv "COMSPEC" and os_getenv "WINDIR" then return end
+    os_execute( "chmod 600 '" .. tostring( path ):gsub( "'", "'\\''" ) .. "'" )
+end
+
 ----------------------------------// PUBLIC: READINESS //--
 
 -- Config sanity the owner nag enumerates. Never raises; returns a list of
@@ -331,6 +343,7 @@ local function run( )
     if not wok then
         return nil, "backup: cannot write '" .. path .. "': " .. tostring( werr )
     end
+    _chmod_600( path )
 
     -- Sidecar: passphrase-free integrity check (sha256sum -c). Best-effort -
     -- the backup itself already succeeded.

--- a/core/backup.lua
+++ b/core/backup.lua
@@ -1,0 +1,397 @@
+--[[
+
+    core/backup.lua - automatic-backup engine (#480, PR-A).
+
+    The operator-state collector + rotation layer on top of the LDBK1
+    archive format (core/backup_archive.lua). Given the hub's own config,
+    it gathers the restore-minimum set of files, seals them into one
+    encrypted `.ldbk` artifact (+ a `.sha256` sidecar), writes it to the
+    configured backup directory, and prunes old artifacts to a retention
+    count. The offline restore path (PR-B) consumes the same archive.
+
+    Exposed to the plugin sandbox (core/scripts.lua SANDBOX_GLOBALS) so the
+    thin scheduler/CLI plugin scripts/etc_backup.lua can drive it:
+        backup.readiness()  -> { ok, issues }   -- config sanity for the owner nag
+        backup.run()        -> result | nil,err -- produce one backup now
+        backup.list()       -> rows | nil,err    -- artifacts in the backup dir
+
+    SECURITY: the engine reads its own policy (dir / keep / passphrase /
+    include_master_key) straight from cfg + core/secrets - it does NOT take
+    them as caller arguments. A sandboxed plugin can therefore only TRIGGER
+    a backup to the operator-configured destination with the operator's
+    passphrase; it cannot redirect the artifact to an arbitrary absolute
+    path or substitute a key it controls. Reading master.key / user.tbl is
+    no new power either - a plugin's path-restricted io already reaches the
+    in-tree cfg/ files; the engine only adds orchestration.
+
+    Passive at load: no init(), no file I/O when the chunk runs. cfg/out are
+    bound at file scope (this module loads after them in _core) and only
+    called at run time.
+
+    Collection set (see docs/BACKUP.md, PR-B):
+        cfg/cfg.tbl, cfg/user.tbl (+ .bak), the TLS material from ssl_params
+        (serverkey.pem = secret 0600, servercert.pem, cacert.pem), every
+        scripts/data/*.tbl + scripts/cfg/*.tbl, and - when included -
+        master.key at master_key_path (stored under the "__masterkey__"
+        sentinel; the real path travels in the manifest so restore can put
+        it back, even when it lives outside the tree). *.tmp is skipped.
+
+]]--
+
+----------------------------------// DECLARATION //--
+
+local use = use
+
+local type      = use "type"
+local pcall     = use "pcall"
+local tostring  = use "tostring"
+local tonumber  = use "tonumber"
+local ipairs    = use "ipairs"
+
+local string       = use "string"
+local string_match = string.match
+local string_gsub  = string.gsub
+local string_sub   = string.sub
+
+local table       = use "table"
+local table_sort  = table.sort
+
+local os        = use "os"
+local os_time   = os.time
+local os_date   = os.date
+local os_rename = os.rename
+local os_remove = os.remove
+
+local io        = use "io"
+local io_open   = io.open
+
+--// core scripts //--
+
+local const         = use "const"
+local PROGRAM_NAME  = const.PROGRAM_NAME
+local VERSION       = const.VERSION
+
+local cfg     = use "cfg"
+local cfg_get = cfg.get
+
+local out       = use "out"
+local out_put   = out.put
+local out_error = out.error
+
+local secrets        = use "secrets"
+local secrets_lookup = secrets.lookup
+
+local archive = use "backup_archive"
+
+-- Raw C primitives from hub.c (core-only, NOT sandboxed). Used directly -
+-- not the safe_path-gated util wrappers - because the backup directory and
+-- master_key_path are operator-configured and MAY be absolute (a mounted
+-- volume, a key relocated out of the tree). Same rationale cfg_secret uses
+-- for the master.key parent dir.
+local makedir = use "makedir"
+local listdir = use "listdir"
+
+----------------------------------// CONSTANTS //--
+
+local MODE_SECRET = 384   -- 0600 (master.key, serverkey.pem)
+local MODE_STATE  = 416   -- 0640 (everything else)
+
+local MASTERKEY_ENTRY  = "__masterkey__"
+local BACKUP_PREFIX     = "luadch-backup-"
+local BACKUP_SUFFIX     = ".ldbk"
+local SIDECAR_SUFFIX    = ".sha256"
+local DEFAULT_DIR       = "backups"
+local DEFAULT_KEEP      = 7
+
+----------------------------------// CONFIG SNAPSHOT //--
+
+-- Strip a trailing slash so `dir .. "/" .. name` never doubles it.
+local function _norm_dir( dir )
+    return ( string_gsub( dir, "[/\\]+$", "" ) )
+end
+
+-- Read the engine's policy from cfg + secrets. Central so run/readiness/
+-- list share one interpretation of the defaults.
+local function _config( )
+    local enabled = cfg_get "etc_backup_enabled"
+    if enabled == nil then enabled = true end
+
+    local dir = cfg_get "etc_backup_dir"
+    if type( dir ) ~= "string" or dir == "" then dir = DEFAULT_DIR end
+    dir = _norm_dir( dir )
+
+    local keep = tonumber( cfg_get "etc_backup_keep" ) or DEFAULT_KEEP
+    if keep < 1 then keep = 1 end
+
+    local include_mk = cfg_get "etc_backup_include_master_key"
+    if include_mk == nil then include_mk = true end
+
+    -- env-var-first via core/secrets; falls back to cfg.tbl for bare-metal.
+    local passphrase = secrets_lookup( "etc_backup_passphrase" )
+
+    return {
+        enabled    = enabled,
+        dir        = dir,
+        keep       = keep,
+        include_mk = include_mk,
+        passphrase = ( type( passphrase ) == "string" and passphrase ~= "" ) and passphrase or nil,
+    }
+end
+
+local function _master_key_path( )
+    local mkp = cfg_get "master_key_path"
+    if type( mkp ) == "string" and mkp ~= "" then return mkp end
+    return "cfg/master.key"
+end
+
+----------------------------------// COLLECTION //--
+
+-- Build the file plan (what to back up + where each entry restores to),
+-- WITHOUT reading anything - pure and unit-testable. `lister(dir)` injects
+-- the directory enumerator (the raw listdir primitive at run time, a stub
+-- in tests). Each item: { read = <path to open>, name = <tar/restore name>,
+-- mode = <octal perms>, kind = "tree"|"masterkey" }.
+local function _collection_spec( include_mk, master_key_path, ssl, lister )
+    local spec = {
+        { read = "cfg/cfg.tbl",      name = "cfg/cfg.tbl",      mode = MODE_STATE,  kind = "tree" },
+        { read = "cfg/user.tbl",     name = "cfg/user.tbl",     mode = MODE_STATE,  kind = "tree" },
+        { read = "cfg/user.tbl.bak", name = "cfg/user.tbl.bak", mode = MODE_STATE,  kind = "tree" },
+    }
+
+    ssl = ssl or { }
+    local key_pem  = ssl.key         or "certs/serverkey.pem"
+    local cert_pem = ssl.certificate or "certs/servercert.pem"
+    local ca_pem   = ssl.cafile      or "certs/cacert.pem"
+    spec[ #spec + 1 ] = { read = key_pem,  name = key_pem,  mode = MODE_SECRET, kind = "tree" }
+    spec[ #spec + 1 ] = { read = cert_pem, name = cert_pem, mode = MODE_STATE,  kind = "tree" }
+    spec[ #spec + 1 ] = { read = ca_pem,   name = ca_pem,   mode = MODE_STATE,  kind = "tree" }
+
+    if include_mk then
+        spec[ #spec + 1 ] = {
+            read = master_key_path, name = MASTERKEY_ENTRY, mode = MODE_SECRET, kind = "masterkey",
+        }
+    end
+
+    -- Variable plugin state. Enumerate scripts/data + scripts/cfg; take the
+    -- .tbl files, skip the .tmp half-writes of an in-flight atomic save.
+    for _, dir in ipairs( { "scripts/data", "scripts/cfg" } ) do
+        local names = lister( dir )
+        if type( names ) == "table" then
+            table_sort( names )   -- deterministic order
+            for _, n in ipairs( names ) do
+                if string_match( n, "%.tbl$" ) and not string_match( n, "%.tmp$" ) then
+                    local p = dir .. "/" .. n
+                    spec[ #spec + 1 ] = { read = p, name = p, mode = MODE_STATE, kind = "tree" }
+                end
+            end
+        end
+    end
+
+    return spec
+end
+
+-- Match a backup artifact name by plain prefix + suffix. Deliberately NOT a
+-- Lua pattern: BACKUP_PREFIX contains '-', which is a pattern magic char
+-- (a quantifier), so a naive `string_match` silently matches nothing. The
+-- ".sha256" sidecar ends in .sha256, so the .ldbk suffix check excludes it.
+local function _is_backup_name( n )
+    return #n > #BACKUP_PREFIX + #BACKUP_SUFFIX
+        and string_sub( n, 1, #BACKUP_PREFIX ) == BACKUP_PREFIX
+        and string_sub( n, -#BACKUP_SUFFIX ) == BACKUP_SUFFIX
+end
+
+-- Pick the artifacts to prune: keep the newest `keep` luadch-backup-*.ldbk
+-- (timestamped names sort lexicographically = chronologically), return the
+-- older ones. Pure/testable. `names` is a raw directory listing.
+local function _rotation_victims( names, keep )
+    local backups = { }
+    for _, n in ipairs( names ) do
+        if _is_backup_name( n ) then
+            backups[ #backups + 1 ] = n
+        end
+    end
+    table_sort( backups )
+    local victims = { }
+    local drop = #backups - keep
+    for i = 1, drop do
+        victims[ #victims + 1 ] = backups[ i ]
+    end
+    return victims
+end
+
+----------------------------------// IO HELPERS //--
+
+local function _read_file( path )
+    local f = io_open( path, "rb" )
+    if not f then return nil end
+    local content = f:read "*a"
+    f:close( )
+    return content
+end
+
+-- Atomic write via tmp + rename. Raw (no safe_path) so an absolute,
+-- operator-configured backup dir works; the paths are trusted cfg, not
+-- untrusted input. Mirrors util.atomic_write's Windows fallback.
+local function _write_atomic( path, content )
+    local tmp = path .. ".tmp"
+    local f, err = io_open( tmp, "wb" )
+    if not f then return false, err end
+    local ok, werr = f:write( content )
+    f:close( )
+    if not ok then os_remove( tmp ); return false, werr end
+    if os_rename( tmp, path ) then return true end
+    os_remove( path )
+    local rok, rerr = os_rename( tmp, path )
+    if rok then return true end
+    os_remove( tmp )
+    return false, rerr or "rename failed"
+end
+
+----------------------------------// PUBLIC: READINESS //--
+
+-- Config sanity the owner nag enumerates. Never raises; returns a list of
+-- machine-readable issue codes (the plugin localises them).
+local function readiness( )
+    local c = _config( )
+    local issues = { }
+
+    if not c.passphrase then
+        issues[ #issues + 1 ] = "no_passphrase"
+    end
+
+    -- Backup dir must be creatable + writable. Probe with a temp file so we
+    -- catch a read-only / missing-parent destination before backup time.
+    local mkok = makedir( c.dir )
+    local probe = c.dir .. "/.backup_write_test"
+    local wok = mkok and _write_atomic( probe, "ok" )
+    if wok then os_remove( probe ) else
+        issues[ #issues + 1 ] = "backup_dir_unwritable"
+    end
+
+    if c.include_mk then
+        local mkp = _master_key_path( )
+        local f = io_open( mkp, "rb" )
+        if f then f:close( ) else
+            issues[ #issues + 1 ] = "master_key_unreadable"
+        end
+    end
+
+    return { ok = #issues == 0, issues = issues }
+end
+
+----------------------------------// PUBLIC: RUN //--
+
+local function run( )
+    local c = _config( )
+    if not c.enabled then
+        return nil, "backup: disabled (etc_backup_enabled = false)"
+    end
+    if not c.passphrase then
+        return nil, "backup: no passphrase configured (etc_backup_passphrase / LUADCH_ETC_BACKUP_PASSPHRASE)"
+    end
+
+    local mkp = c.include_mk and _master_key_path( ) or nil
+    local spec = _collection_spec( c.include_mk, mkp, cfg_get "ssl_params", listdir )
+
+    local files, included, skipped = { }, 0, 0
+    for _, item in ipairs( spec ) do
+        local body = _read_file( item.read )
+        if body then
+            files[ #files + 1 ] = { name = item.name, mode = item.mode, body = body, kind = item.kind }
+            included = included + 1
+        else
+            skipped = skipped + 1
+        end
+    end
+    if included == 0 then
+        return nil, "backup: nothing to back up (no state files found)"
+    end
+
+    local meta = {
+        program            = PROGRAM_NAME,
+        hub_version        = VERSION,
+        created_at         = os_time( ),
+        include_master_key = c.include_mk and true or false,
+    }
+    if mkp then meta.master_key_path = mkp end
+
+    local blob, perr = archive.pack( files, meta, c.passphrase )
+    if not blob then
+        return nil, "backup: seal failed: " .. tostring( perr )
+    end
+
+    local mkdir_ok, mkdir_err = makedir( c.dir )
+    if not mkdir_ok then
+        return nil, "backup: cannot create backup dir '" .. c.dir .. "': " .. tostring( mkdir_err )
+    end
+
+    local fname = BACKUP_PREFIX .. os_date( "%Y%m%d-%H%M%S" ) .. BACKUP_SUFFIX
+    local path  = c.dir .. "/" .. fname
+    local wok, werr = _write_atomic( path, blob )
+    if not wok then
+        return nil, "backup: cannot write '" .. path .. "': " .. tostring( werr )
+    end
+
+    -- Sidecar: passphrase-free integrity check (sha256sum -c). Best-effort -
+    -- the backup itself already succeeded.
+    local sidecar = path .. SIDECAR_SUFFIX
+    local sok = _write_atomic( sidecar, archive.sidecar_line( archive.checksum( blob ), fname ) )
+    if not sok then
+        out_error( "backup: wrote artifact but sidecar failed: ", sidecar )
+        sidecar = nil
+    end
+
+    -- Rotation: prune oldest beyond keep (artifact + its sidecar).
+    local names = listdir( c.dir )
+    if type( names ) == "table" then
+        for _, victim in ipairs( _rotation_victims( names, c.keep ) ) do
+            os_remove( c.dir .. "/" .. victim )
+            os_remove( c.dir .. "/" .. victim .. SIDECAR_SUFFIX )
+        end
+    end
+
+    out_put( "backup: wrote ", path, " (", #blob, " bytes, ", included, " files, ", skipped, " skipped)" )
+    return {
+        path    = path,
+        sidecar = sidecar,
+        bytes   = #blob,
+        files   = included,
+        skipped = skipped,
+    }
+end
+
+----------------------------------// PUBLIC: LIST //--
+
+-- Rows describing the artifacts currently in the backup dir, newest first,
+-- for `+backup list`.
+local function list( )
+    local c = _config( )
+    local names = listdir( c.dir )
+    if type( names ) ~= "table" then
+        return { }   -- dir missing / empty = no backups yet
+    end
+    local rows = { }
+    for _, n in ipairs( names ) do
+        if _is_backup_name( n ) then
+            local size
+            local f = io_open( c.dir .. "/" .. n, "rb" )
+            if f then size = f:seek "end"; f:close( ) end
+            rows[ #rows + 1 ] = { name = n, bytes = size }
+        end
+    end
+    table_sort( rows, function( a, b ) return a.name > b.name end )   -- newest first
+    return rows
+end
+
+----------------------------------// PUBLIC INTERFACE //--
+
+return {
+    readiness = readiness,
+    run       = run,
+    list      = list,
+
+    -- test seams
+    _collection_spec  = _collection_spec,
+    _rotation_victims = _rotation_victims,
+    _config           = _config,
+}

--- a/core/backup_archive.lua
+++ b/core/backup_archive.lua
@@ -87,6 +87,9 @@ local adclib = use "adclib"
 local adclib_random_bytes = adclib.random_bytes
 local adclib_aes_gcm_seal = adclib.aes_gcm_seal
 local adclib_aes_gcm_open = adclib.aes_gcm_open
+-- OpenSSL PBKDF2 (fast). nil on a standalone lua / stubbed adclib, where
+-- _derive_key falls back to the pure-Lua PBKDF2 below.
+local adclib_pbkdf2 = adclib.pbkdf2_sha256
 
 --// core scripts //--
 
@@ -135,13 +138,13 @@ end
 -- needed here (a 256-bit AES key), so a single block index (1) suffices:
 -- DK = U1 XOR U2 XOR ... XOR Uc, Ui = HMAC(pass, U(i-1)), U1 = HMAC(pass,
 -- salt || INT32_BE(1)).
-local function _pbkdf2( password, salt, iters, dklen )
+local function _pbkdf2_lua( password, salt, iters, dklen )
     dklen = dklen or KEY_SIZE
     if dklen > 32 then
-        error( "backup_archive._pbkdf2: dklen > 32 unsupported", 2 )
+        error( "backup_archive._pbkdf2_lua: dklen > 32 unsupported", 2 )
     end
     if type( iters ) ~= "number" or iters < 1 then
-        error( "backup_archive._pbkdf2: iters must be a number >= 1", 2 )
+        error( "backup_archive._pbkdf2_lua: iters must be a number >= 1", 2 )
     end
     local u = hmac_bytes( password, salt .. string_pack( ">I4", 1 ) )
     local t = u
@@ -150,6 +153,19 @@ local function _pbkdf2( password, salt, iters, dklen )
         t = _xor32( t, u )
     end
     return string_sub( t, 1, dklen )
+end
+
+-- Derive the AES key. Prefer OpenSSL's PBKDF2 via adclib: the pure-Lua one
+-- is correct but runs ~tens of seconds at the default iteration count, which
+-- would freeze the single-threaded hub for the whole backup. Both produce
+-- the SAME key (PBKDF2 is deterministic), so artifacts stay interoperable
+-- regardless of which path sealed / opens them; the Lua path is the
+-- standalone / no-adclib fallback (unit tests, a broken build).
+local function _derive_key( password, salt, iters, dklen )
+    if type( adclib_pbkdf2 ) == "function" then
+        return adclib_pbkdf2( password, salt, iters, dklen or KEY_SIZE )
+    end
+    return _pbkdf2_lua( password, salt, iters, dklen )
 end
 
 ----------------------------------// USTAR //--
@@ -396,7 +412,7 @@ local function pack( files, meta, passphrase, opts )
     if type( salt ) ~= "string" or #salt ~= SALT_SIZE then
         return nil, "backup_archive: RNG failed (salt)"
     end
-    local key = _pbkdf2( passphrase, salt, iters, KEY_SIZE )
+    local key = _derive_key( passphrase, salt, iters, KEY_SIZE )
     local nonce = adclib_random_bytes( NONCE_SIZE )
     if type( nonce ) ~= "string" or #nonce ~= NONCE_SIZE then
         return nil, "backup_archive: RNG failed (nonce)"
@@ -455,7 +471,7 @@ local function unpack( blob, passphrase )
     local nonce = string_sub( blob, nonce_start, ct_start - 1 )
     local ct_tag = string_sub( blob, ct_start )
 
-    local key = _pbkdf2( passphrase, salt, iters, KEY_SIZE )
+    local key = _derive_key( passphrase, salt, iters, KEY_SIZE )
     local ok, tar, oerr = pcall( adclib_aes_gcm_open, key, nonce, ct_tag )
     if not ok then
         return nil, "backup_archive: decrypt error: " .. tostring( tar )
@@ -514,11 +530,17 @@ do
     -- never trust memory for crypto vectors. A silent regression in the
     -- XOR / iteration / block-index logic derives wrong keys, i.e.
     -- unrecoverable backups, so fail loud at load like sha256 / hmac.
-    local dk = _pbkdf2( "password", "salt", 1, KEY_SIZE )
+    local dk = _pbkdf2_lua( "password", "salt", 1, KEY_SIZE )
     local hex = { }
     for i = 1, KEY_SIZE do hex[ i ] = string_format( "%02x", string_byte( dk, i ) ) end
     if table_concat( hex ) ~= "120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b" then
         error( "backup_archive self-test FAILED: PBKDF2-HMAC-SHA256 c=1 vector mismatch", 2 )
+    end
+    -- If the OpenSSL PBKDF2 is present it MUST agree with the vetted pure-Lua
+    -- one - a mismatch would silently make artifacts sealed by one path
+    -- unreadable by the other.
+    if type( adclib_pbkdf2 ) == "function" and adclib_pbkdf2( "password", "salt", 1, KEY_SIZE ) ~= dk then
+        error( "backup_archive self-test FAILED: adclib pbkdf2_sha256 disagrees with the PBKDF2 KAT", 2 )
     end
     -- ustar build -> parse fidelity on a tiny fixture (also proves the
     -- checksum our writer emits validates).
@@ -542,7 +564,8 @@ return {
     DEFAULT_ITERS = DEFAULT_ITERS,
 
     -- test seams
-    _pbkdf2             = _pbkdf2,
+    _pbkdf2             = _pbkdf2_lua,
+    _derive_key        = _derive_key,
     _build_tar          = _build_tar,
     _parse_tar          = _parse_tar,
     _manifest_serialize = _manifest_serialize,

--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -3422,6 +3422,81 @@ local defaults = {
         end
     },
 
+    -- etc_backup.lua (#480): automatic encrypted backups of the operator
+    -- state set. The engine (core/backup.lua) reads dir / keep / passphrase /
+    -- include; the plugin drives the schedule + the owner readiness nag.
+    -- See docs/BACKUP.md.
+    etc_backup_enabled = { true,
+        function( value )
+            return types_boolean( value, nil, true )
+        end
+    },
+    -- Destination. Default cfg/backups so artifacts land under the
+    -- upgrade-preserved cfg/ tree (and the Docker cfg mount). An absolute
+    -- path is allowed (a mounted backup volume); the engine creates it via
+    -- the raw makedir primitive.
+    etc_backup_dir = { "cfg/backups",
+        function( value )
+            return types_utf8( value, nil, true )
+        end
+    },
+    -- Retention: keep the newest N artifacts, prune older ones each run.
+    etc_backup_keep = { 7,
+        function( value )
+            return types_number( value, nil, true )
+                and value % 1 == 0 and value >= 1 and value <= 1000
+        end
+    },
+    -- Primary schedule: a daily backup at this server-local HH:MM. Empty
+    -- string disables the daily slot (falls back to the interval below). The
+    -- plugin parses/validates the HH:MM shape and treats a bad value as "no
+    -- daily slot", so the validator only enforces it is a string.
+    etc_backup_daily_at = { "04:00",
+        function( value )
+            return types_utf8( value, nil, true )
+        end
+    },
+    -- Fallback cadence when etc_backup_daily_at is empty: every N hours
+    -- (0 = off). For hubs wanting more than one backup a day.
+    etc_backup_interval_hours = { 0,
+        function( value )
+            return types_number( value, nil, true )
+                and value % 1 == 0 and value >= 0 and value <= 168
+        end
+    },
+    -- Include master.key in the (encrypted) artifact. Default true for
+    -- self-contained disaster recovery; false keeps the key strictly out of
+    -- the backup (the plugin then warns the operator to save it separately).
+    etc_backup_include_master_key = { true,
+        function( value )
+            return types_boolean( value, nil, true )
+        end
+    },
+    -- Secret: the passphrase that encrypts the artifact (PBKDF2 -> AES-256-
+    -- GCM). Resolved env-var-first via core/secrets (registered by the
+    -- plugin) so GET /v1/config redacts it. Prefer the env var
+    -- LUADCH_ETC_BACKUP_PASSPHRASE over a plaintext value here. Independent
+    -- of master.key - store it out-of-band; losing it makes every artifact
+    -- unrecoverable.
+    etc_backup_passphrase = { "",
+        function( value )
+            return types_utf8( value, nil, true )
+        end
+    },
+    -- Level allowed to run +backup now / list / status. Default 80 (ADMIN).
+    etc_backup_oplevel = { 80,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+    -- Level that receives the "backup not configured / not writable" hubbot
+    -- nag on login + at start. Default 100 (HUBOWNER).
+    etc_backup_notify_level = { 100,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+
     -- etc_webhook.lua: inbound webhook receiver (Discourse / GitHub /
     -- ...). Only the master switch lives in cfg.tbl; ALL endpoint config
     -- (paths, headers, secrets, templates, ...) lives in the

--- a/core/init.lua
+++ b/core/init.lua
@@ -188,6 +188,15 @@ _core = {    -- luadch core, order is important
     -- module is in _G when the plugin sandbox iterates the
     -- whitelist.
     "sysinfo",
+    -- core/backup.lua (#480 PR-A): automatic-backup engine - collects the
+    -- restore-minimum state set, seals it via core/backup_archive.lua, writes
+    -- + rotates the .ldbk artifact. Needs full os.rename/remove + raw
+    -- makedir/listdir + secrets, so it lives in core, not the plugin sandbox.
+    -- Loaded AFTER its file-scope use deps (cfg / out / const / secrets;
+    -- backup_archive loads on demand) and BEFORE scripts so it is in _G when
+    -- the plugin sandbox iterates the whitelist (scripts/etc_backup.lua calls
+    -- backup.run / .readiness / .list). Passive at load - no init(), no I/O.
+    "backup",
     "scripts",
     -- #263: HTTP API event ringbuffer. Loaded AFTER scripts so its
     -- init() can register a core-side tap into scripts.firelistener;

--- a/core/scripts.lua
+++ b/core/scripts.lua
@@ -267,6 +267,13 @@ local SANDBOX_GLOBALS = {
     -- HMAC-SHA256). Raw sha256 deliberately stays OUT of the sandbox -
     -- plugins get the MAC primitive, not the underlying hash.
     "hmac",
+    -- core/backup.lua (#480 PR-A): automatic-backup engine. The thin
+    -- scheduler/CLI plugin etc_backup.lua calls backup.run / .readiness /
+    -- .list. The engine reads its own policy (dir / keep / passphrase /
+    -- include_master_key) from cfg + secrets, NOT from caller args, so a
+    -- plugin can only trigger a backup to the operator-configured
+    -- destination - it cannot redirect the artifact or pick the key.
+    "backup",
     "unicode",
     -- read-only program constants (PROGRAM_NAME / VERSION / FORK /
     -- COPYRIGHT / CONFIG_PATH). Static strings, no capability; lets

--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -1354,6 +1354,19 @@ return { -- the settings are a lua table, do not tough this!
     etc_webhook_activate = false,  -- opt-in. false = never receives. Set true AND define at least one endpoint (with a secret) in cfg/webhooks.tbl to start receiving signed webhooks. (boolean)
 
     ---------------------------------------------------------------------------------------------------------------------------------
+    --// etc_backup.lua settings | AUTOMATIC ENCRYPTED BACKUPS of the operator state set (cfg.tbl, user.tbl + .bak, the TLS cert/key, master.key, and every scripts/data + scripts/cfg *.tbl). Each run writes ONE AES-256-GCM sealed .ldbk artifact (+ a .sha256 sidecar) to etc_backup_dir and prunes to etc_backup_keep. Restore is offline (`Luadch --restore <file>`, see docs/BACKUP.md). Off-site copies are the operator's job (rclone/restic/cron the backup dir). REQUIRES a passphrase - without one the plugin nags the owner and does nothing.
+
+    etc_backup_enabled = true,  -- master switch. true = the schedule + `+backup` are live (nagging the owner until a passphrase is set); false = fully inert. (boolean)
+    etc_backup_dir = "cfg/backups",  -- where artifacts are written. Default under cfg/ so they survive an upgrade (cfg/ is excluded) and sit on the Docker cfg mount. An ABSOLUTE path is allowed (a mounted backup volume). This dir is NOT itself backed up. (string)
+    etc_backup_keep = 7,  -- retention: keep the newest N artifacts, delete older ones after each run. (integer 1..1000)
+    etc_backup_daily_at = "04:00",  -- PRIMARY schedule: back up once a day at this SERVER-LOCAL time (quiet hours). Empty "" disables the daily slot and uses the interval below. (string "HH:MM")
+    etc_backup_interval_hours = 0,  -- fallback cadence, used ONLY when etc_backup_daily_at is empty: back up every N hours. 0 = off. (integer 0..168)
+    etc_backup_include_master_key = true,  -- include cfg/master.key in the (encrypted) artifact so a restore is self-contained. false keeps the key strictly out of the backup and reminds you to store it yourself. Losing master.key makes an encrypted user.tbl unreadable. (boolean)
+    etc_backup_passphrase = "",  -- REQUIRED. The passphrase that encrypts every artifact (PBKDF2 -> AES-256-GCM). PREFER the env var LUADCH_ETC_BACKUP_PASSPHRASE over a plaintext value here (redacted from GET /v1/config either way). Store it OUT-OF-BAND (a password manager), independent of master.key: losing it makes EVERY backup unrecoverable. (string)
+    etc_backup_oplevel = 80,  -- minimum level for +backup now|list|status. Default 80 (ADMIN). (integer)
+    etc_backup_notify_level = 100,  -- who gets the "backup not configured / not writable" hubbot reminder on login + at start. Default 100 (HUBOWNER). (integer)
+
+    ---------------------------------------------------------------------------------------------------------------------------------
     --// etc_records.lua settings | this script adds and shows statistics about hubshare/usershare records
 
     etc_records_min_level = 20,  -- minlevel to show record statistic? (integer)
@@ -1574,6 +1587,7 @@ return { -- the settings are a lua table, do not tough this!
         { "etc_blocklist_feeds.lua", enabled = false },  -- #78 Phase E external IP/CIDR feeds (Tor exits, Spamhaus DROP) pulled over HTTPS into the blocklist store. OFF by default. Store WRITER (the engine blocks pre-handshake), so chain position is not load-bearing. Enable here + set etc_blocklist_feeds_enabled=true + turn on a feed - see docs/BLOCKLIST.md.
         { "etc_proxydetect.lua", enabled = false },  -- #78 Phase F live proxy/VPN/Tor detection via a provider API on connect. OFF by default (needs a provider + API key - see docs/BLOCKLIST.md). Per-connection post-handshake lookup; must sit AFTER hub_inf_manager like etc_geoip. Enable here + set etc_proxydetect_enabled=true + etc_proxydetect_action="block".
         { "hub_runtime.lua", enabled = true },  -- using report import; API-toggleable (#261)
+        { "etc_backup.lua", enabled = true },  -- #480 automatic encrypted backups (engine = core/backup.lua). Enabled by default but INERT until a passphrase is set (etc_backup_passphrase / env) - nags the owner until then. onStart/onTimer/onLogin only, so chain position is not load-bearing. See docs/BACKUP.md.
         { "bot_regchat.lua", enabled = true },  -- API-toggleable (#261)
         { "bot_session_chat.lua", enabled = true },  -- API-toggleable (#261)
         "bot_pm2ops.lua",

--- a/hub/hub.c
+++ b/hub/hub.c
@@ -259,8 +259,11 @@ static int listdir(lua_State *L)
   if (h == INVALID_HANDLE_VALUE)
   {
     lua_pushnil(L);
-    lua_pushfstring(L, "listdir: cannot open '%s' (error %lu)",
-                    path, (unsigned long)GetLastError());
+    /* lua_pushfstring understands only %d/%s/%f/%p/%c/%% - NOT %lu; feeding it
+     * %lu raises "invalid option '%l'" and breaks the (nil, err) contract, so
+     * the DWORD error is cast to int (codes are small, positive). */
+    lua_pushfstring(L, "listdir: cannot open '%s' (error %d)",
+                    path, (int)GetLastError());
     return 2;
   }
   lua_newtable(L);
@@ -283,8 +286,8 @@ static int listdir(lua_State *L)
   {
     lua_pop(L, 1);
     lua_pushnil(L);
-    lua_pushfstring(L, "listdir: enumeration failed for '%s' (error %lu)",
-                    path, (unsigned long)ferr);
+    lua_pushfstring(L, "listdir: enumeration failed for '%s' (error %d)",
+                    path, (int)ferr);
     return 2;
   }
   return 1;

--- a/hub/hub.c
+++ b/hub/hub.c
@@ -274,7 +274,19 @@ static int listdir(lua_State *L)
     lua_pushstring(L, fd.cFileName);
     lua_rawseti(L, -2, ++i);
   } while (FindNextFileA(h, &fd));
+  /* A clean end is ERROR_NO_MORE_FILES; anything else means the enumeration
+   * was cut short. Surface it rather than returning a partial listing - a
+   * truncated scripts/data listing would silently under-collect a backup. */
+  DWORD ferr = GetLastError();
   FindClose(h);
+  if (ferr != ERROR_NO_MORE_FILES)
+  {
+    lua_pop(L, 1);
+    lua_pushnil(L);
+    lua_pushfstring(L, "listdir: enumeration failed for '%s' (error %lu)",
+                    path, (unsigned long)ferr);
+    return 2;
+  }
   return 1;
 #elif defined(__unix__)
   DIR *d = opendir(path);

--- a/hub/hub.c
+++ b/hub/hub.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <libgen.h>
 #include <limits.h>
+#include <dirent.h>   /* opendir / readdir - listdir() */
 #endif
 #ifdef _WIN32
 #include <windows.h>
@@ -230,6 +231,80 @@ static int makedir(lua_State *L)
   return 1;
 }
 
+/*
+ * listdir(path) -> { "name1", "name2", ... } | nil, errmsg
+ *
+ * Lists the entries of a directory (excluding "." and ".."), as a Lua array
+ * in readdir / FindNextFile order. Registered as a global so core Lua can
+ * enumerate the operator state directories (scripts/data/, scripts/cfg/)
+ * for the backup engine (#480) - the tree ships no lfs / readdir otherwise.
+ * Core-only, like makedir; NOT exposed to the plugin sandbox. Returns
+ * (nil, message) when the directory cannot be opened (missing, not a
+ * directory, permission). An empty directory yields an empty table.
+ */
+static int listdir(lua_State *L)
+{
+  const char *path = luaL_checkstring(L, 1);
+#ifdef _WIN32
+  char pattern[MAX_PATH];
+  int n = snprintf(pattern, sizeof(pattern), "%s\\*", path);
+  if (n < 0 || n >= (int)sizeof(pattern))
+  {
+    lua_pushnil(L);
+    lua_pushstring(L, "listdir: path too long");
+    return 2;
+  }
+  WIN32_FIND_DATAA fd;
+  HANDLE h = FindFirstFileA(pattern, &fd);
+  if (h == INVALID_HANDLE_VALUE)
+  {
+    lua_pushnil(L);
+    lua_pushfstring(L, "listdir: cannot open '%s' (error %lu)",
+                    path, (unsigned long)GetLastError());
+    return 2;
+  }
+  lua_newtable(L);
+  int i = 0;
+  do
+  {
+    if (strcmp(fd.cFileName, ".") == 0 || strcmp(fd.cFileName, "..") == 0)
+    {
+      continue;
+    }
+    lua_pushstring(L, fd.cFileName);
+    lua_rawseti(L, -2, ++i);
+  } while (FindNextFileA(h, &fd));
+  FindClose(h);
+  return 1;
+#elif defined(__unix__)
+  DIR *d = opendir(path);
+  if (!d)
+  {
+    lua_pushnil(L);
+    lua_pushfstring(L, "listdir: cannot open '%s' (errno %d)", path, errno);
+    return 2;
+  }
+  lua_newtable(L);
+  int i = 0;
+  struct dirent *e;
+  while ((e = readdir(d)) != NULL)
+  {
+    if (strcmp(e->d_name, ".") == 0 || strcmp(e->d_name, "..") == 0)
+    {
+      continue;
+    }
+    lua_pushstring(L, e->d_name);
+    lua_rawseti(L, -2, ++i);
+  }
+  closedir(d);
+  return 1;
+#else
+  lua_pushnil(L);
+  lua_pushstring(L, "listdir: unsupported platform");
+  return 2;
+#endif
+}
+
 /* Resulting soft RLIMIT_NOFILE after raise_fd_limit(): the practical
  * concurrent-socket ceiling on the POSIX poll backend. 0 = unknown (Windows,
  * or getrlimit failed), -1 = unlimited (RLIM_INFINITY), else the fd count.
@@ -338,6 +413,7 @@ static void run_lua(void)
   lua_register(L, "doexit", doexit);
   lua_register(L, "requestexit", requestexit);
   lua_register(L, "makedir", makedir);
+  lua_register(L, "listdir", listdir);
   lua_register(L, "getfdlimit", getfdlimit);
   int err = luaL_loadfile(L, "core/init.lua") || lua_pcall(L, 0, 0, 0);
   if (err)

--- a/scripts/etc_backup.lua
+++ b/scripts/etc_backup.lua
@@ -107,7 +107,11 @@ local function _next_daily( now, hhmm )
     if not h or not m or h < 0 or h > 23 or m < 0 or m > 59 then return nil end
     local t = os_date( "*t", now )
     local cand = os_time{ year = t.year, month = t.month, day = t.day, hour = h, min = m, sec = 0 }
+    -- A spring-forward-gap HH:MM makes os.time return nil; the caller then
+    -- falls back to the interval. Accepted (once-a-year, narrow).
     if not cand then return nil end
+    -- Flat +24h: across a DST change the slot is 1h off for that one day and
+    -- self-corrects on the next recompute. Accepted for a backup schedule.
     if cand <= now then cand = cand + 86400 end   -- today's slot passed -> tomorrow
     return cand
 end
@@ -277,7 +281,15 @@ hub_setlistener( "onStart", { },
 
         load_state( )
         local now = os_time( )
-        next_backup_at = enabled and _schedule_next( now, last_backup_at ) or nil
+        -- Honor the persisted deadline across +reload / restart so an interval
+        -- countdown is not reset on every boot (the #386/#414 anti-pattern)
+        -- and a slot missed while the hub was down still fires on boot. Only
+        -- recompute when there is no persisted deadline (first run).
+        if enabled then
+            next_backup_at = next_backup_at or _schedule_next( now, last_backup_at )
+        else
+            next_backup_at = nil
+        end
 
         -- command trio (help / right-click menu / +cmd dispatcher)
         local help = hub_import( "cmd_help" )
@@ -292,7 +304,6 @@ hub_setlistener( "onStart", { },
         if hubcmd then hubcmd.add( cmd_main, on_backup, oplevel ) end
 
         notify_if_unready( nil )   -- nag owners already online (e.g. after +reload)
-        hub_debug( "** Loaded " .. scriptname .. " " .. scriptversion .. " **" )
         return nil
     end
 )
@@ -305,7 +316,11 @@ hub_setlistener( "onTimer", { },
         local now = os_time( )
         if now >= next_backup_at then
             in_flight = true
-            do_backup( "scheduled", nil )
+            -- Guard the run: a raise deep inside (audit / reply) must not
+            -- wedge the scheduler with in_flight stuck true and next_backup_at
+            -- past-due, which would silently stop all future backups until a
+            -- +reload. next_backup_at is always advanced afterwards.
+            pcall( do_backup, "scheduled", nil )
             next_backup_at = _schedule_next( now, now )
             persist_state( )
             in_flight = false

--- a/scripts/etc_backup.lua
+++ b/scripts/etc_backup.lua
@@ -1,0 +1,334 @@
+--[[
+
+    etc_backup.lua - automatic encrypted hub backups (#480, PR-A)
+
+    The thin scheduler / CLI / owner-nag layer on top of the core engine
+    (core/backup.lua, exposed as the sandbox global `backup`). This plugin
+    owns WHEN a backup runs and HOW the operator is told about it; the engine
+    owns the actual collect -> seal -> write -> rotate work and reads its own
+    policy (dir / keep / passphrase / include_master_key) straight from cfg +
+    core/secrets. See docs/BACKUP.md.
+
+    Schedule (persisted across +reload in scripts/data/etc_backup.tbl):
+      - etc_backup_daily_at "HH:MM" (server-local) is the primary mode.
+      - etc_backup_interval_hours > 0 is the fallback when daily_at is empty.
+    Commands (level etc_backup_oplevel, default 80):
+      +backup now | list | status
+    Owner nag (level etc_backup_notify_level, default 100): when the feature
+    is enabled but not ready (no passphrase / backup dir not writable /
+    master.key unreadable), the hubbot PMs the owner on start + on login,
+    enumerating exactly what is missing.
+
+    License: GPLv3
+
+]]--
+
+local scriptname    = "etc_backup"
+local scriptversion = "0.01"
+
+--// sandbox globals //--
+local cfg     = cfg
+local hub     = hub
+local backup  = backup
+local audit   = audit
+local secrets = secrets
+local util    = util
+local type     = type
+local tonumber = tonumber
+local tostring = tostring
+local pairs    = pairs
+local ipairs   = ipairs
+local table_concat = table.concat
+local os_time = os.time
+local os_date = os.date
+local io_open = io.open
+local PROCESSED = PROCESSED
+
+local hub_debug      = hub.debug
+local hub_getbot     = hub.getbot
+local hub_getusers   = hub.getusers
+local hub_setlistener = hub.setlistener
+local hub_import     = hub.import
+
+--// i18n //--
+local scriptlang = cfg.get( "language" )
+local lang, lang_err = cfg.loadlanguage( scriptlang, scriptname )
+lang = lang or { }
+if lang_err then hub_debug( lang_err ) end
+
+local msg_denied    = lang.msg_denied    or "You are not allowed to use this command."
+local msg_usage     = lang.msg_usage     or "Usage: +backup now|list|status"
+local msg_now_ok    = lang.msg_now_ok    or "Backup written: "
+local msg_now_fail  = lang.msg_now_fail  or "Backup failed: "
+local msg_list_head = lang.msg_list_head or "Backups in "
+local msg_list_none = lang.msg_list_none or "  (none yet)"
+local msg_bytes     = lang.msg_bytes     or " bytes"
+local msg_files     = lang.msg_files     or " files"
+local msg_st_enabled  = lang.msg_st_enabled  or "enabled: "
+local msg_st_schedule = lang.msg_st_schedule or "schedule: "
+local msg_st_daily    = lang.msg_st_daily    or "daily at "
+local msg_st_every    = lang.msg_st_every    or "every "
+local msg_st_none     = lang.msg_st_none     or "none"
+local msg_st_next     = lang.msg_st_next     or "next: "
+local msg_st_last     = lang.msg_st_last     or "last: "
+local msg_st_ready    = lang.msg_st_ready    or "ready: "
+local msg_st_yes      = lang.msg_st_yes      or "yes"
+local msg_st_no       = lang.msg_st_no       or "no"
+local msg_nag_head    = lang.msg_nag_head    or "Backup is ENABLED but not fully configured:"
+local msg_iss_pass    = lang.msg_iss_pass    or "  - no passphrase set (etc_backup_passphrase / env LUADCH_ETC_BACKUP_PASSPHRASE)"
+local msg_iss_dir     = lang.msg_iss_dir     or "  - the backup directory is not writable (etc_backup_dir)"
+local msg_iss_mk      = lang.msg_iss_mk      or "  - master.key is not readable (etc_backup_include_master_key)"
+
+local help_title = lang.help_title or "backup"
+local help_usage = lang.help_usage or "+backup now|list|status"
+local help_desc  = lang.help_desc  or "Automatic encrypted backups: run one now, list artifacts, show status."
+local ucmd_now    = lang.ucmd_now    or { "Backup", "Run now" }
+local ucmd_list   = lang.ucmd_list   or { "Backup", "List" }
+local ucmd_status = lang.ucmd_status or { "Backup", "Status" }
+
+--// constants + runtime state //--
+local cmd_main   = "backup"
+local STATE_FILE = "scripts/data/etc_backup.tbl"
+
+local enabled, daily_at, interval_sec, notify_level, oplevel
+local last_backup_at, next_backup_at
+local in_flight = false
+
+local passphrase_key = "etc_backup_passphrase"
+
+----------------------------------// SCHEDULE (pure helpers) //--
+
+-- Next occurrence of a server-local HH:MM strictly after `now`, or nil if
+-- the string is not a valid HH:MM (caller falls back to the interval).
+local function _next_daily( now, hhmm )
+    if type( hhmm ) ~= "string" then return nil end
+    local h, m = hhmm:match( "^(%d%d?):(%d%d)$" )
+    h, m = tonumber( h ), tonumber( m )
+    if not h or not m or h < 0 or h > 23 or m < 0 or m > 59 then return nil end
+    local t = os_date( "*t", now )
+    local cand = os_time{ year = t.year, month = t.month, day = t.day, hour = h, min = m, sec = 0 }
+    if not cand then return nil end
+    if cand <= now then cand = cand + 86400 end   -- today's slot passed -> tomorrow
+    return cand
+end
+
+-- The next scheduled time after `now`. daily_at wins; else interval from
+-- `anchor` (last run at start, `now` after a run). Overdue interval fires
+-- this tick (n = now) instead of hammering. nil = no schedule configured.
+local function _compute_next( now, anchor, daily, ivl )
+    if daily and daily ~= "" then
+        local n = _next_daily( now, daily )
+        if n then return n end
+    end
+    if ivl and ivl > 0 then
+        local n = ( anchor or now ) + ivl
+        if n <= now then n = now end
+        return n
+    end
+    return nil
+end
+
+local function _schedule_next( now, anchor )
+    return _compute_next( now, anchor, daily_at, interval_sec )
+end
+
+----------------------------------// STATE PERSISTENCE //--
+
+local function load_state( )
+    local f = io_open( STATE_FILE, "r" )   -- peek so loadtable doesn't log "no such file"
+    if not f then return end
+    f:close( )
+    local st = util.loadtable( STATE_FILE )
+    if type( st ) == "table" then
+        last_backup_at = tonumber( st.last_backup_at )
+        next_backup_at = tonumber( st.next_backup_at )
+    end
+end
+
+local function persist_state( )
+    util.savetable( { last_backup_at = last_backup_at, next_backup_at = next_backup_at },
+        "etc_backup_state", STATE_FILE )
+end
+
+----------------------------------// OWNER NAG //--
+
+local function build_nag( issues )
+    local lines = { msg_nag_head }
+    for _, code in ipairs( issues ) do
+        if code == "no_passphrase" then lines[ #lines + 1 ] = msg_iss_pass
+        elseif code == "backup_dir_unwritable" then lines[ #lines + 1 ] = msg_iss_dir
+        elseif code == "master_key_unreadable" then lines[ #lines + 1 ] = msg_iss_mk
+        else lines[ #lines + 1 ] = "  - " .. code end
+    end
+    return table_concat( lines, "\n" )
+end
+
+-- PM the readiness checklist. `target` = one user (on login) or nil = every
+-- online user at/above notify_level (on start / after a failed run).
+local function notify_if_unready( target )
+    if not enabled then return end
+    local r = backup.readiness( )
+    if r.ok then return end
+    local msg = build_nag( r.issues )
+    local bot = hub_getbot( )
+    if target then
+        target:reply( msg, bot, bot )   -- 3-arg = private DMSG
+    else
+        for _, user in pairs( hub_getusers( ) ) do   -- first table = humans only
+            if not user:isbot( ) and user:level( ) >= notify_level then
+                user:reply( msg, bot, bot )
+            end
+        end
+    end
+end
+
+----------------------------------// BACKUP DRIVER //--
+
+-- Run one backup, audit the outcome, update last_backup_at on success. Does
+-- NOT recompute next / persist - the caller (timer or +backup now) does.
+local function do_backup( trigger, actor )
+    local res, err = backup.run( )
+    if res then
+        last_backup_at = os_time( )
+        audit.fire( audit.build( "backup.success", actor, nil, nil, {
+            path = res.path, bytes = res.bytes, files = res.files, trigger = trigger } ) )
+        return res
+    end
+    audit.fire( audit.build( "backup.fail", actor, nil, err, { trigger = trigger } ) )
+    notify_if_unready( nil )   -- a config-class failure is explained to owners
+    return nil, err
+end
+
+----------------------------------// COMMAND: +backup //--
+
+local function cmd_now( user )
+    local res, err = do_backup( "manual", user )
+    local now = os_time( )
+    next_backup_at = _schedule_next( now, now )
+    persist_state( )
+    if res then
+        user:reply( msg_now_ok .. res.path .. " (" .. tostring( res.bytes ) .. msg_bytes
+            .. ", " .. tostring( res.files ) .. msg_files .. ")", hub_getbot( ) )
+    else
+        user:reply( msg_now_fail .. tostring( err ), hub_getbot( ) )
+    end
+end
+
+local function cmd_list( user )
+    local rows = backup.list( )
+    local dir = cfg.get( "etc_backup_dir" ) or "cfg/backups"
+    local lines = { msg_list_head .. dir .. ":" }
+    if not rows or #rows == 0 then
+        lines[ #lines + 1 ] = msg_list_none
+    else
+        for _, r in ipairs( rows ) do
+            lines[ #lines + 1 ] = "  " .. r.name .. "  (" .. tostring( r.bytes or "?" ) .. msg_bytes .. ")"
+        end
+    end
+    user:reply( table_concat( lines, "\n" ), hub_getbot( ) )
+end
+
+local function cmd_status( user )
+    local r = backup.readiness( )
+    local sched
+    if daily_at and daily_at ~= "" then sched = msg_st_daily .. daily_at
+    elseif interval_sec and interval_sec > 0 then sched = msg_st_every .. tostring( interval_sec // 3600 ) .. "h"
+    else sched = msg_st_none end
+    local ready = r.ok and msg_st_yes or ( msg_st_no .. " (" .. table_concat( r.issues, ", " ) .. ")" )
+    local parts = {
+        msg_st_enabled  .. tostring( enabled ),
+        msg_st_schedule .. sched,
+        msg_st_next     .. ( next_backup_at and os_date( "%Y-%m-%d %H:%M", next_backup_at ) or "-" ),
+        msg_st_last     .. ( last_backup_at and os_date( "%Y-%m-%d %H:%M", last_backup_at ) or "-" ),
+        msg_st_ready    .. ready,
+    }
+    user:reply( table_concat( parts, "\n" ), hub_getbot( ) )
+end
+
+local function on_backup( user, command, parameters )
+    if user:level( ) < oplevel then
+        user:reply( msg_denied, hub_getbot( ) )
+        return PROCESSED
+    end
+    local sub = parameters and parameters:match( "^%s*(%S+)" )
+    if sub == "now" then cmd_now( user )
+    elseif sub == "list" then cmd_list( user )
+    elseif sub == "status" then cmd_status( user )
+    else user:reply( msg_usage, hub_getbot( ) ) end
+    return PROCESSED
+end
+
+----------------------------------// LISTENERS //--
+
+hub_setlistener( "onStart", { },
+    function( )
+        in_flight = false
+
+        enabled = cfg.get( "etc_backup_enabled" )
+        if enabled == nil then enabled = true end
+        daily_at = cfg.get( "etc_backup_daily_at" ) or ""
+        interval_sec = ( tonumber( cfg.get( "etc_backup_interval_hours" ) ) or 0 ) * 3600
+        notify_level = tonumber( cfg.get( "etc_backup_notify_level" ) ) or 100
+        oplevel      = tonumber( cfg.get( "etc_backup_oplevel" ) ) or 80
+
+        -- Register the passphrase key as a secret whenever loaded, so a
+        -- value in cfg.tbl is redacted from /v1/config even while inactive.
+        if secrets and secrets.register then secrets.register( passphrase_key ) end
+
+        load_state( )
+        local now = os_time( )
+        next_backup_at = enabled and _schedule_next( now, last_backup_at ) or nil
+
+        -- command trio (help / right-click menu / +cmd dispatcher)
+        local help = hub_import( "cmd_help" )
+        if help then help.reg( help_title, help_usage, help_desc, oplevel ) end
+        local ucmd = hub_import( "etc_usercommands" )
+        if ucmd then
+            ucmd.add( ucmd_now,    cmd_main .. " now",    { }, { "CT1" }, oplevel )
+            ucmd.add( ucmd_list,   cmd_main .. " list",   { }, { "CT1" }, oplevel )
+            ucmd.add( ucmd_status, cmd_main .. " status", { }, { "CT1" }, oplevel )
+        end
+        local hubcmd = hub_import( "etc_hubcommands" )
+        if hubcmd then hubcmd.add( cmd_main, on_backup, oplevel ) end
+
+        notify_if_unready( nil )   -- nag owners already online (e.g. after +reload)
+        hub_debug( "** Loaded " .. scriptname .. " " .. scriptversion .. " **" )
+        return nil
+    end
+)
+
+hub_setlistener( "onTimer", { },
+    function( )
+        if not enabled then return nil end
+        if in_flight then return nil end
+        if not next_backup_at then return nil end
+        local now = os_time( )
+        if now >= next_backup_at then
+            in_flight = true
+            do_backup( "scheduled", nil )
+            next_backup_at = _schedule_next( now, now )
+            persist_state( )
+            in_flight = false
+        end
+        return nil
+    end
+)
+
+hub_setlistener( "onLogin", { },
+    function( user )
+        if not enabled then return nil end
+        if user:isbot( ) then return nil end
+        if user:level( ) >= notify_level then
+            notify_if_unready( user )
+        end
+        return nil
+    end
+)
+
+hub_debug( "** Loaded " .. scriptname .. " " .. scriptversion .. " **" )
+
+-- test seams (pure schedule math)
+return {
+    _next_daily   = _next_daily,
+    _compute_next = _compute_next,
+}

--- a/scripts/lang/etc_backup.lang.de
+++ b/scripts/lang/etc_backup.lang.de
@@ -1,0 +1,36 @@
+return {
+
+    help_title = "etc_backup.lua - Backup",
+    help_usage = "+backup now|list|status",
+    help_desc  = "Automatische verschluesselte Backups: jetzt eins erstellen, Artefakte auflisten, Status anzeigen.",
+
+    ucmd_now    = { "Hub", "Backup", "jetzt erstellen" },
+    ucmd_list   = { "Hub", "Backup", "auflisten" },
+    ucmd_status = { "Hub", "Backup", "Status" },
+
+    msg_denied    = "Du darfst diesen Befehl nicht benutzen.",
+    msg_usage     = "Benutzung: +backup now|list|status",
+    msg_now_ok    = "Backup geschrieben: ",
+    msg_now_fail  = "Backup fehlgeschlagen: ",
+    msg_list_head = "Backups in ",
+    msg_list_none = "  (noch keine)",
+    msg_bytes     = " Bytes",
+    msg_files     = " Dateien",
+
+    msg_st_enabled  = "aktiviert: ",
+    msg_st_schedule = "Zeitplan: ",
+    msg_st_daily    = "taeglich um ",
+    msg_st_every    = "alle ",
+    msg_st_none     = "keiner",
+    msg_st_next     = "naechstes: ",
+    msg_st_last     = "letztes: ",
+    msg_st_ready    = "bereit: ",
+    msg_st_yes      = "ja",
+    msg_st_no       = "nein",
+
+    msg_nag_head = "Backup ist AKTIVIERT, aber nicht vollstaendig konfiguriert:",
+    msg_iss_pass = "  - keine Passphrase gesetzt (etc_backup_passphrase / env LUADCH_ETC_BACKUP_PASSPHRASE)",
+    msg_iss_dir  = "  - das Backup-Verzeichnis ist nicht beschreibbar (etc_backup_dir)",
+    msg_iss_mk   = "  - master.key ist nicht lesbar (etc_backup_include_master_key)",
+
+}

--- a/scripts/lang/etc_backup.lang.en
+++ b/scripts/lang/etc_backup.lang.en
@@ -1,0 +1,36 @@
+return {
+
+    help_title = "etc_backup.lua - backup",
+    help_usage = "+backup now|list|status",
+    help_desc  = "Automatic encrypted backups: run one now, list artifacts, show status.",
+
+    ucmd_now    = { "Hub", "Backup", "run now" },
+    ucmd_list   = { "Hub", "Backup", "list" },
+    ucmd_status = { "Hub", "Backup", "status" },
+
+    msg_denied    = "You are not allowed to use this command.",
+    msg_usage     = "Usage: +backup now|list|status",
+    msg_now_ok    = "Backup written: ",
+    msg_now_fail  = "Backup failed: ",
+    msg_list_head = "Backups in ",
+    msg_list_none = "  (none yet)",
+    msg_bytes     = " bytes",
+    msg_files     = " files",
+
+    msg_st_enabled  = "enabled: ",
+    msg_st_schedule = "schedule: ",
+    msg_st_daily    = "daily at ",
+    msg_st_every    = "every ",
+    msg_st_none     = "none",
+    msg_st_next     = "next: ",
+    msg_st_last     = "last: ",
+    msg_st_ready    = "ready: ",
+    msg_st_yes      = "yes",
+    msg_st_no       = "no",
+
+    msg_nag_head = "Backup is ENABLED but not fully configured:",
+    msg_iss_pass = "  - no passphrase set (etc_backup_passphrase / env LUADCH_ETC_BACKUP_PASSPHRASE)",
+    msg_iss_dir  = "  - the backup directory is not writable (etc_backup_dir)",
+    msg_iss_mk   = "  - master.key is not readable (etc_backup_include_master_key)",
+
+}

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -160,6 +160,12 @@ def override_test_ports(staging_dir: Path):
          '{ "etc_proxydetect.lua", enabled = true }'),
         (r"etc_proxydetect_enabled\s*=\s*false", "etc_proxydetect_enabled = true"),
         (r"etc_proxydetect_check_levels = \{[^}]*\}", "etc_proxydetect_check_levels = { }"),
+        # #480: etc_backup ships ENABLED but is inert (nags, never runs)
+        # until a passphrase is set. Set one so test_backup_now can drive a
+        # real +backup now and assert a sealed artifact lands on disk. The
+        # daily_at schedule stays at 04:00, so no scheduled backup fires
+        # during the run; only the explicit +backup now does.
+        (r'etc_backup_passphrase\s*=\s*""', 'etc_backup_passphrase = "smoke-backup-pass"'),
     ]
     for pattern, replacement in rewrites:
         new_text, count = re.subn(pattern, replacement, text, count=1)
@@ -591,6 +597,58 @@ def test_command_routing():
         )
         if len(response) < 20:
             raise TestFailure(f"+help response unexpectedly short: {response!r}")
+
+
+def test_backup_now(staging_dir: Path):
+    """#480 PR-A: `+backup now` produces an encrypted .ldbk artifact + a
+    .sha256 sidecar. Exercises the whole engine path through the plugin
+    command: real file collection (io + the listdir C primitive over
+    scripts/data + scripts/cfg), OpenSSL PBKDF2 + AES-256-GCM seal, atomic
+    write, and the sidecar. dummy is level 100 (> etc_backup_oplevel 80); the
+    passphrase is set in the staged cfg by override_test_ports."""
+    backups_dir = staging_dir / "cfg" / "backups"
+    before = (
+        set(backups_dir.glob("luadch-backup-*.ldbk"))
+        if backups_dir.exists()
+        else set()
+    )
+    with socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    ) as sock:
+        sid, reader = _adc_login(sock, "dummy", "test")
+        # The space in "+backup now" MUST be the ADC escape \s, or the hub
+        # parses "now" as a separate ADC field and the command sees no
+        # subcommand (multi-word BMSG bodies need \s, not a raw space).
+        sock.sendall(f"BMSG {sid} +backup\\snow\n".encode("utf-8"))
+        # The hubbot reply carries "Backup written: <path>" on success or
+        # "Backup failed: ..." otherwise. Match on those words so we skip
+        # etc_hubcommands' own "[command] +backup" chat-echo frame.
+        response = reader.recv_until(
+            lambda f: f.startswith(("EMSG ", "DMSG ", "BMSG ")) and ("written" in f or "failed" in f),
+            timeout=PROTOCOL_TIMEOUT_SEC,
+        )
+    if "written" not in response:
+        raise TestFailure(f"+backup now did not report success: {response!r}")
+
+    # A new artifact must exist on disk.
+    new = set(backups_dir.glob("luadch-backup-*.ldbk")) - before
+    if not new:
+        raise TestFailure(f"+backup now wrote no .ldbk artifact in {backups_dir}")
+    artifact = next(iter(new))
+    if artifact.stat().st_size < 100:
+        raise TestFailure(
+            f"backup artifact suspiciously small: {artifact.stat().st_size} bytes"
+        )
+    # It must be an LDBK1 blob, not plaintext (the seal actually ran).
+    if artifact.read_bytes()[:4] != b"LDBK":
+        raise TestFailure(f"artifact is not an LDBK archive: {artifact.name}")
+    # The sidecar exists and is the standard `sha256sum` format.
+    sidecar = artifact.parent / (artifact.name + ".sha256")
+    if not sidecar.exists():
+        raise TestFailure(f"backup sidecar missing: {sidecar}")
+    sc = sidecar.read_text(encoding="utf-8").strip()
+    if not re.match(r"^[0-9a-f]{64}  luadch-backup-.*\.ldbk$", sc):
+        raise TestFailure(f"backup sidecar format wrong: {sc!r}")
 
 
 def test_s1_fragmented_frame_reassembled():
@@ -12751,6 +12809,17 @@ def run_tests(staging_dir: Path):
             failed.append(name)
         else:
             log(f"PASS  {name}")
+
+    # #480: drive a real +backup now and assert a sealed artifact lands on
+    # disk. Needs staging_dir for the file check, so it runs here (main hub
+    # still up) rather than in the no-arg TESTS list.
+    try:
+        test_backup_now(staging_dir)
+    except Exception as e:
+        log(f"FAIL  +backup now writes an encrypted artifact (#480): {e}")
+        failed.append("+backup now writes an encrypted artifact (#480)")
+    else:
+        log("PASS  +backup now writes an encrypted artifact (#480)")
 
     # State-of-disk tests run after the protocol tests so any post-login
     # save (HPAS lastconnect update) has had a chance to land.

--- a/tests/unit/backup_test.lua
+++ b/tests/unit/backup_test.lua
@@ -1,0 +1,202 @@
+--[[
+
+    tests/unit/backup_test.lua
+
+    Unit tests for core/backup.lua's pure decision logic, driven through a
+    stubbed `use` shim (no real filesystem / crypto):
+      - _config(): cfg + secrets interpretation, defaults, dir normalisation
+      - _collection_spec(): which files enter a backup + their restore names,
+        modes and kinds; master.key inclusion toggle; .tbl filter that skips
+        .tmp half-writes and non-.tbl files; the injected directory lister
+      - _rotation_victims(): keep-newest-N pruning selection
+
+    The full read/pack/write/rotate path (run/readiness) touches the real
+    filesystem + adclib and is covered by the backup smoke test (PR-A).
+
+    Run: lua5.4 tests/unit/backup_test.lua   (exit 0 = pass, 1 = fail)
+
+]]--
+
+----------------------------------------------------------------------
+-- `use` shim
+----------------------------------------------------------------------
+
+local _cfg    = { }   -- cfg.get source (set per test)
+local _secret = { }   -- secrets.lookup source
+
+local _real = {
+    type = type, pcall = pcall, tostring = tostring, tonumber = tonumber, ipairs = ipairs,
+    string = string, table = table, os = os, io = io,
+    const   = { PROGRAM_NAME = "Luadch-NG", VERSION = "v3.2.0-dev", CONFIG_PATH = "cfg/" },
+    cfg     = { get = function( k ) return _cfg[ k ] end },
+    out     = { put = function( ) end, error = function( ) end },
+    secrets = { lookup = function( k ) return _secret[ k ] end },
+    backup_archive = { pack = function( ) end, checksum = function( ) return "x" end,
+        sidecar_line = function( ) return "" end },
+    makedir = function( ) return true end,
+    listdir = function( ) return { } end,
+}
+_G.use = function( name )
+    local v = _real[ name ]
+    if v == nil then error( "backup_test shim missing dep: use \"" .. tostring( name ) .. "\"" ) end
+    return v
+end
+
+local B = assert( loadfile( "core/backup.lua" ) )( )
+
+----------------------------------------------------------------------
+-- harness
+----------------------------------------------------------------------
+
+local passes, fails = 0, 0
+local function ok( label, cond )
+    if cond then passes = passes + 1
+    else fails = fails + 1; io.stderr:write( "FAIL: " .. label .. "\n" ) end
+end
+local function eq( label, got, want )
+    if got == want then passes = passes + 1
+    else
+        fails = fails + 1
+        io.stderr:write( string.format( "FAIL: %s\n  got:  %s\n  want: %s\n",
+            label, tostring( got ), tostring( want ) ) )
+    end
+end
+local function find_entry( spec, name )
+    for _, e in ipairs( spec ) do if e.name == name then return e end end
+end
+
+----------------------------------------------------------------------
+-- _config: defaults when cfg is empty
+----------------------------------------------------------------------
+
+_cfg, _secret = { }, { }
+do
+    local c = B._config( )
+    eq( "default enabled = true",    c.enabled, true )
+    eq( "default dir = backups",     c.dir,     "backups" )
+    eq( "default keep = 7",          c.keep,    7 )
+    eq( "default include_mk = true", c.include_mk, true )
+    eq( "no passphrase -> nil",      c.passphrase, nil )
+end
+
+----------------------------------------------------------------------
+-- _config: explicit values + dir normalisation + keep clamp
+----------------------------------------------------------------------
+
+_cfg = {
+    etc_backup_enabled = false,
+    etc_backup_dir = "/mnt/backups///",
+    etc_backup_keep = 0,             -- must clamp to >= 1
+    etc_backup_include_master_key = false,
+}
+_secret = { etc_backup_passphrase = "hunter2" }
+do
+    local c = B._config( )
+    eq( "explicit enabled = false",   c.enabled, false )
+    eq( "trailing slashes stripped",  c.dir,     "/mnt/backups" )
+    eq( "keep clamped to 1",          c.keep,    1 )
+    eq( "explicit include_mk = false", c.include_mk, false )
+    eq( "passphrase from secrets",    c.passphrase, "hunter2" )
+end
+
+-- empty-string passphrase is treated as unset
+_secret = { etc_backup_passphrase = "" }
+eq( "empty passphrase -> nil", B._config( ).passphrase, nil )
+
+----------------------------------------------------------------------
+-- _collection_spec: full set with master.key, filtered plugin state
+----------------------------------------------------------------------
+
+local function fake_lister( dir )
+    if dir == "scripts/data" then
+        return { "cmd_ban_bans.tbl", "etc_geoip.tbl", "half.tbl.tmp", "readme.txt" }
+    elseif dir == "scripts/cfg" then
+        return { "etc_something.tbl" }
+    end
+    return { }
+end
+
+do
+    local spec = B._collection_spec( true, "/etc/luadch/master.key", nil, fake_lister )
+
+    ok( "cfg.tbl included",        find_entry( spec, "cfg/cfg.tbl" ) ~= nil )
+    ok( "user.tbl included",       find_entry( spec, "cfg/user.tbl" ) ~= nil )
+    ok( "user.tbl.bak included",   find_entry( spec, "cfg/user.tbl.bak" ) ~= nil )
+
+    local key = find_entry( spec, "certs/serverkey.pem" )
+    ok( "serverkey.pem included",  key ~= nil )
+    eq( "serverkey mode 0600",     key and key.mode, 384 )
+    ok( "servercert.pem included", find_entry( spec, "certs/servercert.pem" ) ~= nil )
+    ok( "cacert.pem included",     find_entry( spec, "certs/cacert.pem" ) ~= nil )
+
+    local mk = find_entry( spec, "__masterkey__" )
+    ok( "master.key entry present", mk ~= nil )
+    eq( "master.key kind",          mk and mk.kind, "masterkey" )
+    eq( "master.key mode 0600",     mk and mk.mode, 384 )
+    eq( "master.key read path",     mk and mk.read, "/etc/luadch/master.key" )
+
+    ok( "scripts/data .tbl included",  find_entry( spec, "scripts/data/cmd_ban_bans.tbl" ) ~= nil )
+    ok( "cache .tbl included too",     find_entry( spec, "scripts/data/etc_geoip.tbl" ) ~= nil )
+    ok( "scripts/cfg .tbl included",   find_entry( spec, "scripts/cfg/etc_something.tbl" ) ~= nil )
+    ok( ".tmp half-write skipped",     find_entry( spec, "scripts/data/half.tbl.tmp" ) == nil )
+    ok( "non-.tbl file skipped",       find_entry( spec, "scripts/data/readme.txt" ) == nil )
+
+    local state = find_entry( spec, "scripts/data/cmd_ban_bans.tbl" )
+    eq( "state mode 0640", state and state.mode, 416 )
+end
+
+-- include_master_key = false -> no master.key entry
+do
+    local spec = B._collection_spec( false, "/etc/luadch/master.key", nil, fake_lister )
+    ok( "master.key excluded when include=false", find_entry( spec, "__masterkey__" ) == nil )
+    ok( "cfg.tbl still there", find_entry( spec, "cfg/cfg.tbl" ) ~= nil )
+end
+
+-- custom ssl_params paths honoured
+do
+    local ssl = { key = "certs/mykey.pem", certificate = "certs/mycert.pem", cafile = "certs/myca.pem" }
+    local spec = B._collection_spec( false, nil, ssl, fake_lister )
+    ok( "custom serverkey path",  find_entry( spec, "certs/mykey.pem" ) ~= nil )
+    ok( "custom cert path",       find_entry( spec, "certs/mycert.pem" ) ~= nil )
+    ok( "default serverkey absent when overridden", find_entry( spec, "certs/serverkey.pem" ) == nil )
+end
+
+----------------------------------------------------------------------
+-- _rotation_victims: keep newest N, oldest pruned; non-backups ignored
+----------------------------------------------------------------------
+
+do
+    local names = {
+        "luadch-backup-20260101-010101.ldbk",
+        "luadch-backup-20260102-010101.ldbk",
+        "luadch-backup-20260103-010101.ldbk",
+        "luadch-backup-20260104-010101.ldbk",
+        "luadch-backup-20260105-010101.ldbk",
+        "luadch-backup-20260105-010101.ldbk.sha256",   -- sidecar, NOT a victim
+        "some-other-file.txt",
+    }
+    local v = B._rotation_victims( names, 3 )
+    eq( "victim count (5 backups, keep 3)", #v, 2 )
+    eq( "oldest victim first",  v[ 1 ], "luadch-backup-20260101-010101.ldbk" )
+    eq( "second oldest victim", v[ 2 ], "luadch-backup-20260102-010101.ldbk" )
+    -- sidecar + non-backup never selected
+    for _, name in ipairs( v ) do
+        ok( "victim is an .ldbk, not a sidecar/other", name:match( "%.ldbk$" ) ~= nil and name:match( "%.sha256$" ) == nil )
+    end
+end
+
+-- fewer backups than keep -> nothing pruned
+do
+    local v = B._rotation_victims( { "luadch-backup-20260101-010101.ldbk" }, 7 )
+    eq( "keep > count -> no victims", #v, 0 )
+end
+
+----------------------------------------------------------------------
+-- output
+----------------------------------------------------------------------
+
+if fails > 0 then
+    io.stderr:write( string.format( "\nFAIL: %d/%d checks failed\n", fails, passes + fails ) )
+    os.exit( 1 )
+end
+print( string.format( "OK: %d checks passed", passes ) )

--- a/tests/unit/backup_test.lua
+++ b/tests/unit/backup_test.lua
@@ -73,7 +73,7 @@ _cfg, _secret = { }, { }
 do
     local c = B._config( )
     eq( "default enabled = true",    c.enabled, true )
-    eq( "default dir = backups",     c.dir,     "backups" )
+    eq( "default dir = cfg/backups", c.dir,     "cfg/backups" )
     eq( "default keep = 7",          c.keep,    7 )
     eq( "default include_mk = true", c.include_mk, true )
     eq( "no passphrase -> nil",      c.passphrase, nil )

--- a/tests/unit/etc_backup_schedule_test.lua
+++ b/tests/unit/etc_backup_schedule_test.lua
@@ -1,0 +1,92 @@
+--[[
+
+    tests/unit/etc_backup_schedule_test.lua
+
+    Unit tests for scripts/etc_backup.lua's pure schedule math (_next_daily,
+    _compute_next), loaded with stubbed sandbox globals. The command
+    dispatch, owner nag and the actual backup run are covered by the backup
+    smoke test (hub boots with etc_backup, +backup now produces an artifact).
+
+    Run: lua5.4 tests/unit/etc_backup_schedule_test.lua   (exit 0 = pass)
+
+]]--
+
+-- Stub the sandbox globals the plugin binds at load. Assigning without
+-- `local` sets the real global the plugin's `local x = x` then captures.
+local _noop = function( ) end
+cfg     = { get = function( ) return nil end, loadlanguage = function( ) return { }, nil end }
+hub     = { debug = _noop, getbot = function( ) return { } end, getusers = function( ) return { } end,
+            setlistener = _noop, import = function( ) return nil end }
+backup  = { readiness = function( ) return { ok = true, issues = { } } end,
+            run = function( ) end, list = function( ) return { } end }
+audit   = { build = function( ) return { } end, fire = _noop }
+secrets = { register = _noop, lookup = function( ) return nil end }
+util    = { loadtable = function( ) return nil end, savetable = _noop }
+utf     = string
+PROCESSED = true
+
+local E = assert( loadfile( "scripts/etc_backup.lua" ) )( )
+
+local passes, fails = 0, 0
+local function ok( label, cond )
+    if cond then passes = passes + 1
+    else fails = fails + 1; io.stderr:write( "FAIL: " .. label .. "\n" ) end
+end
+local function eq( label, got, want )
+    if got == want then passes = passes + 1
+    else fails = fails + 1
+        io.stderr:write( string.format( "FAIL: %s\n  got:  %s\n  want: %s\n", label, tostring( got ), tostring( want ) ) )
+    end
+end
+
+----------------------------------------------------------------------
+-- _next_daily: valid HH:MM -> next local occurrence strictly after now
+----------------------------------------------------------------------
+
+local now = os.time( )   -- real local time
+do
+    local n = E._next_daily( now, "04:00" )
+    ok( "04:00 -> a time",            type( n ) == "number" )
+    ok( "04:00 -> strictly future",   n and n > now )
+    ok( "04:00 -> within 24h",        n and n <= now + 86400 )
+    eq( "04:00 -> lands on 04:00 local", n and os.date( "%H:%M", n ), "04:00" )
+
+    -- a time one minute in the future today should be today (not +24h)
+    local soon = os.date( "*t", now + 120 )
+    local hhmm = string.format( "%02d:%02d", soon.hour, soon.min )
+    local n2 = E._next_daily( now, hhmm )
+    ok( "near-future HH:MM is today (<= 2min away)", n2 and n2 - now <= 120 and n2 > now )
+end
+
+-- invalid inputs -> nil (caller falls back to interval)
+eq( "empty -> nil",       E._next_daily( now, "" ),      nil )
+eq( "bad format -> nil",  E._next_daily( now, "4pm" ),   nil )
+eq( "hour 25 -> nil",     E._next_daily( now, "25:00" ), nil )
+eq( "min 60 -> nil",      E._next_daily( now, "04:60" ), nil )
+eq( "non-string -> nil",  E._next_daily( now, 400 ),     nil )
+
+----------------------------------------------------------------------
+-- _compute_next: daily wins; else interval from anchor; overdue fires now
+----------------------------------------------------------------------
+
+-- interval mode (daily empty)
+eq( "interval from anchor",  E._compute_next( 1000, 500, "", 3600 ), 4100 )   -- 500 + 3600
+eq( "interval from now (no anchor)", E._compute_next( 1000, nil, "", 3600 ), 4600 )   -- 1000 + 3600
+eq( "overdue interval -> now", E._compute_next( 10000, 500, "", 3600 ), 10000 )   -- 500+3600 <= now
+eq( "interval 0 -> nil",     E._compute_next( 1000, 500, "", 0 ),    nil )
+eq( "no schedule -> nil",    E._compute_next( 1000, 500, "", nil ),  nil )
+
+-- daily wins over interval when both set
+do
+    local n = E._compute_next( now, now, "04:00", 3600 )
+    eq( "daily wins over interval", n and os.date( "%H:%M", n ), "04:00" )
+end
+
+-- invalid daily falls through to interval
+eq( "bad daily -> interval fallback", E._compute_next( 1000, 500, "nope", 3600 ), 4100 )
+
+if fails > 0 then
+    io.stderr:write( string.format( "\nFAIL: %d/%d checks failed\n", fails, passes + fails ) )
+    os.exit( 1 )
+end
+print( string.format( "OK: %d checks passed", passes ) )


### PR DESCRIPTION
PR-A of the automatic-backup arc (#480): the backup **engine + scheduler plugin**, on top of the P0 archive format (#481, already on dev). This produces backups; the offline restore is PR-B.

## Core
- **`core/backup.lua`** (new, exposed to the plugin sandbox as `backup`): collects the restore-minimum set (`cfg.tbl`, `user.tbl` + `.bak`, the `ssl_params` TLS material, every `scripts/data` + `scripts/cfg` `*.tbl`, and - when included - `master.key` under a `__masterkey__` sentinel), seals via `backup_archive`, writes `.ldbk` + a `.sha256` sidecar, and rotates to `etc_backup_keep`. Reads its **own** policy from cfg + `core/secrets` (never caller args), so a sandboxed plugin can only trigger a backup to the operator-configured destination - it cannot redirect the artifact or pick the key.
- **`hub.c` `listdir`** C primitive (core-only, NOT sandboxed): the tree ships no lfs/readdir; the engine enumerates the plugin-state dirs with it.
- **`adclib.pbkdf2_sha256`** (OpenSSL): a functional test showed pure-Lua PBKDF2 at 200k iters froze the hub ~40s per backup; the C path is ~1ms, same key, format unchanged (interoperable).

## Plugin
- **`scripts/etc_backup.lua`** - enabled by default but INERT until a passphrase is set (nags the owner until then): daily-at-`HH:MM` schedule with an every-N-hours fallback, both persisted across `+reload`; `+backup now|list|status`; audit `backup.success`/`fail`; owner readiness nag (onStart + onLogin) that enumerates what is unconfigured.
- `cfg_defaults` `etc_backup_*` keys, `examples/cfg/cfg.tbl` entry, `lang/etc_backup.lang.en`+`.de`.

## Tests (both CI legs + a new smoke test)
- Unit: engine collection/rotation/config, archive pack/unpack (+ the real AES-256-GCM round-trip on the Linux leg), plugin schedule math.
- Smoke: `+backup now` drives the real hub and asserts a sealed LDBK artifact + `sha256sum`-format sidecar land on disk.

## Validated locally
All unit tests (Win lua54 + Linux), a full WSL build + the **entire smoke suite green** (boot + all plugins load + no regression + the new backup test), `_ENV` bytecode scans clean. A functional harness proved the real-file collect -> seal -> round-trip path. §1a.6 three-reviewer pass (security / correctness / consistency); all findings fixed (scheduler-wedge pcall guard, persisted-deadline honoring, artifact 0600, listdir Windows-error surfacing, pbkdf2 int guard, dir/dead-code alignment).

## Docs
CLAUDE.md §3 module map + the PLUGIN_API sandbox list get the backup entries in **PR-B** alongside `docs/BACKUP.md` (same as P0 landed on dev doc-less).

Part of #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)
