### PR TITLE
feat(backup): offline --restore for encrypted .ldbk backups (#480 PR-B)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -227,6 +227,13 @@ jobs:
       - name: Run etc_backup schedule unit test
         run: lua5.4 tests/unit/etc_backup_schedule_test.lua
 
+      # core/restore.lua (#480 PR-B) offline-restore pure logic: the
+      # _safe_rel path-traversal guard (reject absolute / ".." / drive /
+      # UNC), master.key dest resolution, plan building + reject routing,
+      # sha256 sidecar verify. Fake adclib; no --restore run.
+      - name: Run restore unit test
+        run: lua5.4 tests/unit/restore_test.lua
+
       # #78 Precursor 0d: core/cacert_bootstrap.lua reconcile_bundle
       # decision-matrix (source-missing / installed / no-op / warned /
       # auto-updated branches). Uses OS temp dir for file fixtures.
@@ -555,6 +562,10 @@ jobs:
       - name: Run etc_backup schedule unit test
         shell: msys2 {0}
         run: lua5.4 tests/unit/etc_backup_schedule_test.lua
+
+      - name: Run restore unit test
+        shell: msys2 {0}
+        run: lua5.4 tests/unit/restore_test.lua
 
       - name: Run cacert_bootstrap unit test
         shell: msys2 {0}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,8 +133,18 @@ order (its inline comments explain each ordering constraint).
 | Boot + config | `init`, `const`, `cfg`, `cfg_defaults`, `cfg_users`, `cfg_lang`, `cfg_secret`, `secrets` | Restricted env + module loader; program constants; settings/user.tbl/language handling; AES-256-GCM at-rest crypto; env-var-first secret lookup |
 | Network + ADC | `server`, `iostream`, `adc`, `hub`, `hub_dispatch`, `hub_user_object`, `hub_bot_object`, `hbri`, `ratelimit`, `blocklist`, `whitelist`, `ipmatch` | event loop + SSL (poll on POSIX / select on Windows, #310); framing pipeline; ADC parse/escape/format; main loop + login; command dispatch; user/bot objects; dual-stack secondary-IP verification; DoS limits; pre-handshake IP/CIDR blocklist; global allowlist (whitelist beats automated blocks, not manual pins); IP/CIDR primitives |
 | HTTP API | `http`, `http_router`, `http_client`, `http_filter`, `http_events`, `util_http` | Inbound HTTP/JSON API + router + auth; non-blocking OUTBOUND client; filter/sort/paginate helper; deferred-event endpoints; plugin endpoint helper |
-| Crypto + boot trust | `sha256`, `hmac`, `cert_bootstrap`, `cacert_bootstrap` | Pure-Lua SHA-256; HMAC-SHA256 (RFC 2104, sandbox-exposed for signed-webhook auth, #398); first-boot TLS-cert auto-gen (#77); CA-bundle reconciliation |
-| Infra | `util`, `out`, `mem`, `signal`, `types`, `scripts`, `audit`, `sysinfo`, `mmdb`, `geoip_update`, `bloom`, `ensuredirs` | File I/O + table helpers; logging; GC; timers; ADC type validation; plugin loader + sandbox + listener registry; onAudit JSONL log; system info; MaxMind DB reader + in-hub GeoLite2 auto-update; bloom filter; boot-time runtime-dir self-heal |
+| Crypto + boot trust | `sha256`, `hmac`, `cert_bootstrap`, `cacert_bootstrap`, `backup_archive` | Pure-Lua SHA-256; HMAC-SHA256 (RFC 2104, sandbox-exposed for signed-webhook auth, #398); first-boot TLS-cert auto-gen (#77); CA-bundle reconciliation; LDBK1 encrypted backup archive format (tar + AES-256-GCM, PBKDF2, #480) |
+| Infra | `util`, `out`, `mem`, `signal`, `types`, `scripts`, `audit`, `sysinfo`, `mmdb`, `geoip_update`, `bloom`, `ensuredirs`, `backup` | File I/O + table helpers; logging; GC; timers; ADC type validation; plugin loader + sandbox + listener registry; onAudit JSONL log; system info; MaxMind DB reader + in-hub GeoLite2 auto-update; bloom filter; boot-time runtime-dir self-heal; backup engine (collect restore-min set + seal + rotate, #480, exposed to the sandbox as `backup`) |
+
+**`core/restore.lua` is a standalone offline entry, not a `_core` module.**
+The C launcher's `run_restore()` (`hub/hub.c`) loads it into a fresh Lua state
+for `./luadch --restore <file>` (backup restore, #480 PR-B); it boots no hub
+(the cfg it would read is what it restores) and never appears in `_core` -
+like `init.lua` itself. Two C primitives back the arc: `listdir(path)`
+(core-only global, like `makedir` - NOT sandboxed) enumerates the state dirs
+for the backup engine, and `adclib.pbkdf2_sha256` (OpenSSL PKCS5_PBKDF2_HMAC)
+keeps the KDF off the pure-Lua path that would freeze the single-threaded hub
+~40s per backup. Operator guide: [`docs/BACKUP.md`](docs/BACKUP.md).
 
 **`core/hci.lua` is a now-legacy data file** (a plain `hubruntime` /
 `hubruntime_last_check` table). It backs `/v1/runtime` +

--- a/core/restore.lua
+++ b/core/restore.lua
@@ -1,0 +1,416 @@
+--[[
+
+    core/restore.lua - offline restore entry for the #480 backup arc (PR-B).
+
+    NOT a hub module: it is never in core/init.lua's `_core` and never runs
+    inside a live hub. The C launcher's run_restore() (hub/hub.c) loads THIS
+    file into a fresh Lua state when the operator runs
+
+        ./luadch --restore <file> [--verify] [--force] [--master-key-path P]
+
+    after chdir-to-install-root and AFTER acquiring the single-instance lock,
+    so a restore can never race a running hub over cfg/user.tbl/master.key.
+    It reverses core/backup.lua: decrypt + verify one .ldbk artifact and lay
+    its files back onto the install tree. It boots NOTHING else (no cfg, no
+    listeners) - the config it would read is exactly what it is restoring.
+
+    Two phases, transactional per file:
+      preflight - sha256 sidecar check, AES-256-GCM decrypt + MANIFEST parse,
+                  path-sanitize every entry, detect dest conflicts. No writes.
+      apply     - tmp-write + atomic rename each file, chmod 0600 the secrets.
+    --verify runs preflight only (a dry run). Without --force, restore refuses
+    to overwrite an existing populated tree.
+
+    SECURITY: an archive entry name is GCM-authenticated but is NOT a trusted
+    path - a valid-yet-crafted (or foreign) archive can carry "../../etc/x".
+    _safe_rel() rejects absolute paths and any ".."/"." component before a
+    single byte is written (the guard core/backup_archive.unpack's note asks
+    for). master.key is the one deliberately-absolute destination (the
+    operator's own configured / --master-key-path location), never a tar name.
+
+    Args arrive as globals set by the C caller: RESTORE_FILE (string),
+    RESTORE_VERIFY / RESTORE_FORCE (bool), RESTORE_MASTER_KEY_PATH (string|nil).
+    The passphrase is read out-of-band from $LUADCH_BACKUP_PASSPHRASE (there is
+    no cfg to read it from on a fresh host - that is the whole point). Returns
+    an integer exit code (0 = success/clean verify, 1 = failure).
+
+]]--
+
+----------------------------------// BOOTSTRAP //--
+-- This chunk runs with _ENV = the real globals (loaded plain by the C side),
+-- so require / io / os / string are directly reachable. We stand up the same
+-- restricted `use` env core modules expect and pull in backup_archive (which
+-- transitively loads hmac + sha256). adclib is a dynamic C lib, required the
+-- way core/init.lua requires it.
+
+local _G = _ENV
+
+local require      = require
+local loadfile     = loadfile
+local setmetatable = setmetatable
+local error        = error
+local type         = type
+local tostring     = tostring
+local tonumber     = tonumber
+local pcall        = pcall
+local ipairs       = ipairs
+local print        = print
+local os           = os
+local io           = io
+local string       = string
+local table        = table
+local package      = package
+
+local os_getenv  = os.getenv
+local os_rename  = os.rename
+local os_remove  = os.remove
+local io_open    = io.open
+
+-- .dll on Windows, .so elsewhere - same probe init.lua uses.
+local _filetype = ( os_getenv "COMSPEC" and os_getenv "WINDIR" and ".dll" ) or ".so"
+
+-- Resolve core/ + the bundled libs the way init.lua does, so require("adclib")
+-- and loadfile("core/backup_archive.lua") work from the install root.
+package.path = package.path .. ";"
+    .. "././core/?.lua;"
+    .. "././lib/?/?.lua;"
+    .. "././lib/luasocket/lua/?.lua;"
+    .. "././lib/luasec/lua/?.lua;"
+package.cpath = package.cpath .. ";"
+    .. "././lib/?/?" .. _filetype .. ";"
+    .. "././lib/luasocket/?/?" .. _filetype .. ";"
+    .. "././lib/luasec/?/?" .. _filetype .. ";"
+
+local _env
+local function loadscript( name )
+    if _G[ name ] ~= nil then return _G[ name ] end
+    local chunk, err = loadfile( "././core/" .. name .. ".lua", "t", _env )
+    if not chunk then error( "restore: cannot load core/" .. name .. ".lua: " .. tostring( err ), 0 ) end
+    _G[ name ] = chunk( )
+    return _G[ name ]
+end
+local function use( name )
+    local v = _G[ name ]
+    if v ~= nil then return v end
+    return loadscript( name )
+end
+_env = setmetatable( { use = use }, {
+    __index    = function( _, k ) error( "attempt to read undeclared var: '" .. tostring( k ) .. "'", 2 ) end,
+    __newindex = function( _, k ) error( "attempt to write undeclared var: '" .. tostring( k ) .. "'", 2 ) end,
+} )
+
+-- adclib is required (dynamic C lib); without it there is no AES-GCM/PBKDF2
+-- and nothing can be decrypted - fail loud with a clear message. A unit test
+-- may pre-inject a fake _G.adclib to exercise the pure helpers without the
+-- built C module; a real --restore always takes the require path.
+if _G.adclib == nil then
+    local ok, lib = pcall( require, "adclib" )
+    if not ok or type( lib ) ~= "table" then
+        print( "luadch restore: FATAL - could not load the adclib crypto module (" .. tostring( lib ) .. ")" )
+        print( "luadch restore: run --restore from the install root so lib/adclib is on the path." )
+        return 1
+    end
+    _G.adclib = lib
+end
+
+local archive = use "backup_archive"
+
+----------------------------------// CONSTANTS //--
+
+local MASTERKEY_ENTRY   = "__masterkey__"
+local DEFAULT_MK_PATH   = "cfg/master.key"
+local SIDECAR_SUFFIX    = ".sha256"
+local MAX_ARCHIVE_BYTES = 1024 * 1024 * 1024   -- 1 GiB read cap (OOM guard)
+
+-- Restored files are made owner-only (0600) by the umask run_restore() sets
+-- before this script runs, so there is no per-file secret classification here -
+-- master.key (0600 is load-bearing: cfg_secret refuses any other mode), the TLS
+-- key, and user.tbl all land 0600 without a post-write chmod race.
+
+----------------------------------// PURE HELPERS (test seams) //--
+
+-- Sanitize a tar entry name into a path that can only land INSIDE the install
+-- root. Rejects absolute paths (POSIX "/...", UNC "\\...", drive "C:...") and
+-- any dot/space-only component ("..", "...", ".. "), which covers traversal and
+-- its Windows normalisation. Returns (clean_relative_path) or (nil, reason).
+local function _safe_rel( name )
+    if type( name ) ~= "string" or name == "" then
+        return nil, "empty name"
+    end
+    -- Absolute: leading slash/backslash, or a "X:" drive prefix.
+    if string.match( name, "^[/\\]" ) or string.match( name, "^%a:" ) then
+        return nil, "absolute path"
+    end
+    local parts = { }
+    for seg in string.gmatch( name, "[^/\\]+" ) do
+        if seg == "." then
+            -- harmless no-op segment ("./x"), drop it
+        elseif string.match( seg, "^[%.%s]+$" ) then
+            -- ".." / "..." / ".. " / whitespace-only: rejects traversal AND the
+            -- Windows trailing-dot/space normalisation that maps them onto "."/".."
+            return nil, "unsafe component '" .. seg .. "'"
+        else
+            parts[ #parts + 1 ] = seg
+        end
+    end
+    if #parts == 0 then return nil, "no path segments" end
+    return table.concat( parts, "/" )
+end
+
+-- Where the master.key travels back to: an explicit --master-key-path wins,
+-- else the path recorded in the manifest (may be absolute - a DR relocation),
+-- else the in-tree default. Absolute here is BY DESIGN (operator-owned), unlike
+-- a tar entry name, so it is not run through _safe_rel.
+local function _resolve_masterkey_dest( meta, mk_override )
+    if type( mk_override ) == "string" and mk_override ~= "" then return mk_override end
+    if type( meta ) == "table" and type( meta.master_key_path ) == "string"
+       and meta.master_key_path ~= "" then
+        return meta.master_key_path
+    end
+    return DEFAULT_MK_PATH
+end
+
+-- Turn the unpacked { meta, files } into a concrete write plan without
+-- touching disk. Returns plan, rejects where:
+--   plan[i]    = { dest, body [, masterkey=true] }   (masterkey => the __masterkey__ entry)
+--   rejects[i] = { name, reason }                    (unsafe path => fatal, aborts restore)
+local function _build_plan( files, meta, mk_override )
+    local plan, rejects = { }, { }
+    local has_override = type( mk_override ) == "string" and mk_override ~= ""
+    for _, f in ipairs( files ) do
+        if f.name == MASTERKEY_ENTRY or f.kind == "masterkey" then
+            local dest = _resolve_masterkey_dest( meta, mk_override )
+            -- The manifest's master_key_path may be absolute / out-of-tree (a DR
+            -- relocation). Honour that ONLY when the operator opted in with
+            -- --master-key-path: a foreign archive must not steer an arbitrary
+            -- absolute write via the manifest. An in-tree relative path is fine.
+            if not has_override and _safe_rel( dest ) == nil then
+                rejects[ #rejects + 1 ] = { name = f.name,
+                    reason = "manifest places master.key out of tree at '" .. dest
+                        .. "'; re-run with --master-key-path to choose where" }
+            else
+                plan[ #plan + 1 ] = { dest = dest, body = f.body, masterkey = true }
+            end
+        else
+            local rel, why = _safe_rel( f.name )
+            if not rel then
+                rejects[ #rejects + 1 ] = { name = f.name, reason = why }
+            else
+                plan[ #plan + 1 ] = { dest = rel, body = f.body }
+            end
+        end
+    end
+    return plan, rejects
+end
+
+-- Verify the sidecar if present. Returns "ok" | "missing" | "mismatch".
+local function _verify_sidecar( blob, sidecar_text )
+    if type( sidecar_text ) ~= "string" or sidecar_text == "" then return "missing" end
+    local want = string.match( sidecar_text, "^(%x+)" )
+    if not want then return "mismatch" end
+    return ( string.lower( want ) == string.lower( archive.checksum( blob ) ) ) and "ok" or "mismatch"
+end
+
+----------------------------------// DISK HELPERS //--
+
+-- Parent-directory chain of a dest path, innermost last, so makedir walks it
+-- top-down. Handles both separators; skips an absolute root / drive prefix.
+local function _dir_of( path )
+    return ( string.match( path, "^(.*)[/\\][^/\\]+$" ) )
+end
+
+local makedir = _G.makedir   -- C primitive registered by run_restore()
+
+-- Create the parent directory chain of `dest`. The makedir C primitive is
+-- already mkdir -p (it walks every separator and tolerates EEXIST, absolute
+-- roots and a Windows drive prefix), so one call suffices; propagate its error
+-- so a genuine failure (permission) surfaces as itself, not a later write error.
+local function _ensure_parent( dest )
+    local dir = _dir_of( dest )
+    if not dir or dir == "" then return true end
+    if not makedir then return true end   -- absent under a standalone lua (tests)
+    local ok, err = makedir( dir )
+    if not ok then return false, "cannot create directory '" .. dir .. "': " .. tostring( err ) end
+    return true
+end
+
+local function _write_atomic( path, content )
+    local tmp = path .. ".restore-tmp"
+    local f, err = io_open( tmp, "wb" )
+    if not f then return false, err end
+    local ok, werr = f:write( content )
+    f:close( )
+    if not ok then os_remove( tmp ); return false, werr end
+    -- Fast path: POSIX rename replaces atomically; Windows rename succeeds when
+    -- the dest does not exist (a fresh-tree restore).
+    local rok, rerr = os_rename( tmp, path )
+    if rok then return true end
+    -- Windows + existing dest (a --force overwrite): rename refuses. Move the
+    -- original aside FIRST so a failed swap can never destroy it, then swap,
+    -- then drop the saved copy. On any failure the original is put back.
+    local saved = path .. ".restore-old"
+    os_remove( saved )
+    if os_rename( path, saved ) then
+        if os_rename( tmp, path ) then os_remove( saved ); return true end
+        os_rename( saved, path )   -- swap failed: restore the original
+        os_remove( tmp )
+        return false, "rename failed (original restored)"
+    end
+    os_remove( tmp )
+    return false, rerr or "rename failed"
+end
+
+local function _exists( path )
+    local f = io_open( path, "rb" )
+    if f then f:close( ); return true end
+    return false
+end
+
+----------------------------------// DRIVER //--
+
+local function _read_capped( path )
+    local f, err = io_open( path, "rb" )
+    if not f then return nil, err end
+    local size = f:seek( "end" )
+    if size and size > MAX_ARCHIVE_BYTES then
+        f:close( )
+        return nil, "archive too large (" .. size .. " bytes > " .. MAX_ARCHIVE_BYTES .. ")"
+    end
+    f:seek( "set" )
+    local data = f:read( "a" )
+    f:close( )
+    return data
+end
+
+local function main( )
+    local file    = _G.RESTORE_FILE
+    local verify  = _G.RESTORE_VERIFY and true or false
+    local force   = _G.RESTORE_FORCE and true or false
+    local mk_over = _G.RESTORE_MASTER_KEY_PATH
+
+    if type( file ) ~= "string" or file == "" then
+        print( "luadch restore: no backup file given" )
+        return 1
+    end
+
+    local passphrase = os_getenv "LUADCH_BACKUP_PASSPHRASE"
+    if type( passphrase ) ~= "string" or passphrase == "" then
+        print( "luadch restore: set the backup passphrase in $LUADCH_BACKUP_PASSPHRASE, e.g." )
+        print( "  LUADCH_BACKUP_PASSPHRASE='...' ./luadch --restore " .. file )
+        return 1
+    end
+
+    print( "luadch restore: reading " .. file )
+    local blob, rerr = _read_capped( file )
+    if not blob then
+        print( "luadch restore: cannot read '" .. file .. "': " .. tostring( rerr ) )
+        return 1
+    end
+
+    -- Passphrase-free integrity gate (sha256sum sidecar). A mismatch means the
+    -- artifact was truncated/altered on the media - abort before spending the
+    -- KDF. A missing sidecar is only a warning (GCM still authenticates).
+    local sidecar_text = _read_capped( file .. SIDECAR_SUFFIX )
+    local sc = _verify_sidecar( blob, sidecar_text )
+    if sc == "mismatch" then
+        print( "luadch restore: ABORT - sidecar sha256 does not match (corrupt/altered archive)" )
+        return 1
+    end
+    print( "luadch restore: sidecar " .. ( sc == "ok" and "sha256 OK" or "absent (skipped)" ) )
+
+    local un, uerr = archive.unpack( blob, passphrase )
+    if not un then
+        print( "luadch restore: cannot open archive: " .. tostring( uerr ) )
+        return 1
+    end
+    local meta = un.meta or { }
+    print( string.format( "luadch restore: unpacked %s %s (%d file(s))",
+        tostring( meta.program or "?" ), tostring( meta.hub_version or "?" ), #un.files ) )
+
+    local plan, rejects = _build_plan( un.files, meta, mk_over )
+    if #rejects > 0 then
+        print( "luadch restore: ABORT - archive contains unsafe path(s):" )
+        for _, r in ipairs( rejects ) do print( "  " .. r.name .. "  (" .. r.reason .. ")" ) end
+        return 1
+    end
+
+    -- Conflict scan: refuse to clobber an already-populated tree unless forced.
+    local conflicts = { }
+    for _, p in ipairs( plan ) do
+        if _exists( p.dest ) then conflicts[ #conflicts + 1 ] = p.dest end
+    end
+
+    print( "luadch restore: plan" )
+    for _, p in ipairs( plan ) do
+        print( "  " .. p.dest .. ( _exists( p.dest ) and "  (exists)" or "" ) )
+    end
+
+    -- --verify is a dry run: report the plan (conflicts included) and exit 0
+    -- WITHOUT writing or refusing. Checked BEFORE the conflict refusal so a
+    -- sanity-check against a live tree does not fail merely because files exist.
+    if verify then
+        local note = ( #conflicts > 0 )
+            and ( " (" .. #conflicts .. " already exist; --force needed to overwrite)" ) or ""
+        print( "luadch restore: --verify OK - " .. #plan .. " file(s) would be restored"
+            .. note .. ", no changes written." )
+        return 0
+    end
+
+    if #conflicts > 0 and not force then
+        print( "luadch restore: REFUSING - " .. #conflicts
+            .. " file(s) already exist. Restore into a clean install, or pass --force to overwrite." )
+        return 1
+    end
+
+    -- Apply. Each file is tmp-write + atomic rename, so a mid-run failure never
+    -- leaves a half-written dest; already-restored files stay put. Files land
+    -- owner-only (0600) via the umask run_restore() set, so no chmod is needed.
+    local done, failed, mk_done = 0, nil, false
+    for _, p in ipairs( plan ) do
+        local pok, perr = _ensure_parent( p.dest )
+        if not pok then failed = perr; break end
+        local ok, werr = _write_atomic( p.dest, p.body )
+        if not ok then
+            failed = "cannot write '" .. p.dest .. "': " .. tostring( werr )
+            break
+        end
+        if p.masterkey then mk_done = true end
+        done = done + 1
+    end
+
+    if failed then
+        print( "luadch restore: FAILED after " .. done .. " file(s): " .. failed )
+        return 1
+    end
+
+    print( "luadch restore: DONE - " .. done .. " file(s) restored." )
+    if mk_done then
+        print( "luadch restore: master.key placed at " .. _resolve_masterkey_dest( meta, mk_over ) )
+    elseif meta.include_master_key then
+        print( "luadch restore: NOTE - this backup was set to include master.key, but none was"
+            .. " present at backup time; supply your own so user.tbl can decrypt." )
+    else
+        print( "luadch restore: NOTE - this backup excluded master.key; put your own in place"
+            .. " (--master-key-path, or at master_key_path) so user.tbl can decrypt." )
+    end
+    print( "luadch restore: review cfg/, then start the hub." )
+    return 0
+end
+
+----------------------------------// TEST SEAM / ENTRY //--
+
+-- When required as a module (unit tests set RESTORE_TEST), export the pure
+-- helpers instead of running. The C launcher never sets that flag, so a real
+-- --restore falls through to main().
+if _G.RESTORE_TEST then
+    return {
+        _safe_rel               = _safe_rel,
+        _resolve_masterkey_dest = _resolve_masterkey_dest,
+        _build_plan             = _build_plan,
+        _verify_sidecar         = _verify_sidecar,
+        _dir_of                 = _dir_of,
+        archive                 = archive,
+    }
+end
+
+return main( )

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -1,0 +1,232 @@
+# Backup and restore
+
+Encrypted, self-contained hub backups (`etc_backup` plugin + `core/backup*`,
+[#480](https://github.com/luadch-ng/luadch/issues/480)) and an offline restore
+(`Luadch --restore`). The hub is a **producer only**: it writes encrypted
+`.ldbk` artifacts to a local directory. Copying them off-site (rclone, restic,
+a cron job, a mounted volume) is the operator's job - see
+[Off-site copies](#off-site-copies).
+
+- [What a backup contains](#what-a-backup-contains)
+- [Enabling backups](#enabling-backups)
+- [Schedule](#schedule)
+- [The passphrase](#the-passphrase)
+- [master.key](#masterkey)
+- [Integrity sidecar](#integrity-sidecar)
+- [Off-site copies](#off-site-copies)
+- [Restore](#restore)
+- [Disaster-recovery runbook](#disaster-recovery-runbook)
+- [Docker](#docker)
+- [Security model](#security-model)
+
+---
+
+## What a backup contains
+
+One backup is the **restore-minimum set** - everything a fresh hub needs to
+come back as the old one:
+
+- `cfg/cfg.tbl` (settings), `cfg/user.tbl` + `cfg/user.tbl.bak` (accounts)
+- the TLS material named by `ssl_params` (`serverkey.pem`, `servercert.pem`,
+  `cacert.pem`)
+- every `scripts/data/*.tbl` and `scripts/cfg/*.tbl` (plugin state)
+- `master.key` (the at-rest encryption key), unless you opt out - see below
+
+Half-written `*.tmp` files are skipped. Everything is packed into one tar,
+sealed with **AES-256-GCM** (key = PBKDF2-HMAC-SHA256 of your passphrase), and
+written as `cfg/backups/luadch-backup-YYYYMMDD-HHMMSS.ldbk` plus a
+`.ldbk.sha256` sidecar. The artifact is 0600 on POSIX.
+
+The hub is single-threaded and takes the snapshot synchronously, so a backup is
+consistent by construction - no file is being written while it runs.
+
+## Enabling backups
+
+`scripts/etc_backup.lua` ships enabled by default, but stays **inert until a
+passphrase is set** (it nags the hub owner until then). To turn it on:
+
+1. Set a passphrase (see [The passphrase](#the-passphrase)).
+2. Confirm the plugin is whitelisted in `cfg.scripts` (the default `cfg.tbl`
+   already lists `{ "etc_backup.lua", enabled = true }`).
+3. `+reload`.
+
+Config keys (`core/cfg_defaults.lua`, all `etc_backup_*`):
+
+| Key | Default | Meaning |
+|---|---|---|
+| `etc_backup_enabled` | `true` | master on/off for the engine |
+| `etc_backup_dir` | `"cfg/backups"` | where artifacts land (may be absolute / a mount) |
+| `etc_backup_keep` | `7` | retention: prune oldest beyond N |
+| `etc_backup_daily_at` | `"04:00"` | server-local HH:MM daily run |
+| `etc_backup_interval_hours` | `0` | fallback cadence when `daily_at` is empty |
+| `etc_backup_include_master_key` | `true` | pack `master.key` into the backup |
+| `etc_backup_passphrase` | `""` | seal passphrase (prefer the env var) |
+| `etc_backup_oplevel` | `80` | level for `+backup` |
+| `etc_backup_notify_level` | `100` | level that gets the readiness nag |
+
+Operator commands (level `etc_backup_oplevel`):
+
+- `+backup now` - run a backup immediately
+- `+backup list` - list artifacts in the backup dir
+- `+backup status` - schedule + readiness summary
+
+## Schedule
+
+Two mutually exclusive modes, both persisted across `+reload` (a reload never
+re-triggers or skips a run):
+
+- **Daily at a fixed time** (default): `etc_backup_daily_at = "04:00"`,
+  server-local. Pick a quiet hour.
+- **Every N hours**: clear `etc_backup_daily_at` (`""`) and set
+  `etc_backup_interval_hours = 6` (or 2 / 4 / 12).
+
+## The passphrase
+
+The passphrase protects the backup independently of `master.key`, so a backup
+stays recoverable even if the hub host and its key are lost together. There is
+**no passphrase-recovery path** - store it in a password manager. Two sources,
+env var first (`core/secrets`):
+
+- **Environment** (recommended, Docker-friendly):
+  `LUADCH_ETC_BACKUP_PASSPHRASE`
+- **cfg.tbl** (bare-metal): `etc_backup_passphrase = "..."`. This is fine - the
+  encrypted backup does not depend on cfg.tbl secrecy; the passphrase only ever
+  seals/opens the artifact.
+
+The restore side reads a **separate** env var, `LUADCH_BACKUP_PASSPHRASE` (there
+is no cfg to read on a fresh host); see [Restore](#restore).
+
+## master.key
+
+`master.key` is the AES key for `user.tbl` at-rest encryption
+([SECURITY.md](SECURITY.md)). By default it is packed **into** the backup, so a
+single artifact + the passphrase is enough to fully restore. That is convenient
+but means the passphrase is the only thing standing between an attacker and
+`user.tbl`. To decouple them, set `etc_backup_include_master_key = false`: the
+backup then omits `master.key`, and a restore leaves you to supply your own
+(`--master-key-path`, or drop it at `master_key_path`). Without the right
+`master.key`, `user.tbl` cannot be decrypted after restore.
+
+`master.key` may live outside the install tree (`master_key_path` in cfg.tbl,
+e.g. `/etc/luadch/master.key`). The real path travels in the backup manifest.
+On restore, an in-tree location (the `cfg/master.key` default) is put back
+automatically; an **out-of-tree absolute path is only used when you pass
+`--master-key-path`** - restore will not write `master.key` to an absolute
+location on the manifest's say-so alone (so a backup from an untrusted source
+cannot steer an arbitrary write). Restoring your own out-of-tree setup is one
+flag: `--master-key-path /etc/luadch/master.key`.
+
+## Integrity sidecar
+
+Every artifact gets a `.ldbk.sha256` sidecar in standard `sha256sum` format, so
+you can check an artifact on any host without the passphrase:
+
+```sh
+cd cfg/backups && sha256sum -c luadch-backup-YYYYMMDD-HHMMSS.ldbk.sha256
+```
+
+`--restore` verifies the sidecar automatically before spending the KDF.
+
+## Off-site copies
+
+The hub does not push anywhere. Copy `cfg/backups/` off the box on your own
+schedule. Examples:
+
+```sh
+# rclone to any remote (S3, B2, WebDAV, SFTP, ...)
+rclone sync /opt/luadch/cfg/backups remote:luadch-backups
+
+# restic (dedup + its own encryption on top)
+restic -r s3:s3.example.com/luadch backup /opt/luadch/cfg/backups
+
+# plain scp in cron
+0 5 * * * scp -q /opt/luadch/cfg/backups/*.ldbk* backup@host:/srv/luadch/
+```
+
+The `.ldbk` is already encrypted, so an untrusted remote is acceptable; restic's
+extra layer is optional defense-in-depth.
+
+## Restore
+
+Offline, one-shot, on a hub that is **not running** (the restore refuses to run
+while a hub holds the install's single-instance lock, so it can never race live
+`cfg`/`user.tbl`/`master.key` writes):
+
+```sh
+cd /opt/luadch          # the install root (where the binary lives)
+export LUADCH_BACKUP_PASSPHRASE='your-backup-passphrase'
+./luadch --restore cfg/backups/luadch-backup-20260721-040000.ldbk
+```
+
+Flags:
+
+| Flag | Effect |
+|---|---|
+| `--restore <file>` | restore this artifact, then exit |
+| `--verify` | dry run: check + decrypt + list the plan, write nothing |
+| `--force` | overwrite files that already exist |
+| `--master-key-path <p>` | place `master.key` at `<p>` instead of its recorded path |
+
+Restore is two-phase and transactional per file: it verifies the sidecar,
+decrypts + authenticates (AES-256-GCM), parses the manifest, **rejects any
+unsafe path** (absolute or `..` - a foreign archive cannot escape the tree),
+checks for conflicts, then writes each file via a temp + atomic rename. Every
+restored file lands owner-only (0600). Into a populated tree it refuses unless
+you pass `--force`; `--verify` is exempt (it only reports). A wrong passphrase
+fails cleanly and writes nothing.
+
+Always dry-run first:
+
+```sh
+./luadch --restore <file> --verify
+```
+
+## Disaster-recovery runbook
+
+Rebuild a dead hub on a fresh host:
+
+1. Install luadch the normal way ([INSTALLING.md](INSTALLING.md)) - do **not**
+   run it yet, or first-boot writes a fresh cfg/certs you would overwrite.
+2. Copy the chosen `.ldbk` (and its `.sha256`) onto the host.
+3. From the install root:
+   ```sh
+   export LUADCH_BACKUP_PASSPHRASE='...'
+   ./luadch --restore /path/to/luadch-backup-....ldbk --verify   # inspect
+   ./luadch --restore /path/to/luadch-backup-....ldbk            # apply
+   ```
+   On a fresh install nothing exists yet, so `--force` is not needed.
+4. If the backup **excluded** `master.key`, put your own copy in place now
+   (`--master-key-path`, or at `master_key_path`), else `user.tbl` will not
+   decrypt.
+5. Start the hub. Log in and confirm accounts/settings.
+
+## Docker
+
+- Mount the backup dir out of the container so artifacts survive it:
+  `-v ./cfg/backups:/luadch/cfg/backups` (or point `etc_backup_dir` at a
+  dedicated volume).
+- Set the passphrase via env: `-e LUADCH_ETC_BACKUP_PASSPHRASE=...`.
+- Container clocks are usually UTC - `etc_backup_daily_at` is server-local, so
+  pick the hour in UTC.
+- To restore, run the one-shot in a container over the target tree with the hub
+  stopped:
+  ```sh
+  docker compose run --rm -e LUADCH_BACKUP_PASSPHRASE=... \
+    luadch --restore cfg/backups/luadch-backup-....ldbk
+  ```
+  See [DOCKER.md](DOCKER.md) for the `master_key_path`-on-`secrets/`-mount
+  layout.
+
+## Security model
+
+- The backup is only as strong as its passphrase (PBKDF2-HMAC-SHA256 ->
+  AES-256-GCM). No recovery path; use a password manager.
+- The engine reads its **own** policy (dir / keep / passphrase / master.key
+  inclusion) from cfg + `core/secrets`, never from a caller, so a sandboxed
+  plugin can trigger a backup only to the operator-configured destination - it
+  cannot redirect the artifact or choose the key.
+- Restore holds the single-instance lock, sanitizes every archive path against
+  `..`/absolute escapes, and authenticates the ciphertext before writing.
+- With `include_master_key = true`, treat the artifact like `master.key`
+  itself: the passphrase is then the only barrier to `user.tbl`. Set it to
+  `false` to keep the two secrets separate.

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -78,7 +78,10 @@ that environment:
     wrapper); plain Lua `string.*` byte methods are not directly
     reachable
   - luadch core: `hub`, `cfg`, `util`, `util_http`, `adc`, `adclib`,
-    `signal`, `out`, `unicode`, `sysinfo`
+    `signal`, `out`, `unicode`, `sysinfo`, `backup` (the automatic-backup
+    engine, #480; `+backup` driver `etc_backup` calls `backup.run`/
+    `.readiness`/`.list`) - and more; the list above is illustrative, so
+    treat `SANDBOX_GLOBALS` as the authority
   - Optional libs (may be `false` if not built): `ssl` (with `.x509`
     pre-attached), `socket`, `basexx`, `zlib_stream`, `dkjson`
 - **Notably absent** (a malicious plugin cannot reach these):

--- a/hub/hub.c
+++ b/hub/hub.c
@@ -36,6 +36,14 @@
 static volatile sig_atomic_t do_exit = 0;
 static int do_daemonization = 0;
 
+/* Offline-restore mode (#480 PR-B): set by handle_args from --restore and
+ * friends, consumed by run_restore() before the hub would ever boot. */
+static int do_restore = 0;
+static int restore_verify = 0;
+static int restore_force = 0;
+static const char *restore_file = NULL;
+static const char *restore_mk_path = NULL;
+
 static void log_error(const char *msg)
 {
   // Write to log/exception.txt next to the binary. chdir_to_binary_dir
@@ -439,6 +447,59 @@ static void run_lua(void)
   exit(EXIT_SUCCESS);
 }
 
+/* Offline restore (#480 PR-B). Mirrors run_lua's state setup (openlibs + the
+ * makedir C primitive core/restore.lua needs) but loads core/restore.lua
+ * instead of the hub, hands it the CLI options as globals, and returns the
+ * integer exit code the script yields. adclib is required dynamically inside
+ * restore.lua, exactly as init.lua requires it - no static registration here.
+ * Never daemonizes and never enters the event loop. */
+static int run_restore(void)
+{
+  lua_State *L = luaL_newstate();
+  if (!L)
+  {
+    log_error("cannot create Lua state: not enough memory");
+    return EXIT_FAILURE;
+  }
+#ifdef __unix__
+  /* Restore does not go through daemonize()'s umask(027), so without this the
+   * files it writes take the operator's interactive umask (often 022 -> 0644),
+   * leaving the freshly-restored PLAINTEXT master.key / user.tbl / TLS key
+   * group/world-readable. 077 makes every restored file owner-only (0600) at
+   * creation - no post-write chmod window - and satisfies cfg_secret's
+   * mandatory 0600 on master.key. No-op on Windows. */
+  umask(077);
+#endif
+  luaL_openlibs(L);
+  lua_register(L, "makedir", makedir);
+
+  lua_pushstring(L, restore_file ? restore_file : "");
+  lua_setglobal(L, "RESTORE_FILE");
+  lua_pushboolean(L, restore_verify);
+  lua_setglobal(L, "RESTORE_VERIFY");
+  lua_pushboolean(L, restore_force);
+  lua_setglobal(L, "RESTORE_FORCE");
+  if (restore_mk_path)
+  {
+    lua_pushstring(L, restore_mk_path);
+    lua_setglobal(L, "RESTORE_MASTER_KEY_PATH");
+  }
+
+  int rc = EXIT_FAILURE;
+  if (luaL_loadfile(L, "core/restore.lua") || lua_pcall(L, 0, 1, 0))
+  {
+    log_error(lua_tostring(L, -1));
+  }
+  else
+  {
+    /* restore.lua returns 0 on success, 1 on failure. Anything non-integer
+     * (a script bug) is treated as failure. */
+    rc = lua_isinteger(L, -1) ? (int)lua_tointeger(L, -1) : EXIT_FAILURE;
+  }
+  lua_close(L);
+  return rc;
+}
+
 static void daemonize(void)
 {
   if (!do_daemonization)
@@ -483,20 +544,58 @@ static void print_help(void)
   fprintf(stderr,
   "usage: luadch [option]\n"
   "available options are:\n"
-  "  -h       show this help\n"
-  "  -d       execute luadch as background daemon\n");
+  "  -h                       show this help\n"
+  "  -d                       execute luadch as background daemon\n"
+  "  --restore <file>         restore an encrypted .ldbk backup, then exit\n"
+  "  --verify                 with --restore: check the archive, write nothing\n"
+  "  --force                  with --restore: overwrite existing files\n"
+  "  --master-key-path <p>    with --restore: place master.key at <p>\n");
   fflush(stderr);
   exit(EXIT_SUCCESS);
 }
 
+/* Parse argv. Keeps the legacy single-letter -h/-d and adds the --restore
+ * family (offline restore, #480 PR-B). --restore consumes the next argv as the
+ * archive path; --master-key-path consumes the next argv as an override. */
 static void handle_args(int argc, char **argv)
 {
-  if (argc > 1 && argv[1][0] == '-')
+  for (int i = 1; i < argc; i++)
   {
-    switch(argv[1][1])
+    const char *a = argv[i];
+    if (strcmp(a, "-h") == 0 || strcmp(a, "--help") == 0)
     {
-      case 'h': print_help(); break;
-      case 'd': do_daemonization = 1; break;
+      print_help();
+    }
+    else if (strcmp(a, "-d") == 0)
+    {
+      do_daemonization = 1;
+    }
+    else if (strcmp(a, "--restore") == 0)
+    {
+      if (i + 1 >= argc)
+      {
+        fprintf(stderr, "luadch: --restore needs a backup file argument\n");
+        exit(EXIT_FAILURE);
+      }
+      do_restore = 1;
+      restore_file = argv[++i];
+    }
+    else if (strcmp(a, "--verify") == 0)
+    {
+      restore_verify = 1;
+    }
+    else if (strcmp(a, "--force") == 0)
+    {
+      restore_force = 1;
+    }
+    else if (strcmp(a, "--master-key-path") == 0)
+    {
+      if (i + 1 >= argc)
+      {
+        fprintf(stderr, "luadch: --master-key-path needs a path argument\n");
+        exit(EXIT_FAILURE);
+      }
+      restore_mk_path = argv[++i];
     }
   }
 }
@@ -662,6 +761,12 @@ int main(int argc, char **argv)
     log_error("luadch: another instance is already running in this "
               "directory; refusing to start.");
     return EXIT_FAILURE;
+  }
+  // Offline restore runs HERE - after the lock (so it can never race a running
+  // hub over cfg/user.tbl/master.key) but before any hub boot - and exits.
+  if (do_restore)
+  {
+    return run_restore();
   }
   // Lift the fd soft limit to the hard limit so the POSIX poll() event loop
   // (#310) is not silently re-capped at the default ulimit -n. Inherited

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -651,6 +651,117 @@ def test_backup_now(staging_dir: Path):
         raise TestFailure(f"backup sidecar format wrong: {sc!r}")
 
 
+def test_backup_restore_roundtrip(source_install: Path, keep_staging=False):
+    """#480 PR-B: an engine-sealed backup restores cleanly through the real
+    binary via `Luadch --restore`, with genuine AES-256-GCM decrypt. Full
+    loop on its OWN staged tree (independent of the shared hub):
+
+        boot -> +backup now -> stop hub -> corrupt cfg/cfg.tbl
+             -> --restore --verify (must write nothing)
+             -> --restore --force  (must restore cfg.tbl byte-for-byte)
+
+    Exercises the C arg parsing (--restore/--verify/--force), run_restore(),
+    core/restore.lua's bootstrap (real adclib require + backup_archive load),
+    the sidecar check, unpack, path-sanitize, and the atomic apply. Provably
+    fails without PR-B: the pre-PR binary rejects --restore as an unknown
+    option and never writes the file back."""
+    st = stage_install(source_install)
+    proc = None
+    log_file = None
+    # Dedicated ports: the shared hub is still running on TEST_PORT_* when this
+    # runs, so reusing them would make the client connect to THAT hub (whose
+    # dummy password an earlier +setpass test changed). Own ports -> own hub.
+    rt_plain = TEST_PORT_PLAIN + 100
+    try:
+        override_test_ports(st)   # sets etc_backup_passphrase = smoke-backup-pass
+        rt_cfg = st / "cfg" / "cfg.tbl"
+        rt_text = rt_cfg.read_text(encoding="utf-8")
+        for pat, repl in (
+            (r"tcp_ports\s*=\s*\{[^}]*\}", f"tcp_ports = {{ {rt_plain} }}"),
+            (r"ssl_ports\s*=\s*\{[^}]*\}", f"ssl_ports = {{ {TEST_PORT_TLS + 100} }}"),
+            (r"tcp_ports_ipv6\s*=\s*\{[^}]*\}", f"tcp_ports_ipv6 = {{ {TEST_PORT_PLAIN_V6 + 100} }}"),
+            (r"ssl_ports_ipv6\s*=\s*\{[^}]*\}", f"ssl_ports_ipv6 = {{ {TEST_PORT_TLS_V6 + 100} }}"),
+        ):
+            rt_text, n = re.subn(pat, repl, rt_text, count=1)
+            if n != 1:
+                raise RuntimeError(f"round-trip: could not re-port cfg.tbl: {pat}")
+        rt_cfg.write_text(rt_text, encoding="utf-8")
+        for stale in ("servercert.pem", "serverkey.pem", "cacert.pem", "cakey.pem"):
+            (st / "certs" / stale).unlink(missing_ok=True)
+        proc, log_file = start_hub(st)
+        wait_for_port(HUB_HOST, rt_plain, START_TIMEOUT_SEC)
+
+        # Produce one real backup through the engine.
+        backups_dir = st / "cfg" / "backups"
+        with socket.create_connection(
+            (HUB_HOST, rt_plain), timeout=PROTOCOL_TIMEOUT_SEC
+        ) as sock:
+            sid, reader = _adc_login(sock, "dummy", "test")
+            sock.sendall(f"BMSG {sid} +backup\\snow\n".encode("utf-8"))
+            reader.recv_until(
+                lambda f: f.startswith(("EMSG ", "DMSG ", "BMSG ")) and ("written" in f or "failed" in f),
+                timeout=PROTOCOL_TIMEOUT_SEC,
+            )
+        arts = sorted(backups_dir.glob("luadch-backup-*.ldbk"))
+        if not arts:
+            raise TestFailure("round-trip: no backup artifact was produced")
+        artifact = arts[-1]
+
+        # Stop the hub so --restore can take the single-instance lock (a
+        # restore over a running hub is refused by design).
+        stop_hub(proc, log_file)
+        proc = None
+
+        cfg = st / "cfg" / "cfg.tbl"
+        original = cfg.read_bytes()
+        corrupt = b"-- CORRUPTED BY SMOKE TEST --\n"
+        cfg.write_bytes(corrupt)
+
+        binary = st / ("Luadch.exe" if sys.platform == "win32" else "luadch")
+        env = dict(os.environ, LUADCH_BACKUP_PASSPHRASE="smoke-backup-pass")
+
+        # --verify is a dry run over the POPULATED tree (no --force): it must
+        # still exit 0 and write nothing - the conflict refusal is for a real
+        # apply, not a verify.
+        rv = subprocess.run(
+            [str(binary), "--restore", str(artifact), "--verify"],
+            cwd=str(st), env=env, capture_output=True, text=True, timeout=60,
+        )
+        if rv.returncode != 0:
+            raise TestFailure(f"--verify exited {rv.returncode}:\n{rv.stdout}\n{rv.stderr}")
+        if cfg.read_bytes() != corrupt:
+            raise TestFailure("--verify wrote to disk; it must be a dry run")
+
+        # Real restore: cfg.tbl must come back exactly.
+        rr = subprocess.run(
+            [str(binary), "--restore", str(artifact), "--force"],
+            cwd=str(st), env=env, capture_output=True, text=True, timeout=60,
+        )
+        if rr.returncode != 0:
+            raise TestFailure(f"--restore exited {rr.returncode}:\n{rr.stdout}\n{rr.stderr}")
+        if cfg.read_bytes() != original:
+            raise TestFailure("cfg.tbl was not restored to its original bytes")
+
+        # A wrong passphrase must be rejected (GCM auth), not silently applied.
+        cfg.write_bytes(corrupt)
+        bad = subprocess.run(
+            [str(binary), "--restore", str(artifact), "--force"],
+            cwd=str(st), env=dict(os.environ, LUADCH_BACKUP_PASSPHRASE="wrong-pass"),
+            capture_output=True, text=True, timeout=60,
+        )
+        if bad.returncode == 0:
+            raise TestFailure("--restore accepted a wrong passphrase")
+        if cfg.read_bytes() != corrupt:
+            raise TestFailure("--restore wrote files despite a wrong passphrase")
+    finally:
+        if proc is not None:
+            stop_hub(proc, log_file)
+        if keep_staging:
+            log(f"restore round-trip staging kept at {st.parent}")
+        else:
+            shutil.rmtree(st.parent, ignore_errors=True)
+
+
 def test_s1_fragmented_frame_reassembled():
     """Phase 8 S1: an ADC frame split across two TCP segments must be
     reassembled and processed as one frame.
@@ -13127,6 +13238,19 @@ def main():
             failed.append("single-instance lock refuses second start")
         else:
             log("PASS  single-instance lock refuses second start")
+
+        # #480 PR-B: backup -> --restore round-trip on its own staged tree
+        # (real AES-256-GCM decrypt through the binary). Independent of the
+        # shared hub above; stages + tears down its own install.
+        try:
+            test_backup_restore_roundtrip(
+                args.install_dir.resolve(), keep_staging=args.keep_staging,
+            )
+        except Exception as e:
+            log(f"FAIL  backup -> restore round-trip (#480 PR-B): {e}")
+            failed.append("backup -> restore round-trip (#480 PR-B)")
+        else:
+            log("PASS  backup -> restore round-trip (#480 PR-B)")
 
         # #128 plaintext-mode test runs AFTER the regular battery
         # because cfg_secret.init() reads encrypt_usertbl once at

--- a/tests/unit/restore_test.lua
+++ b/tests/unit/restore_test.lua
@@ -1,0 +1,178 @@
+--[[
+
+    tests/unit/restore_test.lua
+
+    Unit tests for core/restore.lua's pure decision logic (the offline-restore
+    entry, #480 PR-B), loaded through its RESTORE_TEST seam so no adclib C
+    module, no real filesystem and no `--restore` run is needed:
+      - _safe_rel(): the SECURITY guard - reject absolute paths / ".." / drive
+        / UNC, normalise separators, strip "." (path-traversal defence the
+        backup_archive.unpack note demands before any write)
+      - _resolve_masterkey_dest(): override > manifest path > in-tree default
+      - _build_plan(): __masterkey__ sentinel + secret-mode classification +
+        unsafe entries routed to rejects, never to the write plan
+      - _verify_sidecar(): sha256 sidecar match / mismatch / missing
+
+    A fake _G.adclib lets backup_archive load without the built C module
+    (its sha256 checksum path is pure Lua, so _verify_sidecar is exercised
+    for real).
+
+    Run: lua5.4 tests/unit/restore_test.lua   (exit 0 = pass, 1 = fail)
+
+]]--
+
+-- backup_archive loads via restore.lua's loadscript; a minimal fake adclib
+-- skips the require() and the C-vs-Lua pbkdf2 cross-check at load.
+_G.adclib = { }
+_G.RESTORE_TEST = true
+
+local R = assert( loadfile( "core/restore.lua" ) )( )
+assert( type( R ) == "table", "restore.lua did not return its test seam" )
+
+----------------------------------------------------------------------
+-- harness
+----------------------------------------------------------------------
+
+local passes, fails = 0, 0
+local function ok( label, cond )
+    if cond then passes = passes + 1
+    else fails = fails + 1; io.stderr:write( "FAIL: " .. label .. "\n" ) end
+end
+local function eq( label, got, want )
+    if got == want then passes = passes + 1
+    else
+        fails = fails + 1
+        io.stderr:write( string.format( "FAIL: %s\n  got:  %s\n  want: %s\n",
+            label, tostring( got ), tostring( want ) ) )
+    end
+end
+local function find_dest( plan, dest )
+    for _, p in ipairs( plan ) do if p.dest == dest then return p end end
+end
+
+----------------------------------------------------------------------
+-- _safe_rel: accept in-tree relative paths
+----------------------------------------------------------------------
+
+eq( "plain relative kept",        R._safe_rel( "cfg/cfg.tbl" ),          "cfg/cfg.tbl" )
+eq( "nested relative kept",       R._safe_rel( "scripts/data/x.tbl" ),   "scripts/data/x.tbl" )
+eq( "leading ./ stripped",        R._safe_rel( "./cfg/x.tbl" ),          "cfg/x.tbl" )
+eq( "backslash normalised",       R._safe_rel( "scripts\\data\\x.tbl" ), "scripts/data/x.tbl" )
+eq( "single file kept",           R._safe_rel( "cfg.tbl" ),              "cfg.tbl" )
+
+----------------------------------------------------------------------
+-- _safe_rel: reject anything that could escape the install root
+----------------------------------------------------------------------
+
+ok( "reject empty",               R._safe_rel( "" ) == nil )
+ok( "reject nil",                 R._safe_rel( nil ) == nil )
+ok( "reject POSIX absolute",      R._safe_rel( "/etc/passwd" ) == nil )
+ok( "reject drive absolute",      R._safe_rel( "C:\\Windows\\x" ) == nil )
+ok( "reject UNC backslash",       R._safe_rel( "\\\\host\\share\\x" ) == nil )
+ok( "reject leading ..",          R._safe_rel( "../../etc/cron.d/x" ) == nil )
+ok( "reject mid-path ..",         R._safe_rel( "cfg/../../etc/x" ) == nil )
+ok( "reject bare ..",             R._safe_rel( ".." ) == nil )
+ok( "reject backslash ..",        R._safe_rel( "cfg\\..\\..\\x" ) == nil )
+ok( "reject dot-only",            R._safe_rel( "." ) == nil )
+-- Windows normalises trailing dots/spaces, so a dot/space-only segment could
+-- collapse onto "." / ".." after the check - refuse the whole class.
+ok( "reject dot-dot-space",       R._safe_rel( "cfg/.. /x" ) == nil )
+ok( "reject triple-dot",          R._safe_rel( "a/.../b" ) == nil )
+ok( "reject space-only segment",  R._safe_rel( "a/ /b" ) == nil )
+-- but a leading-dot filename is legitimate and kept
+eq( "leading-dot filename kept",  R._safe_rel( "cfg/..foo" ), "cfg/..foo" )
+
+----------------------------------------------------------------------
+-- _resolve_masterkey_dest: override > manifest > default
+----------------------------------------------------------------------
+
+eq( "mk override wins", R._resolve_masterkey_dest( { master_key_path = "/a/b" }, "/override/mk" ), "/override/mk" )
+eq( "mk from manifest", R._resolve_masterkey_dest( { master_key_path = "/etc/luadch/master.key" }, nil ),
+    "/etc/luadch/master.key" )
+eq( "mk default",       R._resolve_masterkey_dest( { }, nil ),      "cfg/master.key" )
+eq( "mk empty override ignored", R._resolve_masterkey_dest( { master_key_path = "/m" }, "" ), "/m" )
+
+----------------------------------------------------------------------
+-- _build_plan: sentinel, secret classification, reject routing
+----------------------------------------------------------------------
+
+do
+    local files = {
+        { name = "cfg/cfg.tbl",           body = "c",  kind = "tree" },
+        { name = "cfg/user.tbl",          body = "u",  kind = "tree" },
+        { name = "certs/serverkey.pem",   body = "k",  kind = "tree" },
+        { name = "certs/servercert.pem",  body = "cc", kind = "tree" },
+        { name = "scripts/data/a.tbl",    body = "a",  kind = "tree" },
+        { name = "__masterkey__",         body = "MK", kind = "masterkey" },
+        { name = "../../etc/cron.d/evil", body = "x",  kind = "tree" },
+    }
+    local plan, rejects = R._build_plan( files, { master_key_path = "cfg/master.key" }, nil )
+
+    ok( "cfg.tbl in plan",          find_dest( plan, "cfg/cfg.tbl" ) ~= nil )
+    ok( "user.tbl in plan",         find_dest( plan, "cfg/user.tbl" ) ~= nil )
+    ok( "serverkey in plan",        find_dest( plan, "certs/serverkey.pem" ) ~= nil )
+    ok( "servercert in plan",       find_dest( plan, "certs/servercert.pem" ) ~= nil )
+
+    local mk = find_dest( plan, "cfg/master.key" )
+    ok( "masterkey sentinel -> in-tree dest", mk ~= nil )
+    eq( "masterkey body carried",     mk and mk.body, "MK" )
+    eq( "masterkey flagged",          mk and mk.masterkey, true )
+    ok( "non-mk entry unflagged",     find_dest( plan, "cfg/cfg.tbl" ).masterkey == nil )
+
+    ok( "unsafe entry NOT in plan",   find_dest( plan, "../../etc/cron.d/evil" ) == nil )
+    eq( "one reject recorded",        #rejects, 1 )
+    eq( "reject names the entry",     rejects[ 1 ] and rejects[ 1 ].name, "../../etc/cron.d/evil" )
+end
+
+-- master.key override redirects the sentinel dest (operator opted in, absolute OK)
+do
+    local plan = R._build_plan( { { name = "__masterkey__", body = "MK", kind = "masterkey" } },
+        { master_key_path = "cfg/master.key" }, "/secure/mk" )
+    ok( "override redirects sentinel", find_dest( plan, "/secure/mk" ) ~= nil )
+end
+
+-- F1: an out-of-tree manifest master_key_path is NOT honoured without an
+-- explicit --master-key-path (a foreign archive must not steer an absolute write)
+do
+    local plan, rejects = R._build_plan(
+        { { name = "__masterkey__", body = "PWN", kind = "masterkey" } },
+        { master_key_path = "/etc/cron.d/evil" }, nil )
+    eq( "out-of-tree mk -> nothing in plan", #plan, 0 )
+    eq( "out-of-tree mk -> rejected",        #rejects, 1 )
+    ok( "reject mentions --master-key-path",
+        rejects[ 1 ] and rejects[ 1 ].reason:match( "master%-key%-path" ) ~= nil )
+end
+
+-- F1: the SAME out-of-tree path IS honoured when the operator passes it explicitly
+do
+    local plan = R._build_plan(
+        { { name = "__masterkey__", body = "MK", kind = "masterkey" } },
+        { master_key_path = "/etc/cron.d/evil" }, "/etc/luadch/master.key" )
+    ok( "explicit override honours absolute", find_dest( plan, "/etc/luadch/master.key" ) ~= nil )
+end
+
+----------------------------------------------------------------------
+-- _verify_sidecar: real sha256 via the loaded archive module
+----------------------------------------------------------------------
+
+do
+    local blob = "the sealed bytes"
+    local hex  = R.archive.checksum( blob )
+    eq( "sidecar match -> ok",       R._verify_sidecar( blob, hex .. "  luadch-backup.ldbk\n" ), "ok" )
+    eq( "sidecar wrong -> mismatch", R._verify_sidecar( blob, string.rep( "0", 64 ) .. "  x\n" ), "mismatch" )
+    eq( "no hex token -> mismatch",  R._verify_sidecar( blob, "not-a-hash\n" ), "mismatch" )
+    eq( "nil sidecar -> missing",    R._verify_sidecar( blob, nil ), "missing" )
+    eq( "empty sidecar -> missing",  R._verify_sidecar( blob, "" ), "missing" )
+    -- case-insensitive hex compare
+    eq( "uppercase hex still ok",    R._verify_sidecar( blob, string.upper( hex ) .. "  x\n" ), "ok" )
+end
+
+----------------------------------------------------------------------
+-- output
+----------------------------------------------------------------------
+
+if fails > 0 then
+    io.stderr:write( string.format( "\nFAIL: %d/%d checks failed\n", fails, passes + fails ) )
+    os.exit( 1 )
+end
+print( string.format( "OK: %d checks passed", passes ) )


### PR DESCRIPTION
PR-B of the automatic-backup arc (#480): the **offline restore** for the encrypted `.ldbk` artifacts PR-A (#482) produces. Rebuild a dead hub from one backup + its passphrase.

## What it adds
- **`Luadch --restore <file> [--verify] [--force] [--master-key-path P]`** - a one-shot offline mode. `hub/hub.c` grows a long-option parser and `run_restore()`, wired into `main()` AFTER the single-instance lock (a restore can never race a running hub over cfg/user.tbl/master.key) and before any hub boot. On POSIX it sets `umask(077)` so every restored file is owner-only (0600) at creation.
- **`core/restore.lua`** - a standalone entry (NOT a `_core` module; boots no hub - the cfg it would read is what it restores). Two phases: preflight (sidecar sha256 check, AES-256-GCM decrypt + MANIFEST parse, path-sanitize, conflict scan) then apply (tmp-write + atomic rename). `--verify` is a dry run; without `--force` it refuses a populated tree.

## Security (the §1a.6 review earned its keep)
- An archive entry name is GCM-authenticated but NOT a trusted path. `_safe_rel` rejects absolute / drive / UNC / dot-or-space-only components before a byte is written.
- **master.key is the one deliberately-absolute destination, but a manifest-supplied out-of-tree path is honored ONLY via an explicit `--master-key-path`** - so a foreign archive (+ its passphrase) cannot steer an arbitrary absolute write (the review's top finding). In-tree relative paths restore automatically; restoring your own out-of-tree key is one flag.
- Wrong passphrase fails clean and writes nothing; the Windows overwrite path moves the original aside so a failed swap cannot destroy it.

Passphrase read out-of-band from `$LUADCH_BACKUP_PASSPHRASE` (no cfg exists on a fresh host).

## Tests (both CI legs)
- Unit `tests/unit/restore_test.lua` (45 checks): the `_safe_rel` traversal guard (proven to FAIL a bypassed sanitizer, PASS fixed), master.key dest + out-of-tree gating, plan/reject routing, sidecar verify.
- Smoke `test_backup_restore_roundtrip`: `+backup now` -> stop -> corrupt cfg.tbl -> `--verify` (writes nothing on a populated tree) -> `--restore --force` (cfg.tbl byte-identical, real AES-256-GCM) -> wrong-passphrase rejected. Own staged tree + dedicated ports.

## Validated
Real UCRT64 Windows build: full smoke 139 PASS / 0 FAIL incl. backup + round-trip. WSL Linux build + full smoke green. §1a.6 three-reviewer pass (security / correctness / consistency); all actionable findings fixed. Known low item deferred to a follow-up: a crafted foreign MANIFEST body can hang the offline restore (Ctrl-C recoverable; needs the operator's passphrase; the parse env already blocks code exec).

## Docs
`docs/BACKUP.md` (DR runbook) + the deferred CLAUDE.md module-map and PLUGIN_API sandbox-list entries P0/PR-A landed without.

Part of #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)