### PR TITLE
fix(backup_archive): bound manifest eval so a crafted archive can't hang restore (#485)

### DIFF
--- a/core/backup_archive.lua
+++ b/core/backup_archive.lua
@@ -81,6 +81,10 @@ local table        = use "table"
 local table_concat = table.concat
 local table_sort   = table.sort
 
+-- debug.sethook is used ONLY to bound the manifest-eval work (see
+-- _manifest_parse); the standard way to cap untrusted Lua execution.
+local debug_sethook = ( use "debug" ).sethook
+
 --// extern libs //--
 
 local adclib = use "adclib"
@@ -119,6 +123,8 @@ local MAX_TAR_ENTRIES    = 100000   -- parse-side bomb guard
 local MAX_NAME           = 100      -- ustar name field (no prefix-split yet)
 
 local MANIFEST_NAME      = "MANIFEST"
+local MANIFEST_MAX_BYTES = 65536    -- a real manifest is a handful of scalars
+local MANIFEST_MAX_INSTR = 200000   -- eval work ceiling (real parse ~dozens)
 local MODE_0644          = 420      -- rw-r--r-- (caller passes per-file modes)
 
 local ZERO_BLOCK         = string_rep( "\0", TAR_BLOCK )
@@ -342,11 +348,23 @@ local function _manifest_serialize( meta )
 end
 
 -- Parse a manifest chunk in a sandboxed empty environment (text only, no
--- globals) - same protection as util.loadtable_string.
+-- globals) - same protection as util.loadtable_string, PLUS a work bound.
+-- The empty _ENV blocks code execution, but a crafted manifest (a foreign
+-- archive whose passphrase the operator holds) could still `while true do end`
+-- and hang the offline restore. An instruction-count hook aborts any chunk
+-- that runs past a budget far above a real table construction; because the
+-- env is empty the chunk cannot reach a long-running C call that would slip
+-- the hook, so the count bound is sufficient (DEVELOPMENT.md §5: bound the
+-- WORK, not just the depth).
 local function _manifest_parse( str )
+    if type( str ) ~= "string" or #str > MANIFEST_MAX_BYTES then
+        return nil, "manifest: missing or too large"
+    end
     local fn, err = load( str, "backup_manifest", "t", { } )
     if not fn then return nil, "manifest: " .. tostring( err ) end
+    debug_sethook( function( ) error( "manifest: instruction budget exceeded", 0 ) end, "", MANIFEST_MAX_INSTR )
     local ok, tbl = pcall( fn )
+    debug_sethook( )   -- always clear the hook, success or not
     if not ok or type( tbl ) ~= "table" then
         return nil, "manifest: invalid table"
     end

--- a/tests/unit/backup_archive_crypto_test.lua
+++ b/tests/unit/backup_archive_crypto_test.lua
@@ -26,7 +26,7 @@ local adclib = require( "adclib" )
 local _real = {
     type = type, error = error, pcall = pcall, tostring = tostring,
     tonumber = tonumber, load = load, pairs = pairs, ipairs = ipairs,
-    string = string, table = table, io = io,
+    string = string, table = table, io = io, debug = debug,
     adclib = adclib,
 }
 _G.use = function( name )

--- a/tests/unit/backup_archive_test.lua
+++ b/tests/unit/backup_archive_test.lua
@@ -28,7 +28,7 @@
 local _real = {
     type = type, error = error, pcall = pcall, tostring = tostring,
     tonumber = tonumber, load = load, pairs = pairs, ipairs = ipairs,
-    string = string, table = table, io = io,
+    string = string, table = table, io = io, debug = debug,
     adclib = {
         random_bytes = function( n ) return string.rep( "R", n ) end,
         aes_gcm_seal = function( _key, _nonce, pt ) return pt .. string.rep( "\0", 16 ) end,
@@ -131,6 +131,23 @@ eq( "manifest: number field",  m_out.created_at,         1700000000 )
 eq( "manifest: bool field",    m_out.include_master_key, true )
 eq( "manifest: kinds map a",   m_out.kinds[ "__masterkey__" ], "masterkey" )
 eq( "manifest: kinds map b",   m_out.kinds[ "cfg/user.tbl" ],  "tree" )
+
+-- #485: a crafted manifest must not hang the offline restore. Pre-fix this
+-- spins forever (the eval had no work bound); post-fix the instruction-count
+-- hook aborts it and _manifest_parse returns (nil, err). If this test ever
+-- HANGS instead of failing fast, the bound regressed.
+do
+    local bad = A._manifest_parse( "return (function() while true do end end)()" )
+    ok( "manifest: infinite loop bounded -> nil", bad == nil )
+    -- an over-budget bounded loop is refused too, not silently accepted
+    local heavy = A._manifest_parse( "local x=0 for i=1,1e9 do x=x+1 end return {}" )
+    ok( "manifest: over-budget loop -> nil", heavy == nil )
+    -- oversized manifest rejected before load
+    local huge = A._manifest_parse( "return {}" .. string.rep( " ", 70000 ) )
+    ok( "manifest: oversized -> nil", huge == nil )
+    -- a normal manifest still parses after all that
+    ok( "manifest: normal still ok", type( A._manifest_parse( "return { a = 1 }" ) ) == "table" )
+end
 
 ----------------------------------------------------------------------
 -- Full pack()/unpack() plumbing (identity crypto, iters=1 for speed).


### PR DESCRIPTION
`_manifest_parse` `load()`s the archive MANIFEST in an empty `_ENV` (no globals, no code exec), but that does not stop a crafted manifest body (`while true do end`) from spinning and hanging the offline `--restore`. Found in the #484 review (F9).

Threat is low: the manifest is inside the GCM-authenticated tar, so it needs a foreign archive whose passphrase the operator holds; Ctrl-C recoverable; never affects the live hub. But the restore should degrade to `(nil, err)`, not hang.

**Fix** (DEVELOPMENT.md §5, bound the WORK not just depth): a byte cap before `load()`, then an instruction-count `debug.sethook` that aborts any chunk running past a budget far above a real manifest. The eval env is empty, so the chunk cannot reach a long-running C call that would slip an instruction hook - the count bound is sufficient. Keeps `load()` (not a hand parser) so the module's "read and write halves never drift" property holds.

**Regression** (`backup_archive_test`, both legs): infinite-loop / over-budget / oversized manifests each return `(nil, err)`; a normal manifest still parses. Proven to HANG on pre-fix code (unbounded `pcall` times out) and return fast post-fix. Bytecode `_ENV` scan clean (only `use`); isolated boot+backup+restore round-trip green on the real Windows build.

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)