### PR TITLE
feat(backup): smooth the Docker restore path + expand operator docs (#480)

### DIFF
--- a/core/restore.lua
+++ b/core/restore.lua
@@ -293,9 +293,16 @@ local function main( )
         return 1
     end
 
+    -- Primary env for restore; fall back to the backup engine's own env name
+    -- so an operator whose compose already sets LUADCH_ETC_BACKUP_PASSPHRASE
+    -- (secrets.lookup convention) need not add a second variable just to restore.
     local passphrase = os_getenv "LUADCH_BACKUP_PASSPHRASE"
     if type( passphrase ) ~= "string" or passphrase == "" then
-        print( "luadch restore: set the backup passphrase in $LUADCH_BACKUP_PASSPHRASE, e.g." )
+        passphrase = os_getenv "LUADCH_ETC_BACKUP_PASSPHRASE"
+    end
+    if type( passphrase ) ~= "string" or passphrase == "" then
+        print( "luadch restore: set the backup passphrase in $LUADCH_BACKUP_PASSPHRASE" )
+        print( "  (or $LUADCH_ETC_BACKUP_PASSPHRASE), e.g." )
         print( "  LUADCH_BACKUP_PASSPHRASE='...' ./luadch --restore " .. file )
         return 1
     end

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -167,9 +167,17 @@ touch "${LUADCH_HOME}/log/error.log" "${LUADCH_HOME}/log/cmd.log"
 ( tail -F -n 0 "${LUADCH_HOME}/log/cmd.log"   1>&1 & ) 2>/dev/null
 
 # ---------------------------------------------------------------------------
-# 5. exec the hub
+# 5. exec the hub (or forward one-shot args, e.g. --restore)
 # ---------------------------------------------------------------------------
 # WORKDIR is /opt/luadch (set in Dockerfile); the hub anchors its
 # config / scripts / log paths to the binary's directory after Phase 6b
 # (#12), so `cd` is correct here.
-exec "${LUADCH_HOME}/luadch"
+#
+# "$@" forwards any args the operator passed to `docker compose run` /
+# `docker run` straight to the binary. With none (the normal `up`) it
+# expands to nothing, so a plain hub boot is unchanged; with e.g.
+# `--restore <file>` it runs the offline restore (#480 PR-B) in a one-shot
+# container against the same mounted volumes. The seed/log-forward setup
+# above is harmless for a restore (on a fresh DR host it even provides the
+# current bundled scripts/*.lua that the backup deliberately omits).
+exec "${LUADCH_HOME}/luadch" "$@"

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -129,22 +129,59 @@ cd cfg/backups && sha256sum -c luadch-backup-YYYYMMDD-HHMMSS.ldbk.sha256
 
 ## Off-site copies
 
-The hub does not push anywhere. Copy `cfg/backups/` off the box on your own
-schedule. Examples:
+A backup that lives only on the hub host dies with that host. The hub does not
+push anywhere by design, so mirroring `cfg/backups/` off the box is your job -
+and the important half of a real backup strategy. The `.ldbk` is already
+encrypted (AES-256-GCM), so the destination can be any untrusted remote.
+
+### rclone (recommended)
+
+[rclone](https://rclone.org) syncs a local directory to ~all cloud/remote
+backends (S3, Backblaze B2, Google Drive, WebDAV, SFTP, ...) with one config.
+
+1. Install rclone (`apt install rclone`, or the static binary from rclone.org).
+2. Configure a remote once, interactively:
+   ```sh
+   rclone config
+   # n) New remote  -> name it e.g. "backup"
+   #    pick a backend (e.g. Backblaze B2 / S3 / Drive), paste keys/token
+   ```
+3. Test it:
+   ```sh
+   rclone lsd backup:            # lists buckets/dirs on the remote
+   ```
+4. Copy the backups up:
+   ```sh
+   rclone copy ./cfg/backups backup:luadch-hub/backups --progress
+   ```
+5. Automate it in the host's crontab, a little AFTER the daily backup runs
+   (default 04:00, remember the container-UTC note below):
+   ```cron
+   20 4 * * *  rclone copy /srv/luadch/cfg/backups backup:luadch-hub/backups
+   ```
+6. Confirm what landed:
+   ```sh
+   rclone ls backup:luadch-hub/backups
+   ```
+
+**`copy` vs `sync`:** `copy` only adds/updates - the remote keeps every artifact
+even after the hub's rotation (`etc_backup_keep`) prunes it locally, so you get
+a longer off-site history. `sync` mirrors exactly, propagating local deletions.
+Prefer `copy` unless you deliberately want the remote to match local retention.
+
+Optional defense-in-depth: an `rclone crypt` remote encrypts a second time
+on top of the already-encrypted `.ldbk` (useful if the remote's account itself
+is a concern). Not required.
+
+### Alternatives
 
 ```sh
-# rclone to any remote (S3, B2, WebDAV, SFTP, ...)
-rclone sync /opt/luadch/cfg/backups remote:luadch-backups
+# restic (dedup + its own encryption + snapshots)
+restic -r s3:s3.example.com/luadch backup /srv/luadch/cfg/backups
 
-# restic (dedup + its own encryption on top)
-restic -r s3:s3.example.com/luadch backup /opt/luadch/cfg/backups
-
-# plain scp in cron
-0 5 * * * scp -q /opt/luadch/cfg/backups/*.ldbk* backup@host:/srv/luadch/
+# plain scp in cron (simplest, no history management)
+0 5 * * *  scp -q /srv/luadch/cfg/backups/*.ldbk* backup@host:/srv/luadch/
 ```
-
-The `.ldbk` is already encrypted, so an untrusted remote is acceptable; restic's
-extra layer is optional defense-in-depth.
 
 ## Restore
 
@@ -202,20 +239,51 @@ Rebuild a dead hub on a fresh host:
 
 ## Docker
 
-- Mount the backup dir out of the container so artifacts survive it:
-  `-v ./cfg/backups:/luadch/cfg/backups` (or point `etc_backup_dir` at a
-  dedicated volume).
-- Set the passphrase via env: `-e LUADCH_ETC_BACKUP_PASSPHRASE=...`.
-- Container clocks are usually UTC - `etc_backup_daily_at` is server-local, so
-  pick the hour in UTC.
-- To restore, run the one-shot in a container over the target tree with the hub
-  stopped:
-  ```sh
-  docker compose run --rm -e LUADCH_BACKUP_PASSPHRASE=... \
-    luadch --restore cfg/backups/luadch-backup-....ldbk
-  ```
-  See [DOCKER.md](DOCKER.md) for the `master_key_path`-on-`secrets/`-mount
-  layout.
+The install root in the image is `/opt/luadch`. Setup:
+
+- **No separate backups volume needed.** The default `etc_backup_dir =
+  "cfg/backups"` is inside the already-mounted `./cfg:/opt/luadch/cfg`, so
+  artifacts land in `./cfg/backups/` on the host automatically. (Do NOT add a
+  second mount onto `/opt/luadch/cfg` - it shadows the cfg mount and breaks the
+  hub.) Only mount a dedicated volume if you set `etc_backup_dir` to a path
+  *outside* cfg, e.g. `etc_backup_dir = "/opt/luadch/backups"` +
+  `- ./backups:/opt/luadch/backups`.
+- Set the passphrase via env in the service's `environment:` (the standard
+  secrets-lookup name): `LUADCH_ETC_BACKUP_PASSPHRASE=...`. `.env` alone is not
+  enough - it must reach the container via `environment:` or `env_file:`.
+- Container clocks are usually **UTC** - `etc_backup_daily_at` is server-local,
+  so pick the hour in UTC (04:00 = 04:00 UTC).
+
+**Restore** runs as a one-shot container with the hub stopped (the entrypoint
+forwards args to the binary, and restore accepts the same
+`LUADCH_ETC_BACKUP_PASSPHRASE` your compose already sets):
+
+```sh
+docker compose stop luadch
+
+# dry run first
+docker compose run --rm luadch --restore cfg/backups/luadch-backup-....ldbk --verify
+
+# apply (--force overwrites the existing tree)
+docker compose run --rm luadch --restore cfg/backups/luadch-backup-....ldbk --force
+
+docker compose up -d luadch      # boot again, then log in to confirm
+```
+
+**master.key on a `secrets/` mount:** if `master_key_path` points outside the
+tree (e.g. `/secrets/master.key` via a `- ./secrets:/secrets` mount, the
+recommended layout), restore will NOT auto-write there - it refuses an
+out-of-tree path from the manifest so a foreign archive cannot steer an
+arbitrary write. Add `--master-key-path` to opt in explicitly:
+
+```sh
+docker compose run --rm luadch \
+  --restore cfg/backups/luadch-backup-....ldbk --force \
+  --master-key-path /secrets/master.key
+```
+
+(On an older image whose entrypoint does not forward args, override it:
+`docker compose run --rm --entrypoint /opt/luadch/luadch luadch --restore ...`.)
 
 ## Security model
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -113,6 +113,34 @@ or, in the hub itself (after logging in as a level-100 user):
 `+reload` is faster (no TCP listener restart) and what you'll usually
 want for non-network-port changes.
 
+## Backups
+
+Full guide: [`docs/BACKUP.md`](BACKUP.md). The Docker essentials:
+
+- **Enable it:** add `{ "etc_backup.lua", enabled = true }` to the `scripts`
+  list in `cfg/cfg.tbl`, then set the passphrase in the service's
+  `environment:` (it must reach the container - `.env` alone does not):
+  ```yaml
+  environment:
+    - LUADCH_ETC_BACKUP_PASSPHRASE=${LUADCH_ETC_BACKUP_PASSPHRASE}
+  ```
+  Restart the container. `!backup status` should show "ready".
+- **Where they land:** `./cfg/backups/` on the host (default `etc_backup_dir =
+  "cfg/backups"`, inside the already-mounted `./cfg`). No extra volume needed.
+- **Off-site:** the hub only writes locally - mirror `./cfg/backups/` to a
+  remote yourself (rclone/restic/cron). BACKUP.md has an rclone walkthrough.
+- **Restore** (hub stopped, one-shot container; the passphrase env and args are
+  forwarded automatically):
+  ```sh
+  docker compose stop luadch
+  docker compose run --rm luadch --restore cfg/backups/<file>.ldbk --verify
+  docker compose run --rm luadch --restore cfg/backups/<file>.ldbk --force
+  docker compose up -d luadch
+  ```
+  If your `master_key_path` is on the `./secrets/` mount (the recommended
+  layout), add `--master-key-path /secrets/master.key` - restore refuses an
+  out-of-tree path from the manifest unless you name it explicitly.
+
 ## TLS-only deployments
 
 Once your users are on `adcs://` URLs, drop the plain port:

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -722,10 +722,14 @@ def test_backup_restore_roundtrip(source_install: Path, keep_staging=False):
 
         # --verify is a dry run over the POPULATED tree (no --force): it must
         # still exit 0 and write nothing - the conflict refusal is for a real
-        # apply, not a verify.
+        # apply, not a verify. It also drives the passphrase via the FALLBACK
+        # env name (LUADCH_ETC_BACKUP_PASSPHRASE, the backup engine's own) with
+        # the primary NOT set, proving restore accepts either.
+        verify_env = {k: v for k, v in os.environ.items() if k != "LUADCH_BACKUP_PASSPHRASE"}
+        verify_env["LUADCH_ETC_BACKUP_PASSPHRASE"] = "smoke-backup-pass"
         rv = subprocess.run(
             [str(binary), "--restore", str(artifact), "--verify"],
-            cwd=str(st), env=env, capture_output=True, text=True, timeout=60,
+            cwd=str(st), env=verify_env, capture_output=True, text=True, timeout=60,
         )
         if rv.returncode != 0:
             raise TestFailure(f"--verify exited {rv.returncode}:\n{rv.stdout}\n{rv.stderr}")


### PR DESCRIPTION
The #480 testhub (backup+restore validated live on Docker) surfaced three rough edges when restoring inside a container. None are bugs in the restore engine - they are UX/doc gaps:

1. **Entrypoint did not forward args** -> `--restore` needed an `--entrypoint` override. `docker/entrypoint.sh` now `exec`s `"${LUADCH_HOME}/luadch" "$@"`. Empty args (a normal `up`) expand to nothing, so the hub boot is unchanged; the seed/log setup is harmless for a one-shot restore (on a fresh DR host it even provides the current bundled `scripts/*.lua` the backup omits).
2. **Restore env name differed from the backup env** -> `core/restore.lua` reads `LUADCH_BACKUP_PASSPHRASE`, now falling back to `LUADCH_ETC_BACKUP_PASSPHRASE` (the engine's secrets-lookup name), so the operator's existing compose env works for restore too. The smoke round-trip's `--verify` now drives the fallback name (primary unset) to prove either works.
3. **Docs:** `docs/BACKUP.md` gets a full **rclone off-site walkthrough** and a rewritten Docker section - backups already live under the mounted `cfg` (no extra volume; a second mount onto `/opt/luadch/cfg` breaks the hub), the exact one-shot restore commands, and the `master.key`-on-`/secrets` case (needs an explicit `--master-key-path`, by the F1 design). `docs/DOCKER.md` gains a Backups section. Fixed a stale `/luadch` path (image root is `/opt/luadch`).

Net effect: the restore command drops from
`docker compose run --rm -e LUADCH_BACKUP_PASSPHRASE=... --entrypoint /opt/luadch/luadch luadch --restore ...`
to
`docker compose run --rm luadch --restore cfg/backups/<file> --verify [--master-key-path /secrets/master.key]`.

Validated: full Windows smoke 139/0 incl. the round-trip driving the env fallback; `sh -n docker/entrypoint.sh` clean; the `"$@"` forward is a no-op on a plain boot. The entrypoint change is Docker-only (not exercised by the direct-binary smoke) - the rebuilt `:dev` image confirms it live.

Part of #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)