### PR TITLE
docs: pre-milestone currency pass (backup discoverability + stale TLS/levels/paths)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ and operator guidance.
   CVE-tracking process, how to report a security issue
 - **[docs/DOCKER.md](docs/DOCKER.md)** - container image, mount layout,
   TLS-only deployments, troubleshooting
+- **[docs/BACKUP.md](docs/BACKUP.md)** - encrypted backups + offline
+  restore: configuration, the `+backup` command, off-site mirroring
+  (rclone), and the disaster-recovery runbook
 - **[docs/PLUGIN_API.md](docs/PLUGIN_API.md)** - plugin scripting API
   reference (listeners, modules, objects, conventions, pitfalls)
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** - which branch to target, what a

--- a/docs/BLOCKLIST.md
+++ b/docs/BLOCKLIST.md
@@ -140,8 +140,8 @@ hub:
 services:
   luadch:
     volumes:
-      - ./cfg:/luadch/cfg
-      - geoip_data:/luadch/cfg/geoip
+      - ./cfg:/opt/luadch/cfg
+      - geoip_data:/opt/luadch/cfg/geoip
   geoipupdate:
     image: maxmindinc/geoipupdate
     restart: unless-stopped

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -97,13 +97,14 @@ The hub auto-generates a self-signed cert on first boot if none exists at the co
 
 ```lua
 ssl_params = {
-    mode      = "server",
-    protocol  = "any",
-    options   = { "all", "no_sslv2", "no_sslv3", "no_tlsv1", "no_tlsv1_1" },
-    cafile    = "certs/cacert.pem",
+    mode        = "server",
+    key         = "certs/serverkey.pem",
     certificate = "certs/servercert.pem",
-    key       = "certs/serverkey.pem",
-    verify    = { "none" },
+    cafile      = "certs/cacert.pem",
+    protocol    = "tlsv1_3",   -- TLS 1.3 only; cannot negotiate down
+    options     = { "no_sslv2", "no_sslv3", "no_tlsv1", "no_tlsv1_1", "no_renegotiation" },
+    ciphers     = "HIGH+kEDH:HIGH+kEECDH:HIGH:!PSK:!SRP:!3DES:!aNULL",
+    curve       = "prime256v1",
 },
 ```
 
@@ -137,14 +138,14 @@ do not run a public hub with `dummy / test` active.
 The hub uses an integer-based user level system. Higher levels grant
 more permissions. Bundled defaults:
 
-| Level | Name      | What it can do                              |
-|-------|-----------|---------------------------------------------|
-| 100   | HUBOWNER  | Everything (registers / deletes / shutdown) |
-| 80    | OPERATOR  | (TODO: list typical OP-level capabilities)  |
-| 60    | VIP       | (TODO)                                      |
-| 40    | REG       | Registered user, basic chat / commands      |
-| 20    | UNREG     | Anonymous connection                        |
-| 0     | BANNED    | Refused                                     |
+| Level | Name     | What it can do                                  |
+|-------|----------|-------------------------------------------------|
+| 100   | HUBOWNER | Everything (registers / deletes / shutdown)     |
+| 80    | ADMIN    | Admin operations, user + registration management |
+| 60    | OPERATOR | Moderation (ban / kick / gag / redirect)        |
+| 40    | SVIP     | Super-VIP: elevated privileges, exemptions      |
+| 20    | REG      | Registered user, basic chat / commands          |
+| 0     | UNREG    | Anonymous (unregistered) connection             |
 
 Customise per-script `minlevel` in `cfg.tbl` to grant or restrict
 specific commands.

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -206,7 +206,9 @@ What is worth backing up:
 Everything else (`core/`, `scripts/*.lua`, `lib/`, `lang/`) reproduces
 from a fresh build.
 
-Rsync-style nightly backup script template:
+Rsync-style nightly backup script template (a simple *unencrypted* mirror -
+note it copies `user.tbl` and `master.key` together, the exact bundling
+[`docs/SECURITY.md`](SECURITY.md) warns about):
 
 ```sh
 #!/bin/sh
@@ -217,6 +219,10 @@ rsync -a --delete /opt/luadch/cfg/        "$DST"/cfg/
 rsync -a --delete /opt/luadch/certs/      "$DST"/certs/
 rsync -a --delete /opt/luadch/scripts/data/ "$DST"/scripts-data/
 ```
+
+For an encrypted, rotating backup with an offline restore, prefer the built-in
+backup feature instead: [`docs/BACKUP.md`](BACKUP.md) (`+backup`, AES-256-GCM
+`.ldbk` artifacts, `./luadch --restore`).
 
 ---
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -194,6 +194,13 @@ Then handle that path the same way you handle
 The hub still enforces 0600 on the configured path on POSIX. On
 Windows, apply `icacls` to the new path - see §4.
 
+The built-in encrypted backup ([`docs/BACKUP.md`](BACKUP.md), #480) is the
+pass-phrase-encrypted archive this section recommends: the `.ldbk` is sealed
+with AES-256-GCM under an operator passphrase independent of `master.key`, and
+`etc_backup_include_master_key = false` keeps the key out of the archive
+entirely - so an exfiltrated backup does not hand over both halves. Prefer it
+over a raw `tar czf cfg/`.
+
 ### What the on-disk encryption protects against
 
 - Backup / snapshot exfiltration of `cfg/` without the host - **only


### PR DESCRIPTION
A doc-staleness audit ahead of the #480 dev->master merge. Every fix verified against source. (Rebased onto #487; BACKUP.md's Docker section was already fixed there, so this branch touches only the 5 files below.)

**Backup discoverability** (the point of the pass):
- Link `docs/BACKUP.md` from README's doc index.
- SECURITY.md F-AUTH-1: point the master.key-separation section at the encrypted backup feature - it IS the pass-phrase-encrypted archive that section recommends (AES-256-GCM, `include_master_key = false` keeps the key out).
- INSTALLING.md: point the rsync template at BACKUP.md (the rsync mirror bundles `user.tbl` + `master.key` together, the exact risk SECURITY.md warns about).

**Verified staleness the audit turned up** (pre-existing, misleading):
- `CONFIGURATION.md` ssl_params example showed `protocol = "any"` + a `verify` key; the real default is `protocol = "tlsv1_3"` (no verify key) per `core/cfg_defaults.lua` - it even contradicted the doc's own "TLS 1.3" prose.
- `CONFIGURATION.md` user-level table: every non-100 row was wrong. Source is 80=ADMIN / 60=OPERATOR / 40=SVIP / 20=REG / 0=UNREG (no BANNED level).
- `BLOCKLIST.md` GeoIP sidecar mount used the wrong image root `/luadch`; it is `/opt/luadch` (Dockerfile WORKDIR).

**Deferred to #488**: the SCRIPTS.md cfg-key-name drift (11 keys, several 1->N) and the plain-port-5000 assumption in verify/first-login snippets.

Docs-only. Part of #480