### PR TITLE
Promote #480 backup arc + #483 to master

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -207,6 +207,13 @@ jobs:
       - name: Run hmac unit test
         run: lua5.4 tests/unit/hmac_test.lua
 
+      # core/backup_archive.lua (#480 P0): ustar writer/reader, PBKDF2-
+      # HMAC-SHA256 KDF (Python-verified vectors), manifest and the full
+      # pack()/unpack() plumbing via a fake identity crypto. The real
+      # AES-256-GCM round-trip is the crypto test below (Linux-only).
+      - name: Run backup_archive unit test
+        run: lua5.4 tests/unit/backup_archive_test.lua
+
       # #78 Precursor 0d: core/cacert_bootstrap.lua reconcile_bundle
       # decision-matrix (source-missing / installed / no-op / warned /
       # auto-updated branches). Uses OS temp dir for file fixtures.
@@ -361,6 +368,15 @@ jobs:
           cd build/install/luadch
           LD_LIBRARY_PATH=. lua5.4 ../../../tests/unit/zlib_stream_test.lua
 
+      # core/backup_archive.lua real AES-256-GCM round-trip (#480 P0):
+      # pack/unpack fidelity, ciphertext secrecy, wrong-passphrase + GCM
+      # tamper rejection. Same install-tree + bundled-liblua + adclib
+      # requirement as the two C-module tests above, so Linux-only.
+      - name: Run backup_archive crypto unit test
+        run: |
+          cd build/install/luadch
+          LD_LIBRARY_PATH=. lua5.4 ../../../tests/unit/backup_archive_crypto_test.lua
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -514,6 +530,10 @@ jobs:
       - name: Run hmac unit test
         shell: msys2 {0}
         run: lua5.4 tests/unit/hmac_test.lua
+
+      - name: Run backup_archive unit test
+        shell: msys2 {0}
+        run: lua5.4 tests/unit/backup_archive_test.lua
 
       - name: Run cacert_bootstrap unit test
         shell: msys2 {0}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -380,6 +380,15 @@ jobs:
           cd build/install/luadch
           LD_LIBRARY_PATH=. lua5.4 ../../../tests/unit/adclib_unescape_test.lua
 
+      # #483 adclib hashpas/hasholdpas salt-guard diagnostic. Same
+      # install-tree + bundled-liblua requirement as adclib_unescape, so
+      # Linux-only. Proves the guard raises "salt length N out of range"
+      # (not the "invalid option '%z'" format error the pre-fix %zu gave).
+      - name: Run adclib_hashpas unit test
+        run: |
+          cd build/install/luadch
+          LD_LIBRARY_PATH=. lua5.4 ../../../tests/unit/adclib_hashpas_test.lua
+
       # zlib_stream.gunzip() C round-trip (GeoIP auto-update precursor).
       # Same install-tree + bundled-liblua requirement as adclib above, so
       # Linux-only (msys2 lua segfaults loading our C modules).

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -214,6 +214,19 @@ jobs:
       - name: Run backup_archive unit test
         run: lua5.4 tests/unit/backup_archive_test.lua
 
+      # core/backup.lua (#480 PR-A) engine: collection spec (which files +
+      # modes + master.key toggle + .tbl/.tmp filter), rotation victim
+      # selection, cfg/secrets config interpretation. Pure seams; the full
+      # read/pack/write path is covered by the backup smoke test.
+      - name: Run backup engine unit test
+        run: lua5.4 tests/unit/backup_test.lua
+
+      # scripts/etc_backup.lua (#480 PR-A) schedule math: daily-at HH:MM
+      # (today-vs-tomorrow slot), interval-from-anchor, overdue-fires-now,
+      # invalid HH:MM falls back to the interval. Loaded with stubbed globals.
+      - name: Run etc_backup schedule unit test
+        run: lua5.4 tests/unit/etc_backup_schedule_test.lua
+
       # #78 Precursor 0d: core/cacert_bootstrap.lua reconcile_bundle
       # decision-matrix (source-missing / installed / no-op / warned /
       # auto-updated branches). Uses OS temp dir for file fixtures.
@@ -534,6 +547,14 @@ jobs:
       - name: Run backup_archive unit test
         shell: msys2 {0}
         run: lua5.4 tests/unit/backup_archive_test.lua
+
+      - name: Run backup engine unit test
+        shell: msys2 {0}
+        run: lua5.4 tests/unit/backup_test.lua
+
+      - name: Run etc_backup schedule unit test
+        shell: msys2 {0}
+        run: lua5.4 tests/unit/etc_backup_schedule_test.lua
 
       - name: Run cacert_bootstrap unit test
         shell: msys2 {0}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -227,6 +227,13 @@ jobs:
       - name: Run etc_backup schedule unit test
         run: lua5.4 tests/unit/etc_backup_schedule_test.lua
 
+      # core/restore.lua (#480 PR-B) offline-restore pure logic: the
+      # _safe_rel path-traversal guard (reject absolute / ".." / drive /
+      # UNC), master.key dest resolution, plan building + reject routing,
+      # sha256 sidecar verify. Fake adclib; no --restore run.
+      - name: Run restore unit test
+        run: lua5.4 tests/unit/restore_test.lua
+
       # #78 Precursor 0d: core/cacert_bootstrap.lua reconcile_bundle
       # decision-matrix (source-missing / installed / no-op / warned /
       # auto-updated branches). Uses OS temp dir for file fixtures.
@@ -555,6 +562,10 @@ jobs:
       - name: Run etc_backup schedule unit test
         shell: msys2 {0}
         run: lua5.4 tests/unit/etc_backup_schedule_test.lua
+
+      - name: Run restore unit test
+        shell: msys2 {0}
+        run: lua5.4 tests/unit/restore_test.lua
 
       - name: Run cacert_bootstrap unit test
         shell: msys2 {0}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -404,8 +404,9 @@ jobs:
       # #275 COV-2 holistic review follow-up: the Lua-side unit tests
       # MUST run on Windows too. Linux-only coverage masks divergences
       # in the MinGW UCRT64 Lua 5.4 build (locale-dependent string
-      # ops, integer-width / pattern-class edge cases). Same five
-      # tests as the Linux job, same order.
+      # ops, integer-width / pattern-class edge cases). Same set as the
+      # Linux job (minus the two C-module tests, which are Linux-only),
+      # same order.
       - name: Run iostream unit test
         shell: msys2 {0}
         run: lua5.4 tests/unit/iostream_test.lua

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,6 +323,17 @@ master (frozen history - the live delta is always
   They now fall back to `user:firstnick()` - the `etc_trafficmanager` /
   upstream-`luadch/luadch#240` idiom; `bot_session_chat` re-keys its whole
   member/owner identity model to firstnick.
+- **#480 automatic-backup arc** - encrypted local backups + offline restore,
+  no cloud. `core/backup_archive` (LDBK1 = pure-Lua tar + AES-256-GCM,
+  PBKDF2-in-C, P0 #481) + `core/backup` engine + `etc_backup` scheduler
+  plugin (PR-A #482) + `./luadch --restore` as a standalone offline entry
+  (`core/restore` loaded by the C `run_restore` into a fresh Lua state,
+  PR-B #484). Manifest eval bounded by an instruction budget so a crafted
+  archive can't hang restore (#485); Docker restore UX + a `BACKUP.md`
+  operator guide with an rclone off-site walkthrough (#487); docs currency
+  pass (#489). Follow-up: the `adclib` `%zu`->`%I` diagnostic fix (#483,
+  same `lua_pushvfstring`-conversion bug class as the P0 `listdir` `%lu`
+  fix). Operator guide: [`docs/BACKUP.md`](docs/BACKUP.md).
 
 `dev` and `master` track closely; open work is the feature-arc backlog -
 `gh issue list --repo luadch-ng/luadch` (no open bugs). Durable pattern from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ The repo bundles all runtime dependencies as source - there is no external packa
 manager. This is intentional (the project ships as a self-contained build) but means
 dependency updates are manual.
 
-### Bundled dependencies (verified 2026-07-05; a dependency bump MUST update this table)
+### Bundled dependencies (verified 2026-07-21; a dependency bump MUST update this table)
 
 | Component   | Bundled version | Path           | Notes                                |
 |-------------|-----------------|----------------|--------------------------------------|
@@ -254,15 +254,18 @@ the index. Do not re-plan closed phases.
 ### Phase 8+ - feature development (current era)
 
 Each Phase-8+ item gets its own tracker issue, scope, and §1a.6 review gate.
-The strict "one phase at a time" discipline (§1b) still applies. Active
-engineering journals: [`PHASE_8_IO.md`](docs/phases/PHASE_8_IO.md) (IO/framing
-rework), [`PHASE_8A.md`](docs/phases/PHASE_8A.md) (ADC input-validation
-audit), [`PHASE_8B_DUAL_STACK.md`](docs/phases/PHASE_8B_DUAL_STACK.md)
-(dual-stack + HBRI).
+The strict "one phase at a time" discipline (§1b) still applies. The Phase-8
+engineering journals ([`PHASE_8_IO.md`](docs/phases/PHASE_8_IO.md) IO/framing
+rework, [`PHASE_8A.md`](docs/phases/PHASE_8A.md) ADC input-validation audit,
+[`PHASE_8B_DUAL_STACK.md`](docs/phases/PHASE_8B_DUAL_STACK.md) dual-stack +
+HBRI) are **historical** - those arcs shipped; read them for the narrative,
+not for open work.
 
 Shipped feature arcs so far (closed trackers, details in the issues): HTTP
 API #82, audit log #84, real HBRI #214, registered-users API family #236,
-subsystem managers #249, client blocker #81, aliases #327.
+subsystem managers #249, client blocker #81, aliases #327, unified blocklist
++ in-hub GeoIP #78/#79/#352, global whitelist/allowlist (#78 deferred item),
+status-push heartbeat #395, inbound webhook receiver #398.
 
 **Unified blocklist arc [#78](https://github.com/luadch-ng/luadch/issues/78)
 COMPLETE + on master (2026-07-10); #78 + #79 + #352 closed.** All precursors
@@ -274,62 +277,51 @@ cross-host to a signed CDN URL), boot-time runtime-dir self-heal
 (`core/ensuredirs.lua` + a `makedir` C primitive #382, #384) with a daemon
 `umask(027)` hardening, and an `etc_blocklist_feeds` reload-throttle (#386).
 
-**Current era: feature plugins + bug-issue triage.** Shipped to master
-(3.2.x, still no `v3.2.0` tag): push/pull status export (`etc_status_push`
-#395), the inbound webhook receiver (`etc_webhook` #398, the first
-`scope="none"` plugin route - live against a Discourse forum + a GitHub org),
-plus Sopor-reported fixes (v3.1.13 ratelimit hub-crash #401, `usr_uptime`
-undercount #405, BLOM smoke de-flake #408; **v3.1.14** Windows `FD_SETSIZE`
-64->1024 hub-crash #416, Sopor - the Windows luasocket build inherited the
-Winsock-default 64-socket `select()` cap; the Linux `>1024` sibling of that
-crash was the `select`->`poll` port, done in #310/#436). Shipped to master
-2026-07-13 (#419/#420/#423 all closed): the
-ADC parser now discards messages with unknown escape sequences per ADC 3.1
-(#419) + hub-bot INF `EM` escaping (#423), and an `etc_webhook` body-field
-`conditions` filter (#420 - fixed a live double-announce by filtering on a
-JSON body field like a GitHub release `action=released` or a Discourse
-opening post, not just the event header).
+**Current state (3.2.x on `master`, still no `v3.2.0` tag).** The items that
+used to sit here as "in flight on `dev`" have all merged. Recently shipped to
+master (frozen history - the live delta is always
+`git log --oneline origin/master..origin/dev`, never a list written here):
 
-**On `dev`, pending testhub validation then a dev->master MERGE** (exact
-delta: `git log --oneline origin/master..origin/dev` - do not trust a list
-written here): the `select`->`poll` event-loop port (#310 / PR #436) which
-removes the ~1024 concurrent-socket ceiling on POSIX and leaves Windows on
-`select`; `core/sysinfo.lua`'s `Get-CimInstance` -> `Get-WmiObject` fallback
-(#432) so old-Windows hubowners (Server 2008 R2 / Win7 = PowerShell 2.0,
-which has no `Get-CimInstance`) get real `+hubinfo` OS/CPU/RAM instead of
-`<UNKNOWN>` (Sopor; the pre-refactor 3.1.x plugin also CRASHED on the
-nil-concat - shipped a v0.30 `cmd_hubinfo` drop-in per §8); a `release.yml`
-zlib-dev fix (#441 - `find_package(ZLIB REQUIRED)` is unconditional but no
-release leg installed the dev package, so the first `v3.2.0` tag would have
-failed the aarch64 build at configure); a repo-wide plugin lang-key guard
-(#442); `CONTRIBUTING.md` documenting the dev-branch policy (#440); and
-three external cleanups from @Kcchouette (#437/#438/#439). Many hubowners
-run ancient Windows (the UCRT release build also needs KB2999226 there -
-the Universal C Runtime). A
-recurring pattern this era:
-a **periodic-fetch plugin must persist its next-fetch deadline across
-`+reload`**, or every reload re-hits a rate-limited provider - fixed twice
-(`etc_blocklist_feeds` #386, `etc_geoip` auto-update #414); general rule in
-[`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) §3. Alongside, the
-`gh issue list --label bug` backlog is worked one at a time (each: deep-dive
-from source per §1a.3/4, since many are old-version reports asking "fixed in
-3.x?"). GitFlow A per fix; batch dev->master as a MERGE commit (never squash
-- see §8 branch hygiene).
+- **`select`->`poll` event-loop port (#310)** - lifts the ~1024 concurrent-
+  socket ceiling on POSIX (the Linux sibling of Sopor's Windows 64-socket
+  `FD_SETSIZE` crash #416); Windows stays on `select`. `hub/hub.c` raises the
+  fd soft limit to hard at boot.
+- **#78 global whitelist / allowlist** - `core/whitelist.lua` consulted by
+  every IP-blocking path so trusted infra (hublist pingers etc.) is exempt
+  from the AUTOMATED blockers (GeoIP / proxydetect / feeds / hub-limit) but
+  NOT from a deliberate manual `+ban` / `+blocklist` (**Model A**: a manual
+  block wins). Engine + `etc_whitelist` + pinger seed + per-plugin guards +
+  HTTP `/v1/whitelist`. NOT extended to `usr_share` / `usr_slots` /
+  `usr_nick_*`.
+- **single-instance lock + port-hijack fix (#433/#434)**, `sysinfo`
+  old-Windows `Get-WmiObject` fallback (#432), `CONTRIBUTING.md` (#440), a
+  repo-wide plugin lang-key guard (#442), a `release.yml` zlib-dev fix (#441),
+  external cleanups from @Kcchouette (#437/#438/#439).
+- **`etc_status_push` #395** (push heartbeat) + **`etc_webhook` #398** (inbound
+  HMAC receiver, first `scope="none"` route) + the ADC unknown-escape discard
+  #419 / hub-bot `EM` escaping #423 / webhook `conditions` filter #420.
+- **the #447 dead-code audit**, then a post-#447 correctness/i18n batch:
+  `cmd_ban` permanent ban (#444 keyword + #475 right-click menu entry),
+  `hub_runtime` store moved out of shipped `core/` (#445), `etc_records`
+  defensive load (#465), exhaustive PLUGIN_API §8 (#457),
+  `etc_cmdlog` / `cmd_userinfo` / blocklist+whitelist i18n + alignment
+  (#460 / #459 / #456).
+- **nick-prefix resolution arc (#473/#474/#477)** - `usr_nick_prefix` re-keys
+  the hub nick table to the PREFIXED nick, so ten operator commands
+  (+ `bot_session_chat`) that resolved an online user by a TYPED base nick
+  silently took the offline path (`+ban` stored but no kick; others no-op).
+  They now fall back to `user:firstnick()` - the `etc_trafficmanager` /
+  upstream-`luadch/luadch#240` idiom; `bot_session_chat` re-keys its whole
+  member/owner identity model to firstnick.
 
-**On `dev`: the #78 allowlist (global whitelist) - 4-PR arc A-D MERGED
-(PRs #427/#431/#429/#430), pending testhub -> dev->master.** The allowlist deferred from the
-unified-blocklist arc. A `core/whitelist.lua` engine consulted by every
-IP-blocking path so trusted infrastructure (hublist pingers etc.) is exempt
-from the AUTOMATED blockers (GeoIP / proxydetect / feeds / hub-limit) - but
-NOT from a deliberate manual `+ban` / `+blocklist` (Model A: a manual block
-wins). Phase A (engine + `blocklist.check_ip` precedence +
-`whitelist.is_whitelisted` sandbox global), B (`+whitelist` plugin +
-bundled hublist-pinger seed, `etc_whitelist`), C (per-plugin guards in
-etc_geoip / etc_proxydetect / usr_hubs - where the log goes quiet), D (HTTP
-`/v1/whitelist`). NOT extended to the share / slots / nick-policy plugins
-(`usr_share` / `usr_slots` / `usr_nick_*`). Source of truth: the
-whitelist-arc PRs (deferred item of
-[#78](https://github.com/luadch-ng/luadch/issues/78)).
+`dev` and `master` track closely; open work is the feature-arc backlog -
+`gh issue list --repo luadch-ng/luadch` (no open bugs). Durable pattern from
+this era: a **periodic-fetch plugin must persist its next-fetch deadline
+across `+reload`**, or every reload re-hits a rate-limited provider - fixed
+twice (`etc_blocklist_feeds` #386, `etc_geoip` #414); general rule in
+[`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) §3. Workflow: GitFlow A per fix
+(deep-dive from source per §1a.3/4); batch dev->master as a MERGE commit
+(never squash - §8 branch hygiene).
 
 **HTTP-endpoint authoring** (which helper for which endpoint shape, envelope
 contract, preflight): see [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) §3 and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,8 +133,18 @@ order (its inline comments explain each ordering constraint).
 | Boot + config | `init`, `const`, `cfg`, `cfg_defaults`, `cfg_users`, `cfg_lang`, `cfg_secret`, `secrets` | Restricted env + module loader; program constants; settings/user.tbl/language handling; AES-256-GCM at-rest crypto; env-var-first secret lookup |
 | Network + ADC | `server`, `iostream`, `adc`, `hub`, `hub_dispatch`, `hub_user_object`, `hub_bot_object`, `hbri`, `ratelimit`, `blocklist`, `whitelist`, `ipmatch` | event loop + SSL (poll on POSIX / select on Windows, #310); framing pipeline; ADC parse/escape/format; main loop + login; command dispatch; user/bot objects; dual-stack secondary-IP verification; DoS limits; pre-handshake IP/CIDR blocklist; global allowlist (whitelist beats automated blocks, not manual pins); IP/CIDR primitives |
 | HTTP API | `http`, `http_router`, `http_client`, `http_filter`, `http_events`, `util_http` | Inbound HTTP/JSON API + router + auth; non-blocking OUTBOUND client; filter/sort/paginate helper; deferred-event endpoints; plugin endpoint helper |
-| Crypto + boot trust | `sha256`, `hmac`, `cert_bootstrap`, `cacert_bootstrap` | Pure-Lua SHA-256; HMAC-SHA256 (RFC 2104, sandbox-exposed for signed-webhook auth, #398); first-boot TLS-cert auto-gen (#77); CA-bundle reconciliation |
-| Infra | `util`, `out`, `mem`, `signal`, `types`, `scripts`, `audit`, `sysinfo`, `mmdb`, `geoip_update`, `bloom`, `ensuredirs` | File I/O + table helpers; logging; GC; timers; ADC type validation; plugin loader + sandbox + listener registry; onAudit JSONL log; system info; MaxMind DB reader + in-hub GeoLite2 auto-update; bloom filter; boot-time runtime-dir self-heal |
+| Crypto + boot trust | `sha256`, `hmac`, `cert_bootstrap`, `cacert_bootstrap`, `backup_archive` | Pure-Lua SHA-256; HMAC-SHA256 (RFC 2104, sandbox-exposed for signed-webhook auth, #398); first-boot TLS-cert auto-gen (#77); CA-bundle reconciliation; LDBK1 encrypted backup archive format (tar + AES-256-GCM, PBKDF2, #480) |
+| Infra | `util`, `out`, `mem`, `signal`, `types`, `scripts`, `audit`, `sysinfo`, `mmdb`, `geoip_update`, `bloom`, `ensuredirs`, `backup` | File I/O + table helpers; logging; GC; timers; ADC type validation; plugin loader + sandbox + listener registry; onAudit JSONL log; system info; MaxMind DB reader + in-hub GeoLite2 auto-update; bloom filter; boot-time runtime-dir self-heal; backup engine (collect restore-min set + seal + rotate, #480, exposed to the sandbox as `backup`) |
+
+**`core/restore.lua` is a standalone offline entry, not a `_core` module.**
+The C launcher's `run_restore()` (`hub/hub.c`) loads it into a fresh Lua state
+for `./luadch --restore <file>` (backup restore, #480 PR-B); it boots no hub
+(the cfg it would read is what it restores) and never appears in `_core` -
+like `init.lua` itself. Two C primitives back the arc: `listdir(path)`
+(core-only global, like `makedir` - NOT sandboxed) enumerates the state dirs
+for the backup engine, and `adclib.pbkdf2_sha256` (OpenSSL PKCS5_PBKDF2_HMAC)
+keeps the KDF off the pure-Lua path that would freeze the single-threaded hub
+~40s per backup. Operator guide: [`docs/BACKUP.md`](docs/BACKUP.md).
 
 **`core/hci.lua` is a now-legacy data file** (a plain `hubruntime` /
 `hubruntime_last_check` table). It backs `/v1/runtime` +

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ promoted to `master`, so pull requests go against **`dev`** - see
 - **Atomic plugin saves** ([#133](https://github.com/luadch-ng/luadch/issues/133)) - `util.savearray` / `util.savetable` use tmp + rename so a hub crash mid-write leaves the `.tbl` intact
 - **Docker plugin + language autosync** ([#118](https://github.com/luadch-ng/luadch/pull/118)) - container restarts pull in new bundled scripts and lang files without overwriting operator customisations
 
+### 3.2.x feature era (Phase 8+, on `master`)
+
+- **HTTP / JSON API** ([#82](https://github.com/luadch-ng/luadch/issues/82)) - token-authed REST surface for users, bans, registered users, config, logs, and a live `/v1/events` stream; see [`docs/HTTP_API.md`](docs/HTTP_API.md)
+- **Audit log** ([#84](https://github.com/luadch-ng/luadch/issues/84)) - structured JSONL `onAudit` records across ~20 plugins, exposed via `etc_auditlog` + the HTTP event stream
+- **Unified pre-handshake blocklist + in-hub GeoIP** ([#78](https://github.com/luadch-ng/luadch/issues/78) / [#79](https://github.com/luadch-ng/luadch/issues/79)) - CIDR/IPv6 blocklist with provenance, stealth mode, external feeds (Tor / Spamhaus / AbuseIPDB), MaxMind GeoLite2 country/ASN, and live proxy/VPN detection ([#352](https://github.com/luadch-ng/luadch/issues/352)); operator guide in [`docs/BLOCKLIST.md`](docs/BLOCKLIST.md)
+- **Global allowlist / whitelist** (#78 allowlist) - trusted infrastructure (hublist pingers etc.) exempt from the *automated* blockers, never from a manual ban
+- **Client blocker** ([#81](https://github.com/luadch-ng/luadch/issues/81)) - version-range client filtering
+- **Real dual-stack HBRI** ([#214](https://github.com/luadch-ng/luadch/issues/214)) - secondary-IP verification for IPv4+IPv6 clients
+- **Inbound webhook receiver + status-push heartbeat** ([#398](https://github.com/luadch-ng/luadch/issues/398) / [#395](https://github.com/luadch-ng/luadch/issues/395)) - HMAC-authed inbound webhooks (Discourse / GitHub) and an outbound status heartbeat
+- **`select`->`poll` event loop** ([#310](https://github.com/luadch-ng/luadch/issues/310)) - lifts the ~1024 concurrent-socket ceiling on POSIX
+- **ADC command aliases** ([#327](https://github.com/luadch-ng/luadch/issues/327)) - operator-defined `+alias`es
+
 See [`docs/SECURITY.md`](docs/SECURITY.md) for the full threat model
 and operator guidance.
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ and operator guidance.
   CVE-tracking process, how to report a security issue
 - **[docs/DOCKER.md](docs/DOCKER.md)** - container image, mount layout,
   TLS-only deployments, troubleshooting
+- **[docs/BACKUP.md](docs/BACKUP.md)** - encrypted backups + offline
+  restore: configuration, the `+backup` command, off-site mirroring
+  (rclone), and the disaster-recovery runbook
 - **[docs/PLUGIN_API.md](docs/PLUGIN_API.md)** - plugin scripting API
   reference (listeners, modules, objects, conventions, pitfalls)
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** - which branch to target, what a

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ promoted to `master`, so pull requests go against **`dev`** - see
 - **Inbound webhook receiver + status-push heartbeat** ([#398](https://github.com/luadch-ng/luadch/issues/398) / [#395](https://github.com/luadch-ng/luadch/issues/395)) - HMAC-authed inbound webhooks (Discourse / GitHub) and an outbound status heartbeat
 - **`select`->`poll` event loop** ([#310](https://github.com/luadch-ng/luadch/issues/310)) - lifts the ~1024 concurrent-socket ceiling on POSIX
 - **ADC command aliases** ([#327](https://github.com/luadch-ng/luadch/issues/327)) - operator-defined `+alias`es
+- **Encrypted local backup + offline restore** ([#480](https://github.com/luadch-ng/luadch/issues/480)) - scheduled AES-256-GCM `.ldbk` archives of hub state via `+backup`, plus a standalone `./luadch --restore` that rebuilds a hub from an archive without booting it; see [`docs/BACKUP.md`](docs/BACKUP.md)
 
 See [`docs/SECURITY.md`](docs/SECURITY.md) for the full threat model
 and operator guidance.

--- a/adclib/adclib.cpp
+++ b/adclib/adclib.cpp
@@ -215,8 +215,11 @@ int hash_pas(lua_State* L)
 
     size_t saltBytes = salt_len * 5 / 8;
     if (saltBytes == 0 || saltBytes > MAX_SALT_BYTES) {
-        return luaL_error(L, "hashpas: salt length %zu out of range",
-                          saltBytes);
+        // luaL_error routes through lua_pushvfstring, which supports only
+        // a fixed conversion set (no %zu). Use %I with lua_Integer, matching
+        // the gen_self_signed_cert diagnostic below (#483).
+        return luaL_error(L, "hashpas: salt length %I out of range",
+                          (lua_Integer)saltBytes);
     }
     unsigned char chunk[MAX_SALT_BYTES];
 
@@ -240,8 +243,9 @@ int hash_pas_oldschool(lua_State* L)
 
     size_t saltBytes = salt_len * 5 / 8;
     if (saltBytes == 0 || saltBytes > MAX_SALT_BYTES) {
-        return luaL_error(L, "hasholdpas: salt length %zu out of range",
-                          saltBytes);
+        // See hash_pas: %zu is unsupported by lua_pushvfstring (#483).
+        return luaL_error(L, "hasholdpas: salt length %I out of range",
+                          (lua_Integer)saltBytes);
     }
     unsigned char chunk1[MAX_SALT_BYTES];
     unsigned char chunk2[SIZE];

--- a/adclib/adclib.cpp
+++ b/adclib/adclib.cpp
@@ -711,6 +711,48 @@ int unescape(lua_State* L)
     return 1;
 }
 
+/*
+ * pbkdf2_sha256(password, salt, iterations, dklen) -> derived key (raw bytes)
+ *
+ * PBKDF2-HMAC-SHA256 via OpenSSL. The pure-Lua PBKDF2 in
+ * core/backup_archive.lua is correct but ~tens of seconds at 200k
+ * iterations - far too slow for the single-threaded hub, which would freeze
+ * for the whole backup. This C path derives the SAME key (PBKDF2 is
+ * deterministic) in ~1ms, so the backup passphrase keeps a strong iteration
+ * count without stalling the loop. The Lua impl stays as the standalone /
+ * self-test fallback and cross-checks against this one at load.
+ */
+int pbkdf2_sha256(lua_State* L)
+{
+    ERR_clear_error();
+    size_t pw_len, salt_len;
+    const char* pw   = luaL_checklstring(L, 1, &pw_len);
+    const char* salt = luaL_checklstring(L, 2, &salt_len);
+    if (pw_len > INT_MAX || salt_len > INT_MAX)
+    {
+        return luaL_error(L, "pbkdf2_sha256: password/salt too large");
+    }
+    lua_Integer iters = luaL_checkinteger(L, 3);
+    lua_Integer dklen = luaL_checkinteger(L, 4);
+    if (iters < 1 || iters > 100000000)
+    {
+        return luaL_error(L, "pbkdf2_sha256: iterations out of range (1..100000000)");
+    }
+    if (dklen < 1 || dklen > 1024)
+    {
+        return luaL_error(L, "pbkdf2_sha256: dklen out of range (1..1024)");
+    }
+    unsigned char out[1024];
+    if (PKCS5_PBKDF2_HMAC(pw, (int)pw_len,
+                          (const unsigned char *)salt, (int)salt_len,
+                          (int)iters, EVP_sha256(), (int)dklen, out) != 1)
+    {
+        return luaL_error(L, "pbkdf2_sha256: PKCS5_PBKDF2_HMAC failed");
+    }
+    lua_pushlstring(L, (const char *)out, (size_t)dklen);
+    return 1;
+}
+
 static const luaL_Reg adclib[] = {
     {"hash", hash_pid},
     {"hashpas", hash_pas},
@@ -722,6 +764,7 @@ static const luaL_Reg adclib[] = {
     {"random_bytes", random_bytes},
     {"aes_gcm_seal", aes_gcm_seal},
     {"aes_gcm_open", aes_gcm_open},
+    {"pbkdf2_sha256", pbkdf2_sha256},
     {"gen_self_signed_cert", gen_self_signed_cert},
     {"cert_fingerprint_sha256", cert_fingerprint_sha256},
     {"constant_time_eq", constant_time_eq},

--- a/core/backup.lua
+++ b/core/backup.lua
@@ -1,0 +1,410 @@
+--[[
+
+    core/backup.lua - automatic-backup engine (#480, PR-A).
+
+    The operator-state collector + rotation layer on top of the LDBK1
+    archive format (core/backup_archive.lua). Given the hub's own config,
+    it gathers the restore-minimum set of files, seals them into one
+    encrypted `.ldbk` artifact (+ a `.sha256` sidecar), writes it to the
+    configured backup directory, and prunes old artifacts to a retention
+    count. The offline restore path (PR-B) consumes the same archive.
+
+    Exposed to the plugin sandbox (core/scripts.lua SANDBOX_GLOBALS) so the
+    thin scheduler/CLI plugin scripts/etc_backup.lua can drive it:
+        backup.readiness()  -> { ok, issues }   -- config sanity for the owner nag
+        backup.run()        -> result | nil,err -- produce one backup now
+        backup.list()       -> rows | nil,err    -- artifacts in the backup dir
+
+    SECURITY: the engine reads its own policy (dir / keep / passphrase /
+    include_master_key) straight from cfg + core/secrets - it does NOT take
+    them as caller arguments. A sandboxed plugin can therefore only TRIGGER
+    a backup to the operator-configured destination with the operator's
+    passphrase; it cannot redirect the artifact to an arbitrary absolute
+    path or substitute a key it controls. Reading master.key / user.tbl is
+    no new power either - a plugin's path-restricted io already reaches the
+    in-tree cfg/ files; the engine only adds orchestration.
+
+    Passive at load: no init(), no file I/O when the chunk runs. cfg/out are
+    bound at file scope (this module loads after them in _core) and only
+    called at run time.
+
+    Collection set (see docs/BACKUP.md, PR-B):
+        cfg/cfg.tbl, cfg/user.tbl (+ .bak), the TLS material from ssl_params
+        (serverkey.pem = secret 0600, servercert.pem, cacert.pem), every
+        scripts/data/*.tbl + scripts/cfg/*.tbl, and - when included -
+        master.key at master_key_path (stored under the "__masterkey__"
+        sentinel; the real path travels in the manifest so restore can put
+        it back, even when it lives outside the tree). *.tmp is skipped.
+
+]]--
+
+----------------------------------// DECLARATION //--
+
+local use = use
+
+local type      = use "type"
+local pcall     = use "pcall"
+local tostring  = use "tostring"
+local tonumber  = use "tonumber"
+local ipairs    = use "ipairs"
+
+local string       = use "string"
+local string_match = string.match
+local string_gsub  = string.gsub
+local string_sub   = string.sub
+
+local table       = use "table"
+local table_sort  = table.sort
+
+local os        = use "os"
+local os_time    = os.time
+local os_date    = os.date
+local os_rename  = os.rename
+local os_remove  = os.remove
+local os_getenv  = os.getenv
+local os_execute = os.execute
+
+local io        = use "io"
+local io_open   = io.open
+
+--// core scripts //--
+
+local const         = use "const"
+local PROGRAM_NAME  = const.PROGRAM_NAME
+local VERSION       = const.VERSION
+
+local cfg     = use "cfg"
+local cfg_get = cfg.get
+
+local out       = use "out"
+local out_put   = out.put
+local out_error = out.error
+
+local secrets        = use "secrets"
+local secrets_lookup = secrets.lookup
+
+local archive = use "backup_archive"
+
+-- Raw C primitives from hub.c (core-only, NOT sandboxed). Used directly -
+-- not the safe_path-gated util wrappers - because the backup directory and
+-- master_key_path are operator-configured and MAY be absolute (a mounted
+-- volume, a key relocated out of the tree). Same rationale cfg_secret uses
+-- for the master.key parent dir.
+local makedir = use "makedir"
+local listdir = use "listdir"
+
+----------------------------------// CONSTANTS //--
+
+local MODE_SECRET = 384   -- 0600 (master.key, serverkey.pem)
+local MODE_STATE  = 416   -- 0640 (everything else)
+
+local MASTERKEY_ENTRY  = "__masterkey__"
+local BACKUP_PREFIX     = "luadch-backup-"
+local BACKUP_SUFFIX     = ".ldbk"
+local SIDECAR_SUFFIX    = ".sha256"
+local DEFAULT_DIR       = "cfg/backups"
+local DEFAULT_KEEP      = 7
+
+----------------------------------// CONFIG SNAPSHOT //--
+
+-- Strip a trailing slash so `dir .. "/" .. name` never doubles it.
+local function _norm_dir( dir )
+    return ( string_gsub( dir, "[/\\]+$", "" ) )
+end
+
+-- Read the engine's policy from cfg + secrets. Central so run/readiness/
+-- list share one interpretation of the defaults.
+local function _config( )
+    local enabled = cfg_get "etc_backup_enabled"
+    if enabled == nil then enabled = true end
+
+    local dir = cfg_get "etc_backup_dir"
+    if type( dir ) ~= "string" or dir == "" then dir = DEFAULT_DIR end
+    dir = _norm_dir( dir )
+
+    local keep = tonumber( cfg_get "etc_backup_keep" ) or DEFAULT_KEEP
+    if keep < 1 then keep = 1 end
+
+    local include_mk = cfg_get "etc_backup_include_master_key"
+    if include_mk == nil then include_mk = true end
+
+    -- env-var-first via core/secrets; falls back to cfg.tbl for bare-metal.
+    local passphrase = secrets_lookup( "etc_backup_passphrase" )
+
+    return {
+        enabled    = enabled,
+        dir        = dir,
+        keep       = keep,
+        include_mk = include_mk,
+        passphrase = ( type( passphrase ) == "string" and passphrase ~= "" ) and passphrase or nil,
+    }
+end
+
+local function _master_key_path( )
+    local mkp = cfg_get "master_key_path"
+    if type( mkp ) == "string" and mkp ~= "" then return mkp end
+    return "cfg/master.key"
+end
+
+----------------------------------// COLLECTION //--
+
+-- Build the file plan (what to back up + where each entry restores to),
+-- WITHOUT reading anything - pure and unit-testable. `lister(dir)` injects
+-- the directory enumerator (the raw listdir primitive at run time, a stub
+-- in tests). Each item: { read = <path to open>, name = <tar/restore name>,
+-- mode = <octal perms>, kind = "tree"|"masterkey" }.
+local function _collection_spec( include_mk, master_key_path, ssl, lister )
+    local spec = {
+        { read = "cfg/cfg.tbl",      name = "cfg/cfg.tbl",      mode = MODE_STATE,  kind = "tree" },
+        { read = "cfg/user.tbl",     name = "cfg/user.tbl",     mode = MODE_STATE,  kind = "tree" },
+        { read = "cfg/user.tbl.bak", name = "cfg/user.tbl.bak", mode = MODE_STATE,  kind = "tree" },
+    }
+
+    ssl = ssl or { }
+    local key_pem  = ssl.key         or "certs/serverkey.pem"
+    local cert_pem = ssl.certificate or "certs/servercert.pem"
+    local ca_pem   = ssl.cafile      or "certs/cacert.pem"
+    spec[ #spec + 1 ] = { read = key_pem,  name = key_pem,  mode = MODE_SECRET, kind = "tree" }
+    spec[ #spec + 1 ] = { read = cert_pem, name = cert_pem, mode = MODE_STATE,  kind = "tree" }
+    spec[ #spec + 1 ] = { read = ca_pem,   name = ca_pem,   mode = MODE_STATE,  kind = "tree" }
+
+    if include_mk then
+        spec[ #spec + 1 ] = {
+            read = master_key_path, name = MASTERKEY_ENTRY, mode = MODE_SECRET, kind = "masterkey",
+        }
+    end
+
+    -- Variable plugin state. Enumerate scripts/data + scripts/cfg; take the
+    -- .tbl files, skip the .tmp half-writes of an in-flight atomic save.
+    for _, dir in ipairs( { "scripts/data", "scripts/cfg" } ) do
+        local names = lister( dir )
+        if type( names ) == "table" then
+            table_sort( names )   -- deterministic order
+            for _, n in ipairs( names ) do
+                if string_match( n, "%.tbl$" ) and not string_match( n, "%.tmp$" ) then
+                    local p = dir .. "/" .. n
+                    spec[ #spec + 1 ] = { read = p, name = p, mode = MODE_STATE, kind = "tree" }
+                end
+            end
+        end
+    end
+
+    return spec
+end
+
+-- Match a backup artifact name by plain prefix + suffix. Deliberately NOT a
+-- Lua pattern: BACKUP_PREFIX contains '-', which is a pattern magic char
+-- (a quantifier), so a naive `string_match` silently matches nothing. The
+-- ".sha256" sidecar ends in .sha256, so the .ldbk suffix check excludes it.
+local function _is_backup_name( n )
+    return #n > #BACKUP_PREFIX + #BACKUP_SUFFIX
+        and string_sub( n, 1, #BACKUP_PREFIX ) == BACKUP_PREFIX
+        and string_sub( n, -#BACKUP_SUFFIX ) == BACKUP_SUFFIX
+end
+
+-- Pick the artifacts to prune: keep the newest `keep` luadch-backup-*.ldbk
+-- (timestamped names sort lexicographically = chronologically), return the
+-- older ones. Pure/testable. `names` is a raw directory listing.
+local function _rotation_victims( names, keep )
+    local backups = { }
+    for _, n in ipairs( names ) do
+        if _is_backup_name( n ) then
+            backups[ #backups + 1 ] = n
+        end
+    end
+    table_sort( backups )
+    local victims = { }
+    local drop = #backups - keep
+    for i = 1, drop do
+        victims[ #victims + 1 ] = backups[ i ]
+    end
+    return victims
+end
+
+----------------------------------// IO HELPERS //--
+
+local function _read_file( path )
+    local f = io_open( path, "rb" )
+    if not f then return nil end
+    local content = f:read "*a"
+    f:close( )
+    return content
+end
+
+-- Atomic write via tmp + rename. Raw (no safe_path) so an absolute,
+-- operator-configured backup dir works; the paths are trusted cfg, not
+-- untrusted input. Mirrors util.atomic_write's Windows fallback.
+local function _write_atomic( path, content )
+    local tmp = path .. ".tmp"
+    local f, err = io_open( tmp, "wb" )
+    if not f then return false, err end
+    local ok, werr = f:write( content )
+    f:close( )
+    if not ok then os_remove( tmp ); return false, werr end
+    if os_rename( tmp, path ) then return true end
+    os_remove( path )
+    local rok, rerr = os_rename( tmp, path )
+    if rok then return true end
+    os_remove( tmp )
+    return false, rerr or "rename failed"
+end
+
+-- POSIX chmod 600 on the sealed artifact - it bundles the (encrypted)
+-- master.key / user.tbl / serverkey, so keep it owner-only even though the
+-- AES-256-GCM sealing already protects the contents (the daemon umask leaves
+-- new files group-readable). Best-effort, no-op on Windows. Mirrors
+-- cfg_secret's helper.
+local function _chmod_600( path )
+    if os_getenv "COMSPEC" and os_getenv "WINDIR" then return end
+    os_execute( "chmod 600 '" .. tostring( path ):gsub( "'", "'\\''" ) .. "'" )
+end
+
+----------------------------------// PUBLIC: READINESS //--
+
+-- Config sanity the owner nag enumerates. Never raises; returns a list of
+-- machine-readable issue codes (the plugin localises them).
+local function readiness( )
+    local c = _config( )
+    local issues = { }
+
+    if not c.passphrase then
+        issues[ #issues + 1 ] = "no_passphrase"
+    end
+
+    -- Backup dir must be creatable + writable. Probe with a temp file so we
+    -- catch a read-only / missing-parent destination before backup time.
+    local mkok = makedir( c.dir )
+    local probe = c.dir .. "/.backup_write_test"
+    local wok = mkok and _write_atomic( probe, "ok" )
+    if wok then os_remove( probe ) else
+        issues[ #issues + 1 ] = "backup_dir_unwritable"
+    end
+
+    if c.include_mk then
+        local mkp = _master_key_path( )
+        local f = io_open( mkp, "rb" )
+        if f then f:close( ) else
+            issues[ #issues + 1 ] = "master_key_unreadable"
+        end
+    end
+
+    return { ok = #issues == 0, issues = issues }
+end
+
+----------------------------------// PUBLIC: RUN //--
+
+local function run( )
+    local c = _config( )
+    if not c.enabled then
+        return nil, "backup: disabled (etc_backup_enabled = false)"
+    end
+    if not c.passphrase then
+        return nil, "backup: no passphrase configured (etc_backup_passphrase / LUADCH_ETC_BACKUP_PASSPHRASE)"
+    end
+
+    local mkp = c.include_mk and _master_key_path( ) or nil
+    local spec = _collection_spec( c.include_mk, mkp, cfg_get "ssl_params", listdir )
+
+    local files, included, skipped = { }, 0, 0
+    for _, item in ipairs( spec ) do
+        local body = _read_file( item.read )
+        if body then
+            files[ #files + 1 ] = { name = item.name, mode = item.mode, body = body, kind = item.kind }
+            included = included + 1
+        else
+            skipped = skipped + 1
+        end
+    end
+    if included == 0 then
+        return nil, "backup: nothing to back up (no state files found)"
+    end
+
+    local meta = {
+        program            = PROGRAM_NAME,
+        hub_version        = VERSION,
+        created_at         = os_time( ),
+        include_master_key = c.include_mk and true or false,
+    }
+    if mkp then meta.master_key_path = mkp end
+
+    local blob, perr = archive.pack( files, meta, c.passphrase )
+    if not blob then
+        return nil, "backup: seal failed: " .. tostring( perr )
+    end
+
+    local mkdir_ok, mkdir_err = makedir( c.dir )
+    if not mkdir_ok then
+        return nil, "backup: cannot create backup dir '" .. c.dir .. "': " .. tostring( mkdir_err )
+    end
+
+    local fname = BACKUP_PREFIX .. os_date( "%Y%m%d-%H%M%S" ) .. BACKUP_SUFFIX
+    local path  = c.dir .. "/" .. fname
+    local wok, werr = _write_atomic( path, blob )
+    if not wok then
+        return nil, "backup: cannot write '" .. path .. "': " .. tostring( werr )
+    end
+    _chmod_600( path )
+
+    -- Sidecar: passphrase-free integrity check (sha256sum -c). Best-effort -
+    -- the backup itself already succeeded.
+    local sidecar = path .. SIDECAR_SUFFIX
+    local sok = _write_atomic( sidecar, archive.sidecar_line( archive.checksum( blob ), fname ) )
+    if not sok then
+        out_error( "backup: wrote artifact but sidecar failed: ", sidecar )
+        sidecar = nil
+    end
+
+    -- Rotation: prune oldest beyond keep (artifact + its sidecar).
+    local names = listdir( c.dir )
+    if type( names ) == "table" then
+        for _, victim in ipairs( _rotation_victims( names, c.keep ) ) do
+            os_remove( c.dir .. "/" .. victim )
+            os_remove( c.dir .. "/" .. victim .. SIDECAR_SUFFIX )
+        end
+    end
+
+    out_put( "backup: wrote ", path, " (", #blob, " bytes, ", included, " files, ", skipped, " skipped)" )
+    return {
+        path    = path,
+        sidecar = sidecar,
+        bytes   = #blob,
+        files   = included,
+        skipped = skipped,
+    }
+end
+
+----------------------------------// PUBLIC: LIST //--
+
+-- Rows describing the artifacts currently in the backup dir, newest first,
+-- for `+backup list`.
+local function list( )
+    local c = _config( )
+    local names = listdir( c.dir )
+    if type( names ) ~= "table" then
+        return { }   -- dir missing / empty = no backups yet
+    end
+    local rows = { }
+    for _, n in ipairs( names ) do
+        if _is_backup_name( n ) then
+            local size
+            local f = io_open( c.dir .. "/" .. n, "rb" )
+            if f then size = f:seek "end"; f:close( ) end
+            rows[ #rows + 1 ] = { name = n, bytes = size }
+        end
+    end
+    table_sort( rows, function( a, b ) return a.name > b.name end )   -- newest first
+    return rows
+end
+
+----------------------------------// PUBLIC INTERFACE //--
+
+return {
+    readiness = readiness,
+    run       = run,
+    list      = list,
+
+    -- test seams
+    _collection_spec  = _collection_spec,
+    _rotation_victims = _rotation_victims,
+    _config           = _config,
+}

--- a/core/backup_archive.lua
+++ b/core/backup_archive.lua
@@ -1,0 +1,550 @@
+--[[
+
+    core/backup_archive.lua - encrypted backup archive format (LDBK1).
+
+    Format-level core primitive for the automatic-backup arc (#480). Pure
+    in-memory: the caller reads the files off disk and hands their bytes
+    in; this module bundles them into a single POSIX ustar tar, derives an
+    AES-256 key from an operator passphrase via PBKDF2-HMAC-SHA256, and
+    seals the tar with AES-256-GCM (adclib / OpenSSL). unpack() reverses
+    it. Disk I/O, file collection, rotation and scheduling live one layer
+    up in core/backup.lua (PR-A); the offline restore path (PR-B) reuses
+    unpack() so the read and write halves can never drift.
+
+    Why a real ustar tar and not a bespoke container: the decrypted inner
+    blob is a standard `.tar` an operator can `tar xf` for manual disaster
+    recovery, independent of the hub. Uncompressed for now (zlib_stream
+    has no gzip writer); the backup set excludes the large/log data so the
+    artifact stays small.
+
+    Why the backup passphrase is independent of cfg/master.key: a backup
+    exists precisely for the case where master.key is lost with the host,
+    so the archive cannot be keyed on it. The passphrase is stretched with
+    PBKDF2 (salt + iteration count stored in the header) so an operator can
+    keep a memorable secret in a password manager.
+
+    LDBK1 wire format:
+        offset  bytes            field
+          0     4                magic "LDBK"
+          4     1                format version (1)
+          5     1                KDF id (1 = PBKDF2-HMAC-SHA256)
+          6     4                PBKDF2 iterations (big-endian uint32)
+         10     1                salt length S
+         11     S                salt (16 bytes)
+         11+S   12               AES-GCM nonce (96-bit)
+         23+S   N                ciphertext || 16-byte GCM tag
+    The outer header (salt / iters / nonce) is not GCM-authenticated
+    directly - adclib exposes no AAD parameter - but tampering any of it
+    yields a wrong key or wrong nonce, so open() fails closed either way.
+    The authoritative metadata (per-file dest, mode, kind) rides inside the
+    tar, which IS inside the authenticated ciphertext.
+
+    Public surface:
+        pack(files, meta, passphrase [, opts])  -> ldbk_bytes | nil, err
+        unpack(ldbk_bytes, passphrase)          -> { meta, files } | nil, err
+        checksum(bytes)                         -> 64-char lowercase hex
+        sidecar_line(hex, filename)             -> "<hex>  <name>\n"
+        MAGIC / VERSION / DEFAULT_ITERS constants
+      files (pack input) / result.files: array of
+        { name = string, mode = int (octal perms), body = string, kind = string? }
+
+    A PBKDF2 known-answer + ustar round-trip self-test runs at load (same
+    fail-loud discipline as sha256.lua / hmac.lua): a silent KDF regression
+    would derive wrong keys = unrecoverable backups.
+
+]]--
+
+----------------------------------// DECLARATION //--
+
+local use = use
+
+local type         = use "type"
+local error        = use "error"
+local pcall        = use "pcall"
+local tostring     = use "tostring"
+local tonumber     = use "tonumber"
+local load         = use "load"
+local pairs        = use "pairs"
+local ipairs       = use "ipairs"
+
+local string       = use "string"
+local string_sub    = string.sub
+local string_byte   = string.byte
+local string_char   = string.char
+local string_rep    = string.rep
+local string_format = string.format
+local string_pack   = string.pack
+local string_unpack = string.unpack
+local string_match  = string.match
+
+local table        = use "table"
+local table_concat = table.concat
+local table_sort   = table.sort
+
+--// extern libs //--
+
+local adclib = use "adclib"
+local adclib_random_bytes = adclib.random_bytes
+local adclib_aes_gcm_seal = adclib.aes_gcm_seal
+local adclib_aes_gcm_open = adclib.aes_gcm_open
+
+--// core scripts //--
+
+local hmac = use "hmac"
+local hmac_bytes = hmac.sha256_bytes
+
+local sha256 = use "sha256"
+local sha256_hash = sha256.hash
+
+----------------------------------// CONSTANTS //--
+
+local MAGIC              = "LDBK"
+local VERSION            = 1
+local KDF_PBKDF2_SHA256  = 1
+
+local KEY_SIZE           = 32       -- AES-256
+local NONCE_SIZE         = 12       -- GCM 96-bit nonce
+local TAG_SIZE           = 16       -- GCM 128-bit tag
+local SALT_SIZE          = 16
+local DEFAULT_ITERS      = 200000
+local MAX_ITERS          = 10000000   -- KDF work ceiling: guards unpack()
+                                      -- against a crafted header demanding
+                                      -- billions of pre-auth HMAC rounds.
+
+local TAR_BLOCK          = 512
+local MAX_TAR_ENTRIES    = 100000   -- parse-side bomb guard
+local MAX_NAME           = 100      -- ustar name field (no prefix-split yet)
+
+local MANIFEST_NAME      = "MANIFEST"
+local MODE_0644          = 420      -- rw-r--r-- (caller passes per-file modes)
+
+local ZERO_BLOCK         = string_rep( "\0", TAR_BLOCK )
+
+----------------------------------// PBKDF2 //--
+
+-- XOR two 32-byte strings (Lua 5.4 native integer XOR).
+local function _xor32( a, b )
+    local out = { }
+    for i = 1, 32 do
+        out[ i ] = string_char( string_byte( a, i ) ~ string_byte( b, i ) )
+    end
+    return table_concat( out )
+end
+
+-- PBKDF2-HMAC-SHA256, RFC 2898. Only dklen <= 32 (one output block) is
+-- needed here (a 256-bit AES key), so a single block index (1) suffices:
+-- DK = U1 XOR U2 XOR ... XOR Uc, Ui = HMAC(pass, U(i-1)), U1 = HMAC(pass,
+-- salt || INT32_BE(1)).
+local function _pbkdf2( password, salt, iters, dklen )
+    dklen = dklen or KEY_SIZE
+    if dklen > 32 then
+        error( "backup_archive._pbkdf2: dklen > 32 unsupported", 2 )
+    end
+    if type( iters ) ~= "number" or iters < 1 then
+        error( "backup_archive._pbkdf2: iters must be a number >= 1", 2 )
+    end
+    local u = hmac_bytes( password, salt .. string_pack( ">I4", 1 ) )
+    local t = u
+    for _ = 2, iters do
+        u = hmac_bytes( password, u )
+        t = _xor32( t, u )
+    end
+    return string_sub( t, 1, dklen )
+end
+
+----------------------------------// USTAR //--
+
+-- Right-pad (or truncate) a string to exactly `w` bytes with NUL.
+local function _pad( s, w )
+    if #s >= w then return string_sub( s, 1, w ) end
+    return s .. string_rep( "\0", w - #s )
+end
+
+-- Octal ASCII numeric field: (w-1) zero-padded octal digits + trailing
+-- NUL, exactly `w` bytes. Errors if the value does not fit.
+local function _octal( n, w )
+    local s = string_format( "%0" .. ( w - 1 ) .. "o", n )
+    if #s > w - 1 then
+        return nil, "tar: numeric field overflow (" .. n .. ")"
+    end
+    return s .. "\0"
+end
+
+-- Parse an octal numeric field: strip everything but octal digits and
+-- read as base 8. Returns nil on a field with no digits.
+local function _read_octal( block, start, w )
+    local raw = string_sub( block, start, start + w - 1 )
+    local digits = string_match( raw, "[0-7]+" )
+    if not digits then return nil end
+    return tonumber( digits, 8 )
+end
+
+-- Read a NUL-terminated (or full-width) string field.
+local function _read_str( block, start, w )
+    local raw = string_sub( block, start, start + w - 1 )
+    return ( string_match( raw, "^[^%z]*" ) )
+end
+
+-- Build one 512-byte ustar header for a regular file. Deterministic
+-- (uid/gid/mtime = 0, no owner names) so identical inputs produce a
+-- byte-identical archive - the round-trip test relies on it.
+local function _tar_header( name, mode, size )
+    if #name > MAX_NAME then
+        return nil, "tar: name too long (" .. #name .. " > " .. MAX_NAME .. "): " .. name
+    end
+    local mode_f, e1 = _octal( mode & 0x1FF, 8 )
+    if not mode_f then return nil, e1 end
+    local size_f, e2 = _octal( size, 12 )
+    if not size_f then return nil, e2 end
+    local zero8  = _octal( 0, 8 )
+    local zero12 = _octal( 0, 12 )
+    local parts = {
+        _pad( name, 100 ),   -- name
+        mode_f,              -- mode
+        zero8,               -- uid
+        zero8,               -- gid
+        size_f,              -- size
+        zero12,              -- mtime (0 = reproducible)
+        "        ",          -- chksum placeholder: 8 spaces
+        "0",                 -- typeflag: regular file
+        _pad( "", 100 ),     -- linkname
+        "ustar\0",           -- magic
+        "00",                -- version
+        _pad( "", 32 ),      -- uname
+        _pad( "", 32 ),      -- gname
+        zero8,               -- devmajor
+        zero8,               -- devminor
+        _pad( "", 155 ),     -- prefix
+        _pad( "", 12 ),      -- pad to 512
+    }
+    local header = table_concat( parts )
+    -- Checksum: unsigned sum of all 512 bytes with the chksum field taken
+    -- as ASCII spaces (still spaces at this point). Written as 6 octal
+    -- digits + NUL + space.
+    local sum = 0
+    for i = 1, TAR_BLOCK do
+        sum = sum + string_byte( header, i )
+    end
+    local chk = string_format( "%06o", sum ) .. "\0 "
+    return string_sub( header, 1, 148 ) .. chk .. string_sub( header, 157 )
+end
+
+-- Verify a header's stored checksum (validates our own writer, and any
+-- corruption a wrong passphrase would NOT catch - defence in depth on top
+-- of the GCM tag).
+local function _verify_checksum( block )
+    local stored = _read_octal( block, 149, 8 )
+    if not stored then return false end
+    local sum = 0
+    for i = 1, TAR_BLOCK do
+        local b = string_byte( block, i )
+        if i >= 149 and i <= 156 then b = 32 end   -- chksum field = spaces
+        sum = sum + b
+    end
+    return sum == stored
+end
+
+local function _build_tar( entries )
+    local parts = { }
+    for _, e in ipairs( entries ) do
+        local hdr, err = _tar_header( e.name, e.mode or MODE_0644, #e.body )
+        if not hdr then return nil, err end
+        parts[ #parts + 1 ] = hdr
+        parts[ #parts + 1 ] = e.body
+        local rem = ( -#e.body ) % TAR_BLOCK
+        if rem > 0 then parts[ #parts + 1 ] = string_rep( "\0", rem ) end
+    end
+    parts[ #parts + 1 ] = ZERO_BLOCK
+    parts[ #parts + 1 ] = ZERO_BLOCK    -- two zero blocks terminate the archive
+    return table_concat( parts )
+end
+
+-- Parse a ustar stream into { {name, mode, size, body}, ... }. Defensive
+-- per DEVELOPMENT.md S5: bound every read, cap the entry count, degrade to
+-- (nil, err) rather than erroring. (The stream is GCM-authenticated by the
+-- time we get here, but corrupt-degradation stays cheap and correct.)
+local function _parse_tar( bytes )
+    local entries = { }
+    local off, n = 1, #bytes
+    local terminated = false
+    while off + TAR_BLOCK - 1 <= n do
+        local block = string_sub( bytes, off, off + TAR_BLOCK - 1 )
+        if block == ZERO_BLOCK then terminated = true; break end
+        if not _verify_checksum( block ) then
+            return nil, "tar: header checksum mismatch"
+        end
+        local name = _read_str( block, 1, 100 )
+        local mode = _read_octal( block, 101, 8 ) or MODE_0644
+        local size = _read_octal( block, 125, 12 )
+        if not size then return nil, "tar: bad size field" end
+        off = off + TAR_BLOCK
+        if off + size - 1 > n then return nil, "tar: truncated file content" end
+        local body = string_sub( bytes, off, off + size - 1 )
+        off = off + size + ( ( -size ) % TAR_BLOCK )
+        entries[ #entries + 1 ] = { name = name, mode = mode, size = size, body = body }
+        if #entries > MAX_TAR_ENTRIES then
+            return nil, "tar: too many entries"
+        end
+    end
+    -- A well-formed archive ends on the zero terminator block. Reaching the
+    -- end of input without one means the stream is truncated or not a tar.
+    if not terminated then
+        return nil, "tar: unterminated / truncated stream"
+    end
+    return entries
+end
+
+----------------------------------// MANIFEST //--
+
+-- Serialise the flat metadata table (scalars + a string->string `kinds`
+-- map) to a deterministic `return { ... }` Lua chunk. %q keeps arbitrary
+-- paths / versions safe to load back.
+local function _manifest_serialize( meta )
+    local keys = { }
+    for k in pairs( meta ) do keys[ #keys + 1 ] = k end
+    table_sort( keys )
+    local lines = { "return {" }
+    for _, k in ipairs( keys ) do
+        local v = meta[ k ]
+        if k == "kinds" and type( v ) == "table" then
+            local kk = { }
+            for name in pairs( v ) do kk[ #kk + 1 ] = name end
+            table_sort( kk )
+            lines[ #lines + 1 ] = "  kinds = {"
+            for _, name in ipairs( kk ) do
+                lines[ #lines + 1 ] = string_format( "    [%q] = %q,", name, tostring( v[ name ] ) )
+            end
+            lines[ #lines + 1 ] = "  },"
+        elseif type( v ) == "string" then
+            lines[ #lines + 1 ] = string_format( "  [%q] = %q,", k, v )
+        elseif type( v ) == "number" or type( v ) == "boolean" then
+            lines[ #lines + 1 ] = string_format( "  [%q] = %s,", k, tostring( v ) )
+        end
+    end
+    lines[ #lines + 1 ] = "}"
+    return table_concat( lines, "\n" )
+end
+
+-- Parse a manifest chunk in a sandboxed empty environment (text only, no
+-- globals) - same protection as util.loadtable_string.
+local function _manifest_parse( str )
+    local fn, err = load( str, "backup_manifest", "t", { } )
+    if not fn then return nil, "manifest: " .. tostring( err ) end
+    local ok, tbl = pcall( fn )
+    if not ok or type( tbl ) ~= "table" then
+        return nil, "manifest: invalid table"
+    end
+    return tbl
+end
+
+----------------------------------// PACK / UNPACK //--
+
+local function pack( files, meta, passphrase, opts )
+    if type( passphrase ) ~= "string" or passphrase == "" then
+        return nil, "backup_archive: passphrase required"
+    end
+    if type( files ) ~= "table" then
+        return nil, "backup_archive: files must be a table"
+    end
+    opts = opts or { }
+    -- `opts.iters or DEFAULT` cannot default a literal 0 (0 is truthy in
+    -- Lua), so validate the resolved value explicitly.
+    local iters = opts.iters or DEFAULT_ITERS
+    if type( iters ) ~= "number" or iters < 1 or iters > MAX_ITERS then
+        return nil, "backup_archive: iterations out of range (1.." .. MAX_ITERS .. ")"
+    end
+
+    -- Validate every file up front so a malformed caller entry degrades to
+    -- (nil, err) instead of raising deeper in _manifest_serialize / _build_tar.
+    for _, f in ipairs( files ) do
+        if type( f.name ) ~= "string" or type( f.body ) ~= "string" then
+            return nil, "backup_archive: each file needs a string name and body"
+        end
+        if f.name == MANIFEST_NAME then
+            return nil, "backup_archive: file name '" .. MANIFEST_NAME .. "' is reserved"
+        end
+        if f.mode ~= nil and type( f.mode ) ~= "number" then
+            return nil, "backup_archive: file mode must be a number (octal perms)"
+        end
+        if f.kind ~= nil and type( f.kind ) ~= "string" then
+            return nil, "backup_archive: file kind must be a string"
+        end
+    end
+
+    -- Build the manifest: caller meta + our format version + per-file kind.
+    local m = { format_version = VERSION }
+    if type( meta ) == "table" then
+        for k, v in pairs( meta ) do
+            if k ~= "format_version" and k ~= "kinds" then m[ k ] = v end
+        end
+    end
+    local kinds = { }
+    for _, f in ipairs( files ) do
+        if f.kind then kinds[ f.name ] = f.kind end
+    end
+    m.kinds = kinds
+
+    local entries = { { name = MANIFEST_NAME, mode = MODE_0644, body = _manifest_serialize( m ) } }
+    for _, f in ipairs( files ) do
+        entries[ #entries + 1 ] = { name = f.name, mode = f.mode or MODE_0644, body = f.body }
+    end
+
+    local tar, terr = _build_tar( entries )
+    if not tar then return nil, terr end
+
+    local salt = adclib_random_bytes( SALT_SIZE )
+    if type( salt ) ~= "string" or #salt ~= SALT_SIZE then
+        return nil, "backup_archive: RNG failed (salt)"
+    end
+    local key = _pbkdf2( passphrase, salt, iters, KEY_SIZE )
+    local nonce = adclib_random_bytes( NONCE_SIZE )
+    if type( nonce ) ~= "string" or #nonce ~= NONCE_SIZE then
+        return nil, "backup_archive: RNG failed (nonce)"
+    end
+    local ok, ct_tag = pcall( adclib_aes_gcm_seal, key, nonce, tar )
+    if not ok then
+        return nil, "backup_archive: seal failed: " .. tostring( ct_tag )
+    end
+
+    local header = MAGIC
+        .. string_char( VERSION )
+        .. string_char( KDF_PBKDF2_SHA256 )
+        .. string_pack( ">I4", iters )
+        .. string_char( SALT_SIZE )
+        .. salt
+        .. nonce
+    return header .. ct_tag
+end
+
+local function unpack( blob, passphrase )
+    if type( passphrase ) ~= "string" or passphrase == "" then
+        return nil, "backup_archive: passphrase required"
+    end
+    if type( blob ) ~= "string" or #blob < 12 then
+        return nil, "backup_archive: not an LDBK archive (too short)"
+    end
+    if string_sub( blob, 1, 4 ) ~= MAGIC then
+        return nil, "backup_archive: bad magic (not an LDBK archive)"
+    end
+    local version = string_byte( blob, 5 )
+    if version ~= VERSION then
+        return nil, "backup_archive: unsupported format version " .. tostring( version )
+    end
+    local kdf_id = string_byte( blob, 6 )
+    if kdf_id ~= KDF_PBKDF2_SHA256 then
+        return nil, "backup_archive: unsupported KDF id " .. tostring( kdf_id )
+    end
+    local iters = string_unpack( ">I4", blob, 7 )
+    -- iters comes straight off an attacker/corruptible header. Bound it: 0
+    -- would make _pbkdf2 raise (breaking the (nil,err) contract), and ~2^32
+    -- would spin billions of pre-auth HMAC rounds (DoS on the restore path).
+    if iters < 1 or iters > MAX_ITERS then
+        return nil, "backup_archive: bad iteration count in header"
+    end
+    local salt_len = string_byte( blob, 11 )
+    if not salt_len or salt_len < 8 or salt_len > 64 then
+        return nil, "backup_archive: bad salt length"
+    end
+    local salt_start  = 12
+    local nonce_start = salt_start + salt_len
+    local ct_start    = nonce_start + NONCE_SIZE
+    if #blob < ct_start + TAG_SIZE - 1 then
+        return nil, "backup_archive: truncated header/ciphertext"
+    end
+    local salt  = string_sub( blob, salt_start, nonce_start - 1 )
+    local nonce = string_sub( blob, nonce_start, ct_start - 1 )
+    local ct_tag = string_sub( blob, ct_start )
+
+    local key = _pbkdf2( passphrase, salt, iters, KEY_SIZE )
+    local ok, tar, oerr = pcall( adclib_aes_gcm_open, key, nonce, ct_tag )
+    if not ok then
+        return nil, "backup_archive: decrypt error: " .. tostring( tar )
+    end
+    if not tar then
+        return nil, "backup_archive: decrypt failed (wrong passphrase or corrupt archive: "
+            .. tostring( oerr ) .. ")"
+    end
+
+    local entries, perr = _parse_tar( tar )
+    if not entries then return nil, perr end
+
+    local meta, files = nil, { }
+    for _, e in ipairs( entries ) do
+        if e.name == MANIFEST_NAME then
+            local m, merr = _manifest_parse( e.body )
+            if not m then return nil, merr end
+            meta = m
+        else
+            files[ #files + 1 ] = { name = e.name, mode = e.mode, body = e.body }
+        end
+    end
+    if not meta then
+        return nil, "backup_archive: archive is missing its MANIFEST"
+    end
+    local kinds = ( type( meta.kinds ) == "table" ) and meta.kinds or { }
+    for _, f in ipairs( files ) do
+        f.kind = kinds[ f.name ]
+    end
+    -- NOTE for the restore writer (PR-B): file names here are GCM-
+    -- authenticated but NOT trusted paths. A valid-yet-crafted archive can
+    -- carry names like "../../etc/cron.d/x". Sanitize every name against the
+    -- target root (reject absolute / "..") before writing to disk.
+    return { meta = meta, files = files }
+end
+
+----------------------------------// SIDECAR //--
+
+-- SHA-256 of the whole artifact, hex. The caller already holds the sealed
+-- bytes in memory, so hashing them here avoids a re-read.
+local function checksum( bytes )
+    return sha256_hash( bytes )
+end
+
+-- One line in the standard `sha256sum` format ("<hex><space><space><name>")
+-- so an operator can verify with `sha256sum -c <name>.sha256`, passphrase-free.
+local function sidecar_line( hex, filename )
+    return hex .. "  " .. filename .. "\n"
+end
+
+----------------------------------// SELF-TEST (load-time) //--
+
+do
+    -- PBKDF2-HMAC-SHA256 known-answer (P="password", S="salt", c=1),
+    -- cross-checked with Python hashlib.pbkdf2_hmac at authoring time -
+    -- never trust memory for crypto vectors. A silent regression in the
+    -- XOR / iteration / block-index logic derives wrong keys, i.e.
+    -- unrecoverable backups, so fail loud at load like sha256 / hmac.
+    local dk = _pbkdf2( "password", "salt", 1, KEY_SIZE )
+    local hex = { }
+    for i = 1, KEY_SIZE do hex[ i ] = string_format( "%02x", string_byte( dk, i ) ) end
+    if table_concat( hex ) ~= "120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b" then
+        error( "backup_archive self-test FAILED: PBKDF2-HMAC-SHA256 c=1 vector mismatch", 2 )
+    end
+    -- ustar build -> parse fidelity on a tiny fixture (also proves the
+    -- checksum our writer emits validates).
+    local tar = _build_tar( { { name = "a.txt", mode = MODE_0644, body = "hello" } } )
+    local ents = _parse_tar( tar )
+    if not ents or #ents ~= 1 or ents[ 1 ].name ~= "a.txt" or ents[ 1 ].body ~= "hello" then
+        error( "backup_archive self-test FAILED: ustar round-trip", 2 )
+    end
+end
+
+----------------------------------// PUBLIC INTERFACE //--
+
+return {
+    pack         = pack,
+    unpack       = unpack,
+    checksum     = checksum,
+    sidecar_line = sidecar_line,
+
+    MAGIC         = MAGIC,
+    VERSION       = VERSION,
+    DEFAULT_ITERS = DEFAULT_ITERS,
+
+    -- test seams
+    _pbkdf2             = _pbkdf2,
+    _build_tar          = _build_tar,
+    _parse_tar          = _parse_tar,
+    _manifest_serialize = _manifest_serialize,
+    _manifest_parse     = _manifest_parse,
+}

--- a/core/backup_archive.lua
+++ b/core/backup_archive.lua
@@ -81,6 +81,10 @@ local table        = use "table"
 local table_concat = table.concat
 local table_sort   = table.sort
 
+-- debug.sethook is used ONLY to bound the manifest-eval work (see
+-- _manifest_parse); the standard way to cap untrusted Lua execution.
+local debug_sethook = ( use "debug" ).sethook
+
 --// extern libs //--
 
 local adclib = use "adclib"
@@ -119,6 +123,8 @@ local MAX_TAR_ENTRIES    = 100000   -- parse-side bomb guard
 local MAX_NAME           = 100      -- ustar name field (no prefix-split yet)
 
 local MANIFEST_NAME      = "MANIFEST"
+local MANIFEST_MAX_BYTES = 65536    -- a real manifest is a handful of scalars
+local MANIFEST_MAX_INSTR = 200000   -- eval work ceiling (real parse ~dozens)
 local MODE_0644          = 420      -- rw-r--r-- (caller passes per-file modes)
 
 local ZERO_BLOCK         = string_rep( "\0", TAR_BLOCK )
@@ -342,11 +348,23 @@ local function _manifest_serialize( meta )
 end
 
 -- Parse a manifest chunk in a sandboxed empty environment (text only, no
--- globals) - same protection as util.loadtable_string.
+-- globals) - same protection as util.loadtable_string, PLUS a work bound.
+-- The empty _ENV blocks code execution, but a crafted manifest (a foreign
+-- archive whose passphrase the operator holds) could still `while true do end`
+-- and hang the offline restore. An instruction-count hook aborts any chunk
+-- that runs past a budget far above a real table construction; because the
+-- env is empty the chunk cannot reach a long-running C call that would slip
+-- the hook, so the count bound is sufficient (DEVELOPMENT.md §5: bound the
+-- WORK, not just the depth).
 local function _manifest_parse( str )
+    if type( str ) ~= "string" or #str > MANIFEST_MAX_BYTES then
+        return nil, "manifest: missing or too large"
+    end
     local fn, err = load( str, "backup_manifest", "t", { } )
     if not fn then return nil, "manifest: " .. tostring( err ) end
+    debug_sethook( function( ) error( "manifest: instruction budget exceeded", 0 ) end, "", MANIFEST_MAX_INSTR )
     local ok, tbl = pcall( fn )
+    debug_sethook( )   -- always clear the hook, success or not
     if not ok or type( tbl ) ~= "table" then
         return nil, "manifest: invalid table"
     end

--- a/core/backup_archive.lua
+++ b/core/backup_archive.lua
@@ -87,6 +87,9 @@ local adclib = use "adclib"
 local adclib_random_bytes = adclib.random_bytes
 local adclib_aes_gcm_seal = adclib.aes_gcm_seal
 local adclib_aes_gcm_open = adclib.aes_gcm_open
+-- OpenSSL PBKDF2 (fast). nil on a standalone lua / stubbed adclib, where
+-- _derive_key falls back to the pure-Lua PBKDF2 below.
+local adclib_pbkdf2 = adclib.pbkdf2_sha256
 
 --// core scripts //--
 
@@ -135,13 +138,13 @@ end
 -- needed here (a 256-bit AES key), so a single block index (1) suffices:
 -- DK = U1 XOR U2 XOR ... XOR Uc, Ui = HMAC(pass, U(i-1)), U1 = HMAC(pass,
 -- salt || INT32_BE(1)).
-local function _pbkdf2( password, salt, iters, dklen )
+local function _pbkdf2_lua( password, salt, iters, dklen )
     dklen = dklen or KEY_SIZE
     if dklen > 32 then
-        error( "backup_archive._pbkdf2: dklen > 32 unsupported", 2 )
+        error( "backup_archive._pbkdf2_lua: dklen > 32 unsupported", 2 )
     end
     if type( iters ) ~= "number" or iters < 1 then
-        error( "backup_archive._pbkdf2: iters must be a number >= 1", 2 )
+        error( "backup_archive._pbkdf2_lua: iters must be a number >= 1", 2 )
     end
     local u = hmac_bytes( password, salt .. string_pack( ">I4", 1 ) )
     local t = u
@@ -150,6 +153,19 @@ local function _pbkdf2( password, salt, iters, dklen )
         t = _xor32( t, u )
     end
     return string_sub( t, 1, dklen )
+end
+
+-- Derive the AES key. Prefer OpenSSL's PBKDF2 via adclib: the pure-Lua one
+-- is correct but runs ~tens of seconds at the default iteration count, which
+-- would freeze the single-threaded hub for the whole backup. Both produce
+-- the SAME key (PBKDF2 is deterministic), so artifacts stay interoperable
+-- regardless of which path sealed / opens them; the Lua path is the
+-- standalone / no-adclib fallback (unit tests, a broken build).
+local function _derive_key( password, salt, iters, dklen )
+    if type( adclib_pbkdf2 ) == "function" then
+        return adclib_pbkdf2( password, salt, iters, dklen or KEY_SIZE )
+    end
+    return _pbkdf2_lua( password, salt, iters, dklen )
 end
 
 ----------------------------------// USTAR //--
@@ -396,7 +412,7 @@ local function pack( files, meta, passphrase, opts )
     if type( salt ) ~= "string" or #salt ~= SALT_SIZE then
         return nil, "backup_archive: RNG failed (salt)"
     end
-    local key = _pbkdf2( passphrase, salt, iters, KEY_SIZE )
+    local key = _derive_key( passphrase, salt, iters, KEY_SIZE )
     local nonce = adclib_random_bytes( NONCE_SIZE )
     if type( nonce ) ~= "string" or #nonce ~= NONCE_SIZE then
         return nil, "backup_archive: RNG failed (nonce)"
@@ -455,7 +471,7 @@ local function unpack( blob, passphrase )
     local nonce = string_sub( blob, nonce_start, ct_start - 1 )
     local ct_tag = string_sub( blob, ct_start )
 
-    local key = _pbkdf2( passphrase, salt, iters, KEY_SIZE )
+    local key = _derive_key( passphrase, salt, iters, KEY_SIZE )
     local ok, tar, oerr = pcall( adclib_aes_gcm_open, key, nonce, ct_tag )
     if not ok then
         return nil, "backup_archive: decrypt error: " .. tostring( tar )
@@ -514,11 +530,17 @@ do
     -- never trust memory for crypto vectors. A silent regression in the
     -- XOR / iteration / block-index logic derives wrong keys, i.e.
     -- unrecoverable backups, so fail loud at load like sha256 / hmac.
-    local dk = _pbkdf2( "password", "salt", 1, KEY_SIZE )
+    local dk = _pbkdf2_lua( "password", "salt", 1, KEY_SIZE )
     local hex = { }
     for i = 1, KEY_SIZE do hex[ i ] = string_format( "%02x", string_byte( dk, i ) ) end
     if table_concat( hex ) ~= "120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b" then
         error( "backup_archive self-test FAILED: PBKDF2-HMAC-SHA256 c=1 vector mismatch", 2 )
+    end
+    -- If the OpenSSL PBKDF2 is present it MUST agree with the vetted pure-Lua
+    -- one - a mismatch would silently make artifacts sealed by one path
+    -- unreadable by the other.
+    if type( adclib_pbkdf2 ) == "function" and adclib_pbkdf2( "password", "salt", 1, KEY_SIZE ) ~= dk then
+        error( "backup_archive self-test FAILED: adclib pbkdf2_sha256 disagrees with the PBKDF2 KAT", 2 )
     end
     -- ustar build -> parse fidelity on a tiny fixture (also proves the
     -- checksum our writer emits validates).
@@ -542,7 +564,8 @@ return {
     DEFAULT_ITERS = DEFAULT_ITERS,
 
     -- test seams
-    _pbkdf2             = _pbkdf2,
+    _pbkdf2             = _pbkdf2_lua,
+    _derive_key        = _derive_key,
     _build_tar          = _build_tar,
     _parse_tar          = _parse_tar,
     _manifest_serialize = _manifest_serialize,

--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -3422,6 +3422,81 @@ local defaults = {
         end
     },
 
+    -- etc_backup.lua (#480): automatic encrypted backups of the operator
+    -- state set. The engine (core/backup.lua) reads dir / keep / passphrase /
+    -- include; the plugin drives the schedule + the owner readiness nag.
+    -- See docs/BACKUP.md.
+    etc_backup_enabled = { true,
+        function( value )
+            return types_boolean( value, nil, true )
+        end
+    },
+    -- Destination. Default cfg/backups so artifacts land under the
+    -- upgrade-preserved cfg/ tree (and the Docker cfg mount). An absolute
+    -- path is allowed (a mounted backup volume); the engine creates it via
+    -- the raw makedir primitive.
+    etc_backup_dir = { "cfg/backups",
+        function( value )
+            return types_utf8( value, nil, true )
+        end
+    },
+    -- Retention: keep the newest N artifacts, prune older ones each run.
+    etc_backup_keep = { 7,
+        function( value )
+            return types_number( value, nil, true )
+                and value % 1 == 0 and value >= 1 and value <= 1000
+        end
+    },
+    -- Primary schedule: a daily backup at this server-local HH:MM. Empty
+    -- string disables the daily slot (falls back to the interval below). The
+    -- plugin parses/validates the HH:MM shape and treats a bad value as "no
+    -- daily slot", so the validator only enforces it is a string.
+    etc_backup_daily_at = { "04:00",
+        function( value )
+            return types_utf8( value, nil, true )
+        end
+    },
+    -- Fallback cadence when etc_backup_daily_at is empty: every N hours
+    -- (0 = off). For hubs wanting more than one backup a day.
+    etc_backup_interval_hours = { 0,
+        function( value )
+            return types_number( value, nil, true )
+                and value % 1 == 0 and value >= 0 and value <= 168
+        end
+    },
+    -- Include master.key in the (encrypted) artifact. Default true for
+    -- self-contained disaster recovery; false keeps the key strictly out of
+    -- the backup (the plugin then warns the operator to save it separately).
+    etc_backup_include_master_key = { true,
+        function( value )
+            return types_boolean( value, nil, true )
+        end
+    },
+    -- Secret: the passphrase that encrypts the artifact (PBKDF2 -> AES-256-
+    -- GCM). Resolved env-var-first via core/secrets (registered by the
+    -- plugin) so GET /v1/config redacts it. Prefer the env var
+    -- LUADCH_ETC_BACKUP_PASSPHRASE over a plaintext value here. Independent
+    -- of master.key - store it out-of-band; losing it makes every artifact
+    -- unrecoverable.
+    etc_backup_passphrase = { "",
+        function( value )
+            return types_utf8( value, nil, true )
+        end
+    },
+    -- Level allowed to run +backup now / list / status. Default 80 (ADMIN).
+    etc_backup_oplevel = { 80,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+    -- Level that receives the "backup not configured / not writable" hubbot
+    -- nag on login + at start. Default 100 (HUBOWNER).
+    etc_backup_notify_level = { 100,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+
     -- etc_webhook.lua: inbound webhook receiver (Discourse / GitHub /
     -- ...). Only the master switch lives in cfg.tbl; ALL endpoint config
     -- (paths, headers, secrets, templates, ...) lives in the

--- a/core/init.lua
+++ b/core/init.lua
@@ -188,6 +188,15 @@ _core = {    -- luadch core, order is important
     -- module is in _G when the plugin sandbox iterates the
     -- whitelist.
     "sysinfo",
+    -- core/backup.lua (#480 PR-A): automatic-backup engine - collects the
+    -- restore-minimum state set, seals it via core/backup_archive.lua, writes
+    -- + rotates the .ldbk artifact. Needs full os.rename/remove + raw
+    -- makedir/listdir + secrets, so it lives in core, not the plugin sandbox.
+    -- Loaded AFTER its file-scope use deps (cfg / out / const / secrets;
+    -- backup_archive loads on demand) and BEFORE scripts so it is in _G when
+    -- the plugin sandbox iterates the whitelist (scripts/etc_backup.lua calls
+    -- backup.run / .readiness / .list). Passive at load - no init(), no I/O.
+    "backup",
     "scripts",
     -- #263: HTTP API event ringbuffer. Loaded AFTER scripts so its
     -- init() can register a core-side tap into scripts.firelistener;

--- a/core/restore.lua
+++ b/core/restore.lua
@@ -293,9 +293,16 @@ local function main( )
         return 1
     end
 
+    -- Primary env for restore; fall back to the backup engine's own env name
+    -- so an operator whose compose already sets LUADCH_ETC_BACKUP_PASSPHRASE
+    -- (secrets.lookup convention) need not add a second variable just to restore.
     local passphrase = os_getenv "LUADCH_BACKUP_PASSPHRASE"
     if type( passphrase ) ~= "string" or passphrase == "" then
-        print( "luadch restore: set the backup passphrase in $LUADCH_BACKUP_PASSPHRASE, e.g." )
+        passphrase = os_getenv "LUADCH_ETC_BACKUP_PASSPHRASE"
+    end
+    if type( passphrase ) ~= "string" or passphrase == "" then
+        print( "luadch restore: set the backup passphrase in $LUADCH_BACKUP_PASSPHRASE" )
+        print( "  (or $LUADCH_ETC_BACKUP_PASSPHRASE), e.g." )
         print( "  LUADCH_BACKUP_PASSPHRASE='...' ./luadch --restore " .. file )
         return 1
     end

--- a/core/restore.lua
+++ b/core/restore.lua
@@ -1,0 +1,416 @@
+--[[
+
+    core/restore.lua - offline restore entry for the #480 backup arc (PR-B).
+
+    NOT a hub module: it is never in core/init.lua's `_core` and never runs
+    inside a live hub. The C launcher's run_restore() (hub/hub.c) loads THIS
+    file into a fresh Lua state when the operator runs
+
+        ./luadch --restore <file> [--verify] [--force] [--master-key-path P]
+
+    after chdir-to-install-root and AFTER acquiring the single-instance lock,
+    so a restore can never race a running hub over cfg/user.tbl/master.key.
+    It reverses core/backup.lua: decrypt + verify one .ldbk artifact and lay
+    its files back onto the install tree. It boots NOTHING else (no cfg, no
+    listeners) - the config it would read is exactly what it is restoring.
+
+    Two phases, transactional per file:
+      preflight - sha256 sidecar check, AES-256-GCM decrypt + MANIFEST parse,
+                  path-sanitize every entry, detect dest conflicts. No writes.
+      apply     - tmp-write + atomic rename each file, chmod 0600 the secrets.
+    --verify runs preflight only (a dry run). Without --force, restore refuses
+    to overwrite an existing populated tree.
+
+    SECURITY: an archive entry name is GCM-authenticated but is NOT a trusted
+    path - a valid-yet-crafted (or foreign) archive can carry "../../etc/x".
+    _safe_rel() rejects absolute paths and any ".."/"." component before a
+    single byte is written (the guard core/backup_archive.unpack's note asks
+    for). master.key is the one deliberately-absolute destination (the
+    operator's own configured / --master-key-path location), never a tar name.
+
+    Args arrive as globals set by the C caller: RESTORE_FILE (string),
+    RESTORE_VERIFY / RESTORE_FORCE (bool), RESTORE_MASTER_KEY_PATH (string|nil).
+    The passphrase is read out-of-band from $LUADCH_BACKUP_PASSPHRASE (there is
+    no cfg to read it from on a fresh host - that is the whole point). Returns
+    an integer exit code (0 = success/clean verify, 1 = failure).
+
+]]--
+
+----------------------------------// BOOTSTRAP //--
+-- This chunk runs with _ENV = the real globals (loaded plain by the C side),
+-- so require / io / os / string are directly reachable. We stand up the same
+-- restricted `use` env core modules expect and pull in backup_archive (which
+-- transitively loads hmac + sha256). adclib is a dynamic C lib, required the
+-- way core/init.lua requires it.
+
+local _G = _ENV
+
+local require      = require
+local loadfile     = loadfile
+local setmetatable = setmetatable
+local error        = error
+local type         = type
+local tostring     = tostring
+local tonumber     = tonumber
+local pcall        = pcall
+local ipairs       = ipairs
+local print        = print
+local os           = os
+local io           = io
+local string       = string
+local table        = table
+local package      = package
+
+local os_getenv  = os.getenv
+local os_rename  = os.rename
+local os_remove  = os.remove
+local io_open    = io.open
+
+-- .dll on Windows, .so elsewhere - same probe init.lua uses.
+local _filetype = ( os_getenv "COMSPEC" and os_getenv "WINDIR" and ".dll" ) or ".so"
+
+-- Resolve core/ + the bundled libs the way init.lua does, so require("adclib")
+-- and loadfile("core/backup_archive.lua") work from the install root.
+package.path = package.path .. ";"
+    .. "././core/?.lua;"
+    .. "././lib/?/?.lua;"
+    .. "././lib/luasocket/lua/?.lua;"
+    .. "././lib/luasec/lua/?.lua;"
+package.cpath = package.cpath .. ";"
+    .. "././lib/?/?" .. _filetype .. ";"
+    .. "././lib/luasocket/?/?" .. _filetype .. ";"
+    .. "././lib/luasec/?/?" .. _filetype .. ";"
+
+local _env
+local function loadscript( name )
+    if _G[ name ] ~= nil then return _G[ name ] end
+    local chunk, err = loadfile( "././core/" .. name .. ".lua", "t", _env )
+    if not chunk then error( "restore: cannot load core/" .. name .. ".lua: " .. tostring( err ), 0 ) end
+    _G[ name ] = chunk( )
+    return _G[ name ]
+end
+local function use( name )
+    local v = _G[ name ]
+    if v ~= nil then return v end
+    return loadscript( name )
+end
+_env = setmetatable( { use = use }, {
+    __index    = function( _, k ) error( "attempt to read undeclared var: '" .. tostring( k ) .. "'", 2 ) end,
+    __newindex = function( _, k ) error( "attempt to write undeclared var: '" .. tostring( k ) .. "'", 2 ) end,
+} )
+
+-- adclib is required (dynamic C lib); without it there is no AES-GCM/PBKDF2
+-- and nothing can be decrypted - fail loud with a clear message. A unit test
+-- may pre-inject a fake _G.adclib to exercise the pure helpers without the
+-- built C module; a real --restore always takes the require path.
+if _G.adclib == nil then
+    local ok, lib = pcall( require, "adclib" )
+    if not ok or type( lib ) ~= "table" then
+        print( "luadch restore: FATAL - could not load the adclib crypto module (" .. tostring( lib ) .. ")" )
+        print( "luadch restore: run --restore from the install root so lib/adclib is on the path." )
+        return 1
+    end
+    _G.adclib = lib
+end
+
+local archive = use "backup_archive"
+
+----------------------------------// CONSTANTS //--
+
+local MASTERKEY_ENTRY   = "__masterkey__"
+local DEFAULT_MK_PATH   = "cfg/master.key"
+local SIDECAR_SUFFIX    = ".sha256"
+local MAX_ARCHIVE_BYTES = 1024 * 1024 * 1024   -- 1 GiB read cap (OOM guard)
+
+-- Restored files are made owner-only (0600) by the umask run_restore() sets
+-- before this script runs, so there is no per-file secret classification here -
+-- master.key (0600 is load-bearing: cfg_secret refuses any other mode), the TLS
+-- key, and user.tbl all land 0600 without a post-write chmod race.
+
+----------------------------------// PURE HELPERS (test seams) //--
+
+-- Sanitize a tar entry name into a path that can only land INSIDE the install
+-- root. Rejects absolute paths (POSIX "/...", UNC "\\...", drive "C:...") and
+-- any dot/space-only component ("..", "...", ".. "), which covers traversal and
+-- its Windows normalisation. Returns (clean_relative_path) or (nil, reason).
+local function _safe_rel( name )
+    if type( name ) ~= "string" or name == "" then
+        return nil, "empty name"
+    end
+    -- Absolute: leading slash/backslash, or a "X:" drive prefix.
+    if string.match( name, "^[/\\]" ) or string.match( name, "^%a:" ) then
+        return nil, "absolute path"
+    end
+    local parts = { }
+    for seg in string.gmatch( name, "[^/\\]+" ) do
+        if seg == "." then
+            -- harmless no-op segment ("./x"), drop it
+        elseif string.match( seg, "^[%.%s]+$" ) then
+            -- ".." / "..." / ".. " / whitespace-only: rejects traversal AND the
+            -- Windows trailing-dot/space normalisation that maps them onto "."/".."
+            return nil, "unsafe component '" .. seg .. "'"
+        else
+            parts[ #parts + 1 ] = seg
+        end
+    end
+    if #parts == 0 then return nil, "no path segments" end
+    return table.concat( parts, "/" )
+end
+
+-- Where the master.key travels back to: an explicit --master-key-path wins,
+-- else the path recorded in the manifest (may be absolute - a DR relocation),
+-- else the in-tree default. Absolute here is BY DESIGN (operator-owned), unlike
+-- a tar entry name, so it is not run through _safe_rel.
+local function _resolve_masterkey_dest( meta, mk_override )
+    if type( mk_override ) == "string" and mk_override ~= "" then return mk_override end
+    if type( meta ) == "table" and type( meta.master_key_path ) == "string"
+       and meta.master_key_path ~= "" then
+        return meta.master_key_path
+    end
+    return DEFAULT_MK_PATH
+end
+
+-- Turn the unpacked { meta, files } into a concrete write plan without
+-- touching disk. Returns plan, rejects where:
+--   plan[i]    = { dest, body [, masterkey=true] }   (masterkey => the __masterkey__ entry)
+--   rejects[i] = { name, reason }                    (unsafe path => fatal, aborts restore)
+local function _build_plan( files, meta, mk_override )
+    local plan, rejects = { }, { }
+    local has_override = type( mk_override ) == "string" and mk_override ~= ""
+    for _, f in ipairs( files ) do
+        if f.name == MASTERKEY_ENTRY or f.kind == "masterkey" then
+            local dest = _resolve_masterkey_dest( meta, mk_override )
+            -- The manifest's master_key_path may be absolute / out-of-tree (a DR
+            -- relocation). Honour that ONLY when the operator opted in with
+            -- --master-key-path: a foreign archive must not steer an arbitrary
+            -- absolute write via the manifest. An in-tree relative path is fine.
+            if not has_override and _safe_rel( dest ) == nil then
+                rejects[ #rejects + 1 ] = { name = f.name,
+                    reason = "manifest places master.key out of tree at '" .. dest
+                        .. "'; re-run with --master-key-path to choose where" }
+            else
+                plan[ #plan + 1 ] = { dest = dest, body = f.body, masterkey = true }
+            end
+        else
+            local rel, why = _safe_rel( f.name )
+            if not rel then
+                rejects[ #rejects + 1 ] = { name = f.name, reason = why }
+            else
+                plan[ #plan + 1 ] = { dest = rel, body = f.body }
+            end
+        end
+    end
+    return plan, rejects
+end
+
+-- Verify the sidecar if present. Returns "ok" | "missing" | "mismatch".
+local function _verify_sidecar( blob, sidecar_text )
+    if type( sidecar_text ) ~= "string" or sidecar_text == "" then return "missing" end
+    local want = string.match( sidecar_text, "^(%x+)" )
+    if not want then return "mismatch" end
+    return ( string.lower( want ) == string.lower( archive.checksum( blob ) ) ) and "ok" or "mismatch"
+end
+
+----------------------------------// DISK HELPERS //--
+
+-- Parent-directory chain of a dest path, innermost last, so makedir walks it
+-- top-down. Handles both separators; skips an absolute root / drive prefix.
+local function _dir_of( path )
+    return ( string.match( path, "^(.*)[/\\][^/\\]+$" ) )
+end
+
+local makedir = _G.makedir   -- C primitive registered by run_restore()
+
+-- Create the parent directory chain of `dest`. The makedir C primitive is
+-- already mkdir -p (it walks every separator and tolerates EEXIST, absolute
+-- roots and a Windows drive prefix), so one call suffices; propagate its error
+-- so a genuine failure (permission) surfaces as itself, not a later write error.
+local function _ensure_parent( dest )
+    local dir = _dir_of( dest )
+    if not dir or dir == "" then return true end
+    if not makedir then return true end   -- absent under a standalone lua (tests)
+    local ok, err = makedir( dir )
+    if not ok then return false, "cannot create directory '" .. dir .. "': " .. tostring( err ) end
+    return true
+end
+
+local function _write_atomic( path, content )
+    local tmp = path .. ".restore-tmp"
+    local f, err = io_open( tmp, "wb" )
+    if not f then return false, err end
+    local ok, werr = f:write( content )
+    f:close( )
+    if not ok then os_remove( tmp ); return false, werr end
+    -- Fast path: POSIX rename replaces atomically; Windows rename succeeds when
+    -- the dest does not exist (a fresh-tree restore).
+    local rok, rerr = os_rename( tmp, path )
+    if rok then return true end
+    -- Windows + existing dest (a --force overwrite): rename refuses. Move the
+    -- original aside FIRST so a failed swap can never destroy it, then swap,
+    -- then drop the saved copy. On any failure the original is put back.
+    local saved = path .. ".restore-old"
+    os_remove( saved )
+    if os_rename( path, saved ) then
+        if os_rename( tmp, path ) then os_remove( saved ); return true end
+        os_rename( saved, path )   -- swap failed: restore the original
+        os_remove( tmp )
+        return false, "rename failed (original restored)"
+    end
+    os_remove( tmp )
+    return false, rerr or "rename failed"
+end
+
+local function _exists( path )
+    local f = io_open( path, "rb" )
+    if f then f:close( ); return true end
+    return false
+end
+
+----------------------------------// DRIVER //--
+
+local function _read_capped( path )
+    local f, err = io_open( path, "rb" )
+    if not f then return nil, err end
+    local size = f:seek( "end" )
+    if size and size > MAX_ARCHIVE_BYTES then
+        f:close( )
+        return nil, "archive too large (" .. size .. " bytes > " .. MAX_ARCHIVE_BYTES .. ")"
+    end
+    f:seek( "set" )
+    local data = f:read( "a" )
+    f:close( )
+    return data
+end
+
+local function main( )
+    local file    = _G.RESTORE_FILE
+    local verify  = _G.RESTORE_VERIFY and true or false
+    local force   = _G.RESTORE_FORCE and true or false
+    local mk_over = _G.RESTORE_MASTER_KEY_PATH
+
+    if type( file ) ~= "string" or file == "" then
+        print( "luadch restore: no backup file given" )
+        return 1
+    end
+
+    local passphrase = os_getenv "LUADCH_BACKUP_PASSPHRASE"
+    if type( passphrase ) ~= "string" or passphrase == "" then
+        print( "luadch restore: set the backup passphrase in $LUADCH_BACKUP_PASSPHRASE, e.g." )
+        print( "  LUADCH_BACKUP_PASSPHRASE='...' ./luadch --restore " .. file )
+        return 1
+    end
+
+    print( "luadch restore: reading " .. file )
+    local blob, rerr = _read_capped( file )
+    if not blob then
+        print( "luadch restore: cannot read '" .. file .. "': " .. tostring( rerr ) )
+        return 1
+    end
+
+    -- Passphrase-free integrity gate (sha256sum sidecar). A mismatch means the
+    -- artifact was truncated/altered on the media - abort before spending the
+    -- KDF. A missing sidecar is only a warning (GCM still authenticates).
+    local sidecar_text = _read_capped( file .. SIDECAR_SUFFIX )
+    local sc = _verify_sidecar( blob, sidecar_text )
+    if sc == "mismatch" then
+        print( "luadch restore: ABORT - sidecar sha256 does not match (corrupt/altered archive)" )
+        return 1
+    end
+    print( "luadch restore: sidecar " .. ( sc == "ok" and "sha256 OK" or "absent (skipped)" ) )
+
+    local un, uerr = archive.unpack( blob, passphrase )
+    if not un then
+        print( "luadch restore: cannot open archive: " .. tostring( uerr ) )
+        return 1
+    end
+    local meta = un.meta or { }
+    print( string.format( "luadch restore: unpacked %s %s (%d file(s))",
+        tostring( meta.program or "?" ), tostring( meta.hub_version or "?" ), #un.files ) )
+
+    local plan, rejects = _build_plan( un.files, meta, mk_over )
+    if #rejects > 0 then
+        print( "luadch restore: ABORT - archive contains unsafe path(s):" )
+        for _, r in ipairs( rejects ) do print( "  " .. r.name .. "  (" .. r.reason .. ")" ) end
+        return 1
+    end
+
+    -- Conflict scan: refuse to clobber an already-populated tree unless forced.
+    local conflicts = { }
+    for _, p in ipairs( plan ) do
+        if _exists( p.dest ) then conflicts[ #conflicts + 1 ] = p.dest end
+    end
+
+    print( "luadch restore: plan" )
+    for _, p in ipairs( plan ) do
+        print( "  " .. p.dest .. ( _exists( p.dest ) and "  (exists)" or "" ) )
+    end
+
+    -- --verify is a dry run: report the plan (conflicts included) and exit 0
+    -- WITHOUT writing or refusing. Checked BEFORE the conflict refusal so a
+    -- sanity-check against a live tree does not fail merely because files exist.
+    if verify then
+        local note = ( #conflicts > 0 )
+            and ( " (" .. #conflicts .. " already exist; --force needed to overwrite)" ) or ""
+        print( "luadch restore: --verify OK - " .. #plan .. " file(s) would be restored"
+            .. note .. ", no changes written." )
+        return 0
+    end
+
+    if #conflicts > 0 and not force then
+        print( "luadch restore: REFUSING - " .. #conflicts
+            .. " file(s) already exist. Restore into a clean install, or pass --force to overwrite." )
+        return 1
+    end
+
+    -- Apply. Each file is tmp-write + atomic rename, so a mid-run failure never
+    -- leaves a half-written dest; already-restored files stay put. Files land
+    -- owner-only (0600) via the umask run_restore() set, so no chmod is needed.
+    local done, failed, mk_done = 0, nil, false
+    for _, p in ipairs( plan ) do
+        local pok, perr = _ensure_parent( p.dest )
+        if not pok then failed = perr; break end
+        local ok, werr = _write_atomic( p.dest, p.body )
+        if not ok then
+            failed = "cannot write '" .. p.dest .. "': " .. tostring( werr )
+            break
+        end
+        if p.masterkey then mk_done = true end
+        done = done + 1
+    end
+
+    if failed then
+        print( "luadch restore: FAILED after " .. done .. " file(s): " .. failed )
+        return 1
+    end
+
+    print( "luadch restore: DONE - " .. done .. " file(s) restored." )
+    if mk_done then
+        print( "luadch restore: master.key placed at " .. _resolve_masterkey_dest( meta, mk_over ) )
+    elseif meta.include_master_key then
+        print( "luadch restore: NOTE - this backup was set to include master.key, but none was"
+            .. " present at backup time; supply your own so user.tbl can decrypt." )
+    else
+        print( "luadch restore: NOTE - this backup excluded master.key; put your own in place"
+            .. " (--master-key-path, or at master_key_path) so user.tbl can decrypt." )
+    end
+    print( "luadch restore: review cfg/, then start the hub." )
+    return 0
+end
+
+----------------------------------// TEST SEAM / ENTRY //--
+
+-- When required as a module (unit tests set RESTORE_TEST), export the pure
+-- helpers instead of running. The C launcher never sets that flag, so a real
+-- --restore falls through to main().
+if _G.RESTORE_TEST then
+    return {
+        _safe_rel               = _safe_rel,
+        _resolve_masterkey_dest = _resolve_masterkey_dest,
+        _build_plan             = _build_plan,
+        _verify_sidecar         = _verify_sidecar,
+        _dir_of                 = _dir_of,
+        archive                 = archive,
+    }
+end
+
+return main( )

--- a/core/scripts.lua
+++ b/core/scripts.lua
@@ -267,6 +267,13 @@ local SANDBOX_GLOBALS = {
     -- HMAC-SHA256). Raw sha256 deliberately stays OUT of the sandbox -
     -- plugins get the MAC primitive, not the underlying hash.
     "hmac",
+    -- core/backup.lua (#480 PR-A): automatic-backup engine. The thin
+    -- scheduler/CLI plugin etc_backup.lua calls backup.run / .readiness /
+    -- .list. The engine reads its own policy (dir / keep / passphrase /
+    -- include_master_key) from cfg + secrets, NOT from caller args, so a
+    -- plugin can only trigger a backup to the operator-configured
+    -- destination - it cannot redirect the artifact or pick the key.
+    "backup",
     "unicode",
     -- read-only program constants (PROGRAM_NAME / VERSION / FORK /
     -- COPYRIGHT / CONFIG_PATH). Static strings, no capability; lets

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -167,9 +167,17 @@ touch "${LUADCH_HOME}/log/error.log" "${LUADCH_HOME}/log/cmd.log"
 ( tail -F -n 0 "${LUADCH_HOME}/log/cmd.log"   1>&1 & ) 2>/dev/null
 
 # ---------------------------------------------------------------------------
-# 5. exec the hub
+# 5. exec the hub (or forward one-shot args, e.g. --restore)
 # ---------------------------------------------------------------------------
 # WORKDIR is /opt/luadch (set in Dockerfile); the hub anchors its
 # config / scripts / log paths to the binary's directory after Phase 6b
 # (#12), so `cd` is correct here.
-exec "${LUADCH_HOME}/luadch"
+#
+# "$@" forwards any args the operator passed to `docker compose run` /
+# `docker run` straight to the binary. With none (the normal `up`) it
+# expands to nothing, so a plain hub boot is unchanged; with e.g.
+# `--restore <file>` it runs the offline restore (#480 PR-B) in a one-shot
+# container against the same mounted volumes. The seed/log-forward setup
+# above is harmless for a restore (on a fresh DR host it even provides the
+# current bundled scripts/*.lua that the backup deliberately omits).
+exec "${LUADCH_HOME}/luadch" "$@"

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -129,22 +129,59 @@ cd cfg/backups && sha256sum -c luadch-backup-YYYYMMDD-HHMMSS.ldbk.sha256
 
 ## Off-site copies
 
-The hub does not push anywhere. Copy `cfg/backups/` off the box on your own
-schedule. Examples:
+A backup that lives only on the hub host dies with that host. The hub does not
+push anywhere by design, so mirroring `cfg/backups/` off the box is your job -
+and the important half of a real backup strategy. The `.ldbk` is already
+encrypted (AES-256-GCM), so the destination can be any untrusted remote.
+
+### rclone (recommended)
+
+[rclone](https://rclone.org) syncs a local directory to ~all cloud/remote
+backends (S3, Backblaze B2, Google Drive, WebDAV, SFTP, ...) with one config.
+
+1. Install rclone (`apt install rclone`, or the static binary from rclone.org).
+2. Configure a remote once, interactively:
+   ```sh
+   rclone config
+   # n) New remote  -> name it e.g. "backup"
+   #    pick a backend (e.g. Backblaze B2 / S3 / Drive), paste keys/token
+   ```
+3. Test it:
+   ```sh
+   rclone lsd backup:            # lists buckets/dirs on the remote
+   ```
+4. Copy the backups up:
+   ```sh
+   rclone copy ./cfg/backups backup:luadch-hub/backups --progress
+   ```
+5. Automate it in the host's crontab, a little AFTER the daily backup runs
+   (default 04:00, remember the container-UTC note below):
+   ```cron
+   20 4 * * *  rclone copy /srv/luadch/cfg/backups backup:luadch-hub/backups
+   ```
+6. Confirm what landed:
+   ```sh
+   rclone ls backup:luadch-hub/backups
+   ```
+
+**`copy` vs `sync`:** `copy` only adds/updates - the remote keeps every artifact
+even after the hub's rotation (`etc_backup_keep`) prunes it locally, so you get
+a longer off-site history. `sync` mirrors exactly, propagating local deletions.
+Prefer `copy` unless you deliberately want the remote to match local retention.
+
+Optional defense-in-depth: an `rclone crypt` remote encrypts a second time
+on top of the already-encrypted `.ldbk` (useful if the remote's account itself
+is a concern). Not required.
+
+### Alternatives
 
 ```sh
-# rclone to any remote (S3, B2, WebDAV, SFTP, ...)
-rclone sync /opt/luadch/cfg/backups remote:luadch-backups
+# restic (dedup + its own encryption + snapshots)
+restic -r s3:s3.example.com/luadch backup /srv/luadch/cfg/backups
 
-# restic (dedup + its own encryption on top)
-restic -r s3:s3.example.com/luadch backup /opt/luadch/cfg/backups
-
-# plain scp in cron
-0 5 * * * scp -q /opt/luadch/cfg/backups/*.ldbk* backup@host:/srv/luadch/
+# plain scp in cron (simplest, no history management)
+0 5 * * *  scp -q /srv/luadch/cfg/backups/*.ldbk* backup@host:/srv/luadch/
 ```
-
-The `.ldbk` is already encrypted, so an untrusted remote is acceptable; restic's
-extra layer is optional defense-in-depth.
 
 ## Restore
 
@@ -202,20 +239,51 @@ Rebuild a dead hub on a fresh host:
 
 ## Docker
 
-- Mount the backup dir out of the container so artifacts survive it:
-  `-v ./cfg/backups:/luadch/cfg/backups` (or point `etc_backup_dir` at a
-  dedicated volume).
-- Set the passphrase via env: `-e LUADCH_ETC_BACKUP_PASSPHRASE=...`.
-- Container clocks are usually UTC - `etc_backup_daily_at` is server-local, so
-  pick the hour in UTC.
-- To restore, run the one-shot in a container over the target tree with the hub
-  stopped:
-  ```sh
-  docker compose run --rm -e LUADCH_BACKUP_PASSPHRASE=... \
-    luadch --restore cfg/backups/luadch-backup-....ldbk
-  ```
-  See [DOCKER.md](DOCKER.md) for the `master_key_path`-on-`secrets/`-mount
-  layout.
+The install root in the image is `/opt/luadch`. Setup:
+
+- **No separate backups volume needed.** The default `etc_backup_dir =
+  "cfg/backups"` is inside the already-mounted `./cfg:/opt/luadch/cfg`, so
+  artifacts land in `./cfg/backups/` on the host automatically. (Do NOT add a
+  second mount onto `/opt/luadch/cfg` - it shadows the cfg mount and breaks the
+  hub.) Only mount a dedicated volume if you set `etc_backup_dir` to a path
+  *outside* cfg, e.g. `etc_backup_dir = "/opt/luadch/backups"` +
+  `- ./backups:/opt/luadch/backups`.
+- Set the passphrase via env in the service's `environment:` (the standard
+  secrets-lookup name): `LUADCH_ETC_BACKUP_PASSPHRASE=...`. `.env` alone is not
+  enough - it must reach the container via `environment:` or `env_file:`.
+- Container clocks are usually **UTC** - `etc_backup_daily_at` is server-local,
+  so pick the hour in UTC (04:00 = 04:00 UTC).
+
+**Restore** runs as a one-shot container with the hub stopped (the entrypoint
+forwards args to the binary, and restore accepts the same
+`LUADCH_ETC_BACKUP_PASSPHRASE` your compose already sets):
+
+```sh
+docker compose stop luadch
+
+# dry run first
+docker compose run --rm luadch --restore cfg/backups/luadch-backup-....ldbk --verify
+
+# apply (--force overwrites the existing tree)
+docker compose run --rm luadch --restore cfg/backups/luadch-backup-....ldbk --force
+
+docker compose up -d luadch      # boot again, then log in to confirm
+```
+
+**master.key on a `secrets/` mount:** if `master_key_path` points outside the
+tree (e.g. `/secrets/master.key` via a `- ./secrets:/secrets` mount, the
+recommended layout), restore will NOT auto-write there - it refuses an
+out-of-tree path from the manifest so a foreign archive cannot steer an
+arbitrary write. Add `--master-key-path` to opt in explicitly:
+
+```sh
+docker compose run --rm luadch \
+  --restore cfg/backups/luadch-backup-....ldbk --force \
+  --master-key-path /secrets/master.key
+```
+
+(On an older image whose entrypoint does not forward args, override it:
+`docker compose run --rm --entrypoint /opt/luadch/luadch luadch --restore ...`.)
 
 ## Security model
 

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -1,0 +1,232 @@
+# Backup and restore
+
+Encrypted, self-contained hub backups (`etc_backup` plugin + `core/backup*`,
+[#480](https://github.com/luadch-ng/luadch/issues/480)) and an offline restore
+(`Luadch --restore`). The hub is a **producer only**: it writes encrypted
+`.ldbk` artifacts to a local directory. Copying them off-site (rclone, restic,
+a cron job, a mounted volume) is the operator's job - see
+[Off-site copies](#off-site-copies).
+
+- [What a backup contains](#what-a-backup-contains)
+- [Enabling backups](#enabling-backups)
+- [Schedule](#schedule)
+- [The passphrase](#the-passphrase)
+- [master.key](#masterkey)
+- [Integrity sidecar](#integrity-sidecar)
+- [Off-site copies](#off-site-copies)
+- [Restore](#restore)
+- [Disaster-recovery runbook](#disaster-recovery-runbook)
+- [Docker](#docker)
+- [Security model](#security-model)
+
+---
+
+## What a backup contains
+
+One backup is the **restore-minimum set** - everything a fresh hub needs to
+come back as the old one:
+
+- `cfg/cfg.tbl` (settings), `cfg/user.tbl` + `cfg/user.tbl.bak` (accounts)
+- the TLS material named by `ssl_params` (`serverkey.pem`, `servercert.pem`,
+  `cacert.pem`)
+- every `scripts/data/*.tbl` and `scripts/cfg/*.tbl` (plugin state)
+- `master.key` (the at-rest encryption key), unless you opt out - see below
+
+Half-written `*.tmp` files are skipped. Everything is packed into one tar,
+sealed with **AES-256-GCM** (key = PBKDF2-HMAC-SHA256 of your passphrase), and
+written as `cfg/backups/luadch-backup-YYYYMMDD-HHMMSS.ldbk` plus a
+`.ldbk.sha256` sidecar. The artifact is 0600 on POSIX.
+
+The hub is single-threaded and takes the snapshot synchronously, so a backup is
+consistent by construction - no file is being written while it runs.
+
+## Enabling backups
+
+`scripts/etc_backup.lua` ships enabled by default, but stays **inert until a
+passphrase is set** (it nags the hub owner until then). To turn it on:
+
+1. Set a passphrase (see [The passphrase](#the-passphrase)).
+2. Confirm the plugin is whitelisted in `cfg.scripts` (the default `cfg.tbl`
+   already lists `{ "etc_backup.lua", enabled = true }`).
+3. `+reload`.
+
+Config keys (`core/cfg_defaults.lua`, all `etc_backup_*`):
+
+| Key | Default | Meaning |
+|---|---|---|
+| `etc_backup_enabled` | `true` | master on/off for the engine |
+| `etc_backup_dir` | `"cfg/backups"` | where artifacts land (may be absolute / a mount) |
+| `etc_backup_keep` | `7` | retention: prune oldest beyond N |
+| `etc_backup_daily_at` | `"04:00"` | server-local HH:MM daily run |
+| `etc_backup_interval_hours` | `0` | fallback cadence when `daily_at` is empty |
+| `etc_backup_include_master_key` | `true` | pack `master.key` into the backup |
+| `etc_backup_passphrase` | `""` | seal passphrase (prefer the env var) |
+| `etc_backup_oplevel` | `80` | level for `+backup` |
+| `etc_backup_notify_level` | `100` | level that gets the readiness nag |
+
+Operator commands (level `etc_backup_oplevel`):
+
+- `+backup now` - run a backup immediately
+- `+backup list` - list artifacts in the backup dir
+- `+backup status` - schedule + readiness summary
+
+## Schedule
+
+Two mutually exclusive modes, both persisted across `+reload` (a reload never
+re-triggers or skips a run):
+
+- **Daily at a fixed time** (default): `etc_backup_daily_at = "04:00"`,
+  server-local. Pick a quiet hour.
+- **Every N hours**: clear `etc_backup_daily_at` (`""`) and set
+  `etc_backup_interval_hours = 6` (or 2 / 4 / 12).
+
+## The passphrase
+
+The passphrase protects the backup independently of `master.key`, so a backup
+stays recoverable even if the hub host and its key are lost together. There is
+**no passphrase-recovery path** - store it in a password manager. Two sources,
+env var first (`core/secrets`):
+
+- **Environment** (recommended, Docker-friendly):
+  `LUADCH_ETC_BACKUP_PASSPHRASE`
+- **cfg.tbl** (bare-metal): `etc_backup_passphrase = "..."`. This is fine - the
+  encrypted backup does not depend on cfg.tbl secrecy; the passphrase only ever
+  seals/opens the artifact.
+
+The restore side reads a **separate** env var, `LUADCH_BACKUP_PASSPHRASE` (there
+is no cfg to read on a fresh host); see [Restore](#restore).
+
+## master.key
+
+`master.key` is the AES key for `user.tbl` at-rest encryption
+([SECURITY.md](SECURITY.md)). By default it is packed **into** the backup, so a
+single artifact + the passphrase is enough to fully restore. That is convenient
+but means the passphrase is the only thing standing between an attacker and
+`user.tbl`. To decouple them, set `etc_backup_include_master_key = false`: the
+backup then omits `master.key`, and a restore leaves you to supply your own
+(`--master-key-path`, or drop it at `master_key_path`). Without the right
+`master.key`, `user.tbl` cannot be decrypted after restore.
+
+`master.key` may live outside the install tree (`master_key_path` in cfg.tbl,
+e.g. `/etc/luadch/master.key`). The real path travels in the backup manifest.
+On restore, an in-tree location (the `cfg/master.key` default) is put back
+automatically; an **out-of-tree absolute path is only used when you pass
+`--master-key-path`** - restore will not write `master.key` to an absolute
+location on the manifest's say-so alone (so a backup from an untrusted source
+cannot steer an arbitrary write). Restoring your own out-of-tree setup is one
+flag: `--master-key-path /etc/luadch/master.key`.
+
+## Integrity sidecar
+
+Every artifact gets a `.ldbk.sha256` sidecar in standard `sha256sum` format, so
+you can check an artifact on any host without the passphrase:
+
+```sh
+cd cfg/backups && sha256sum -c luadch-backup-YYYYMMDD-HHMMSS.ldbk.sha256
+```
+
+`--restore` verifies the sidecar automatically before spending the KDF.
+
+## Off-site copies
+
+The hub does not push anywhere. Copy `cfg/backups/` off the box on your own
+schedule. Examples:
+
+```sh
+# rclone to any remote (S3, B2, WebDAV, SFTP, ...)
+rclone sync /opt/luadch/cfg/backups remote:luadch-backups
+
+# restic (dedup + its own encryption on top)
+restic -r s3:s3.example.com/luadch backup /opt/luadch/cfg/backups
+
+# plain scp in cron
+0 5 * * * scp -q /opt/luadch/cfg/backups/*.ldbk* backup@host:/srv/luadch/
+```
+
+The `.ldbk` is already encrypted, so an untrusted remote is acceptable; restic's
+extra layer is optional defense-in-depth.
+
+## Restore
+
+Offline, one-shot, on a hub that is **not running** (the restore refuses to run
+while a hub holds the install's single-instance lock, so it can never race live
+`cfg`/`user.tbl`/`master.key` writes):
+
+```sh
+cd /opt/luadch          # the install root (where the binary lives)
+export LUADCH_BACKUP_PASSPHRASE='your-backup-passphrase'
+./luadch --restore cfg/backups/luadch-backup-20260721-040000.ldbk
+```
+
+Flags:
+
+| Flag | Effect |
+|---|---|
+| `--restore <file>` | restore this artifact, then exit |
+| `--verify` | dry run: check + decrypt + list the plan, write nothing |
+| `--force` | overwrite files that already exist |
+| `--master-key-path <p>` | place `master.key` at `<p>` instead of its recorded path |
+
+Restore is two-phase and transactional per file: it verifies the sidecar,
+decrypts + authenticates (AES-256-GCM), parses the manifest, **rejects any
+unsafe path** (absolute or `..` - a foreign archive cannot escape the tree),
+checks for conflicts, then writes each file via a temp + atomic rename. Every
+restored file lands owner-only (0600). Into a populated tree it refuses unless
+you pass `--force`; `--verify` is exempt (it only reports). A wrong passphrase
+fails cleanly and writes nothing.
+
+Always dry-run first:
+
+```sh
+./luadch --restore <file> --verify
+```
+
+## Disaster-recovery runbook
+
+Rebuild a dead hub on a fresh host:
+
+1. Install luadch the normal way ([INSTALLING.md](INSTALLING.md)) - do **not**
+   run it yet, or first-boot writes a fresh cfg/certs you would overwrite.
+2. Copy the chosen `.ldbk` (and its `.sha256`) onto the host.
+3. From the install root:
+   ```sh
+   export LUADCH_BACKUP_PASSPHRASE='...'
+   ./luadch --restore /path/to/luadch-backup-....ldbk --verify   # inspect
+   ./luadch --restore /path/to/luadch-backup-....ldbk            # apply
+   ```
+   On a fresh install nothing exists yet, so `--force` is not needed.
+4. If the backup **excluded** `master.key`, put your own copy in place now
+   (`--master-key-path`, or at `master_key_path`), else `user.tbl` will not
+   decrypt.
+5. Start the hub. Log in and confirm accounts/settings.
+
+## Docker
+
+- Mount the backup dir out of the container so artifacts survive it:
+  `-v ./cfg/backups:/luadch/cfg/backups` (or point `etc_backup_dir` at a
+  dedicated volume).
+- Set the passphrase via env: `-e LUADCH_ETC_BACKUP_PASSPHRASE=...`.
+- Container clocks are usually UTC - `etc_backup_daily_at` is server-local, so
+  pick the hour in UTC.
+- To restore, run the one-shot in a container over the target tree with the hub
+  stopped:
+  ```sh
+  docker compose run --rm -e LUADCH_BACKUP_PASSPHRASE=... \
+    luadch --restore cfg/backups/luadch-backup-....ldbk
+  ```
+  See [DOCKER.md](DOCKER.md) for the `master_key_path`-on-`secrets/`-mount
+  layout.
+
+## Security model
+
+- The backup is only as strong as its passphrase (PBKDF2-HMAC-SHA256 ->
+  AES-256-GCM). No recovery path; use a password manager.
+- The engine reads its **own** policy (dir / keep / passphrase / master.key
+  inclusion) from cfg + `core/secrets`, never from a caller, so a sandboxed
+  plugin can trigger a backup only to the operator-configured destination - it
+  cannot redirect the artifact or choose the key.
+- Restore holds the single-instance lock, sanitizes every archive path against
+  `..`/absolute escapes, and authenticates the ciphertext before writing.
+- With `include_master_key = true`, treat the artifact like `master.key`
+  itself: the passphrase is then the only barrier to `user.tbl`. Set it to
+  `false` to keep the two secrets separate.

--- a/docs/BLOCKLIST.md
+++ b/docs/BLOCKLIST.md
@@ -140,8 +140,8 @@ hub:
 services:
   luadch:
     volumes:
-      - ./cfg:/luadch/cfg
-      - geoip_data:/luadch/cfg/geoip
+      - ./cfg:/opt/luadch/cfg
+      - geoip_data:/opt/luadch/cfg/geoip
   geoipupdate:
     image: maxmindinc/geoipupdate
     restart: unless-stopped

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -49,9 +49,14 @@ cmake --install build
 
 ```sh
 cd build/install/luadch
-./luadch              # plain ADC on port 5000
-./certs/make_cert.sh  # once, for TLS on port 5001
+./luadch              # TLS-only by default: adcs://<host>:5001
 ```
+
+Fresh installs are **TLS-only** (`ssl_ports = {5001}`, `tcp_ports = {}`);
+the TLS certificate is **auto-generated on first boot** by
+`core/cert_bootstrap.lua` (#77) - no cert step needed.
+`certs/make_cert.{sh,bat}` exist only for manual regeneration. Plain
+`adc://` requires explicitly enabling `tcp_ports` in `cfg/cfg.tbl`.
 
 ---
 
@@ -140,11 +145,12 @@ cmake --install build
 
 ```cmd
 cd build\install\luadch
-Luadch.exe                 :: plain ADC on port 5000
-certs\make_cert.bat        :: once, for TLS on port 5001
+Luadch.exe                 :: TLS-only by default: adcs://<host>:5001
 ```
 
-The OpenSSL DLLs are bundled into the install tree automatically.
+The TLS certificate is auto-generated on first boot (#77);
+`certs\make_cert.bat` is only for manual regeneration. The OpenSSL DLLs are
+bundled into the install tree automatically.
 
 ---
 
@@ -208,14 +214,17 @@ Pi 4 / Pi 5 / Apple Silicon Linux / AWS Graviton, etc.). Verify with
 
 ## First-time login
 
-Whichever platform you built on:
+Whichever platform you built on (TLS-only by default; the certificate is
+auto-generated on first boot, #77):
 
 ```
 Nick:     dummy
 Password: test
-Address:  adc://127.0.0.1:5000     (plain)
-          adcs://127.0.0.1:5001    (TLS, after the cert script)
+Address:  adcs://127.0.0.1:5001    (TLS; production clients should pin the
+                                    keyprint: adcs://host:5001/?kp=SHA256/...)
 ```
+
+Plain `adc://` requires explicitly enabling `tcp_ports` in `cfg/cfg.tbl`.
 
 After login: `+reg <yournick> 100`, `+delreg dummy`, `+reload`. The dummy
 default account is hubowner — **delete it as soon as you have your own**.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -97,13 +97,14 @@ The hub auto-generates a self-signed cert on first boot if none exists at the co
 
 ```lua
 ssl_params = {
-    mode      = "server",
-    protocol  = "any",
-    options   = { "all", "no_sslv2", "no_sslv3", "no_tlsv1", "no_tlsv1_1" },
-    cafile    = "certs/cacert.pem",
+    mode        = "server",
+    key         = "certs/serverkey.pem",
     certificate = "certs/servercert.pem",
-    key       = "certs/serverkey.pem",
-    verify    = { "none" },
+    cafile      = "certs/cacert.pem",
+    protocol    = "tlsv1_3",   -- TLS 1.3 only; cannot negotiate down
+    options     = { "no_sslv2", "no_sslv3", "no_tlsv1", "no_tlsv1_1", "no_renegotiation" },
+    ciphers     = "HIGH+kEDH:HIGH+kEECDH:HIGH:!PSK:!SRP:!3DES:!aNULL",
+    curve       = "prime256v1",
 },
 ```
 
@@ -137,14 +138,14 @@ do not run a public hub with `dummy / test` active.
 The hub uses an integer-based user level system. Higher levels grant
 more permissions. Bundled defaults:
 
-| Level | Name      | What it can do                              |
-|-------|-----------|---------------------------------------------|
-| 100   | HUBOWNER  | Everything (registers / deletes / shutdown) |
-| 80    | OPERATOR  | (TODO: list typical OP-level capabilities)  |
-| 60    | VIP       | (TODO)                                      |
-| 40    | REG       | Registered user, basic chat / commands      |
-| 20    | UNREG     | Anonymous connection                        |
-| 0     | BANNED    | Refused                                     |
+| Level | Name     | What it can do                                  |
+|-------|----------|-------------------------------------------------|
+| 100   | HUBOWNER | Everything (registers / deletes / shutdown)     |
+| 80    | ADMIN    | Admin operations, user + registration management |
+| 60    | OPERATOR | Moderation (ban / kick / gag / redirect)        |
+| 40    | SVIP     | Super-VIP: elevated privileges, exemptions      |
+| 20    | REG      | Registered user, basic chat / commands          |
+| 0     | UNREG    | Anonymous (unregistered) connection             |
 
 Customise per-script `minlevel` in `cfg.tbl` to grant or restrict
 specific commands.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -113,6 +113,34 @@ or, in the hub itself (after logging in as a level-100 user):
 `+reload` is faster (no TCP listener restart) and what you'll usually
 want for non-network-port changes.
 
+## Backups
+
+Full guide: [`docs/BACKUP.md`](BACKUP.md). The Docker essentials:
+
+- **Enable it:** add `{ "etc_backup.lua", enabled = true }` to the `scripts`
+  list in `cfg/cfg.tbl`, then set the passphrase in the service's
+  `environment:` (it must reach the container - `.env` alone does not):
+  ```yaml
+  environment:
+    - LUADCH_ETC_BACKUP_PASSPHRASE=${LUADCH_ETC_BACKUP_PASSPHRASE}
+  ```
+  Restart the container. `!backup status` should show "ready".
+- **Where they land:** `./cfg/backups/` on the host (default `etc_backup_dir =
+  "cfg/backups"`, inside the already-mounted `./cfg`). No extra volume needed.
+- **Off-site:** the hub only writes locally - mirror `./cfg/backups/` to a
+  remote yourself (rclone/restic/cron). BACKUP.md has an rclone walkthrough.
+- **Restore** (hub stopped, one-shot container; the passphrase env and args are
+  forwarded automatically):
+  ```sh
+  docker compose stop luadch
+  docker compose run --rm luadch --restore cfg/backups/<file>.ldbk --verify
+  docker compose run --rm luadch --restore cfg/backups/<file>.ldbk --force
+  docker compose up -d luadch
+  ```
+  If your `master_key_path` is on the `./secrets/` mount (the recommended
+  layout), add `--master-key-path /secrets/master.key` - restore refuses an
+  out-of-tree path from the manifest unless you name it explicitly.
+
 ## TLS-only deployments
 
 Once your users are on `adcs://` URLs, drop the plain port:

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -1123,6 +1123,9 @@ is disabled in `cfg.scripts`, the endpoint returns 404
 | GET | `/v1/whitelist/counts` | read | `etc_whitelist` (= ADC `+whitelist count`) - **landed (#78 allowlist Phase D)** [^http-whitelist-2] |
 | POST | `/v1/whitelist` | admin | `etc_whitelist` (= ADC `+whitelist add`) - **landed (#78 allowlist Phase D)** [^http-whitelist-3] |
 | DELETE | `/v1/whitelist/{id}` | admin | `etc_whitelist` (= ADC `+whitelist del`) - **landed (#78 allowlist Phase D)** [^http-whitelist-4] |
+| GET | `/v1/geoip` | read | `etc_geoip` - GeoIP policy + MMDB status (country/ASN DB freshness) |
+| GET | `/v1/proxydetect` | read | `etc_proxydetect` - proxy/VPN detection provider + cache status |
+| GET | `/v1/blocklist/feeds` | read | `etc_blocklist_feeds` - per-feed refresh status (last pull, entry counts, errors) |
 
 [^http-ban-1]: Returns `{ok:true, data:{bans:[entry, ...]}}`. Each entry carries `id` (1-based index into the live bans array - the same `{id}` accepted by DELETE), `nick`, `cid`, `hash`, `ip`, `reason`, `by_nick`, `by_level`, `ban_seconds`, `ban_start` (epoch seconds, hub clock), `permanent` (bool - a permanent ban never expires; #444), `remaining_seconds` (can be negative for not-yet-pruned-expired entries; pruning happens on `onConnect` of the banned user, not on a timer), and `expires_at` (ISO 8601 UTC, omitted when `remaining_seconds <= 0`). **For a permanent ban** (`permanent:true`) `ban_seconds` is `0` and BOTH `remaining_seconds` and `expires_at` are omitted - a consumer distinguishes "permanent" from "expired-not-yet-pruned" by the `permanent` flag, not by the absent expiry. The `id` is NOT a stable surrogate key - it shifts every time a ban is removed (the underlying `bans` array is reindexed by `table.remove`). Operators / tooling MUST re-list before issuing a follow-up DELETE.
 

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -206,7 +206,9 @@ What is worth backing up:
 Everything else (`core/`, `scripts/*.lua`, `lib/`, `lang/`) reproduces
 from a fresh build.
 
-Rsync-style nightly backup script template:
+Rsync-style nightly backup script template (a simple *unencrypted* mirror -
+note it copies `user.tbl` and `master.key` together, the exact bundling
+[`docs/SECURITY.md`](SECURITY.md) warns about):
 
 ```sh
 #!/bin/sh
@@ -217,6 +219,10 @@ rsync -a --delete /opt/luadch/cfg/        "$DST"/cfg/
 rsync -a --delete /opt/luadch/certs/      "$DST"/certs/
 rsync -a --delete /opt/luadch/scripts/data/ "$DST"/scripts-data/
 ```
+
+For an encrypted, rotating backup with an offline restore, prefer the built-in
+backup feature instead: [`docs/BACKUP.md`](BACKUP.md) (`+backup`, AES-256-GCM
+`.ldbk` artifacts, `./luadch --restore`).
 
 ---
 

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -277,6 +277,7 @@ claimed.
 |---|---|---|
 | `onStart` | `function()` | Plugin loaded at hub startup or `+restartscripts` |
 | `onExit` | `function()` | Plugin unloaded at hub shutdown or `+restartscripts` |
+| `onShutdown` | `function()` | Hub is shutting down (fired once, distinct from `onExit`'s per-plugin unload) |
 | `onError` | `function( msg )` | Lua error in another listener (do not raise here - infinite loop) |
 | `onTimer` | `function()` | Fires roughly once per second |
 | `onConnect` | `function( user )` | User passed identify state, before login completes |
@@ -294,6 +295,7 @@ claimed.
 | `onSearchResult` | `function( user, targetuser, adccmd )` | Incoming DRES / FRES search result |
 | `onReg` | `function( nick )` | A user was successfully registered. `nick` is the firstnick |
 | `onDelreg` | `function( nick )` | A user was successfully delregistered. `nick` is the firstnick |
+| `onAudit` | `function( event )` | An audit record was emitted (via `audit.fire`); `event` is the structured audit object. Backs `etc_auditlog` + the HTTP `/v1/events` stream (#84) |
 | `onFailedAuth` | `function( nick, ip, cid, reason )` | Authentication failed at any stage during login |
 
 > **Rate-limit interaction:** per-user rate limits fire before the
@@ -359,10 +361,13 @@ local regs, regs_by_nick, regs_by_cid = hub.getregusers()
 ```
 
 > `hub.getusers()` returns three tables of decreasing strictness.
-> The first table is documented as "no-bot, normal state" but
-> currently contains bots due to [#179](https://github.com/luadch-ng/luadch/issues/179).
-> Plugins should defensively filter via `if not user:isbot() then`
-> until that issue is fixed.
+> The first (`_nobot_normalstatesids`) is **normal-state humans only** -
+> bots are inserted into the second/third tables only, never the first
+> (a single-assignment `for _, u in pairs( hub.getusers() )` therefore
+> iterates humans-only). Use it for per-human iteration; reach for the
+> second/third table when you deliberately need bots or in-handshake
+> connections. ([#179](https://github.com/luadch-ng/luadch/issues/179),
+> which had bots leaking into the first table, is fixed.)
 
 #### Escaping
 
@@ -866,12 +871,16 @@ returning `PROCESSED` blocks plugins later in the list. For
 "catch-all" plugins like `etc_unknown_command.lua`, place them at
 the tail of `cfg.scripts`.
 
-### 10.5 Bots in user iteration
+### 10.5 Picking the right `getusers()` table
 
-`hub.getusers()`'s first return is documented as "no-bot, normal
-state" but currently contains bots due to a known
-[issue](https://github.com/luadch-ng/luadch/issues/179). Filter
-defensively with `if not user:isbot() then` for any per-human iteration.
+`hub.getusers()` returns three tables (see §5.1). The first
+(`_nobot_normalstatesids`) is normal-state **humans only** - bots go into
+the second/third tables, never the first - so a single-assignment
+`for _, u in pairs( hub.getusers() )` iterates humans-only. Use the second
+table when you deliberately need bots too. (The old
+[#179](https://github.com/luadch-ng/luadch/issues/179) bot-leak into the
+first table is fixed; the `if not user:isbot() then` guard is no longer
+needed for the first table, only harmless.)
 
 ### 10.6 Forbidden post-login INF fields
 

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -78,7 +78,10 @@ that environment:
     wrapper); plain Lua `string.*` byte methods are not directly
     reachable
   - luadch core: `hub`, `cfg`, `util`, `util_http`, `adc`, `adclib`,
-    `signal`, `out`, `unicode`, `sysinfo`
+    `signal`, `out`, `unicode`, `sysinfo`, `backup` (the automatic-backup
+    engine, #480; `+backup` driver `etc_backup` calls `backup.run`/
+    `.readiness`/`.list`) - and more; the list above is illustrative, so
+    treat `SANDBOX_GLOBALS` as the authority
   - Optional libs (may be `false` if not built): `ssl` (with `.x509`
     pre-attached), `socket`, `basexx`, `zlib_stream`, `dkjson`
 - **Notably absent** (a malicious plugin cannot reach these):

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -194,6 +194,13 @@ Then handle that path the same way you handle
 The hub still enforces 0600 on the configured path on POSIX. On
 Windows, apply `icacls` to the new path - see §4.
 
+The built-in encrypted backup ([`docs/BACKUP.md`](BACKUP.md), #480) is the
+pass-phrase-encrypted archive this section recommends: the `.ldbk` is sealed
+with AES-256-GCM under an operator passphrase independent of `master.key`, and
+`etc_backup_include_master_key = false` keeps the key out of the archive
+entirely - so an exfiltrated backup does not hand over both halves. Prefer it
+over a raw `tar czf cfg/`.
+
 ### What the on-disk encryption protects against
 
 - Backup / snapshot exfiltration of `cfg/` without the host - **only

--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -1354,6 +1354,19 @@ return { -- the settings are a lua table, do not tough this!
     etc_webhook_activate = false,  -- opt-in. false = never receives. Set true AND define at least one endpoint (with a secret) in cfg/webhooks.tbl to start receiving signed webhooks. (boolean)
 
     ---------------------------------------------------------------------------------------------------------------------------------
+    --// etc_backup.lua settings | AUTOMATIC ENCRYPTED BACKUPS of the operator state set (cfg.tbl, user.tbl + .bak, the TLS cert/key, master.key, and every scripts/data + scripts/cfg *.tbl). Each run writes ONE AES-256-GCM sealed .ldbk artifact (+ a .sha256 sidecar) to etc_backup_dir and prunes to etc_backup_keep. Restore is offline (`Luadch --restore <file>`, see docs/BACKUP.md). Off-site copies are the operator's job (rclone/restic/cron the backup dir). REQUIRES a passphrase - without one the plugin nags the owner and does nothing.
+
+    etc_backup_enabled = true,  -- master switch. true = the schedule + `+backup` are live (nagging the owner until a passphrase is set); false = fully inert. (boolean)
+    etc_backup_dir = "cfg/backups",  -- where artifacts are written. Default under cfg/ so they survive an upgrade (cfg/ is excluded) and sit on the Docker cfg mount. An ABSOLUTE path is allowed (a mounted backup volume). This dir is NOT itself backed up. (string)
+    etc_backup_keep = 7,  -- retention: keep the newest N artifacts, delete older ones after each run. (integer 1..1000)
+    etc_backup_daily_at = "04:00",  -- PRIMARY schedule: back up once a day at this SERVER-LOCAL time (quiet hours). Empty "" disables the daily slot and uses the interval below. (string "HH:MM")
+    etc_backup_interval_hours = 0,  -- fallback cadence, used ONLY when etc_backup_daily_at is empty: back up every N hours. 0 = off. (integer 0..168)
+    etc_backup_include_master_key = true,  -- include cfg/master.key in the (encrypted) artifact so a restore is self-contained. false keeps the key strictly out of the backup and reminds you to store it yourself. Losing master.key makes an encrypted user.tbl unreadable. (boolean)
+    etc_backup_passphrase = "",  -- REQUIRED. The passphrase that encrypts every artifact (PBKDF2 -> AES-256-GCM). PREFER the env var LUADCH_ETC_BACKUP_PASSPHRASE over a plaintext value here (redacted from GET /v1/config either way). Store it OUT-OF-BAND (a password manager), independent of master.key: losing it makes EVERY backup unrecoverable. (string)
+    etc_backup_oplevel = 80,  -- minimum level for +backup now|list|status. Default 80 (ADMIN). (integer)
+    etc_backup_notify_level = 100,  -- who gets the "backup not configured / not writable" hubbot reminder on login + at start. Default 100 (HUBOWNER). (integer)
+
+    ---------------------------------------------------------------------------------------------------------------------------------
     --// etc_records.lua settings | this script adds and shows statistics about hubshare/usershare records
 
     etc_records_min_level = 20,  -- minlevel to show record statistic? (integer)
@@ -1574,6 +1587,7 @@ return { -- the settings are a lua table, do not tough this!
         { "etc_blocklist_feeds.lua", enabled = false },  -- #78 Phase E external IP/CIDR feeds (Tor exits, Spamhaus DROP) pulled over HTTPS into the blocklist store. OFF by default. Store WRITER (the engine blocks pre-handshake), so chain position is not load-bearing. Enable here + set etc_blocklist_feeds_enabled=true + turn on a feed - see docs/BLOCKLIST.md.
         { "etc_proxydetect.lua", enabled = false },  -- #78 Phase F live proxy/VPN/Tor detection via a provider API on connect. OFF by default (needs a provider + API key - see docs/BLOCKLIST.md). Per-connection post-handshake lookup; must sit AFTER hub_inf_manager like etc_geoip. Enable here + set etc_proxydetect_enabled=true + etc_proxydetect_action="block".
         { "hub_runtime.lua", enabled = true },  -- using report import; API-toggleable (#261)
+        { "etc_backup.lua", enabled = true },  -- #480 automatic encrypted backups (engine = core/backup.lua). Enabled by default but INERT until a passphrase is set (etc_backup_passphrase / env) - nags the owner until then. onStart/onTimer/onLogin only, so chain position is not load-bearing. See docs/BACKUP.md.
         { "bot_regchat.lua", enabled = true },  -- API-toggleable (#261)
         { "bot_session_chat.lua", enabled = true },  -- API-toggleable (#261)
         "bot_pm2ops.lua",

--- a/hub/hub.c
+++ b/hub/hub.c
@@ -36,6 +36,14 @@
 static volatile sig_atomic_t do_exit = 0;
 static int do_daemonization = 0;
 
+/* Offline-restore mode (#480 PR-B): set by handle_args from --restore and
+ * friends, consumed by run_restore() before the hub would ever boot. */
+static int do_restore = 0;
+static int restore_verify = 0;
+static int restore_force = 0;
+static const char *restore_file = NULL;
+static const char *restore_mk_path = NULL;
+
 static void log_error(const char *msg)
 {
   // Write to log/exception.txt next to the binary. chdir_to_binary_dir
@@ -439,6 +447,59 @@ static void run_lua(void)
   exit(EXIT_SUCCESS);
 }
 
+/* Offline restore (#480 PR-B). Mirrors run_lua's state setup (openlibs + the
+ * makedir C primitive core/restore.lua needs) but loads core/restore.lua
+ * instead of the hub, hands it the CLI options as globals, and returns the
+ * integer exit code the script yields. adclib is required dynamically inside
+ * restore.lua, exactly as init.lua requires it - no static registration here.
+ * Never daemonizes and never enters the event loop. */
+static int run_restore(void)
+{
+  lua_State *L = luaL_newstate();
+  if (!L)
+  {
+    log_error("cannot create Lua state: not enough memory");
+    return EXIT_FAILURE;
+  }
+#ifdef __unix__
+  /* Restore does not go through daemonize()'s umask(027), so without this the
+   * files it writes take the operator's interactive umask (often 022 -> 0644),
+   * leaving the freshly-restored PLAINTEXT master.key / user.tbl / TLS key
+   * group/world-readable. 077 makes every restored file owner-only (0600) at
+   * creation - no post-write chmod window - and satisfies cfg_secret's
+   * mandatory 0600 on master.key. No-op on Windows. */
+  umask(077);
+#endif
+  luaL_openlibs(L);
+  lua_register(L, "makedir", makedir);
+
+  lua_pushstring(L, restore_file ? restore_file : "");
+  lua_setglobal(L, "RESTORE_FILE");
+  lua_pushboolean(L, restore_verify);
+  lua_setglobal(L, "RESTORE_VERIFY");
+  lua_pushboolean(L, restore_force);
+  lua_setglobal(L, "RESTORE_FORCE");
+  if (restore_mk_path)
+  {
+    lua_pushstring(L, restore_mk_path);
+    lua_setglobal(L, "RESTORE_MASTER_KEY_PATH");
+  }
+
+  int rc = EXIT_FAILURE;
+  if (luaL_loadfile(L, "core/restore.lua") || lua_pcall(L, 0, 1, 0))
+  {
+    log_error(lua_tostring(L, -1));
+  }
+  else
+  {
+    /* restore.lua returns 0 on success, 1 on failure. Anything non-integer
+     * (a script bug) is treated as failure. */
+    rc = lua_isinteger(L, -1) ? (int)lua_tointeger(L, -1) : EXIT_FAILURE;
+  }
+  lua_close(L);
+  return rc;
+}
+
 static void daemonize(void)
 {
   if (!do_daemonization)
@@ -483,20 +544,58 @@ static void print_help(void)
   fprintf(stderr,
   "usage: luadch [option]\n"
   "available options are:\n"
-  "  -h       show this help\n"
-  "  -d       execute luadch as background daemon\n");
+  "  -h                       show this help\n"
+  "  -d                       execute luadch as background daemon\n"
+  "  --restore <file>         restore an encrypted .ldbk backup, then exit\n"
+  "  --verify                 with --restore: check the archive, write nothing\n"
+  "  --force                  with --restore: overwrite existing files\n"
+  "  --master-key-path <p>    with --restore: place master.key at <p>\n");
   fflush(stderr);
   exit(EXIT_SUCCESS);
 }
 
+/* Parse argv. Keeps the legacy single-letter -h/-d and adds the --restore
+ * family (offline restore, #480 PR-B). --restore consumes the next argv as the
+ * archive path; --master-key-path consumes the next argv as an override. */
 static void handle_args(int argc, char **argv)
 {
-  if (argc > 1 && argv[1][0] == '-')
+  for (int i = 1; i < argc; i++)
   {
-    switch(argv[1][1])
+    const char *a = argv[i];
+    if (strcmp(a, "-h") == 0 || strcmp(a, "--help") == 0)
     {
-      case 'h': print_help(); break;
-      case 'd': do_daemonization = 1; break;
+      print_help();
+    }
+    else if (strcmp(a, "-d") == 0)
+    {
+      do_daemonization = 1;
+    }
+    else if (strcmp(a, "--restore") == 0)
+    {
+      if (i + 1 >= argc)
+      {
+        fprintf(stderr, "luadch: --restore needs a backup file argument\n");
+        exit(EXIT_FAILURE);
+      }
+      do_restore = 1;
+      restore_file = argv[++i];
+    }
+    else if (strcmp(a, "--verify") == 0)
+    {
+      restore_verify = 1;
+    }
+    else if (strcmp(a, "--force") == 0)
+    {
+      restore_force = 1;
+    }
+    else if (strcmp(a, "--master-key-path") == 0)
+    {
+      if (i + 1 >= argc)
+      {
+        fprintf(stderr, "luadch: --master-key-path needs a path argument\n");
+        exit(EXIT_FAILURE);
+      }
+      restore_mk_path = argv[++i];
     }
   }
 }
@@ -662,6 +761,12 @@ int main(int argc, char **argv)
     log_error("luadch: another instance is already running in this "
               "directory; refusing to start.");
     return EXIT_FAILURE;
+  }
+  // Offline restore runs HERE - after the lock (so it can never race a running
+  // hub over cfg/user.tbl/master.key) but before any hub boot - and exits.
+  if (do_restore)
+  {
+    return run_restore();
   }
   // Lift the fd soft limit to the hard limit so the POSIX poll() event loop
   // (#310) is not silently re-capped at the default ulimit -n. Inherited

--- a/hub/hub.c
+++ b/hub/hub.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <libgen.h>
 #include <limits.h>
+#include <dirent.h>   /* opendir / readdir - listdir() */
 #endif
 #ifdef _WIN32
 #include <windows.h>
@@ -230,6 +231,95 @@ static int makedir(lua_State *L)
   return 1;
 }
 
+/*
+ * listdir(path) -> { "name1", "name2", ... } | nil, errmsg
+ *
+ * Lists the entries of a directory (excluding "." and ".."), as a Lua array
+ * in readdir / FindNextFile order. Registered as a global so core Lua can
+ * enumerate the operator state directories (scripts/data/, scripts/cfg/)
+ * for the backup engine (#480) - the tree ships no lfs / readdir otherwise.
+ * Core-only, like makedir; NOT exposed to the plugin sandbox. Returns
+ * (nil, message) when the directory cannot be opened (missing, not a
+ * directory, permission). An empty directory yields an empty table.
+ */
+static int listdir(lua_State *L)
+{
+  const char *path = luaL_checkstring(L, 1);
+#ifdef _WIN32
+  char pattern[MAX_PATH];
+  int n = snprintf(pattern, sizeof(pattern), "%s\\*", path);
+  if (n < 0 || n >= (int)sizeof(pattern))
+  {
+    lua_pushnil(L);
+    lua_pushstring(L, "listdir: path too long");
+    return 2;
+  }
+  WIN32_FIND_DATAA fd;
+  HANDLE h = FindFirstFileA(pattern, &fd);
+  if (h == INVALID_HANDLE_VALUE)
+  {
+    lua_pushnil(L);
+    /* lua_pushfstring understands only %d/%s/%f/%p/%c/%% - NOT %lu; feeding it
+     * %lu raises "invalid option '%l'" and breaks the (nil, err) contract, so
+     * the DWORD error is cast to int (codes are small, positive). */
+    lua_pushfstring(L, "listdir: cannot open '%s' (error %d)",
+                    path, (int)GetLastError());
+    return 2;
+  }
+  lua_newtable(L);
+  int i = 0;
+  do
+  {
+    if (strcmp(fd.cFileName, ".") == 0 || strcmp(fd.cFileName, "..") == 0)
+    {
+      continue;
+    }
+    lua_pushstring(L, fd.cFileName);
+    lua_rawseti(L, -2, ++i);
+  } while (FindNextFileA(h, &fd));
+  /* A clean end is ERROR_NO_MORE_FILES; anything else means the enumeration
+   * was cut short. Surface it rather than returning a partial listing - a
+   * truncated scripts/data listing would silently under-collect a backup. */
+  DWORD ferr = GetLastError();
+  FindClose(h);
+  if (ferr != ERROR_NO_MORE_FILES)
+  {
+    lua_pop(L, 1);
+    lua_pushnil(L);
+    lua_pushfstring(L, "listdir: enumeration failed for '%s' (error %d)",
+                    path, (int)ferr);
+    return 2;
+  }
+  return 1;
+#elif defined(__unix__)
+  DIR *d = opendir(path);
+  if (!d)
+  {
+    lua_pushnil(L);
+    lua_pushfstring(L, "listdir: cannot open '%s' (errno %d)", path, errno);
+    return 2;
+  }
+  lua_newtable(L);
+  int i = 0;
+  struct dirent *e;
+  while ((e = readdir(d)) != NULL)
+  {
+    if (strcmp(e->d_name, ".") == 0 || strcmp(e->d_name, "..") == 0)
+    {
+      continue;
+    }
+    lua_pushstring(L, e->d_name);
+    lua_rawseti(L, -2, ++i);
+  }
+  closedir(d);
+  return 1;
+#else
+  lua_pushnil(L);
+  lua_pushstring(L, "listdir: unsupported platform");
+  return 2;
+#endif
+}
+
 /* Resulting soft RLIMIT_NOFILE after raise_fd_limit(): the practical
  * concurrent-socket ceiling on the POSIX poll backend. 0 = unknown (Windows,
  * or getrlimit failed), -1 = unlimited (RLIM_INFINITY), else the fd count.
@@ -338,6 +428,7 @@ static void run_lua(void)
   lua_register(L, "doexit", doexit);
   lua_register(L, "requestexit", requestexit);
   lua_register(L, "makedir", makedir);
+  lua_register(L, "listdir", listdir);
   lua_register(L, "getfdlimit", getfdlimit);
   int err = luaL_loadfile(L, "core/init.lua") || lua_pcall(L, 0, 0, 0);
   if (err)

--- a/scripts/etc_backup.lua
+++ b/scripts/etc_backup.lua
@@ -1,0 +1,349 @@
+--[[
+
+    etc_backup.lua - automatic encrypted hub backups (#480, PR-A)
+
+    The thin scheduler / CLI / owner-nag layer on top of the core engine
+    (core/backup.lua, exposed as the sandbox global `backup`). This plugin
+    owns WHEN a backup runs and HOW the operator is told about it; the engine
+    owns the actual collect -> seal -> write -> rotate work and reads its own
+    policy (dir / keep / passphrase / include_master_key) straight from cfg +
+    core/secrets. See docs/BACKUP.md.
+
+    Schedule (persisted across +reload in scripts/data/etc_backup.tbl):
+      - etc_backup_daily_at "HH:MM" (server-local) is the primary mode.
+      - etc_backup_interval_hours > 0 is the fallback when daily_at is empty.
+    Commands (level etc_backup_oplevel, default 80):
+      +backup now | list | status
+    Owner nag (level etc_backup_notify_level, default 100): when the feature
+    is enabled but not ready (no passphrase / backup dir not writable /
+    master.key unreadable), the hubbot PMs the owner on start + on login,
+    enumerating exactly what is missing.
+
+    License: GPLv3
+
+]]--
+
+local scriptname    = "etc_backup"
+local scriptversion = "0.01"
+
+--// sandbox globals //--
+local cfg     = cfg
+local hub     = hub
+local backup  = backup
+local audit   = audit
+local secrets = secrets
+local util    = util
+local type     = type
+local tonumber = tonumber
+local tostring = tostring
+local pairs    = pairs
+local ipairs   = ipairs
+local table_concat = table.concat
+local os_time = os.time
+local os_date = os.date
+local io_open = io.open
+local PROCESSED = PROCESSED
+
+local hub_debug      = hub.debug
+local hub_getbot     = hub.getbot
+local hub_getusers   = hub.getusers
+local hub_setlistener = hub.setlistener
+local hub_import     = hub.import
+
+--// i18n //--
+local scriptlang = cfg.get( "language" )
+local lang, lang_err = cfg.loadlanguage( scriptlang, scriptname )
+lang = lang or { }
+if lang_err then hub_debug( lang_err ) end
+
+local msg_denied    = lang.msg_denied    or "You are not allowed to use this command."
+local msg_usage     = lang.msg_usage     or "Usage: +backup now|list|status"
+local msg_now_ok    = lang.msg_now_ok    or "Backup written: "
+local msg_now_fail  = lang.msg_now_fail  or "Backup failed: "
+local msg_list_head = lang.msg_list_head or "Backups in "
+local msg_list_none = lang.msg_list_none or "  (none yet)"
+local msg_bytes     = lang.msg_bytes     or " bytes"
+local msg_files     = lang.msg_files     or " files"
+local msg_st_enabled  = lang.msg_st_enabled  or "enabled: "
+local msg_st_schedule = lang.msg_st_schedule or "schedule: "
+local msg_st_daily    = lang.msg_st_daily    or "daily at "
+local msg_st_every    = lang.msg_st_every    or "every "
+local msg_st_none     = lang.msg_st_none     or "none"
+local msg_st_next     = lang.msg_st_next     or "next: "
+local msg_st_last     = lang.msg_st_last     or "last: "
+local msg_st_ready    = lang.msg_st_ready    or "ready: "
+local msg_st_yes      = lang.msg_st_yes      or "yes"
+local msg_st_no       = lang.msg_st_no       or "no"
+local msg_nag_head    = lang.msg_nag_head    or "Backup is ENABLED but not fully configured:"
+local msg_iss_pass    = lang.msg_iss_pass    or "  - no passphrase set (etc_backup_passphrase / env LUADCH_ETC_BACKUP_PASSPHRASE)"
+local msg_iss_dir     = lang.msg_iss_dir     or "  - the backup directory is not writable (etc_backup_dir)"
+local msg_iss_mk      = lang.msg_iss_mk      or "  - master.key is not readable (etc_backup_include_master_key)"
+
+local help_title = lang.help_title or "backup"
+local help_usage = lang.help_usage or "+backup now|list|status"
+local help_desc  = lang.help_desc  or "Automatic encrypted backups: run one now, list artifacts, show status."
+local ucmd_now    = lang.ucmd_now    or { "Backup", "Run now" }
+local ucmd_list   = lang.ucmd_list   or { "Backup", "List" }
+local ucmd_status = lang.ucmd_status or { "Backup", "Status" }
+
+--// constants + runtime state //--
+local cmd_main   = "backup"
+local STATE_FILE = "scripts/data/etc_backup.tbl"
+
+local enabled, daily_at, interval_sec, notify_level, oplevel
+local last_backup_at, next_backup_at
+local in_flight = false
+
+local passphrase_key = "etc_backup_passphrase"
+
+----------------------------------// SCHEDULE (pure helpers) //--
+
+-- Next occurrence of a server-local HH:MM strictly after `now`, or nil if
+-- the string is not a valid HH:MM (caller falls back to the interval).
+local function _next_daily( now, hhmm )
+    if type( hhmm ) ~= "string" then return nil end
+    local h, m = hhmm:match( "^(%d%d?):(%d%d)$" )
+    h, m = tonumber( h ), tonumber( m )
+    if not h or not m or h < 0 or h > 23 or m < 0 or m > 59 then return nil end
+    local t = os_date( "*t", now )
+    local cand = os_time{ year = t.year, month = t.month, day = t.day, hour = h, min = m, sec = 0 }
+    -- A spring-forward-gap HH:MM makes os.time return nil; the caller then
+    -- falls back to the interval. Accepted (once-a-year, narrow).
+    if not cand then return nil end
+    -- Flat +24h: across a DST change the slot is 1h off for that one day and
+    -- self-corrects on the next recompute. Accepted for a backup schedule.
+    if cand <= now then cand = cand + 86400 end   -- today's slot passed -> tomorrow
+    return cand
+end
+
+-- The next scheduled time after `now`. daily_at wins; else interval from
+-- `anchor` (last run at start, `now` after a run). Overdue interval fires
+-- this tick (n = now) instead of hammering. nil = no schedule configured.
+local function _compute_next( now, anchor, daily, ivl )
+    if daily and daily ~= "" then
+        local n = _next_daily( now, daily )
+        if n then return n end
+    end
+    if ivl and ivl > 0 then
+        local n = ( anchor or now ) + ivl
+        if n <= now then n = now end
+        return n
+    end
+    return nil
+end
+
+local function _schedule_next( now, anchor )
+    return _compute_next( now, anchor, daily_at, interval_sec )
+end
+
+----------------------------------// STATE PERSISTENCE //--
+
+local function load_state( )
+    local f = io_open( STATE_FILE, "r" )   -- peek so loadtable doesn't log "no such file"
+    if not f then return end
+    f:close( )
+    local st = util.loadtable( STATE_FILE )
+    if type( st ) == "table" then
+        last_backup_at = tonumber( st.last_backup_at )
+        next_backup_at = tonumber( st.next_backup_at )
+    end
+end
+
+local function persist_state( )
+    util.savetable( { last_backup_at = last_backup_at, next_backup_at = next_backup_at },
+        "etc_backup_state", STATE_FILE )
+end
+
+----------------------------------// OWNER NAG //--
+
+local function build_nag( issues )
+    local lines = { msg_nag_head }
+    for _, code in ipairs( issues ) do
+        if code == "no_passphrase" then lines[ #lines + 1 ] = msg_iss_pass
+        elseif code == "backup_dir_unwritable" then lines[ #lines + 1 ] = msg_iss_dir
+        elseif code == "master_key_unreadable" then lines[ #lines + 1 ] = msg_iss_mk
+        else lines[ #lines + 1 ] = "  - " .. code end
+    end
+    return table_concat( lines, "\n" )
+end
+
+-- PM the readiness checklist. `target` = one user (on login) or nil = every
+-- online user at/above notify_level (on start / after a failed run).
+local function notify_if_unready( target )
+    if not enabled then return end
+    local r = backup.readiness( )
+    if r.ok then return end
+    local msg = build_nag( r.issues )
+    local bot = hub_getbot( )
+    if target then
+        target:reply( msg, bot, bot )   -- 3-arg = private DMSG
+    else
+        for _, user in pairs( hub_getusers( ) ) do   -- first table = humans only
+            if not user:isbot( ) and user:level( ) >= notify_level then
+                user:reply( msg, bot, bot )
+            end
+        end
+    end
+end
+
+----------------------------------// BACKUP DRIVER //--
+
+-- Run one backup, audit the outcome, update last_backup_at on success. Does
+-- NOT recompute next / persist - the caller (timer or +backup now) does.
+local function do_backup( trigger, actor )
+    local res, err = backup.run( )
+    if res then
+        last_backup_at = os_time( )
+        audit.fire( audit.build( "backup.success", actor, nil, nil, {
+            path = res.path, bytes = res.bytes, files = res.files, trigger = trigger } ) )
+        return res
+    end
+    audit.fire( audit.build( "backup.fail", actor, nil, err, { trigger = trigger } ) )
+    notify_if_unready( nil )   -- a config-class failure is explained to owners
+    return nil, err
+end
+
+----------------------------------// COMMAND: +backup //--
+
+local function cmd_now( user )
+    local res, err = do_backup( "manual", user )
+    local now = os_time( )
+    next_backup_at = _schedule_next( now, now )
+    persist_state( )
+    if res then
+        user:reply( msg_now_ok .. res.path .. " (" .. tostring( res.bytes ) .. msg_bytes
+            .. ", " .. tostring( res.files ) .. msg_files .. ")", hub_getbot( ) )
+    else
+        user:reply( msg_now_fail .. tostring( err ), hub_getbot( ) )
+    end
+end
+
+local function cmd_list( user )
+    local rows = backup.list( )
+    local dir = cfg.get( "etc_backup_dir" ) or "cfg/backups"
+    local lines = { msg_list_head .. dir .. ":" }
+    if not rows or #rows == 0 then
+        lines[ #lines + 1 ] = msg_list_none
+    else
+        for _, r in ipairs( rows ) do
+            lines[ #lines + 1 ] = "  " .. r.name .. "  (" .. tostring( r.bytes or "?" ) .. msg_bytes .. ")"
+        end
+    end
+    user:reply( table_concat( lines, "\n" ), hub_getbot( ) )
+end
+
+local function cmd_status( user )
+    local r = backup.readiness( )
+    local sched
+    if daily_at and daily_at ~= "" then sched = msg_st_daily .. daily_at
+    elseif interval_sec and interval_sec > 0 then sched = msg_st_every .. tostring( interval_sec // 3600 ) .. "h"
+    else sched = msg_st_none end
+    local ready = r.ok and msg_st_yes or ( msg_st_no .. " (" .. table_concat( r.issues, ", " ) .. ")" )
+    local parts = {
+        msg_st_enabled  .. tostring( enabled ),
+        msg_st_schedule .. sched,
+        msg_st_next     .. ( next_backup_at and os_date( "%Y-%m-%d %H:%M", next_backup_at ) or "-" ),
+        msg_st_last     .. ( last_backup_at and os_date( "%Y-%m-%d %H:%M", last_backup_at ) or "-" ),
+        msg_st_ready    .. ready,
+    }
+    user:reply( table_concat( parts, "\n" ), hub_getbot( ) )
+end
+
+local function on_backup( user, command, parameters )
+    if user:level( ) < oplevel then
+        user:reply( msg_denied, hub_getbot( ) )
+        return PROCESSED
+    end
+    local sub = parameters and parameters:match( "^%s*(%S+)" )
+    if sub == "now" then cmd_now( user )
+    elseif sub == "list" then cmd_list( user )
+    elseif sub == "status" then cmd_status( user )
+    else user:reply( msg_usage, hub_getbot( ) ) end
+    return PROCESSED
+end
+
+----------------------------------// LISTENERS //--
+
+hub_setlistener( "onStart", { },
+    function( )
+        in_flight = false
+
+        enabled = cfg.get( "etc_backup_enabled" )
+        if enabled == nil then enabled = true end
+        daily_at = cfg.get( "etc_backup_daily_at" ) or ""
+        interval_sec = ( tonumber( cfg.get( "etc_backup_interval_hours" ) ) or 0 ) * 3600
+        notify_level = tonumber( cfg.get( "etc_backup_notify_level" ) ) or 100
+        oplevel      = tonumber( cfg.get( "etc_backup_oplevel" ) ) or 80
+
+        -- Register the passphrase key as a secret whenever loaded, so a
+        -- value in cfg.tbl is redacted from /v1/config even while inactive.
+        if secrets and secrets.register then secrets.register( passphrase_key ) end
+
+        load_state( )
+        local now = os_time( )
+        -- Honor the persisted deadline across +reload / restart so an interval
+        -- countdown is not reset on every boot (the #386/#414 anti-pattern)
+        -- and a slot missed while the hub was down still fires on boot. Only
+        -- recompute when there is no persisted deadline (first run).
+        if enabled then
+            next_backup_at = next_backup_at or _schedule_next( now, last_backup_at )
+        else
+            next_backup_at = nil
+        end
+
+        -- command trio (help / right-click menu / +cmd dispatcher)
+        local help = hub_import( "cmd_help" )
+        if help then help.reg( help_title, help_usage, help_desc, oplevel ) end
+        local ucmd = hub_import( "etc_usercommands" )
+        if ucmd then
+            ucmd.add( ucmd_now,    cmd_main .. " now",    { }, { "CT1" }, oplevel )
+            ucmd.add( ucmd_list,   cmd_main .. " list",   { }, { "CT1" }, oplevel )
+            ucmd.add( ucmd_status, cmd_main .. " status", { }, { "CT1" }, oplevel )
+        end
+        local hubcmd = hub_import( "etc_hubcommands" )
+        if hubcmd then hubcmd.add( cmd_main, on_backup, oplevel ) end
+
+        notify_if_unready( nil )   -- nag owners already online (e.g. after +reload)
+        return nil
+    end
+)
+
+hub_setlistener( "onTimer", { },
+    function( )
+        if not enabled then return nil end
+        if in_flight then return nil end
+        if not next_backup_at then return nil end
+        local now = os_time( )
+        if now >= next_backup_at then
+            in_flight = true
+            -- Guard the run: a raise deep inside (audit / reply) must not
+            -- wedge the scheduler with in_flight stuck true and next_backup_at
+            -- past-due, which would silently stop all future backups until a
+            -- +reload. next_backup_at is always advanced afterwards.
+            pcall( do_backup, "scheduled", nil )
+            next_backup_at = _schedule_next( now, now )
+            persist_state( )
+            in_flight = false
+        end
+        return nil
+    end
+)
+
+hub_setlistener( "onLogin", { },
+    function( user )
+        if not enabled then return nil end
+        if user:isbot( ) then return nil end
+        if user:level( ) >= notify_level then
+            notify_if_unready( user )
+        end
+        return nil
+    end
+)
+
+hub_debug( "** Loaded " .. scriptname .. " " .. scriptversion .. " **" )
+
+-- test seams (pure schedule math)
+return {
+    _next_daily   = _next_daily,
+    _compute_next = _compute_next,
+}

--- a/scripts/lang/etc_backup.lang.de
+++ b/scripts/lang/etc_backup.lang.de
@@ -1,0 +1,36 @@
+return {
+
+    help_title = "etc_backup.lua - Backup",
+    help_usage = "+backup now|list|status",
+    help_desc  = "Automatische verschluesselte Backups: jetzt eins erstellen, Artefakte auflisten, Status anzeigen.",
+
+    ucmd_now    = { "Hub", "Backup", "jetzt erstellen" },
+    ucmd_list   = { "Hub", "Backup", "auflisten" },
+    ucmd_status = { "Hub", "Backup", "Status" },
+
+    msg_denied    = "Du darfst diesen Befehl nicht benutzen.",
+    msg_usage     = "Benutzung: +backup now|list|status",
+    msg_now_ok    = "Backup geschrieben: ",
+    msg_now_fail  = "Backup fehlgeschlagen: ",
+    msg_list_head = "Backups in ",
+    msg_list_none = "  (noch keine)",
+    msg_bytes     = " Bytes",
+    msg_files     = " Dateien",
+
+    msg_st_enabled  = "aktiviert: ",
+    msg_st_schedule = "Zeitplan: ",
+    msg_st_daily    = "taeglich um ",
+    msg_st_every    = "alle ",
+    msg_st_none     = "keiner",
+    msg_st_next     = "naechstes: ",
+    msg_st_last     = "letztes: ",
+    msg_st_ready    = "bereit: ",
+    msg_st_yes      = "ja",
+    msg_st_no       = "nein",
+
+    msg_nag_head = "Backup ist AKTIVIERT, aber nicht vollstaendig konfiguriert:",
+    msg_iss_pass = "  - keine Passphrase gesetzt (etc_backup_passphrase / env LUADCH_ETC_BACKUP_PASSPHRASE)",
+    msg_iss_dir  = "  - das Backup-Verzeichnis ist nicht beschreibbar (etc_backup_dir)",
+    msg_iss_mk   = "  - master.key ist nicht lesbar (etc_backup_include_master_key)",
+
+}

--- a/scripts/lang/etc_backup.lang.en
+++ b/scripts/lang/etc_backup.lang.en
@@ -1,0 +1,36 @@
+return {
+
+    help_title = "etc_backup.lua - backup",
+    help_usage = "+backup now|list|status",
+    help_desc  = "Automatic encrypted backups: run one now, list artifacts, show status.",
+
+    ucmd_now    = { "Hub", "Backup", "run now" },
+    ucmd_list   = { "Hub", "Backup", "list" },
+    ucmd_status = { "Hub", "Backup", "status" },
+
+    msg_denied    = "You are not allowed to use this command.",
+    msg_usage     = "Usage: +backup now|list|status",
+    msg_now_ok    = "Backup written: ",
+    msg_now_fail  = "Backup failed: ",
+    msg_list_head = "Backups in ",
+    msg_list_none = "  (none yet)",
+    msg_bytes     = " bytes",
+    msg_files     = " files",
+
+    msg_st_enabled  = "enabled: ",
+    msg_st_schedule = "schedule: ",
+    msg_st_daily    = "daily at ",
+    msg_st_every    = "every ",
+    msg_st_none     = "none",
+    msg_st_next     = "next: ",
+    msg_st_last     = "last: ",
+    msg_st_ready    = "ready: ",
+    msg_st_yes      = "yes",
+    msg_st_no       = "no",
+
+    msg_nag_head = "Backup is ENABLED but not fully configured:",
+    msg_iss_pass = "  - no passphrase set (etc_backup_passphrase / env LUADCH_ETC_BACKUP_PASSPHRASE)",
+    msg_iss_dir  = "  - the backup directory is not writable (etc_backup_dir)",
+    msg_iss_mk   = "  - master.key is not readable (etc_backup_include_master_key)",
+
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,10 +23,10 @@ tests/
                   CIDs and password challenge responses for the login
                   flow tests. Self-tests on import.
   unit/
-    iostream_test.lua  Pure-Lua unit test for core/iostream.lua
-                  (Phase 8 framing pipeline). Stubs the `use` sandbox
-                  shim, loads the module standalone, asserts the
-                  stage/pipeline contract. Exit 0/1.
+    *_test.lua    Pure-Lua unit tests (one per module/plugin) - stub the
+                  `use` sandbox shim / plugin globals, load the target
+                  standalone, assert its contract. Exit 0/1. Run
+                  `ls tests/unit/*.lua` for the current set.
   README.md       (this file)
 ```
 
@@ -51,9 +51,8 @@ tests/
   matching `CID = Tiger(PID)`, GPA salt receipt, HPAS response
   computed as `Tiger(password || salt)`. Asserts the hub transitions
   the client to NORMAL state by emitting our own BINF echo. Exercises
-  `createuser`'s user object end-to-end (the user object factory is
-  the largest single function in `core/hub.lua` and a top target for
-  the Phase 6d refactor), the BINF parser, salt generation, and
+  `createuser`'s user object end-to-end (the user object factory in
+  `core/hub_user_object.lua`), the BINF parser, salt generation, and
   password verification.
 - **TLS ADC full login (dummy/test).** Same login flow over TLS.
 - **`+cmd` routing (post-login `+help`).** After a successful login,
@@ -111,11 +110,13 @@ lua tests/unit/iostream_test.lua      # exit 0 = all pass, 1 = a failure
 
 **These run in CI on BOTH platforms.** `.github/workflows/smoke.yml` runs
 the whole `tests/unit/*_test.lua` set on the Linux leg (`lua5.4`) and the
-Windows leg (msys2 `lua`) before the build+smoke step. When you add a unit
-test you MUST add a step for it to both legs, or it is silent
-non-coverage. (The one exception is `adclib_unescape_test.lua`, which
-needs the built C module and so runs on the Linux leg only, after install,
-with `LD_LIBRARY_PATH=.`.)
+Windows leg (msys2 `lua5.4`, the versioned `lua54` package - the unversioned
+`lua` rolled to Lua 5.5 and broke the suite, #388) before the build+smoke
+step. When you add a unit test you MUST add a step for it to both legs, or
+it is silent non-coverage. (The exceptions are the C-module tests -
+`adclib_unescape_test.lua` and `zlib_stream_test.lua` - which need the built
+C module and so run on the Linux leg only, after install, with
+`LD_LIBRARY_PATH=.`.)
 
 The unit-test authoring contract + the regression-fail-pre-fix recipe are
 in [`../docs/DEVELOPMENT.md`](../docs/DEVELOPMENT.md) §4.

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -722,10 +722,14 @@ def test_backup_restore_roundtrip(source_install: Path, keep_staging=False):
 
         # --verify is a dry run over the POPULATED tree (no --force): it must
         # still exit 0 and write nothing - the conflict refusal is for a real
-        # apply, not a verify.
+        # apply, not a verify. It also drives the passphrase via the FALLBACK
+        # env name (LUADCH_ETC_BACKUP_PASSPHRASE, the backup engine's own) with
+        # the primary NOT set, proving restore accepts either.
+        verify_env = {k: v for k, v in os.environ.items() if k != "LUADCH_BACKUP_PASSPHRASE"}
+        verify_env["LUADCH_ETC_BACKUP_PASSPHRASE"] = "smoke-backup-pass"
         rv = subprocess.run(
             [str(binary), "--restore", str(artifact), "--verify"],
-            cwd=str(st), env=env, capture_output=True, text=True, timeout=60,
+            cwd=str(st), env=verify_env, capture_output=True, text=True, timeout=60,
         )
         if rv.returncode != 0:
             raise TestFailure(f"--verify exited {rv.returncode}:\n{rv.stdout}\n{rv.stderr}")

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -651,6 +651,117 @@ def test_backup_now(staging_dir: Path):
         raise TestFailure(f"backup sidecar format wrong: {sc!r}")
 
 
+def test_backup_restore_roundtrip(source_install: Path, keep_staging=False):
+    """#480 PR-B: an engine-sealed backup restores cleanly through the real
+    binary via `Luadch --restore`, with genuine AES-256-GCM decrypt. Full
+    loop on its OWN staged tree (independent of the shared hub):
+
+        boot -> +backup now -> stop hub -> corrupt cfg/cfg.tbl
+             -> --restore --verify (must write nothing)
+             -> --restore --force  (must restore cfg.tbl byte-for-byte)
+
+    Exercises the C arg parsing (--restore/--verify/--force), run_restore(),
+    core/restore.lua's bootstrap (real adclib require + backup_archive load),
+    the sidecar check, unpack, path-sanitize, and the atomic apply. Provably
+    fails without PR-B: the pre-PR binary rejects --restore as an unknown
+    option and never writes the file back."""
+    st = stage_install(source_install)
+    proc = None
+    log_file = None
+    # Dedicated ports: the shared hub is still running on TEST_PORT_* when this
+    # runs, so reusing them would make the client connect to THAT hub (whose
+    # dummy password an earlier +setpass test changed). Own ports -> own hub.
+    rt_plain = TEST_PORT_PLAIN + 100
+    try:
+        override_test_ports(st)   # sets etc_backup_passphrase = smoke-backup-pass
+        rt_cfg = st / "cfg" / "cfg.tbl"
+        rt_text = rt_cfg.read_text(encoding="utf-8")
+        for pat, repl in (
+            (r"tcp_ports\s*=\s*\{[^}]*\}", f"tcp_ports = {{ {rt_plain} }}"),
+            (r"ssl_ports\s*=\s*\{[^}]*\}", f"ssl_ports = {{ {TEST_PORT_TLS + 100} }}"),
+            (r"tcp_ports_ipv6\s*=\s*\{[^}]*\}", f"tcp_ports_ipv6 = {{ {TEST_PORT_PLAIN_V6 + 100} }}"),
+            (r"ssl_ports_ipv6\s*=\s*\{[^}]*\}", f"ssl_ports_ipv6 = {{ {TEST_PORT_TLS_V6 + 100} }}"),
+        ):
+            rt_text, n = re.subn(pat, repl, rt_text, count=1)
+            if n != 1:
+                raise RuntimeError(f"round-trip: could not re-port cfg.tbl: {pat}")
+        rt_cfg.write_text(rt_text, encoding="utf-8")
+        for stale in ("servercert.pem", "serverkey.pem", "cacert.pem", "cakey.pem"):
+            (st / "certs" / stale).unlink(missing_ok=True)
+        proc, log_file = start_hub(st)
+        wait_for_port(HUB_HOST, rt_plain, START_TIMEOUT_SEC)
+
+        # Produce one real backup through the engine.
+        backups_dir = st / "cfg" / "backups"
+        with socket.create_connection(
+            (HUB_HOST, rt_plain), timeout=PROTOCOL_TIMEOUT_SEC
+        ) as sock:
+            sid, reader = _adc_login(sock, "dummy", "test")
+            sock.sendall(f"BMSG {sid} +backup\\snow\n".encode("utf-8"))
+            reader.recv_until(
+                lambda f: f.startswith(("EMSG ", "DMSG ", "BMSG ")) and ("written" in f or "failed" in f),
+                timeout=PROTOCOL_TIMEOUT_SEC,
+            )
+        arts = sorted(backups_dir.glob("luadch-backup-*.ldbk"))
+        if not arts:
+            raise TestFailure("round-trip: no backup artifact was produced")
+        artifact = arts[-1]
+
+        # Stop the hub so --restore can take the single-instance lock (a
+        # restore over a running hub is refused by design).
+        stop_hub(proc, log_file)
+        proc = None
+
+        cfg = st / "cfg" / "cfg.tbl"
+        original = cfg.read_bytes()
+        corrupt = b"-- CORRUPTED BY SMOKE TEST --\n"
+        cfg.write_bytes(corrupt)
+
+        binary = st / ("Luadch.exe" if sys.platform == "win32" else "luadch")
+        env = dict(os.environ, LUADCH_BACKUP_PASSPHRASE="smoke-backup-pass")
+
+        # --verify is a dry run over the POPULATED tree (no --force): it must
+        # still exit 0 and write nothing - the conflict refusal is for a real
+        # apply, not a verify.
+        rv = subprocess.run(
+            [str(binary), "--restore", str(artifact), "--verify"],
+            cwd=str(st), env=env, capture_output=True, text=True, timeout=60,
+        )
+        if rv.returncode != 0:
+            raise TestFailure(f"--verify exited {rv.returncode}:\n{rv.stdout}\n{rv.stderr}")
+        if cfg.read_bytes() != corrupt:
+            raise TestFailure("--verify wrote to disk; it must be a dry run")
+
+        # Real restore: cfg.tbl must come back exactly.
+        rr = subprocess.run(
+            [str(binary), "--restore", str(artifact), "--force"],
+            cwd=str(st), env=env, capture_output=True, text=True, timeout=60,
+        )
+        if rr.returncode != 0:
+            raise TestFailure(f"--restore exited {rr.returncode}:\n{rr.stdout}\n{rr.stderr}")
+        if cfg.read_bytes() != original:
+            raise TestFailure("cfg.tbl was not restored to its original bytes")
+
+        # A wrong passphrase must be rejected (GCM auth), not silently applied.
+        cfg.write_bytes(corrupt)
+        bad = subprocess.run(
+            [str(binary), "--restore", str(artifact), "--force"],
+            cwd=str(st), env=dict(os.environ, LUADCH_BACKUP_PASSPHRASE="wrong-pass"),
+            capture_output=True, text=True, timeout=60,
+        )
+        if bad.returncode == 0:
+            raise TestFailure("--restore accepted a wrong passphrase")
+        if cfg.read_bytes() != corrupt:
+            raise TestFailure("--restore wrote files despite a wrong passphrase")
+    finally:
+        if proc is not None:
+            stop_hub(proc, log_file)
+        if keep_staging:
+            log(f"restore round-trip staging kept at {st.parent}")
+        else:
+            shutil.rmtree(st.parent, ignore_errors=True)
+
+
 def test_s1_fragmented_frame_reassembled():
     """Phase 8 S1: an ADC frame split across two TCP segments must be
     reassembled and processed as one frame.
@@ -13127,6 +13238,19 @@ def main():
             failed.append("single-instance lock refuses second start")
         else:
             log("PASS  single-instance lock refuses second start")
+
+        # #480 PR-B: backup -> --restore round-trip on its own staged tree
+        # (real AES-256-GCM decrypt through the binary). Independent of the
+        # shared hub above; stages + tears down its own install.
+        try:
+            test_backup_restore_roundtrip(
+                args.install_dir.resolve(), keep_staging=args.keep_staging,
+            )
+        except Exception as e:
+            log(f"FAIL  backup -> restore round-trip (#480 PR-B): {e}")
+            failed.append("backup -> restore round-trip (#480 PR-B)")
+        else:
+            log("PASS  backup -> restore round-trip (#480 PR-B)")
 
         # #128 plaintext-mode test runs AFTER the regular battery
         # because cfg_secret.init() reads encrypt_usertbl once at

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -160,6 +160,12 @@ def override_test_ports(staging_dir: Path):
          '{ "etc_proxydetect.lua", enabled = true }'),
         (r"etc_proxydetect_enabled\s*=\s*false", "etc_proxydetect_enabled = true"),
         (r"etc_proxydetect_check_levels = \{[^}]*\}", "etc_proxydetect_check_levels = { }"),
+        # #480: etc_backup ships ENABLED but is inert (nags, never runs)
+        # until a passphrase is set. Set one so test_backup_now can drive a
+        # real +backup now and assert a sealed artifact lands on disk. The
+        # daily_at schedule stays at 04:00, so no scheduled backup fires
+        # during the run; only the explicit +backup now does.
+        (r'etc_backup_passphrase\s*=\s*""', 'etc_backup_passphrase = "smoke-backup-pass"'),
     ]
     for pattern, replacement in rewrites:
         new_text, count = re.subn(pattern, replacement, text, count=1)
@@ -591,6 +597,58 @@ def test_command_routing():
         )
         if len(response) < 20:
             raise TestFailure(f"+help response unexpectedly short: {response!r}")
+
+
+def test_backup_now(staging_dir: Path):
+    """#480 PR-A: `+backup now` produces an encrypted .ldbk artifact + a
+    .sha256 sidecar. Exercises the whole engine path through the plugin
+    command: real file collection (io + the listdir C primitive over
+    scripts/data + scripts/cfg), OpenSSL PBKDF2 + AES-256-GCM seal, atomic
+    write, and the sidecar. dummy is level 100 (> etc_backup_oplevel 80); the
+    passphrase is set in the staged cfg by override_test_ports."""
+    backups_dir = staging_dir / "cfg" / "backups"
+    before = (
+        set(backups_dir.glob("luadch-backup-*.ldbk"))
+        if backups_dir.exists()
+        else set()
+    )
+    with socket.create_connection(
+        (HUB_HOST, TEST_PORT_PLAIN), timeout=PROTOCOL_TIMEOUT_SEC
+    ) as sock:
+        sid, reader = _adc_login(sock, "dummy", "test")
+        # The space in "+backup now" MUST be the ADC escape \s, or the hub
+        # parses "now" as a separate ADC field and the command sees no
+        # subcommand (multi-word BMSG bodies need \s, not a raw space).
+        sock.sendall(f"BMSG {sid} +backup\\snow\n".encode("utf-8"))
+        # The hubbot reply carries "Backup written: <path>" on success or
+        # "Backup failed: ..." otherwise. Match on those words so we skip
+        # etc_hubcommands' own "[command] +backup" chat-echo frame.
+        response = reader.recv_until(
+            lambda f: f.startswith(("EMSG ", "DMSG ", "BMSG ")) and ("written" in f or "failed" in f),
+            timeout=PROTOCOL_TIMEOUT_SEC,
+        )
+    if "written" not in response:
+        raise TestFailure(f"+backup now did not report success: {response!r}")
+
+    # A new artifact must exist on disk.
+    new = set(backups_dir.glob("luadch-backup-*.ldbk")) - before
+    if not new:
+        raise TestFailure(f"+backup now wrote no .ldbk artifact in {backups_dir}")
+    artifact = next(iter(new))
+    if artifact.stat().st_size < 100:
+        raise TestFailure(
+            f"backup artifact suspiciously small: {artifact.stat().st_size} bytes"
+        )
+    # It must be an LDBK1 blob, not plaintext (the seal actually ran).
+    if artifact.read_bytes()[:4] != b"LDBK":
+        raise TestFailure(f"artifact is not an LDBK archive: {artifact.name}")
+    # The sidecar exists and is the standard `sha256sum` format.
+    sidecar = artifact.parent / (artifact.name + ".sha256")
+    if not sidecar.exists():
+        raise TestFailure(f"backup sidecar missing: {sidecar}")
+    sc = sidecar.read_text(encoding="utf-8").strip()
+    if not re.match(r"^[0-9a-f]{64}  luadch-backup-.*\.ldbk$", sc):
+        raise TestFailure(f"backup sidecar format wrong: {sc!r}")
 
 
 def test_s1_fragmented_frame_reassembled():
@@ -12751,6 +12809,17 @@ def run_tests(staging_dir: Path):
             failed.append(name)
         else:
             log(f"PASS  {name}")
+
+    # #480: drive a real +backup now and assert a sealed artifact lands on
+    # disk. Needs staging_dir for the file check, so it runs here (main hub
+    # still up) rather than in the no-arg TESTS list.
+    try:
+        test_backup_now(staging_dir)
+    except Exception as e:
+        log(f"FAIL  +backup now writes an encrypted artifact (#480): {e}")
+        failed.append("+backup now writes an encrypted artifact (#480)")
+    else:
+        log("PASS  +backup now writes an encrypted artifact (#480)")
 
     # State-of-disk tests run after the protocol tests so any post-login
     # save (HPAS lastconnect update) has had a chance to land.

--- a/tests/unit/adclib_hashpas_test.lua
+++ b/tests/unit/adclib_hashpas_test.lua
@@ -1,0 +1,126 @@
+--[[
+
+    tests/unit/adclib_hashpas_test.lua
+
+    Regression test for #483 - the salt-length guard in adclib's ADC
+    password hashers formatted its diagnostic with %zu:
+
+        return luaL_error(L, "hashpas: salt length %zu out of range", ...)
+
+    luaL_error routes through lua_pushvfstring, whose conversion set is
+    fixed (%s %d %f %p %c %I %%) and does NOT include %zu. So when the
+    guard tripped, the interpreter raised "invalid option '%z' to
+    'lua_pushfstring'" instead of the intended "salt length N out of
+    range" message - masking the real cause on an auth error path.
+
+    The fix casts saltBytes to lua_Integer and uses %I (matching the
+    gen_self_signed_cert diagnostic in the same file).
+
+    Coverage:
+      - hashpas   lower-bound guard (empty salt -> saltBytes 0)
+      - hashpas   upper-bound guard (oversized salt -> saltBytes > 64)
+      - hasholdpas lower- and upper-bound guards
+      - the rendered integer is correct ("salt length 0")   [proves %I]
+      - a valid salt still hashes (guard not over-triggering)
+
+    Pre-fix, every guard check FAILS: the raised message is the
+    "invalid conversion '%z'" format error, not "salt length ...".
+
+    Requires the built adclib shared object (and its libssl / libcrypto
+    deps loadable), so it must run from inside the install tree:
+
+      cd build/install/luadch
+      lua5.4 ../../../tests/unit/adclib_hashpas_test.lua
+
+    CI runs this after `cmake --install build` on the Linux leg only
+    (the bundled adclib.dll segfaults under msys2 lua via ABI clash,
+    per the adclib_unescape test).
+
+    Exit 0 = all pass, 1 = a failure.
+
+]]--
+
+-- CWD-relative cpath - the install tree has lib/adclib/adclib.<so|dll>.
+local filetype = ( os.getenv "COMSPEC" and os.getenv "WINDIR" and ".dll" ) or ".so"
+package.cpath = "lib/?/?" .. filetype .. ";lib/?" .. filetype .. ";" .. package.cpath
+local adclib = require("adclib")
+
+local failures, checks = 0, 0
+
+-- Assert the call raises, and the raised message is the INTENDED
+-- salt-length diagnostic (not the "%z" format error from the bug).
+local function guard_ok( label, fn, ... )
+    checks = checks + 1
+    local ok, err = pcall( fn, ... )
+    err = tostring( err )
+    if ok then
+        failures = failures + 1
+        io.write( string.format( "FAIL %-46s expected error, got success\n", label ) )
+    elseif err:find( "salt length", 1, true ) and err:find( "out of range", 1, true ) then
+        io.write( string.format( "ok   %-46s (%s)\n", label, err ) )
+    else
+        failures = failures + 1
+        io.write( string.format( "FAIL %-46s err=%q\n", label, err ) )
+    end
+end
+
+local function eq( label, got, want )
+    checks = checks + 1
+    if got ~= want then
+        failures = failures + 1
+        io.write( string.format( "FAIL %-46s got=%q want=%q\n", label, tostring( got ), tostring( want ) ) )
+    else
+        io.write( string.format( "ok   %s\n", label ) )
+    end
+end
+
+-- ============================================================
+-- hashpas: salt-length guard, both bounds.
+-- ""          -> salt_len 0   -> saltBytes 0        (lower bound)
+-- 104 chars   -> salt_len 104 -> saltBytes 65 > 64  (upper bound)
+-- ============================================================
+guard_ok( "hashpas lower-bound (empty salt)",      adclib.hashpas, "password", "" )
+guard_ok( "hashpas upper-bound (oversized salt)",  adclib.hashpas, "password", string.rep( "A", 104 ) )
+
+-- ============================================================
+-- hasholdpas: same guard (3-arg variant; cid is 3rd arg).
+-- ============================================================
+guard_ok( "hasholdpas lower-bound (empty salt)",     adclib.hasholdpas, "password", "", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" )
+guard_ok( "hasholdpas upper-bound (oversized salt)", adclib.hasholdpas, "password", string.rep( "A", 104 ), "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" )
+
+-- ============================================================
+-- The rendered integer must be correct - proves %I actually formats
+-- the value (a bare "salt length  out of range" would pass the guard
+-- check above but not this one).
+-- ============================================================
+do
+    checks = checks + 1
+    local ok, err = pcall( adclib.hashpas, "password", "" )
+    err = tostring( err )
+    if not ok and err:find( "salt length 0 out of range", 1, true ) then
+        io.write( "ok   hashpas message renders 'salt length 0'\n" )
+    else
+        failures = failures + 1
+        io.write( string.format( "FAIL %-46s err=%q\n", "hashpas message renders 'salt length 0'", err ) )
+    end
+end
+
+-- ============================================================
+-- A valid salt (16 base32 chars -> saltBytes 10, in range) still
+-- hashes to a non-empty base32 result. Confirms the guard is not
+-- over-triggering and the happy path is intact.
+-- ============================================================
+do
+    local h = adclib.hashpas( "password", "MFRGGZDFMZTWQ2LK" )
+    eq( "valid salt hashes to string", type( h ), "string" )
+    checks = checks + 1
+    if type( h ) == "string" and #h > 0 then
+        io.write( "ok   valid salt hash is non-empty\n" )
+    else
+        failures = failures + 1
+        io.write( string.format( "FAIL valid salt hash is non-empty len=%s\n", tostring( h and #h ) ) )
+    end
+end
+
+io.write( string.format( "\n%d checks, %d failures\n", checks, failures ) )
+os.exit( failures == 0 and 0 or 1 )

--- a/tests/unit/backup_archive_crypto_test.lua
+++ b/tests/unit/backup_archive_crypto_test.lua
@@ -26,7 +26,7 @@ local adclib = require( "adclib" )
 local _real = {
     type = type, error = error, pcall = pcall, tostring = tostring,
     tonumber = tonumber, load = load, pairs = pairs, ipairs = ipairs,
-    string = string, table = table, io = io,
+    string = string, table = table, io = io, debug = debug,
     adclib = adclib,
 }
 _G.use = function( name )

--- a/tests/unit/backup_archive_crypto_test.lua
+++ b/tests/unit/backup_archive_crypto_test.lua
@@ -1,0 +1,113 @@
+--[[
+
+    tests/unit/backup_archive_crypto_test.lua
+
+    Real-AES-256-GCM tests for core/backup_archive.lua: a full pack()/
+    unpack() round-trip that actually encrypts, proof the ciphertext hides
+    the plaintext, wrong-passphrase rejection, and GCM tamper detection.
+
+    Needs the built adclib shared object (OpenSSL) and the bundled liblua
+    it links against, so - like adclib_unescape_test.lua / zlib_stream_test
+    .lua - it must run from INSIDE the install tree, LINUX CI leg only
+    (the msys2/Windows adclib segfaults via an ABI clash, #318):
+
+      cd build/install/luadch
+      LD_LIBRARY_PATH=. lua5.4 ../../../tests/unit/backup_archive_crypto_test.lua
+
+    Exit 0 = all pass, 1 = a failure.
+
+]]--
+
+-- CWD-relative cpath - the install tree has lib/adclib/adclib.<so|dll>.
+local filetype = ( os.getenv "COMSPEC" and os.getenv "WINDIR" and ".dll" ) or ".so"
+package.cpath = "lib/?/?" .. filetype .. ";lib/?" .. filetype .. ";" .. package.cpath
+local adclib = require( "adclib" )
+
+local _real = {
+    type = type, error = error, pcall = pcall, tostring = tostring,
+    tonumber = tonumber, load = load, pairs = pairs, ipairs = ipairs,
+    string = string, table = table, io = io,
+    adclib = adclib,
+}
+_G.use = function( name )
+    local v = _real[ name ]
+    if v == nil then error( "crypto_test shim missing dep: use \"" .. tostring( name ) .. "\"" ) end
+    return v
+end
+
+local sha256 = assert( loadfile( "core/sha256.lua" ) )( )
+_real.sha256 = sha256
+local hmac = assert( loadfile( "core/hmac.lua" ) )( )
+_real.hmac = hmac
+local A = assert( loadfile( "core/backup_archive.lua" ) )( )
+
+local passes, fails = 0, 0
+local function ok( label, cond )
+    if cond then passes = passes + 1
+    else fails = fails + 1; io.stderr:write( "FAIL: " .. label .. "\n" ) end
+end
+local function eq( label, got, want )
+    if got == want then passes = passes + 1
+    else
+        fails = fails + 1
+        io.stderr:write( string.format( "FAIL: %s\n  got:  %q\n  want: %q\n",
+            label, tostring( got ), tostring( want ) ) )
+    end
+end
+
+local PW = "correct horse battery staple"
+local files = {
+    { name = "cfg/cfg.tbl",   mode = 420, body = "hub_name = \"secretHub\"\0binary" , kind = "tree" },
+    { name = "cfg/user.tbl",  mode = 384, body = string.rep( "u", 1000 ),              kind = "tree" },
+    { name = "__masterkey__", mode = 384, body = string.rep( "\255", 32 ),             kind = "masterkey" },
+}
+local meta = { hub_version = "v3.2.0-dev", created_at = 1700000000,
+    master_key_path = "/etc/luadch/master.key", include_master_key = true }
+
+-- iters low so the test is fast; the KDF itself is vector-checked in the
+-- pure test. This proves the AES-GCM path + framing end to end.
+local blob = assert( A.pack( files, meta, PW, { iters = 2 } ) )
+ok( "pack returned bytes", type( blob ) == "string" and #blob > 0 )
+
+-- real encryption: the plaintext markers must NOT appear in the ciphertext
+ok( "ciphertext hides 'secretHub'", blob:find( "secretHub", 1, true ) == nil )
+ok( "ciphertext hides master.key bytes", blob:find( string.rep( "\255", 32 ), 1, true ) == nil )
+
+-- round-trip fidelity
+local res = assert( A.unpack( blob, PW ) )
+eq( "meta hub_version", res.meta.hub_version, "v3.2.0-dev" )
+eq( "meta master_key_path", res.meta.master_key_path, "/etc/luadch/master.key" )
+eq( "file count", #res.files, 3 )
+local by = { }
+for _, f in ipairs( res.files ) do by[ f.name ] = f end
+eq( "cfg.tbl body byte-identical",   by[ "cfg/cfg.tbl" ].body,   files[ 1 ].body )
+eq( "user.tbl body byte-identical",  by[ "cfg/user.tbl" ].body,  files[ 2 ].body )
+eq( "masterkey body byte-identical", by[ "__masterkey__" ].body, files[ 3 ].body )
+eq( "masterkey kind",                by[ "__masterkey__" ].kind, "masterkey" )
+
+-- wrong passphrase must fail (derives a different key -> GCM auth fails)
+local r2, e2 = A.unpack( blob, "wrong passphrase" )
+ok( "wrong passphrase -> nil", r2 == nil )
+ok( "wrong passphrase -> error string", type( e2 ) == "string" )
+
+-- tamper: flip the last ciphertext byte -> GCM tag rejects it
+local last = string.byte( blob, #blob )
+local tampered = string.sub( blob, 1, #blob - 1 ) .. string.char( last ~ 0xFF )
+local r3 = A.unpack( tampered, PW )
+ok( "tampered ciphertext -> nil (GCM auth)", r3 == nil )
+
+-- tamper the outer salt (byte 12) -> wrong key -> fail closed
+local s = string.byte( blob, 12 )
+local tampsalt = string.sub( blob, 1, 11 ) .. string.char( s ~ 0xFF ) .. string.sub( blob, 13 )
+local r4 = A.unpack( tampsalt, PW )
+ok( "tampered salt -> nil (fail closed)", r4 == nil )
+
+-- checksum sidecar is stable + hex
+eq( "checksum length", #A.checksum( blob ), 64 )
+eq( "checksum deterministic", A.checksum( blob ), A.checksum( blob ) )
+
+if fails > 0 then
+    io.stderr:write( string.format( "\nFAIL: %d/%d checks failed\n", fails, passes + fails ) )
+    os.exit( 1 )
+end
+print( string.format( "OK: %d checks passed", passes ) )

--- a/tests/unit/backup_archive_test.lua
+++ b/tests/unit/backup_archive_test.lua
@@ -1,0 +1,220 @@
+--[[
+
+    tests/unit/backup_archive_test.lua
+
+    Pure-Lua unit tests for core/backup_archive.lua that need NO real
+    crypto: the ustar writer/reader, the PBKDF2-HMAC-SHA256 KDF (against
+    Python-verified known-answer vectors), the manifest serialiser, and the
+    full pack()/unpack() plumbing driven through a FAKE identity "adclib"
+    (seal = append 16-byte tag, open = strip it). The real AES-GCM
+    round-trip, ciphertext-secrecy, tamper and wrong-passphrase behaviour
+    live in backup_archive_crypto_test.lua (needs the built adclib C module,
+    Linux CI leg only, per #318).
+
+    core/backup_archive.lua depends on core/hmac.lua -> core/sha256.lua, so
+    the `use` shim loads those (stdlib-only) first and hands them back.
+
+    Run: lua5.4 tests/unit/backup_archive_test.lua
+    Exit 0 = all pass, 1 = a failure.
+
+]]--
+
+----------------------------------------------------------------------
+-- `use` shim + fake adclib (identity crypto so pack/unpack round-trips
+-- without OpenSSL). random_bytes is deterministic; seal appends a fake
+-- 16-byte tag, open strips it - mirrors the real ct||tag length shape.
+----------------------------------------------------------------------
+
+local _real = {
+    type = type, error = error, pcall = pcall, tostring = tostring,
+    tonumber = tonumber, load = load, pairs = pairs, ipairs = ipairs,
+    string = string, table = table, io = io,
+    adclib = {
+        random_bytes = function( n ) return string.rep( "R", n ) end,
+        aes_gcm_seal = function( _key, _nonce, pt ) return pt .. string.rep( "\0", 16 ) end,
+        aes_gcm_open = function( _key, _nonce, ct ) return string.sub( ct, 1, #ct - 16 ) end,
+    },
+}
+_G.use = function( name )
+    local v = _real[ name ]
+    if v == nil then error( "backup_archive_test shim missing dep: use \"" .. tostring( name ) .. "\"" ) end
+    return v
+end
+
+local sha256 = assert( loadfile( "core/sha256.lua" ) )( )
+_real.sha256 = sha256
+local hmac = assert( loadfile( "core/hmac.lua" ) )( )
+_real.hmac = hmac
+
+local A = assert( loadfile( "core/backup_archive.lua" ) )( )
+
+----------------------------------------------------------------------
+-- Tiny harness
+----------------------------------------------------------------------
+
+local passes, fails = 0, 0
+local function ok( label, cond )
+    if cond then passes = passes + 1
+    else fails = fails + 1; io.stderr:write( "FAIL: " .. label .. "\n" ) end
+end
+local function eq( label, got, want )
+    if got == want then passes = passes + 1
+    else
+        fails = fails + 1
+        io.stderr:write( string.format( "FAIL: %s\n  got:  %s\n  want: %s\n",
+            label, tostring( got ), tostring( want ) ) )
+    end
+end
+local function hexof( s )
+    local t = { }
+    for i = 1, #s do t[ i ] = string.format( "%02x", string.byte( s, i ) ) end
+    return table.concat( t )
+end
+
+----------------------------------------------------------------------
+-- Surface
+----------------------------------------------------------------------
+
+eq( "pack is function",   type( A.pack ),   "function" )
+eq( "unpack is function", type( A.unpack ), "function" )
+eq( "MAGIC is LDBK",      A.MAGIC,          "LDBK" )
+eq( "VERSION is 1",       A.VERSION,        1 )
+
+----------------------------------------------------------------------
+-- PBKDF2-HMAC-SHA256 known-answer vectors (Python hashlib.pbkdf2_hmac).
+----------------------------------------------------------------------
+
+eq( "PBKDF2 c=1",
+    hexof( A._pbkdf2( "password", "salt", 1, 32 ) ),
+    "120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b" )
+eq( "PBKDF2 c=4096",
+    hexof( A._pbkdf2( "password", "salt", 4096, 32 ) ),
+    "c5e478d59288c841aa530db6845c4c8d962893a001ce4e11a4963873aa98134a" )
+eq( "PBKDF2 long key/salt c=4096",
+    hexof( A._pbkdf2( "passwordPASSWORDpassword",
+        "saltSALTsaltSALTsaltSALTsaltSALTsalt", 4096, 32 ) ),
+    "348c89dbcbd32b2f32d814b8116e84cf2b17347ebc1800181c4e2a1fb8dd53e1" )
+
+----------------------------------------------------------------------
+-- ustar writer/reader round-trip, incl. binary bodies with NUL bytes and
+-- a body that is an exact multiple of 512 (padding edge).
+----------------------------------------------------------------------
+
+local tar = assert( A._build_tar( {
+    { name = "cfg/user.tbl",            mode = 384, body = "a\0b\0c" },
+    { name = "scripts/data/x.tbl",      mode = 420, body = string.rep( "Z", 512 ) },
+    { name = "empty",                   mode = 420, body = "" },
+} ) )
+local ents = assert( A._parse_tar( tar ) )
+eq( "tar: entry count",        #ents,           3 )
+eq( "tar: name 1",             ents[ 1 ].name,  "cfg/user.tbl" )
+eq( "tar: mode 1 preserved",   ents[ 1 ].mode,  384 )
+eq( "tar: binary body 1",      ents[ 1 ].body,  "a\0b\0c" )
+eq( "tar: 512-multiple body",  ents[ 2 ].body,  string.rep( "Z", 512 ) )
+eq( "tar: empty body",         ents[ 3 ].body,  "" )
+
+-- an all-zero stream parses to zero entries (two terminator blocks only)
+eq( "tar: terminator-only -> 0 entries", #assert( A._parse_tar( string.rep( "\0", 1024 ) ) ), 0 )
+-- garbage / truncated stream degrades to (nil, err), never a raise
+ok( "tar: truncated stream -> nil", A._parse_tar( "not-a-tar-block-too-short" ) == nil )
+
+----------------------------------------------------------------------
+-- Manifest serialise/parse round-trip.
+----------------------------------------------------------------------
+
+local m_in = { hub_version = "v3.2.0-dev", created_at = 1700000000,
+    include_master_key = true, master_key_path = "cfg/master.key",
+    kinds = { ["__masterkey__"] = "masterkey", ["cfg/user.tbl"] = "tree" } }
+local m_out = assert( A._manifest_parse( A._manifest_serialize( m_in ) ) )
+eq( "manifest: string field",  m_out.hub_version,        "v3.2.0-dev" )
+eq( "manifest: number field",  m_out.created_at,         1700000000 )
+eq( "manifest: bool field",    m_out.include_master_key, true )
+eq( "manifest: kinds map a",   m_out.kinds[ "__masterkey__" ], "masterkey" )
+eq( "manifest: kinds map b",   m_out.kinds[ "cfg/user.tbl" ],  "tree" )
+
+----------------------------------------------------------------------
+-- Full pack()/unpack() plumbing (identity crypto, iters=1 for speed).
+----------------------------------------------------------------------
+
+local files = {
+    { name = "cfg/cfg.tbl",   mode = 420, body = "settings=1",       kind = "tree" },
+    { name = "cfg/user.tbl",  mode = 384, body = "user\0secret",     kind = "tree" },
+    { name = "__masterkey__", mode = 384, body = string.rep( "K", 32 ), kind = "masterkey" },
+}
+local meta = { hub_version = "v3.2.0-dev", created_at = 1700000042,
+    master_key_path = "/etc/luadch/master.key", include_master_key = true }
+
+local blob = assert( A.pack( files, meta, "correct horse", { iters = 1 } ) )
+eq( "pack: LDBK magic prefix", string.sub( blob, 1, 4 ), "LDBK" )
+
+local res = assert( A.unpack( blob, "correct horse" ) )
+eq( "unpack: format_version in meta", res.meta.format_version, 1 )
+eq( "unpack: hub_version",            res.meta.hub_version,    "v3.2.0-dev" )
+eq( "unpack: created_at",             res.meta.created_at,     1700000042 )
+eq( "unpack: master_key_path",        res.meta.master_key_path, "/etc/luadch/master.key" )
+eq( "unpack: include_master_key",     res.meta.include_master_key, true )
+eq( "unpack: file count (MANIFEST hidden)", #res.files, 3 )
+
+-- files come back in order, byte-identical, with mode + kind
+local by = { }
+for _, f in ipairs( res.files ) do by[ f.name ] = f end
+eq( "unpack: cfg.tbl body",       by[ "cfg/cfg.tbl" ].body,   "settings=1" )
+eq( "unpack: user.tbl body",      by[ "cfg/user.tbl" ].body,  "user\0secret" )
+eq( "unpack: user.tbl mode 0600", by[ "cfg/user.tbl" ].mode,  384 )
+eq( "unpack: masterkey body",     by[ "__masterkey__" ].body, string.rep( "K", 32 ) )
+eq( "unpack: masterkey kind",     by[ "__masterkey__" ].kind, "masterkey" )
+eq( "unpack: tree kind",          by[ "cfg/cfg.tbl" ].kind,   "tree" )
+ok( "unpack: MANIFEST not surfaced as a file", by[ "MANIFEST" ] == nil )
+
+----------------------------------------------------------------------
+-- Error paths
+----------------------------------------------------------------------
+
+ok( "pack: empty passphrase rejected",  ( A.pack( files, meta, "" ) ) == nil )
+ok( "pack: nil passphrase rejected",    ( A.pack( files, meta, nil ) ) == nil )
+ok( "pack: reserved name MANIFEST rejected",
+    ( A.pack( { { name = "MANIFEST", body = "x" } }, meta, "pw", { iters = 1 } ) ) == nil )
+ok( "unpack: empty passphrase rejected", ( A.unpack( blob, "" ) ) == nil )
+ok( "unpack: bad magic rejected",        ( A.unpack( "XXXX" .. string.rep( "\0", 60 ), "pw" ) ) == nil )
+ok( "unpack: too-short blob rejected",   ( A.unpack( "LDBK", "pw" ) ) == nil )
+
+-- bad format version byte
+local badver = "LDBK" .. string.char( 9 ) .. string.sub( blob, 6 )
+ok( "unpack: unsupported version rejected", ( A.unpack( badver, "correct horse" ) ) == nil )
+
+-- iterations bounds (pack side)
+ok( "pack: iters=0 rejected",     ( A.pack( files, meta, "pw", { iters = 0 } ) ) == nil )
+ok( "pack: iters>MAX rejected",   ( A.pack( files, meta, "pw", { iters = 99999999 } ) ) == nil )
+ok( "pack: non-string name rejected",
+    ( A.pack( { { name = 42, body = "x" } }, meta, "pw", { iters = 1 } ) ) == nil )
+ok( "pack: non-number mode rejected",
+    ( A.pack( { { name = "a", body = "x", mode = "644" } }, meta, "pw", { iters = 1 } ) ) == nil )
+
+-- iterations bounds (unpack side): a crafted header must DEGRADE to
+-- (nil, err), never raise and never spin an unbounded KDF (Finding 2).
+local iters0  = string.sub( blob, 1, 6 ) .. "\0\0\0\0"     .. string.sub( blob, 11 )
+local itersXL = string.sub( blob, 1, 6 ) .. "\255\255\255\255" .. string.sub( blob, 11 )
+local c0, r0 = pcall( A.unpack, iters0, "correct horse" )
+ok( "unpack: iters=0 header -> nil, no raise", c0 and r0 == nil )
+local cx, rx = pcall( A.unpack, itersXL, "correct horse" )
+ok( "unpack: huge iters header -> nil, no raise (no KDF spin)", cx and rx == nil )
+
+----------------------------------------------------------------------
+-- checksum + sidecar helpers
+----------------------------------------------------------------------
+
+eq( "checksum length 64 hex", #A.checksum( "hello" ), 64 )
+eq( "checksum == sha256(hello)", A.checksum( "hello" ),
+    "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824" )
+eq( "sidecar_line format", A.sidecar_line( "deadbeef", "backup.ldbk" ),
+    "deadbeef  backup.ldbk\n" )
+
+----------------------------------------------------------------------
+-- Output
+----------------------------------------------------------------------
+
+if fails > 0 then
+    io.stderr:write( string.format( "\nFAIL: %d/%d checks failed\n", fails, passes + fails ) )
+    os.exit( 1 )
+end
+print( string.format( "OK: %d checks passed", passes ) )

--- a/tests/unit/backup_archive_test.lua
+++ b/tests/unit/backup_archive_test.lua
@@ -28,7 +28,7 @@
 local _real = {
     type = type, error = error, pcall = pcall, tostring = tostring,
     tonumber = tonumber, load = load, pairs = pairs, ipairs = ipairs,
-    string = string, table = table, io = io,
+    string = string, table = table, io = io, debug = debug,
     adclib = {
         random_bytes = function( n ) return string.rep( "R", n ) end,
         aes_gcm_seal = function( _key, _nonce, pt ) return pt .. string.rep( "\0", 16 ) end,
@@ -131,6 +131,23 @@ eq( "manifest: number field",  m_out.created_at,         1700000000 )
 eq( "manifest: bool field",    m_out.include_master_key, true )
 eq( "manifest: kinds map a",   m_out.kinds[ "__masterkey__" ], "masterkey" )
 eq( "manifest: kinds map b",   m_out.kinds[ "cfg/user.tbl" ],  "tree" )
+
+-- #485: a crafted manifest must not hang the offline restore. Pre-fix this
+-- spins forever (the eval had no work bound); post-fix the instruction-count
+-- hook aborts it and _manifest_parse returns (nil, err). If this test ever
+-- HANGS instead of failing fast, the bound regressed.
+do
+    local bad = A._manifest_parse( "return (function() while true do end end)()" )
+    ok( "manifest: infinite loop bounded -> nil", bad == nil )
+    -- an over-budget bounded loop is refused too, not silently accepted
+    local heavy = A._manifest_parse( "local x=0 for i=1,1e9 do x=x+1 end return {}" )
+    ok( "manifest: over-budget loop -> nil", heavy == nil )
+    -- oversized manifest rejected before load
+    local huge = A._manifest_parse( "return {}" .. string.rep( " ", 70000 ) )
+    ok( "manifest: oversized -> nil", huge == nil )
+    -- a normal manifest still parses after all that
+    ok( "manifest: normal still ok", type( A._manifest_parse( "return { a = 1 }" ) ) == "table" )
+end
 
 ----------------------------------------------------------------------
 -- Full pack()/unpack() plumbing (identity crypto, iters=1 for speed).

--- a/tests/unit/backup_test.lua
+++ b/tests/unit/backup_test.lua
@@ -1,0 +1,202 @@
+--[[
+
+    tests/unit/backup_test.lua
+
+    Unit tests for core/backup.lua's pure decision logic, driven through a
+    stubbed `use` shim (no real filesystem / crypto):
+      - _config(): cfg + secrets interpretation, defaults, dir normalisation
+      - _collection_spec(): which files enter a backup + their restore names,
+        modes and kinds; master.key inclusion toggle; .tbl filter that skips
+        .tmp half-writes and non-.tbl files; the injected directory lister
+      - _rotation_victims(): keep-newest-N pruning selection
+
+    The full read/pack/write/rotate path (run/readiness) touches the real
+    filesystem + adclib and is covered by the backup smoke test (PR-A).
+
+    Run: lua5.4 tests/unit/backup_test.lua   (exit 0 = pass, 1 = fail)
+
+]]--
+
+----------------------------------------------------------------------
+-- `use` shim
+----------------------------------------------------------------------
+
+local _cfg    = { }   -- cfg.get source (set per test)
+local _secret = { }   -- secrets.lookup source
+
+local _real = {
+    type = type, pcall = pcall, tostring = tostring, tonumber = tonumber, ipairs = ipairs,
+    string = string, table = table, os = os, io = io,
+    const   = { PROGRAM_NAME = "Luadch-NG", VERSION = "v3.2.0-dev", CONFIG_PATH = "cfg/" },
+    cfg     = { get = function( k ) return _cfg[ k ] end },
+    out     = { put = function( ) end, error = function( ) end },
+    secrets = { lookup = function( k ) return _secret[ k ] end },
+    backup_archive = { pack = function( ) end, checksum = function( ) return "x" end,
+        sidecar_line = function( ) return "" end },
+    makedir = function( ) return true end,
+    listdir = function( ) return { } end,
+}
+_G.use = function( name )
+    local v = _real[ name ]
+    if v == nil then error( "backup_test shim missing dep: use \"" .. tostring( name ) .. "\"" ) end
+    return v
+end
+
+local B = assert( loadfile( "core/backup.lua" ) )( )
+
+----------------------------------------------------------------------
+-- harness
+----------------------------------------------------------------------
+
+local passes, fails = 0, 0
+local function ok( label, cond )
+    if cond then passes = passes + 1
+    else fails = fails + 1; io.stderr:write( "FAIL: " .. label .. "\n" ) end
+end
+local function eq( label, got, want )
+    if got == want then passes = passes + 1
+    else
+        fails = fails + 1
+        io.stderr:write( string.format( "FAIL: %s\n  got:  %s\n  want: %s\n",
+            label, tostring( got ), tostring( want ) ) )
+    end
+end
+local function find_entry( spec, name )
+    for _, e in ipairs( spec ) do if e.name == name then return e end end
+end
+
+----------------------------------------------------------------------
+-- _config: defaults when cfg is empty
+----------------------------------------------------------------------
+
+_cfg, _secret = { }, { }
+do
+    local c = B._config( )
+    eq( "default enabled = true",    c.enabled, true )
+    eq( "default dir = cfg/backups", c.dir,     "cfg/backups" )
+    eq( "default keep = 7",          c.keep,    7 )
+    eq( "default include_mk = true", c.include_mk, true )
+    eq( "no passphrase -> nil",      c.passphrase, nil )
+end
+
+----------------------------------------------------------------------
+-- _config: explicit values + dir normalisation + keep clamp
+----------------------------------------------------------------------
+
+_cfg = {
+    etc_backup_enabled = false,
+    etc_backup_dir = "/mnt/backups///",
+    etc_backup_keep = 0,             -- must clamp to >= 1
+    etc_backup_include_master_key = false,
+}
+_secret = { etc_backup_passphrase = "hunter2" }
+do
+    local c = B._config( )
+    eq( "explicit enabled = false",   c.enabled, false )
+    eq( "trailing slashes stripped",  c.dir,     "/mnt/backups" )
+    eq( "keep clamped to 1",          c.keep,    1 )
+    eq( "explicit include_mk = false", c.include_mk, false )
+    eq( "passphrase from secrets",    c.passphrase, "hunter2" )
+end
+
+-- empty-string passphrase is treated as unset
+_secret = { etc_backup_passphrase = "" }
+eq( "empty passphrase -> nil", B._config( ).passphrase, nil )
+
+----------------------------------------------------------------------
+-- _collection_spec: full set with master.key, filtered plugin state
+----------------------------------------------------------------------
+
+local function fake_lister( dir )
+    if dir == "scripts/data" then
+        return { "cmd_ban_bans.tbl", "etc_geoip.tbl", "half.tbl.tmp", "readme.txt" }
+    elseif dir == "scripts/cfg" then
+        return { "etc_something.tbl" }
+    end
+    return { }
+end
+
+do
+    local spec = B._collection_spec( true, "/etc/luadch/master.key", nil, fake_lister )
+
+    ok( "cfg.tbl included",        find_entry( spec, "cfg/cfg.tbl" ) ~= nil )
+    ok( "user.tbl included",       find_entry( spec, "cfg/user.tbl" ) ~= nil )
+    ok( "user.tbl.bak included",   find_entry( spec, "cfg/user.tbl.bak" ) ~= nil )
+
+    local key = find_entry( spec, "certs/serverkey.pem" )
+    ok( "serverkey.pem included",  key ~= nil )
+    eq( "serverkey mode 0600",     key and key.mode, 384 )
+    ok( "servercert.pem included", find_entry( spec, "certs/servercert.pem" ) ~= nil )
+    ok( "cacert.pem included",     find_entry( spec, "certs/cacert.pem" ) ~= nil )
+
+    local mk = find_entry( spec, "__masterkey__" )
+    ok( "master.key entry present", mk ~= nil )
+    eq( "master.key kind",          mk and mk.kind, "masterkey" )
+    eq( "master.key mode 0600",     mk and mk.mode, 384 )
+    eq( "master.key read path",     mk and mk.read, "/etc/luadch/master.key" )
+
+    ok( "scripts/data .tbl included",  find_entry( spec, "scripts/data/cmd_ban_bans.tbl" ) ~= nil )
+    ok( "cache .tbl included too",     find_entry( spec, "scripts/data/etc_geoip.tbl" ) ~= nil )
+    ok( "scripts/cfg .tbl included",   find_entry( spec, "scripts/cfg/etc_something.tbl" ) ~= nil )
+    ok( ".tmp half-write skipped",     find_entry( spec, "scripts/data/half.tbl.tmp" ) == nil )
+    ok( "non-.tbl file skipped",       find_entry( spec, "scripts/data/readme.txt" ) == nil )
+
+    local state = find_entry( spec, "scripts/data/cmd_ban_bans.tbl" )
+    eq( "state mode 0640", state and state.mode, 416 )
+end
+
+-- include_master_key = false -> no master.key entry
+do
+    local spec = B._collection_spec( false, "/etc/luadch/master.key", nil, fake_lister )
+    ok( "master.key excluded when include=false", find_entry( spec, "__masterkey__" ) == nil )
+    ok( "cfg.tbl still there", find_entry( spec, "cfg/cfg.tbl" ) ~= nil )
+end
+
+-- custom ssl_params paths honoured
+do
+    local ssl = { key = "certs/mykey.pem", certificate = "certs/mycert.pem", cafile = "certs/myca.pem" }
+    local spec = B._collection_spec( false, nil, ssl, fake_lister )
+    ok( "custom serverkey path",  find_entry( spec, "certs/mykey.pem" ) ~= nil )
+    ok( "custom cert path",       find_entry( spec, "certs/mycert.pem" ) ~= nil )
+    ok( "default serverkey absent when overridden", find_entry( spec, "certs/serverkey.pem" ) == nil )
+end
+
+----------------------------------------------------------------------
+-- _rotation_victims: keep newest N, oldest pruned; non-backups ignored
+----------------------------------------------------------------------
+
+do
+    local names = {
+        "luadch-backup-20260101-010101.ldbk",
+        "luadch-backup-20260102-010101.ldbk",
+        "luadch-backup-20260103-010101.ldbk",
+        "luadch-backup-20260104-010101.ldbk",
+        "luadch-backup-20260105-010101.ldbk",
+        "luadch-backup-20260105-010101.ldbk.sha256",   -- sidecar, NOT a victim
+        "some-other-file.txt",
+    }
+    local v = B._rotation_victims( names, 3 )
+    eq( "victim count (5 backups, keep 3)", #v, 2 )
+    eq( "oldest victim first",  v[ 1 ], "luadch-backup-20260101-010101.ldbk" )
+    eq( "second oldest victim", v[ 2 ], "luadch-backup-20260102-010101.ldbk" )
+    -- sidecar + non-backup never selected
+    for _, name in ipairs( v ) do
+        ok( "victim is an .ldbk, not a sidecar/other", name:match( "%.ldbk$" ) ~= nil and name:match( "%.sha256$" ) == nil )
+    end
+end
+
+-- fewer backups than keep -> nothing pruned
+do
+    local v = B._rotation_victims( { "luadch-backup-20260101-010101.ldbk" }, 7 )
+    eq( "keep > count -> no victims", #v, 0 )
+end
+
+----------------------------------------------------------------------
+-- output
+----------------------------------------------------------------------
+
+if fails > 0 then
+    io.stderr:write( string.format( "\nFAIL: %d/%d checks failed\n", fails, passes + fails ) )
+    os.exit( 1 )
+end
+print( string.format( "OK: %d checks passed", passes ) )

--- a/tests/unit/etc_backup_schedule_test.lua
+++ b/tests/unit/etc_backup_schedule_test.lua
@@ -1,0 +1,92 @@
+--[[
+
+    tests/unit/etc_backup_schedule_test.lua
+
+    Unit tests for scripts/etc_backup.lua's pure schedule math (_next_daily,
+    _compute_next), loaded with stubbed sandbox globals. The command
+    dispatch, owner nag and the actual backup run are covered by the backup
+    smoke test (hub boots with etc_backup, +backup now produces an artifact).
+
+    Run: lua5.4 tests/unit/etc_backup_schedule_test.lua   (exit 0 = pass)
+
+]]--
+
+-- Stub the sandbox globals the plugin binds at load. Assigning without
+-- `local` sets the real global the plugin's `local x = x` then captures.
+local _noop = function( ) end
+cfg     = { get = function( ) return nil end, loadlanguage = function( ) return { }, nil end }
+hub     = { debug = _noop, getbot = function( ) return { } end, getusers = function( ) return { } end,
+            setlistener = _noop, import = function( ) return nil end }
+backup  = { readiness = function( ) return { ok = true, issues = { } } end,
+            run = function( ) end, list = function( ) return { } end }
+audit   = { build = function( ) return { } end, fire = _noop }
+secrets = { register = _noop, lookup = function( ) return nil end }
+util    = { loadtable = function( ) return nil end, savetable = _noop }
+utf     = string
+PROCESSED = true
+
+local E = assert( loadfile( "scripts/etc_backup.lua" ) )( )
+
+local passes, fails = 0, 0
+local function ok( label, cond )
+    if cond then passes = passes + 1
+    else fails = fails + 1; io.stderr:write( "FAIL: " .. label .. "\n" ) end
+end
+local function eq( label, got, want )
+    if got == want then passes = passes + 1
+    else fails = fails + 1
+        io.stderr:write( string.format( "FAIL: %s\n  got:  %s\n  want: %s\n", label, tostring( got ), tostring( want ) ) )
+    end
+end
+
+----------------------------------------------------------------------
+-- _next_daily: valid HH:MM -> next local occurrence strictly after now
+----------------------------------------------------------------------
+
+local now = os.time( )   -- real local time
+do
+    local n = E._next_daily( now, "04:00" )
+    ok( "04:00 -> a time",            type( n ) == "number" )
+    ok( "04:00 -> strictly future",   n and n > now )
+    ok( "04:00 -> within 24h",        n and n <= now + 86400 )
+    eq( "04:00 -> lands on 04:00 local", n and os.date( "%H:%M", n ), "04:00" )
+
+    -- a time one minute in the future today should be today (not +24h)
+    local soon = os.date( "*t", now + 120 )
+    local hhmm = string.format( "%02d:%02d", soon.hour, soon.min )
+    local n2 = E._next_daily( now, hhmm )
+    ok( "near-future HH:MM is today (<= 2min away)", n2 and n2 - now <= 120 and n2 > now )
+end
+
+-- invalid inputs -> nil (caller falls back to interval)
+eq( "empty -> nil",       E._next_daily( now, "" ),      nil )
+eq( "bad format -> nil",  E._next_daily( now, "4pm" ),   nil )
+eq( "hour 25 -> nil",     E._next_daily( now, "25:00" ), nil )
+eq( "min 60 -> nil",      E._next_daily( now, "04:60" ), nil )
+eq( "non-string -> nil",  E._next_daily( now, 400 ),     nil )
+
+----------------------------------------------------------------------
+-- _compute_next: daily wins; else interval from anchor; overdue fires now
+----------------------------------------------------------------------
+
+-- interval mode (daily empty)
+eq( "interval from anchor",  E._compute_next( 1000, 500, "", 3600 ), 4100 )   -- 500 + 3600
+eq( "interval from now (no anchor)", E._compute_next( 1000, nil, "", 3600 ), 4600 )   -- 1000 + 3600
+eq( "overdue interval -> now", E._compute_next( 10000, 500, "", 3600 ), 10000 )   -- 500+3600 <= now
+eq( "interval 0 -> nil",     E._compute_next( 1000, 500, "", 0 ),    nil )
+eq( "no schedule -> nil",    E._compute_next( 1000, 500, "", nil ),  nil )
+
+-- daily wins over interval when both set
+do
+    local n = E._compute_next( now, now, "04:00", 3600 )
+    eq( "daily wins over interval", n and os.date( "%H:%M", n ), "04:00" )
+end
+
+-- invalid daily falls through to interval
+eq( "bad daily -> interval fallback", E._compute_next( 1000, 500, "nope", 3600 ), 4100 )
+
+if fails > 0 then
+    io.stderr:write( string.format( "\nFAIL: %d/%d checks failed\n", fails, passes + fails ) )
+    os.exit( 1 )
+end
+print( string.format( "OK: %d checks passed", passes ) )

--- a/tests/unit/restore_test.lua
+++ b/tests/unit/restore_test.lua
@@ -1,0 +1,178 @@
+--[[
+
+    tests/unit/restore_test.lua
+
+    Unit tests for core/restore.lua's pure decision logic (the offline-restore
+    entry, #480 PR-B), loaded through its RESTORE_TEST seam so no adclib C
+    module, no real filesystem and no `--restore` run is needed:
+      - _safe_rel(): the SECURITY guard - reject absolute paths / ".." / drive
+        / UNC, normalise separators, strip "." (path-traversal defence the
+        backup_archive.unpack note demands before any write)
+      - _resolve_masterkey_dest(): override > manifest path > in-tree default
+      - _build_plan(): __masterkey__ sentinel + secret-mode classification +
+        unsafe entries routed to rejects, never to the write plan
+      - _verify_sidecar(): sha256 sidecar match / mismatch / missing
+
+    A fake _G.adclib lets backup_archive load without the built C module
+    (its sha256 checksum path is pure Lua, so _verify_sidecar is exercised
+    for real).
+
+    Run: lua5.4 tests/unit/restore_test.lua   (exit 0 = pass, 1 = fail)
+
+]]--
+
+-- backup_archive loads via restore.lua's loadscript; a minimal fake adclib
+-- skips the require() and the C-vs-Lua pbkdf2 cross-check at load.
+_G.adclib = { }
+_G.RESTORE_TEST = true
+
+local R = assert( loadfile( "core/restore.lua" ) )( )
+assert( type( R ) == "table", "restore.lua did not return its test seam" )
+
+----------------------------------------------------------------------
+-- harness
+----------------------------------------------------------------------
+
+local passes, fails = 0, 0
+local function ok( label, cond )
+    if cond then passes = passes + 1
+    else fails = fails + 1; io.stderr:write( "FAIL: " .. label .. "\n" ) end
+end
+local function eq( label, got, want )
+    if got == want then passes = passes + 1
+    else
+        fails = fails + 1
+        io.stderr:write( string.format( "FAIL: %s\n  got:  %s\n  want: %s\n",
+            label, tostring( got ), tostring( want ) ) )
+    end
+end
+local function find_dest( plan, dest )
+    for _, p in ipairs( plan ) do if p.dest == dest then return p end end
+end
+
+----------------------------------------------------------------------
+-- _safe_rel: accept in-tree relative paths
+----------------------------------------------------------------------
+
+eq( "plain relative kept",        R._safe_rel( "cfg/cfg.tbl" ),          "cfg/cfg.tbl" )
+eq( "nested relative kept",       R._safe_rel( "scripts/data/x.tbl" ),   "scripts/data/x.tbl" )
+eq( "leading ./ stripped",        R._safe_rel( "./cfg/x.tbl" ),          "cfg/x.tbl" )
+eq( "backslash normalised",       R._safe_rel( "scripts\\data\\x.tbl" ), "scripts/data/x.tbl" )
+eq( "single file kept",           R._safe_rel( "cfg.tbl" ),              "cfg.tbl" )
+
+----------------------------------------------------------------------
+-- _safe_rel: reject anything that could escape the install root
+----------------------------------------------------------------------
+
+ok( "reject empty",               R._safe_rel( "" ) == nil )
+ok( "reject nil",                 R._safe_rel( nil ) == nil )
+ok( "reject POSIX absolute",      R._safe_rel( "/etc/passwd" ) == nil )
+ok( "reject drive absolute",      R._safe_rel( "C:\\Windows\\x" ) == nil )
+ok( "reject UNC backslash",       R._safe_rel( "\\\\host\\share\\x" ) == nil )
+ok( "reject leading ..",          R._safe_rel( "../../etc/cron.d/x" ) == nil )
+ok( "reject mid-path ..",         R._safe_rel( "cfg/../../etc/x" ) == nil )
+ok( "reject bare ..",             R._safe_rel( ".." ) == nil )
+ok( "reject backslash ..",        R._safe_rel( "cfg\\..\\..\\x" ) == nil )
+ok( "reject dot-only",            R._safe_rel( "." ) == nil )
+-- Windows normalises trailing dots/spaces, so a dot/space-only segment could
+-- collapse onto "." / ".." after the check - refuse the whole class.
+ok( "reject dot-dot-space",       R._safe_rel( "cfg/.. /x" ) == nil )
+ok( "reject triple-dot",          R._safe_rel( "a/.../b" ) == nil )
+ok( "reject space-only segment",  R._safe_rel( "a/ /b" ) == nil )
+-- but a leading-dot filename is legitimate and kept
+eq( "leading-dot filename kept",  R._safe_rel( "cfg/..foo" ), "cfg/..foo" )
+
+----------------------------------------------------------------------
+-- _resolve_masterkey_dest: override > manifest > default
+----------------------------------------------------------------------
+
+eq( "mk override wins", R._resolve_masterkey_dest( { master_key_path = "/a/b" }, "/override/mk" ), "/override/mk" )
+eq( "mk from manifest", R._resolve_masterkey_dest( { master_key_path = "/etc/luadch/master.key" }, nil ),
+    "/etc/luadch/master.key" )
+eq( "mk default",       R._resolve_masterkey_dest( { }, nil ),      "cfg/master.key" )
+eq( "mk empty override ignored", R._resolve_masterkey_dest( { master_key_path = "/m" }, "" ), "/m" )
+
+----------------------------------------------------------------------
+-- _build_plan: sentinel, secret classification, reject routing
+----------------------------------------------------------------------
+
+do
+    local files = {
+        { name = "cfg/cfg.tbl",           body = "c",  kind = "tree" },
+        { name = "cfg/user.tbl",          body = "u",  kind = "tree" },
+        { name = "certs/serverkey.pem",   body = "k",  kind = "tree" },
+        { name = "certs/servercert.pem",  body = "cc", kind = "tree" },
+        { name = "scripts/data/a.tbl",    body = "a",  kind = "tree" },
+        { name = "__masterkey__",         body = "MK", kind = "masterkey" },
+        { name = "../../etc/cron.d/evil", body = "x",  kind = "tree" },
+    }
+    local plan, rejects = R._build_plan( files, { master_key_path = "cfg/master.key" }, nil )
+
+    ok( "cfg.tbl in plan",          find_dest( plan, "cfg/cfg.tbl" ) ~= nil )
+    ok( "user.tbl in plan",         find_dest( plan, "cfg/user.tbl" ) ~= nil )
+    ok( "serverkey in plan",        find_dest( plan, "certs/serverkey.pem" ) ~= nil )
+    ok( "servercert in plan",       find_dest( plan, "certs/servercert.pem" ) ~= nil )
+
+    local mk = find_dest( plan, "cfg/master.key" )
+    ok( "masterkey sentinel -> in-tree dest", mk ~= nil )
+    eq( "masterkey body carried",     mk and mk.body, "MK" )
+    eq( "masterkey flagged",          mk and mk.masterkey, true )
+    ok( "non-mk entry unflagged",     find_dest( plan, "cfg/cfg.tbl" ).masterkey == nil )
+
+    ok( "unsafe entry NOT in plan",   find_dest( plan, "../../etc/cron.d/evil" ) == nil )
+    eq( "one reject recorded",        #rejects, 1 )
+    eq( "reject names the entry",     rejects[ 1 ] and rejects[ 1 ].name, "../../etc/cron.d/evil" )
+end
+
+-- master.key override redirects the sentinel dest (operator opted in, absolute OK)
+do
+    local plan = R._build_plan( { { name = "__masterkey__", body = "MK", kind = "masterkey" } },
+        { master_key_path = "cfg/master.key" }, "/secure/mk" )
+    ok( "override redirects sentinel", find_dest( plan, "/secure/mk" ) ~= nil )
+end
+
+-- F1: an out-of-tree manifest master_key_path is NOT honoured without an
+-- explicit --master-key-path (a foreign archive must not steer an absolute write)
+do
+    local plan, rejects = R._build_plan(
+        { { name = "__masterkey__", body = "PWN", kind = "masterkey" } },
+        { master_key_path = "/etc/cron.d/evil" }, nil )
+    eq( "out-of-tree mk -> nothing in plan", #plan, 0 )
+    eq( "out-of-tree mk -> rejected",        #rejects, 1 )
+    ok( "reject mentions --master-key-path",
+        rejects[ 1 ] and rejects[ 1 ].reason:match( "master%-key%-path" ) ~= nil )
+end
+
+-- F1: the SAME out-of-tree path IS honoured when the operator passes it explicitly
+do
+    local plan = R._build_plan(
+        { { name = "__masterkey__", body = "MK", kind = "masterkey" } },
+        { master_key_path = "/etc/cron.d/evil" }, "/etc/luadch/master.key" )
+    ok( "explicit override honours absolute", find_dest( plan, "/etc/luadch/master.key" ) ~= nil )
+end
+
+----------------------------------------------------------------------
+-- _verify_sidecar: real sha256 via the loaded archive module
+----------------------------------------------------------------------
+
+do
+    local blob = "the sealed bytes"
+    local hex  = R.archive.checksum( blob )
+    eq( "sidecar match -> ok",       R._verify_sidecar( blob, hex .. "  luadch-backup.ldbk\n" ), "ok" )
+    eq( "sidecar wrong -> mismatch", R._verify_sidecar( blob, string.rep( "0", 64 ) .. "  x\n" ), "mismatch" )
+    eq( "no hex token -> mismatch",  R._verify_sidecar( blob, "not-a-hash\n" ), "mismatch" )
+    eq( "nil sidecar -> missing",    R._verify_sidecar( blob, nil ), "missing" )
+    eq( "empty sidecar -> missing",  R._verify_sidecar( blob, "" ), "missing" )
+    -- case-insensitive hex compare
+    eq( "uppercase hex still ok",    R._verify_sidecar( blob, string.upper( hex ) .. "  x\n" ), "ok" )
+end
+
+----------------------------------------------------------------------
+-- output
+----------------------------------------------------------------------
+
+if fails > 0 then
+    io.stderr:write( string.format( "\nFAIL: %d/%d checks failed\n", fails, passes + fails ) )
+    os.exit( 1 )
+end
+print( string.format( "OK: %d checks passed", passes ) )


### PR DESCRIPTION
Promote the **#480 automatic-backup arc** to master (validated on the dev testhub).

## What lands

Encrypted local backup + offline restore, no cloud:
- **P0** LDBK1 archive format (#481) - pure-Lua tar + AES-256-GCM, PBKDF2-in-C
- **PR-A** engine + `etc_backup` scheduler plugin (#482)
- **PR-B** `./luadch --restore` standalone offline entry (#484)
- Manifest eval bound so a crafted archive can't hang restore (#485)
- Docker restore UX + `BACKUP.md` operator guide with an rclone off-site walkthrough (#487)
- Docs currency pass (#489) + on-master feature-list bullets

Plus the `adclib` `%zu`->`%I` diagnostic fix (#483, same `lua_pushvfstring`-conversion bug class as the P0 `listdir` `%lu` fix) and the pre-arc docs refresh (#479).

## Validation

- Live Docker testhub PASSED end-to-end: `+backup now` -> stop -> `--verify` -> `--restore --force` (F1 out-of-tree master.key guard fired) -> 40 files restored -> hub boots + login works.
- Every arc PR carried its own two-pass review into dev.
- #483 is CI-proven (RED/GREEN regression + independent review); all Smoke green on both legs.

Merge commit, no squash, no tag (per §8). Arc tracker #480 is closed manually after merge; #483 / #485 close via their commit keywords.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
