### PR TITLE
docs(docker): wire backup passphrase + secret env vars in compose/.env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,31 @@ PGID=1000
 # scripts; with that pattern you can keep the auto-sync ON.
 #
 # LUADCH_AUTOSYNC_SCRIPTS=1
+
+
+# --- Secrets (env-var-first; see core/secrets.lua) --------------------
+#
+# Any cfg key that holds a secret can be supplied via the environment
+# instead of cfg/cfg.tbl, using the name LUADCH_<UPPER_CFG_KEY>. The env
+# var wins over cfg.tbl; an empty or unset var falls back to cfg.tbl.
+#
+# Docker note: setting a value here is not enough on its own - the
+# variable must ALSO be listed in the service's `environment:` block in
+# docker-compose.yml (an .env entry alone only does compose
+# interpolation, it does not reach the container). The shipped compose
+# already wires LUADCH_ETC_BACKUP_PASSPHRASE for you; uncomment the
+# matching line there for the opt-in plugin keys below.
+
+# Backup passphrase for the bundled etc_backup plugin (#480). The plugin
+# is inert until this is set (and etc_backup.lua is enabled in the cfg
+# scripts list). Also used by `docker compose run --rm luadch --restore`.
+# Use a long passphrase and store it somewhere safe: lose it and existing
+# .ldbk backups are unrecoverable. See docs/BACKUP.md.
+# LUADCH_ETC_BACKUP_PASSPHRASE=change-me-to-a-long-passphrase
+
+# Opt-in blocklist / GeoIP plugin secrets (only if you enable those
+# plugins; see docs/BLOCKLIST.md). Uncomment the matching line in
+# docker-compose.yml's environment: block as well.
+# LUADCH_ETC_GEOIP_LICENSE_KEY=
+# LUADCH_ETC_PROXYDETECT_API_KEY=
+# LUADCH_ETC_BLOCKLIST_FEEDS_ABUSEIPDB_KEY=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,19 @@ services:
       # the mounted scripts/ on every container start. See .env.example
       # for the full explanation. Default ON (1).
       LUADCH_AUTOSYNC_SCRIPTS: "${LUADCH_AUTOSYNC_SCRIPTS:-1}"
+      # Backup passphrase for the bundled etc_backup plugin (#480). The
+      # plugin ships enabled-but-inert; it activates once this is set AND
+      # etc_backup.lua is in cfg.scripts. Set the value in .env - it MUST
+      # be listed here to reach the container (an .env entry alone only
+      # does compose interpolation). Empty = unset (falls back to
+      # cfg.tbl). Also used by `--restore`. See docs/BACKUP.md.
+      LUADCH_ETC_BACKUP_PASSPHRASE: "${LUADCH_ETC_BACKUP_PASSPHRASE:-}"
+      # Opt-in blocklist / GeoIP plugin secrets (env-var-first, see
+      # core/secrets.lua). Only needed if you enable those plugins;
+      # uncomment the matching .env line too. See docs/BLOCKLIST.md.
+      # LUADCH_ETC_GEOIP_LICENSE_KEY: "${LUADCH_ETC_GEOIP_LICENSE_KEY:-}"
+      # LUADCH_ETC_PROXYDETECT_API_KEY: "${LUADCH_ETC_PROXYDETECT_API_KEY:-}"
+      # LUADCH_ETC_BLOCKLIST_FEEDS_ABUSEIPDB_KEY: "${LUADCH_ETC_BLOCKLIST_FEEDS_ABUSEIPDB_KEY:-}"
     ports:
       # ADC over TLS. The keyprint is logged on container start;
       # share the resulting adcs://host:5001/?kp=SHA256/<hash> URL
@@ -33,9 +46,14 @@ services:
       # Plain ADC (legacy clients / debug). Default OFF since v3.1.6;
       # uncomment AND add 5000 to tcp_ports in cfg/cfg.tbl to enable.
       # - "5000:5000"
+      # HTTP / JSON API (#82). Off by default (http_port = false). To
+      # enable: set http_port + an http_api_tokens entry in cfg/cfg.tbl,
+      # then expose the matching port here. See docs/HTTP_API.md.
+      # - "8080:8080"
     volumes:
       # Hub configuration. cfg/cfg.tbl is the main settings file;
-      # cfg/user.tbl is the (encrypted) user database.
+      # cfg/user.tbl is the (encrypted) user database. Encrypted backups
+      # also land here by default (cfg/backups/, #480) - no extra mount.
       - ./cfg:/opt/luadch/cfg
       # Plugin scripts. Seeded from the bundled set on first start;
       # drop-in additions or per-file overrides land here.


### PR DESCRIPTION
The shipped `docker-compose.yml` and `.env.example` predated the #480 backup arc and `core/secrets.lua`, so an operator had no in-file pointer to the `LUADCH_*` secret variables.

- **`docker-compose.yml`:** pre-wire `LUADCH_ETC_BACKUP_PASSPHRASE` (active with an empty default = "unset" per `secrets.lua:90`, so just setting it in `.env` activates the bundled `etc_backup` plugin); commented `LUADCH_ETC_{GEOIP_LICENSE_KEY,PROXYDETECT_API_KEY,BLOCKLIST_FEEDS_ABUSEIPDB_KEY}` for the opt-in plugins; a commented HTTP-API port (#82); note that backups land in the already-mounted `cfg/backups/`.
- **`.env.example`:** a Secrets section documenting the `LUADCH_<UPPER_CFG_KEY>` convention, the Docker "must also be in `environment:`" gotcha, and the four keys.

All four env-var names verified against the `secrets.lookup` call sites; `docker compose config` validates clean. Consistent with `docs/DOCKER.md` §Backups (#487). Config/docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
