### PR TITLE
fix(proxydetect): report/audit the connect-time nick, not "?" (#504)

### DIFF
--- a/scripts/etc_proxydetect.lua
+++ b/scripts/etc_proxydetect.lua
@@ -106,6 +106,13 @@
         - Phase F2 (closes #352): VPNAPI.io + IPQualityScore adapters
           (key kept out of the failure log via http_client `log_url`) +
           op-chat alert on a run of provider failures.
+    v0.03: by Aybo
+        - #504: the op-chat report + audit now carry the connect-time
+          nick as a fallback. The async verdict re-resolves the user by
+          SID; a connection that dropped before the reply landed (common
+          for short-lived hosting/proxy IPs) resolved to nil, so the
+          report rendered "The user ? with IP ...". The nick is now
+          captured at connect and threaded through as a fallback.
 
 ]]--
 
@@ -115,7 +122,7 @@
 --------------
 
 local scriptname = "etc_proxydetect"
-local scriptversion = "0.02"
+local scriptversion = "0.03"
 
 local cmd_status = "proxydetect"
 
@@ -555,16 +562,24 @@ end
 -- left by the time an async lookup returned) - we still audit / report
 -- / cache / store-push for observability + future pre-handshake blocks;
 -- we only KICK when the user is still live.
-local function apply_positive( user, ip, family, types, matched, cached )
+local function apply_positive( user, ip, family, types, matched, cached, last_nick )
     local matched_str = table_concat( matched, "," )
+    -- `user` is nil when the connection dropped before the async verdict
+    -- returned (the SID re-resolve found nobody). `last_nick` is the nick
+    -- captured at connect time, used as a fallback so the report + audit
+    -- still name who was flagged instead of rendering "?" (#504). Stored
+    -- in `meta.nick` too so log consumers have an always-present nick even
+    -- when the audit target snapshot is absent (the dropped-user case);
+    -- it intentionally overlaps the target snapshot for a live user.
+    local nick = ( user and user:nick( ) ) or last_nick or "?"
     if audit then
         audit.fire( audit.build( "proxydetect.block", scriptname, user, kick_reason,
             { ip = ip, provider = adapter.source, types = matched_str,
-              action = action, cached = cached and true or false } ) )
+              action = action, cached = cached and true or false, nick = nick } ) )
     end
     if report then
         report.send( report_activate, report_hubbot, report_opchat, report_llevel,
-            utf_format( msg_report, user and user:nick( ) or "?", ip, matched_str,
+            utf_format( msg_report, nick, ip, matched_str,
                 adapter.source, action ) )
     end
     if action == "block" then
@@ -636,7 +651,7 @@ end
 
 -- The async response handler. Re-resolves the user from the SID (never
 -- the closed-over listener object) and guards SID reuse via the CID.
-local function handle_response( res, ip, family, sid, cid )
+local function handle_response( res, ip, family, sid, cid, nick )
     inflight[ ip ] = nil
     if res.status ~= 200 then
         return apply_failure( sid, cid, ip, "HTTP status " .. tostring( res.status ) )
@@ -668,7 +683,7 @@ local function handle_response( res, ip, family, sid, cid )
 
     local u = hub_issidonline( sid )
     if u and u:cid( ) ~= cid then u = nil end    -- SID reused by another client
-    apply_positive( u, ip, family, types, matched, false )
+    apply_positive( u, ip, family, types, matched, false, nick )
 end
 
 
@@ -706,6 +721,11 @@ local check_proxydetect = function( user )
 
     inflight[ ip ] = true
     local sid, cid = user:sid( ), user:cid( )
+    -- Capture the nick now, while the user is live: the async callback
+    -- may re-resolve to nil if the connection drops first (#504). Empty
+    -- -> nil so the "?" fallback still applies for a nickless login.
+    local nick = user:nick( )
+    if nick == "" then nick = nil end
     local rq = adapter.build_request( ip, api_key )
     local ok, rerr = http_client.request{
         url          = rq.url,
@@ -715,7 +735,7 @@ local check_proxydetect = function( user )
         log_url      = rq.log_url,    -- key-free url for the failure log (vpnapi/ipqs put the key in the url)
         timeout      = query_timeout,
         max_response = 65536,    -- provider JSON is a few KiB; bound a misbehaving one
-        on_complete  = function( res ) handle_response( res, ip, family, sid, cid ) end,
+        on_complete  = function( res ) handle_response( res, ip, family, sid, cid, nick ) end,
         on_error     = function( err )
             inflight[ ip ] = nil
             apply_failure( sid, cid, ip, err )

--- a/tests/unit/etc_proxydetect_test.lua
+++ b/tests/unit/etc_proxydetect_test.lua
@@ -427,6 +427,50 @@ do
 end
 
 ----------------------------------------------------------------------
+-- #504: connection left before the async verdict -> report + audit
+-- show the connect-time nick as a fallback, not "?". The three
+-- assertions below FAIL on v0.02 (report renders "The user ? ...";
+-- audit meta has no nick) and PASS on v0.03.
+----------------------------------------------------------------------
+do
+    load_plugin( { etc_proxydetect_action = "log_only" } )   -- report/audit path, no kick
+    local u = mkuser( 20, "1.2.3.4", "SID1", "CID1" )        -- nick = "uSID1"
+    connect( u )
+    _online[ "SID1" ] = nil                                   -- dropped before the reply
+    complete( 200, PROXY_JSON )
+    local rep = _reports[ #_reports ] or ""
+    truthy( "left-nick: report shows the connect-time nick", rep:find( "uSID1", 1, true ) ~= nil )
+    falsy(  "left-nick: report has no '?' placeholder",       rep:find( "user ? ", 1, true ) )
+    truthy( "left-nick: audit meta carries the nick",
+        _audit[ #_audit ] and _audit[ #_audit ].meta and _audit[ #_audit ].meta.nick == "uSID1" )
+end
+
+----------------------------------------------------------------------
+-- #504 guard: a LIVE user's report still uses the current nick (no
+-- regression), and a truly nickless connection that left falls back
+-- to "?" (the empty-nick -> nil guard at connect time).
+----------------------------------------------------------------------
+do
+    load_plugin( { etc_proxydetect_action = "log_only" } )
+    local u = mkuser( 20, "1.2.3.4", "SID1", "CID1" )
+    connect( u )
+    complete( 200, PROXY_JSON )                               -- still online
+    local rep = _reports[ #_reports ] or ""
+    truthy( "live-nick: report uses the live nick", rep:find( "uSID1", 1, true ) ~= nil )
+end
+do
+    load_plugin( { etc_proxydetect_action = "log_only" } )
+    -- a login that never set a nick (nick() == "")
+    local u = mkuser( 20, "1.2.3.4", "SID9", "CID9" )
+    u.nick = function( ) return "" end
+    connect( u )
+    _online[ "SID9" ] = nil                                   -- left before reply
+    complete( 200, PROXY_JSON )
+    local rep = _reports[ #_reports ] or ""
+    truthy( "nickless-left: falls back to '?'", rep:find( "user ? ", 1, true ) ~= nil )
+end
+
+----------------------------------------------------------------------
 -- v6 -> /128 store push
 ----------------------------------------------------------------------
 do


### PR DESCRIPTION
## Problem

`etc_proxydetect`'s op-chat report sometimes shows `?` for the nick:

```
[ PROXYDETECT ]--> The user ? with IP 2001:41d0:404:200::5e8c is a proxy (proxycheck). Action: log_only.
```

## Cause

The provider lookup is async. `check_proxydetect` (onConnect) captures only `sid`/`cid` and lets the connection through; `handle_response` re-resolves the user via `hub.issidonline(sid)` when the reply lands. A connection that dropped before the round-trip finished (typical for a short-lived hosting/proxy IP) re-resolves to nil, so `apply_positive` rendered `user and user:nick() or "?"`. The IP is retained (captured at query time); the nick was not.

Not a missing name or weird characters - the user disconnected before the verdict. Benign in `log_only`, but the line is less useful than it could be.

## Fix (v0.02 -> v0.03)

Capture the nick at connect time (empty coerced to nil so a nickless login still falls back to `?`), thread it through `handle_response` -> `apply_positive` as `last_nick`, and render `(user and user:nick()) or last_nick or "?"` in the report and the audit `meta.nick`. Live users unchanged (current nick wins); `apply_failure` untouched (shows no nick).

## Tests

`tests/unit/etc_proxydetect_test.lua` extended: 3 assertions FAIL on `origin/dev` (report nick / no `?` / audit meta nick) and PASS post-fix, plus live-nick and nickless-`?`-fallback guards. Full suite 123/0. Already registered on both smoke.yml legs. Independent §1a.6 review: approve, no blockers.

Cosmetic/observability only.

Closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)