### PR TITLE
Merge dev into master: #502 trafficmanager auto-blocked list + #504 proxydetect connect-time nick

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -165,6 +165,12 @@ jobs:
       - name: Run etc_clientblocker unit test
         run: lua5.4 tests/unit/etc_clientblocker_test.lua
 
+      # #502 etc_trafficmanager: `show blocks` lists online users
+      # auto-blocked by share/level (runtime, not in block_tbl) +
+      # `show settings` minshare-check line. Stubbed hub.getusers/cfg.
+      - name: Run etc_trafficmanager unit test
+        run: lua5.4 tests/unit/etc_trafficmanager_test.lua
+
       # Coverage completeness: these two unit tests existed but were never
       # wired into CI. Both pass; registering them keeps tests/README's
       # "the whole tests/unit set runs in CI" statement true.
@@ -537,6 +543,10 @@ jobs:
       - name: Run etc_clientblocker unit test
         shell: msys2 {0}
         run: lua5.4 tests/unit/etc_clientblocker_test.lua
+
+      - name: Run etc_trafficmanager unit test
+        shell: msys2 {0}
+        run: lua5.4 tests/unit/etc_trafficmanager_test.lua
 
       - name: Run etc_blocklist unit test
         shell: msys2 {0}

--- a/scripts/etc_proxydetect.lua
+++ b/scripts/etc_proxydetect.lua
@@ -106,6 +106,13 @@
         - Phase F2 (closes #352): VPNAPI.io + IPQualityScore adapters
           (key kept out of the failure log via http_client `log_url`) +
           op-chat alert on a run of provider failures.
+    v0.03: by Aybo
+        - #504: the op-chat report + audit now carry the connect-time
+          nick as a fallback. The async verdict re-resolves the user by
+          SID; a connection that dropped before the reply landed (common
+          for short-lived hosting/proxy IPs) resolved to nil, so the
+          report rendered "The user ? with IP ...". The nick is now
+          captured at connect and threaded through as a fallback.
 
 ]]--
 
@@ -115,7 +122,7 @@
 --------------
 
 local scriptname = "etc_proxydetect"
-local scriptversion = "0.02"
+local scriptversion = "0.03"
 
 local cmd_status = "proxydetect"
 
@@ -555,16 +562,24 @@ end
 -- left by the time an async lookup returned) - we still audit / report
 -- / cache / store-push for observability + future pre-handshake blocks;
 -- we only KICK when the user is still live.
-local function apply_positive( user, ip, family, types, matched, cached )
+local function apply_positive( user, ip, family, types, matched, cached, last_nick )
     local matched_str = table_concat( matched, "," )
+    -- `user` is nil when the connection dropped before the async verdict
+    -- returned (the SID re-resolve found nobody). `last_nick` is the nick
+    -- captured at connect time, used as a fallback so the report + audit
+    -- still name who was flagged instead of rendering "?" (#504). Stored
+    -- in `meta.nick` too so log consumers have an always-present nick even
+    -- when the audit target snapshot is absent (the dropped-user case);
+    -- it intentionally overlaps the target snapshot for a live user.
+    local nick = ( user and user:nick( ) ) or last_nick or "?"
     if audit then
         audit.fire( audit.build( "proxydetect.block", scriptname, user, kick_reason,
             { ip = ip, provider = adapter.source, types = matched_str,
-              action = action, cached = cached and true or false } ) )
+              action = action, cached = cached and true or false, nick = nick } ) )
     end
     if report then
         report.send( report_activate, report_hubbot, report_opchat, report_llevel,
-            utf_format( msg_report, user and user:nick( ) or "?", ip, matched_str,
+            utf_format( msg_report, nick, ip, matched_str,
                 adapter.source, action ) )
     end
     if action == "block" then
@@ -636,7 +651,7 @@ end
 
 -- The async response handler. Re-resolves the user from the SID (never
 -- the closed-over listener object) and guards SID reuse via the CID.
-local function handle_response( res, ip, family, sid, cid )
+local function handle_response( res, ip, family, sid, cid, nick )
     inflight[ ip ] = nil
     if res.status ~= 200 then
         return apply_failure( sid, cid, ip, "HTTP status " .. tostring( res.status ) )
@@ -668,7 +683,7 @@ local function handle_response( res, ip, family, sid, cid )
 
     local u = hub_issidonline( sid )
     if u and u:cid( ) ~= cid then u = nil end    -- SID reused by another client
-    apply_positive( u, ip, family, types, matched, false )
+    apply_positive( u, ip, family, types, matched, false, nick )
 end
 
 
@@ -706,6 +721,11 @@ local check_proxydetect = function( user )
 
     inflight[ ip ] = true
     local sid, cid = user:sid( ), user:cid( )
+    -- Capture the nick now, while the user is live: the async callback
+    -- may re-resolve to nil if the connection drops first (#504). Empty
+    -- -> nil so the "?" fallback still applies for a nickless login.
+    local nick = user:nick( )
+    if nick == "" then nick = nil end
     local rq = adapter.build_request( ip, api_key )
     local ok, rerr = http_client.request{
         url          = rq.url,
@@ -715,7 +735,7 @@ local check_proxydetect = function( user )
         log_url      = rq.log_url,    -- key-free url for the failure log (vpnapi/ipqs put the key in the url)
         timeout      = query_timeout,
         max_response = 65536,    -- provider JSON is a few KiB; bound a misbehaving one
-        on_complete  = function( res ) handle_response( res, ip, family, sid, cid ) end,
+        on_complete  = function( res ) handle_response( res, ip, family, sid, cid, nick ) end,
         on_error     = function( err )
             inflight[ ip ] = nil
             apply_failure( sid, cid, ip, err )

--- a/scripts/etc_trafficmanager.lua
+++ b/scripts/etc_trafficmanager.lua
@@ -33,6 +33,24 @@
         the block list and accept the corresponding file-transfer
         permission.
 
+        v2.7:
+            - `show blocks` now also lists currently-online users who
+              are auto-blocked by share (0 B / below minshare) or by a
+              blocked level. These are runtime classifications computed
+              by need_block() on every event and are never persisted to
+              block_tbl, so `show blocks` (which only iterates block_tbl)
+              previously showed nothing for them - the operator saw an
+              empty list plus an empty etc_trafficmanager.tbl while the
+              users were in fact being blocked (luadch-ng/luadch#502,
+              reported by Sopor). The new section is online-only (share
+              is a per-session INF field; an offline user is not being
+              share-blocked) and skips nicks already in the manual
+              block_tbl list so each user appears in exactly one section.
+            - `show settings` now also reports the minshare-check toggle
+              (etc_trafficmanager_check_minshare); it previously showed
+              only the 0-B-share toggle, so a hub running minshare-only
+              gave no indication in settings that share-blocking was on.
+
         v2.5:
             - fix latent dispatch bug in add() / del() exports
               (closes #257). `( not scriptname ) or ( not scriptname == 1 )`
@@ -194,7 +212,7 @@
 --------------
 
 local scriptname = "etc_trafficmanager"
-local scriptversion = "2.6"
+local scriptversion = "2.7"
 
 local cmd = "trafficmanager"
 local cmd_b = "block"
@@ -255,6 +273,10 @@ local msg_unknown = lang.msg_unknown or "<UNKNOWN>"
 local msg_reason = lang.msg_reason or "Reason:"
 local msg_blocked_by = lang.msg_blocked_by or "Blocked by:"
 local msg_date = lang.msg_date or "Blocked date:"
+local msg_ab_level = lang.msg_ab_level or "Blocked level"
+local msg_ab_zeroshare = lang.msg_ab_zeroshare or "0 B share"
+local msg_ab_minshare = lang.msg_ab_minshare or "Below minshare"
+local msg_ab_none = lang.msg_ab_none or "(none)"
 local msg_target_block = lang.msg_target_block or "[ TRAFFICMANAGER ]--> You were blocked by:  %s  |  reason:  %s"
 local msg_target_unblock = lang.msg_target_unblock or "[ TRAFFICMANAGER ]--> You were unblocked by:  %s"
 local ucmd_nick = lang.ucmd_nick or "User firstnick:"
@@ -322,6 +344,7 @@ local opmsg = lang.opmsg or [[
 
 %s
    Block users with 0 B share:  %s
+   Block users below minshare:  %s
 
 ===================================== TRAFFIC MANAGER ===
   ]]
@@ -350,12 +373,16 @@ local msg_users = lang.msg_users or [[
    Blocked levels:
 
 %s
+
+   Auto-blocked ( online ):
+%s
 ======================================================================== TRAFFIC MANAGER ===
   ]]
 
 --// functions
 local onbmsg
 local get_blocklevels
+local get_autoblocked_online
 local get_bool
 local check_share
 local is_blocked
@@ -439,6 +466,52 @@ get_blocklevels = function()
     for _, level in pairs( tbl ) do
         msg = msg .. "\t" .. level .. "\t[ " .. levels[ level ] .. " ]\n"
     end
+    return msg
+end
+
+--// list currently online users that are auto-blocked by share or by
+--  a blocked level. These are runtime need_block() classifications
+--  that are never written to block_tbl, so `show blocks` (which only
+--  iterates block_tbl) would otherwise not surface them (#502). Nicks
+--  already present in block_tbl are skipped so each user appears in
+--  exactly one section (the manual list is the actionable one). Only
+--  online users are listed: share is a per-session INF field, so an
+--  offline user is not being share-blocked. hub.getusers() single-
+--  assignment yields the humans-only table, so bots are excluded.
+get_autoblocked_online = function()
+    local levels = cfg.get( "levels" ) or {}
+    local rows = {}
+    for sid, user in pairs( hub.getusers() ) do
+        local firstnick = user:firstnick()
+        if not is_blocked( firstnick ) then
+            local level = user:level()
+            local reason
+            if blocklevel_tbl[ level ] then
+                reason = msg_ab_level .. " [ " .. ( levels[ level ] or "Unreg" ) .. " ]"
+            elseif check_share( user ) then
+                --> distinguish the two share triggers for the operator.
+                --  check_share short-circuits on the 0-B case only when
+                --  sharecheck is on; a 0-B user under a minshare-only
+                --  config is correctly labelled "below minshare".
+                local share = user:share() or 0
+                if sharecheck and share == 0 then
+                    reason = msg_ab_zeroshare
+                else
+                    reason = msg_ab_minshare
+                end
+            end
+            if reason then
+                rows[ #rows + 1 ] = { nick = firstnick, reason = reason }
+            end
+        end
+    end
+    table.sort( rows, function( a, b ) return a.nick < b.nick end )
+    local msg = ""
+    for _, row in ipairs( rows ) do
+        msg = msg .. "\n   Nickname:  " .. row.nick .. "\n" ..
+                     "\t" .. msg_reason .. " " .. row.reason .. "\n"
+    end
+    if msg == "" then msg = "\n   " .. msg_ab_none .. "\n" end
     return msg
 end
 
@@ -903,7 +976,8 @@ onbmsg = function( user, command, parameters )
             get_bool( report_main ),
             get_bool( report_pm ),
             get_blocklevels(),
-            get_bool( sharecheck )
+            get_bool( sharecheck ),
+            get_bool( minsharecheck )
         )
         user:reply( msg, hub.getbot() )
         return PROCESSED
@@ -946,7 +1020,13 @@ onbmsg = function( user, command, parameters )
                          "\t" .. msg_date .. " " .. blockdate .. "\n" ..
                          "\t" .. msg_reason .. " " .. reason .. "\n"
         end
-        local msg_out = utf.format( msg_users, msg, get_blocklevels() )
+        --> arg order MUST match msg_users' %s order (manual, levels,
+        --  auto-blocked). The auto-blocked %s is LAST so a stale lang
+        --  file with the old two-%s msg_users degrades gracefully
+        --  (drops the auto section) instead of rendering it under the
+        --  "Blocked levels" header and losing the real level list -
+        --  lang files are add-only on upgrade, so drift is the norm.
+        local msg_out = utf.format( msg_users, msg, get_blocklevels(), get_autoblocked_online() )
         user:reply( msg_out, hub.getbot() )
         return PROCESSED
     end

--- a/scripts/lang/etc_trafficmanager.lang.de
+++ b/scripts/lang/etc_trafficmanager.lang.de
@@ -23,6 +23,10 @@
     msg_reason = "Grund:",
     msg_blocked_by = "Geblockt von:",
     msg_date = "Geblockt am:",
+    msg_ab_level = "Geblocktes Level",
+    msg_ab_zeroshare = "0 B Share",
+    msg_ab_minshare = "Unter Minshare",
+    msg_ab_none = "(keine)",
     msg_target_block = "[ TRAFFICMANAGER ]--> Du wurdest geblockt von:  %s  |  Grund:  %s",
     msg_target_unblock = "[ TRAFFICMANAGER ]--> Dein Block wurde aufgehoben von:  %s",
     ucmd_nick = "User firstnick:",
@@ -90,6 +94,7 @@
 
 %s
    Blocke User mit 0 B Share:  %s
+   Blocke User unter Minshare:  %s
 
 ===================================== TRAFFIC MANAGER ===
   ]],
@@ -117,6 +122,9 @@ Gebrauch:
 
    Geblockte Levels:
 
+%s
+
+   Auto-geblockt ( online ):
 %s
 ======================================================================== TRAFFIC MANAGER ===
   ]],

--- a/scripts/lang/etc_trafficmanager.lang.en
+++ b/scripts/lang/etc_trafficmanager.lang.en
@@ -23,6 +23,10 @@
     msg_reason = "Reason:",
     msg_blocked_by = "Blocked by:",
     msg_date = "Blocked date:",
+    msg_ab_level = "Blocked level",
+    msg_ab_zeroshare = "0 B share",
+    msg_ab_minshare = "Below minshare",
+    msg_ab_none = "(none)",
     msg_target_block = "[ TRAFFICMANAGER ]--> You were blocked by:  %s  |  reason:  %s",
     msg_target_unblock = "[ TRAFFICMANAGER ]--> You were unblocked by:  %s",
     ucmd_nick = "User firstnick:",
@@ -90,6 +94,7 @@
 
 %s
    Block users with 0 B share:  %s
+   Block users below minshare:  %s
 
 ===================================== TRAFFIC MANAGER ===
   ]],
@@ -117,6 +122,9 @@ Usage:
 
    Blocked levels:
 
+%s
+
+   Auto-blocked ( online ):
 %s
 ======================================================================== TRAFFIC MANAGER ===
   ]],

--- a/tests/unit/etc_proxydetect_test.lua
+++ b/tests/unit/etc_proxydetect_test.lua
@@ -427,6 +427,50 @@ do
 end
 
 ----------------------------------------------------------------------
+-- #504: connection left before the async verdict -> report + audit
+-- show the connect-time nick as a fallback, not "?". The three
+-- assertions below FAIL on v0.02 (report renders "The user ? ...";
+-- audit meta has no nick) and PASS on v0.03.
+----------------------------------------------------------------------
+do
+    load_plugin( { etc_proxydetect_action = "log_only" } )   -- report/audit path, no kick
+    local u = mkuser( 20, "1.2.3.4", "SID1", "CID1" )        -- nick = "uSID1"
+    connect( u )
+    _online[ "SID1" ] = nil                                   -- dropped before the reply
+    complete( 200, PROXY_JSON )
+    local rep = _reports[ #_reports ] or ""
+    truthy( "left-nick: report shows the connect-time nick", rep:find( "uSID1", 1, true ) ~= nil )
+    falsy(  "left-nick: report has no '?' placeholder",       rep:find( "user ? ", 1, true ) )
+    truthy( "left-nick: audit meta carries the nick",
+        _audit[ #_audit ] and _audit[ #_audit ].meta and _audit[ #_audit ].meta.nick == "uSID1" )
+end
+
+----------------------------------------------------------------------
+-- #504 guard: a LIVE user's report still uses the current nick (no
+-- regression), and a truly nickless connection that left falls back
+-- to "?" (the empty-nick -> nil guard at connect time).
+----------------------------------------------------------------------
+do
+    load_plugin( { etc_proxydetect_action = "log_only" } )
+    local u = mkuser( 20, "1.2.3.4", "SID1", "CID1" )
+    connect( u )
+    complete( 200, PROXY_JSON )                               -- still online
+    local rep = _reports[ #_reports ] or ""
+    truthy( "live-nick: report uses the live nick", rep:find( "uSID1", 1, true ) ~= nil )
+end
+do
+    load_plugin( { etc_proxydetect_action = "log_only" } )
+    -- a login that never set a nick (nick() == "")
+    local u = mkuser( 20, "1.2.3.4", "SID9", "CID9" )
+    u.nick = function( ) return "" end
+    connect( u )
+    _online[ "SID9" ] = nil                                   -- left before reply
+    complete( 200, PROXY_JSON )
+    local rep = _reports[ #_reports ] or ""
+    truthy( "nickless-left: falls back to '?'", rep:find( "user ? ", 1, true ) ~= nil )
+end
+
+----------------------------------------------------------------------
 -- v6 -> /128 store push
 ----------------------------------------------------------------------
 do

--- a/tests/unit/etc_trafficmanager_test.lua
+++ b/tests/unit/etc_trafficmanager_test.lua
@@ -1,0 +1,318 @@
+--[[
+
+    tests/unit/etc_trafficmanager_test.lua
+
+    Unit tests for scripts/etc_trafficmanager.lua `show blocks` /
+    `show settings` output (luadch-ng/luadch#502).
+
+    Focus: the v2.7 change that makes `+trafficmanager show blocks`
+    also list currently-online users who are auto-blocked by share
+    (0 B / below minshare) or by a blocked level. These are runtime
+    need_block() classifications never persisted to block_tbl, so the
+    pre-v2.7 handler (which only iterated block_tbl) showed nothing
+    for them. Also covers the v2.7 `show settings` minshare-check line.
+
+    The plugin is loaded with a stubbed sandbox environment; the
+    `+trafficmanager` chat handler (onbmsg) is captured through the
+    etc_hubcommands.add stub and invoked directly. hub.getusers() is
+    stubbed to return a controllable online set.
+
+    Run: lua5.4 tests/unit/etc_trafficmanager_test.lua
+    Exit 0 = all pass, 1 = a failure (CI-friendly).
+
+    Regression contract (CLAUDE.md §1a.7): the positive auto-block
+    assertions, the "(none)" placeholder, and the settings minshare
+    line (9 checks) FAIL on the pre-v2.7 plugin (no auto-block section;
+    msg_users had only two %s) and PASS on v2.7. The negative auto
+    assertions (clean/op NOT listed) and the manual-section / permission
+    checks are guards that pass on both revisions. Verified by running
+    this file against `git show origin/dev:scripts/etc_trafficmanager.lua`
+    (9 failures pre-fix, 0 post-fix).
+
+]]--
+
+local GiB = 1024 * 1024 * 1024
+
+----------------------------------------------------------------------
+-- controllable state
+----------------------------------------------------------------------
+
+local _registered = { }        -- event/listener name -> fn
+local _hubcmds = { }           -- cmd name -> handler (onbmsg)
+local _online = { }            -- sid -> stub user (hub.getusers)
+local _block_seed = nil        -- what util.loadtable returns for block_tbl
+
+----------------------------------------------------------------------
+-- stub sandbox globals the plugin reads at file scope + runtime
+----------------------------------------------------------------------
+
+_G.PROCESSED = 1
+
+_G.hub = {
+    setlistener = function( event, opts, fn ) _registered[ event ] = fn end,
+    debug       = function( ) end,
+    getbot      = function( ) return "stub-bot" end,
+    sendtoall   = function( ) end,
+    escapeto    = function( s ) return s end,
+    escapefrom  = function( s ) return s end,
+    isnickonline = function( ) return nil end,
+    getusers    = function( ) return _online end,
+    getregusers = function( ) return { }, { }, { } end,
+    import = function( name )
+        if name == "etc_hubcommands" then
+            return {
+                add = function( cmd, fn ) _hubcmds[ cmd ] = fn; return true end,
+                has = function( ) return false end,
+                list = function( ) return { } end,
+            }
+        end
+        if name == "etc_report" then
+            return { send = function( ) end }
+        end
+        return nil    -- cmd_help / etc_usercommands absent in the test
+    end,
+    http_register = function( ) end,
+}
+
+_G.cfg = {
+    loadlanguage = function( ) return { }, nil end,   -- exercise inline fallbacks
+    get = function( key )
+        local t = {
+            language                        = "en",
+            etc_trafficmanager_activate     = true,
+            etc_trafficmanager_permission   = { [ 60 ] = 60, [ 70 ] = 70, [ 80 ] = 80, [ 100 ] = 100 },
+            etc_trafficmanager_report       = false,
+            etc_trafficmanager_report_hubbot = false,
+            etc_trafficmanager_report_opchat = false,
+            etc_trafficmanager_llevel       = 60,
+            etc_trafficmanager_blocklevel_tbl = { [ 10 ] = true },   -- level 10 auto-blocked
+            etc_trafficmanager_sharecheck   = true,
+            etc_trafficmanager_check_minshare = true,
+            min_share                       = { [ 0 ] = 0, [ 10 ] = 0, [ 20 ] = 5, [ 60 ] = 0, [ 100 ] = 0 },
+            etc_trafficmanager_oplevel      = 60,
+            etc_trafficmanager_login_report = false,
+            etc_trafficmanager_report_main  = false,
+            etc_trafficmanager_report_pm    = false,
+            usr_nick_prefix_activate        = false,
+            usr_nick_prefix_permission      = { },
+            usr_nick_prefix_prefix_table    = { },
+            usr_desc_prefix_activate        = false,
+            usr_desc_prefix_permission      = { },
+            usr_desc_prefix_prefix_table    = { },
+            etc_trafficmanager_send_loop    = false,
+            etc_trafficmanager_loop_time    = 1,
+            etc_trafficmanager_flag_blocked = "[BLOCKED]",
+            levels = { [ 10 ] = "Guest", [ 20 ] = "Reg", [ 60 ] = "Op", [ 100 ] = "Owner" },
+        }
+        return t[ key ]
+    end,
+}
+
+_G.util = {
+    loadtable = function( ) return _block_seed end,
+    savetable = function( ) return true end,
+    date      = function( ) return "20260101000000" end,
+    strip_control_bytes = function( s ) return s end,
+    getlowestlevel = function( ) return 60 end,
+    -- real spairs impl (copied from core/util.lua) so the manual-block
+    -- section iterates in sorted order deterministically.
+    spairs = ( function( )
+        local function genOrderedIndex( tbl )
+            local idx = { }
+            for k in pairs( tbl ) do
+                if k ~= "orderedIndex" then idx[ #idx + 1 ] = k end
+            end
+            table.sort( idx )
+            return idx
+        end
+        local function orderedNext( tbl, state )
+            local key
+            if state == nil then
+                tbl.orderedIndex = genOrderedIndex( tbl )
+                key = tbl.orderedIndex[ 1 ]
+            else
+                for i = 1, #tbl.orderedIndex do
+                    if tbl.orderedIndex[ i ] == state then key = tbl.orderedIndex[ i + 1 ] end
+                end
+            end
+            if key then return key, tbl[ key ] end
+            tbl.orderedIndex = nil
+            return
+        end
+        return function( tbl ) return orderedNext, tbl, nil end
+    end )( ),
+}
+
+_G.utf = {
+    match  = string.match,
+    format = string.format,
+    sub    = string.sub,
+    len    = string.len,
+}
+
+----------------------------------------------------------------------
+-- minimal test framework
+----------------------------------------------------------------------
+
+local failures, checks = 0, 0
+local function eq( label, got, want )
+    checks = checks + 1
+    if got ~= want then
+        failures = failures + 1
+        io.write( string.format( "FAIL %-60s got=%q want=%q\n", label, tostring( got ), tostring( want ) ) )
+    else
+        io.write( string.format( "ok   %s\n", label ) )
+    end
+end
+
+local function contains( hay, needle ) return ( hay or "" ):find( needle, 1, true ) ~= nil end
+local function count( hay, needle )
+    local n, i = 0, 1
+    while true do
+        local s = ( hay or "" ):find( needle, i, true )
+        if not s then break end
+        n = n + 1; i = s + #needle
+    end
+    return n
+end
+
+----------------------------------------------------------------------
+-- stub user + op factory
+----------------------------------------------------------------------
+
+local function stub_user( opts )
+    return {
+        level     = function( ) return opts.level end,
+        share     = function( ) return opts.share end,      -- may be nil
+        firstnick = function( ) return opts.firstnick end,
+        nick      = function( ) return opts.firstnick end,
+        isbot     = function( ) return false end,
+    }
+end
+
+local function op_user( )
+    local replied
+    local u = {
+        level = function( ) return 100 end,
+        nick  = function( ) return "owner" end,
+        reply = function( _, msg ) replied = msg end,
+    }
+    return u, function( ) return replied end
+end
+
+----------------------------------------------------------------------
+-- load plugin + onStart (empty online set) so onbmsg is captured
+----------------------------------------------------------------------
+
+_block_seed = { manual_guy = { "admin", "manual reason", "20260101000000" } }
+_online = { }
+assert( loadfile( "scripts/etc_trafficmanager.lua" ) )( )
+assert( _registered.onStart, "onStart not registered" )
+_registered.onStart( )
+local onbmsg = _hubcmds.trafficmanager
+assert( onbmsg, "+trafficmanager handler not registered" )
+
+----------------------------------------------------------------------
+-- 1. show blocks: auto-blocked online users appear with the right
+--    reason, clean/op users do not, manual user appears once.
+----------------------------------------------------------------------
+
+do
+    _online = {
+        s1 = stub_user{ firstnick = "zeroshare_guy", level = 20, share = 0 },
+        s2 = stub_user{ firstnick = "small_guy",     level = 20, share = 1 * GiB },
+        s3 = stub_user{ firstnick = "level_guy",      level = 10, share = 999 * GiB },
+        s4 = stub_user{ firstnick = "clean_guy",      level = 20, share = 10 * GiB },
+        s5 = stub_user{ firstnick = "op_guy",         level = 60, share = 0 },
+        s6 = stub_user{ firstnick = "manual_guy",     level = 20, share = 0 },  -- also in block_tbl
+    }
+    local op, replied_of = op_user( )
+    local r = onbmsg( op, "trafficmanager", "show blocks" )
+    local out = replied_of( )
+    eq( "show blocks returns PROCESSED", r, 1 )
+    eq( "auto: section header present",  contains( out, "Auto-blocked ( online )" ), true )
+
+    eq( "auto: zeroshare_guy listed",    contains( out, "zeroshare_guy" ), true )
+    eq( "auto: zeroshare reason",        contains( out, "0 B share" ),     true )
+    eq( "auto: small_guy listed",        contains( out, "small_guy" ),     true )
+    eq( "auto: minshare reason",         contains( out, "Below minshare" ), true )
+    eq( "auto: level_guy listed",        contains( out, "level_guy" ),     true )
+    eq( "auto: level reason + name",     contains( out, "Blocked level [ Guest ]" ), true )
+
+    eq( "auto: clean_guy NOT listed",    contains( out, "clean_guy" ),     false )
+    eq( "auto: op_guy NOT listed (>= oplevel)", contains( out, "op_guy" ), false )
+
+    eq( "manual: manual_guy present",    contains( out, "manual_guy" ),    true )
+    eq( "manual: manual_guy appears once (not duplicated in auto)", count( out, "manual_guy" ), 1 )
+    eq( "manual: block reason present",  contains( out, "manual reason" ), true )
+    eq( "manual: blocker present",       contains( out, "admin" ),         true )
+end
+
+----------------------------------------------------------------------
+-- 2. show blocks: no online auto-blocked user -> "(none)" placeholder.
+----------------------------------------------------------------------
+
+do
+    _online = {
+        s1 = stub_user{ firstnick = "clean_guy", level = 20, share = 10 * GiB },
+    }
+    local op, replied_of = op_user( )
+    onbmsg( op, "trafficmanager", "show blocks" )
+    local out = replied_of( )
+    eq( "empty auto: (none) placeholder", contains( out, "(none)" ), true )
+    eq( "empty auto: clean_guy still not listed", contains( out, "clean_guy" ), false )
+end
+
+----------------------------------------------------------------------
+-- 3. show settings: minshare-check toggle now reported.
+----------------------------------------------------------------------
+
+do
+    local op, replied_of = op_user( )
+    local r = onbmsg( op, "trafficmanager", "show settings" )
+    local out = replied_of( )
+    eq( "show settings returns PROCESSED",   r, 1 )
+    eq( "settings: 0-B-share line present",  contains( out, "Block users with 0 B share" ), true )
+    eq( "settings: minshare line present",   contains( out, "Block users below minshare" ), true )
+end
+
+----------------------------------------------------------------------
+-- 4. non-op is denied show blocks (permission gate intact).
+----------------------------------------------------------------------
+
+do
+    local replied
+    local low = {
+        level = function( ) return 20 end,
+        reply = function( _, msg ) replied = msg end,
+    }
+    _online = { }
+    onbmsg( low, "trafficmanager", "show blocks" )
+    eq( "denied: low-level got denial reply", contains( replied, "not allowed" ), true )
+end
+
+----------------------------------------------------------------------
+-- 5. lang-file template placeholder parity. The show-blocks / settings
+--    call sites pass a fixed number of args; the bundled lang files
+--    MUST carry the matching %s count. Lang files are add-only on
+--    upgrade (never overwritten), so a bundled-file edit that drops a
+--    %s is a realistic drift. The auto-block %s is intentionally LAST
+--    in msg_users so a stale two-%s file degrades gracefully rather
+--    than mislabelling the section - this guards the bundled files.
+----------------------------------------------------------------------
+
+do
+    local function pct( s ) return select( 2, ( s or "" ):gsub( "%%s", "" ) ) end
+    for _, lc in ipairs( { "en", "de" } ) do
+        local L = assert( loadfile( "scripts/lang/etc_trafficmanager.lang." .. lc ) )( )
+        eq( "lang " .. lc .. ": msg_users has 3 %s", pct( L.msg_users ), 3 )
+        eq( "lang " .. lc .. ": opmsg has 8 %s",     pct( L.opmsg ),     8 )
+    end
+end
+
+----------------------------------------------------------------------
+-- summary
+----------------------------------------------------------------------
+
+io.write( string.format( "\n%d checks, %d failures\n", checks, failures ) )
+os.exit( failures > 0 and 1 or 0 )


### PR DESCRIPTION
Promotes two Sopor-reported plugin fixes from dev to master.

- **#502 / #503** etc_trafficmanager v2.7: `+trafficmanager show blocks` now also lists ONLINE users auto-blocked by share (0 B / below minshare) or a blocked level. These are runtime `need_block()` classifications never persisted to `block_tbl`, so before this fix they were invisible while their traffic was in fact blocked (empty `.tbl` + empty list was Sopor's report). `show settings` now also reports the minshare-check toggle. New `msg_ab_*` lang keys (en+de). Live-verified on the `:dev` testhub: both the blocked-level and 0-B-share branches list correctly, the owner is excluded, and the "Blocked levels" list is preserved.
- **#504 / #505** etc_proxydetect v0.03: the op-chat report and audit now name the connect-time nick instead of "?" when a short-lived hosting/proxy IP dropped before the async provider verdict re-resolved the user by SID.

Both reviewed (two-pass per working agreement), RED-proven unit tests on both smoke legs, CI green on dev HEAD.

Refs #502, #504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)