### PR TITLE
Merge dev into master: #501 etc_lockdown maintenance-mode gate

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -171,6 +171,13 @@ jobs:
       - name: Run etc_trafficmanager unit test
         run: lua5.4 tests/unit/etc_trafficmanager_test.lua
 
+      # #501 etc_lockdown: transient maintenance-mode gate. Stubbed
+      # hub.getusers / whitelist + a controllable os.time. Covers the
+      # minutes-vs-reason parser, onConnect veto (ISTA 226 + TL), kick-
+      # on-enable, whitelist exemption, self-lockout guard, timed expiry.
+      - name: Run etc_lockdown unit test
+        run: lua5.4 tests/unit/etc_lockdown_test.lua
+
       # Coverage completeness: these two unit tests existed but were never
       # wired into CI. Both pass; registering them keeps tests/README's
       # "the whole tests/unit set runs in CI" statement true.
@@ -547,6 +554,10 @@ jobs:
       - name: Run etc_trafficmanager unit test
         shell: msys2 {0}
         run: lua5.4 tests/unit/etc_trafficmanager_test.lua
+
+      - name: Run etc_lockdown unit test
+        shell: msys2 {0}
+        run: lua5.4 tests/unit/etc_lockdown_test.lua
 
       - name: Run etc_blocklist unit test
         shell: msys2 {0}

--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -4706,6 +4706,46 @@ local defaults = {
             return types_number( value, nil, true )
         end
     },
+    -- #501: etc_lockdown.lua transient maintenance-mode gate. The
+    -- lockdown state itself is RUNTIME ( the `+lockdown` command,
+    -- persisted to scripts/data/etc_lockdown.tbl ); these keys only tune
+    -- the plugin. The plugin ships disabled in examples/cfg.
+    etc_lockdown_command_minlevel = { 60,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
+    etc_lockdown_default_retry = { 120,
+        function( value )
+            if not types_number( value, nil, true ) then return false end
+            return value >= 1 and value <= 86400
+        end
+    },
+    etc_lockdown_exempt_whitelist = { true,
+        function( value )
+            return types_boolean( value, nil, true )
+        end
+    },
+    etc_lockdown_report = { true,
+        function( value )
+            return types_boolean( value, nil, true )
+        end
+    },
+    etc_lockdown_report_hubbot = { false,
+        function( value )
+            return types_boolean( value, nil, true )
+        end
+    },
+    etc_lockdown_report_opchat = { true,
+        function( value )
+            return types_boolean( value, nil, true )
+        end
+    },
+    etc_lockdown_llevel = { 60,
+        function( value )
+            return types_number( value, nil, true )
+        end
+    },
     -- #78 Phase B: `+blocklist` admin plugin (etc_blocklist.lua).
     -- Operator-facing chat command + JSONL export/import. The
     -- engine in core/blocklist.lua is independent; these keys

--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -1024,6 +1024,17 @@ return { -- the settings are a lua table, do not tough this!
     etc_whitelist_import_min_level = 100,  -- min level to run `+whitelist import <path>` - same threat model as blocklist (JSONL may carry master-added rows); default 100 = master-only (integer)
 
     ---------------------------------------------------------------------------------------------------------------------------------
+    --// etc_lockdown.lua settings | transient maintenance-mode gate (#501). Admit only users >= a chosen level, kick + refuse the rest, until you run `+lockdown off`. Lockdown state is RUNTIME (the command, persisted to scripts/data/etc_lockdown.tbl) - these keys only tune the plugin. Plugin ships DISABLED (enable it in the scripts list below)
+
+    etc_lockdown_command_minlevel = 60,  -- min level to run `+lockdown <level> [minutes] [reason] | off | status` (integer)
+    etc_lockdown_default_retry = 120,  -- IQUI TL in seconds sent to a refused login when the lockdown has NO time set, so clients keep re-knocking until you lift it; a timed lockdown uses its own remaining time instead (integer 1..86400)
+    etc_lockdown_exempt_whitelist = true,  -- admit whitelisted IPs (core/whitelist - hublist pingers etc.) despite the lockdown, so the hub stays visible on hublists (essential under reg_only). A deliberate, plugin-scoped exemption from this manual gate (boolean)
+    etc_lockdown_report = true,  -- on enable / disable / auto-expire, fire etc_report.send with the state change so staff see it live (boolean)
+    etc_lockdown_report_hubbot = false,  -- send the report as a hubbot PM to operators at or above etc_lockdown_llevel (boolean)
+    etc_lockdown_report_opchat = true,  -- send the report into op-chat (boolean)
+    etc_lockdown_llevel = 60,  -- min level for the hubbot-PM report (integer)
+
+    ---------------------------------------------------------------------------------------------------------------------------------
     --// etc_geoip.lua settings | country / ASN blocking via MaxMind GeoLite2 (#78 Phase D2). Needs geoipupdate for the DB - see docs/BLOCKLIST.md
 
     etc_geoip_enabled = false,  -- master toggle; plugin loads either way but the onConnect check is inert when false (boolean)
@@ -1581,6 +1592,7 @@ return { -- the settings are a lua table, do not tough this!
         "usr_nick_length.lua",
         "hub_inf_manager.lua",
         { "etc_clientblocker.lua", enabled = true },  -- #81 client AP/VE blocklist. API-toggleable (#261). Must sit AFTER hub_inf_manager so structural BINF rejects (forbidden flags / identity spoofing) happen first; client-policy kicks then run on already-validated INFs.
+        { "etc_lockdown.lua", enabled = false },  -- #501 transient maintenance-mode gate: admit only users >= <level>, kick + refuse the rest until `+lockdown off`. OFF by default. onConnect veto placed early in the access cluster so a locked-out login short-circuits before the heavier automated blockers (geoip / proxydetect); transparent to staff/exempt (returns nil), so chain position is not load-bearing for correctness. Enable here + use `+lockdown <level> [minutes] [reason]`.
         { "etc_blocklist.lua", enabled = true },  -- #78 Phase B `+blocklist` admin CLI for the unified pre-handshake IP/CIDR blocklist (engine = core/blocklist.lua, Phase A). API-toggleable (#261). Manages MANUAL entries; Phase D/E/F plugins (geoip / external feeds / proxydetect) will push auto-feed entries into the same store.
         { "etc_whitelist.lua", enabled = true },  -- #78 allowlist, Phase B `+whitelist` admin CLI for the global IP/CIDR allowlist (engine = core/whitelist.lua). API-toggleable (#261). Exempts trusted IPs (hublist pingers, seeded on first run) from the automated blockers; a manual +ban still wins. Chain position not load-bearing (consulted by the blockers, not a listener itself).
         { "etc_geoip.lua", enabled = false },  -- #78 Phase D2 country / ASN blocking via MaxMind GeoLite2. OFF by default (needs a geoipupdate-managed DB - see docs/BLOCKLIST.md). Per-connection post-handshake lookup; must sit AFTER hub_inf_manager like etc_clientblocker. Enable here + set etc_geoip_enabled=true + populate etc_geoip_blocked_countries.

--- a/scripts/etc_lockdown.lua
+++ b/scripts/etc_lockdown.lua
@@ -1,0 +1,447 @@
+--[[
+
+    etc_lockdown.lua v0.01 by Aybo ( #501 )
+
+        Transient "maintenance mode": temporarily admit only users at or
+        above a chosen level, kick everyone below, and refuse new logins
+        below it with a clear message and a reconnect hint - until the
+        operator lifts it (or an optional timer expires). Distinct from
+        `reg_only`, which is a PERMANENT access tier; this is a quick
+        on/off switch for staff to reconfigure or test while the hub
+        stays up.
+
+        Command ( min level etc_lockdown_command_minlevel, default 60 ):
+
+            [+!#]lockdown <level> [minutes] [reason]   enable
+            [+!#]lockdown off                          disable
+            [+!#]lockdown status                       show current state
+
+        <level>    mandatory; admit users whose level >= <level>. Self-
+                   lockout guard: you cannot set a level ABOVE your own
+                   (a HUBOWNER at 100 can never lock themselves out; a
+                   level-60 op cannot set 80).
+        [minutes]  optional whole minutes ( like +ban's <time> ); omit
+                   for an indefinite lockdown lifted only by `off`.
+        [reason]   optional. The token after <level> is taken as
+                   [minutes] only when it is a positive integer; a non-
+                   numeric token means "no time", and everything from
+                   there is the reason ( mirrors +ban's time-vs-reason
+                   split so the operator muscle memory carries over ).
+
+        Behaviour:
+          - onConnect vetoes a login from level < the active level with
+            ISTA 226 + an IQUI TL so the client reconnects on its own
+            ( TL = remaining seconds when timed, else the configured
+            etc_lockdown_default_retry ). Bots never fire onConnect, so
+            they are exempt with no special case.
+          - on enable, online users below the level are kicked with the
+            same message; staff at/above the level are untouched.
+          - whitelisted IPs ( core/whitelist - hublist pingers etc. ) are
+            admitted when etc_lockdown_exempt_whitelist is true, so the
+            hub stays visible on hublists during a lockdown ( essential
+            under reg_only, where info pingers must log in ). This is a
+            deliberate, plugin-scoped exemption from a manual gate.
+          - state persists to scripts/data/etc_lockdown.tbl as an
+            ABSOLUTE expiry timestamp, so a +reload neither resets nor
+            extends the deadline; a lockdown that expired while the hub
+            was down is cleared on boot.
+
+        Off by default: add { "etc_lockdown.lua", enabled = false } to
+        cfg.scripts to load it.
+
+]]--
+
+
+--------------
+--[SETTINGS]--
+--------------
+
+local scriptname    = "etc_lockdown"
+local scriptversion = "0.01"
+
+local cmd_main = "lockdown"
+
+--// imports
+local scriptlang = cfg.get( "language" )
+local lang, lang_err = cfg.loadlanguage( scriptlang, scriptname )
+lang = lang or { }
+if lang_err then hub.debug( lang_err ) end
+
+local command_minlevel = cfg.get( "etc_lockdown_command_minlevel" ) or 60
+local default_retry    = cfg.get( "etc_lockdown_default_retry" ) or 120
+local exempt_whitelist = cfg.get( "etc_lockdown_exempt_whitelist" )
+if exempt_whitelist == nil then exempt_whitelist = true end
+
+local report_activate = cfg.get( "etc_lockdown_report" )
+local report_hubbot   = cfg.get( "etc_lockdown_report_hubbot" )
+local report_opchat   = cfg.get( "etc_lockdown_report_opchat" )
+local report_llevel   = cfg.get( "etc_lockdown_llevel" )
+
+local report = hub.import( "etc_report" )
+
+local store_path = "scripts/data/etc_lockdown.tbl"
+
+--// table lookups
+local hub_getbot    = hub.getbot
+local hub_getusers  = hub.getusers
+local hub_escapeto  = hub.escapeto
+local hub_import    = hub.import
+local utf_match     = utf.match
+local utf_format    = utf.format
+local os_time       = os.time
+local math_floor    = math.floor
+local math_ceil     = math.ceil
+local math_type     = math.type
+
+-- ADC status code for the refuse. 226 is the hub's "access restricted"
+-- family ( same code as reg_only, of which a maintenance min-level gate
+-- is the transient sibling ). The reconnect timeout rides on the IQUI as
+-- the `TL` flag ( user:kill's quitstring1 ), NOT crammed into the ISTA
+-- line - the correct 2-arg form ( see usr_share / cmd_ban ).
+local ISTA_CODE = "226"
+
+-- Upper bound on a timed lockdown, in whole minutes ( 1 year - already
+-- absurd for a maintenance window ). Guards against a typo, and against a
+-- float / inf slipping past the integer check into overflow or a
+-- never-expiring "timed" lockdown.
+local MAX_MINUTES = 525600
+
+
+--// lang
+local help_title = lang.help_title or "etc_lockdown.lua - maintenance gate"
+local help_usage = lang.help_usage or "[+!#]lockdown <level> [minutes] [reason] | off | status"
+local help_desc  = lang.help_desc  or "Temporarily admit only users at or above <level>; kick + refuse everyone below until you run `lockdown off` (or the timer expires)."
+
+local ucmd_menu_status = lang.ucmd_menu_status or { "Hub", "Lockdown", "status" }
+local ucmd_menu_off    = lang.ucmd_menu_off    or { "Hub", "Lockdown", "off" }
+local ucmd_menu_on     = lang.ucmd_menu_on     or { "Hub", "Lockdown", "enable" }
+local ucmd_popup_level  = lang.ucmd_popup_level  or "Minimum level to admit (e.g. 60):"
+local ucmd_popup_min    = lang.ucmd_popup_min    or "Minutes (empty = indefinite):"
+local ucmd_popup_reason = lang.ucmd_popup_reason or "Reason (optional):"
+
+local msg_denied       = lang.msg_denied       or "[ LOCKDOWN ]--> You are not allowed to use this command."
+local msg_usage        = lang.msg_usage        or "Usage: [+!#]lockdown <level> [minutes] [reason] | off | status"
+local msg_bad_level    = lang.msg_bad_level    or "[ LOCKDOWN ]--> <level> must be a whole number 0-100, or use: off / status"
+local msg_notint       = lang.msg_notint       or "[ LOCKDOWN ]--> Time must be a whole number of minutes."
+local msg_badtime      = lang.msg_badtime      or "[ LOCKDOWN ]--> Time must be between 1 and 525600 minutes."
+local msg_self_lockout = lang.msg_self_lockout or "[ LOCKDOWN ]--> You cannot lock down at level %d - it is above your own level ( %d )."
+local msg_enabled      = lang.msg_enabled      or "[ LOCKDOWN ]--> %s enabled lockdown: min level %d, %s. Kicked %d online user( s )."
+local msg_disabled     = lang.msg_disabled     or "[ LOCKDOWN ]--> %s lifted the lockdown."
+local msg_already_off  = lang.msg_already_off  or "[ LOCKDOWN ]--> Lockdown is not active."
+local msg_indefinite   = lang.msg_indefinite   or "indefinite"
+local msg_status_off   = lang.msg_status_off   or "[ LOCKDOWN ]--> Lockdown is OFF."
+local msg_status_on    = lang.msg_status_on    or "[ LOCKDOWN ]--> Lockdown is ON  |  min level: %d  |  remaining: %s  |  message: %s  |  by: %s"
+local msg_expired      = lang.msg_expired      or "[ LOCKDOWN ]--> Lockdown ( min level %d ) expired and was lifted."
+local msg_default_kick = lang.msg_default_kick or "The hub is in maintenance mode. Please try again later."
+local msg_kick         = lang.msg_kick         or "[ LOCKDOWN ]--> %s"
+
+
+----------
+--[CODE]--
+----------
+
+-- Coerce a corrupt / hand-edited store to a safe inactive state. An
+-- `active=true` record missing a numeric `level` ( or with a non-numeric
+-- `expires_at` ) would otherwise crash EVERY onConnect on the level
+-- comparison against nil = a hub-wide login block. Degrade untrusted
+-- on-disk input to safe rather than trusting its shape.
+local function sane_state( s )
+    if type( s ) ~= "table" or not s.active then return { active = false } end
+    if type( s.level ) ~= "number" then return { active = false } end
+    if s.expires_at ~= nil and type( s.expires_at ) ~= "number" then return { active = false } end
+    return s
+end
+
+-- Persisted lockdown state. Shape ( when active ):
+--   { active=true, level=N, message=<str|nil>, expires_at=<abs os.time|nil>,
+--     by_nick=<str>, by_level=<int>, started_at=<abs os.time> }
+-- Loaded once at module load; util.loadtable returns nil on a fresh hub.
+local state = sane_state( util.loadtable( store_path ) )
+
+local function persist( )
+    util.savetable( state, "etc_lockdown_state", store_path )
+end
+
+-- Active NOW = flagged active AND ( no deadline OR deadline in the future ).
+-- A passed deadline reads as inactive here WITHOUT mutating state; onTimer
+-- performs the actual clear + notify, so this stays side-effect free and is
+-- safe to call from the onConnect hot path.
+local function is_active_now( )
+    if not state.active then return false end
+    if state.expires_at and os_time( ) >= state.expires_at then return false end
+    return true
+end
+
+-- The refuse message body: the operator's reason, else the default.
+local function refuse_text( )
+    local m = ( state.message and state.message ~= "" ) and state.message or msg_default_kick
+    return utf_format( msg_kick, m )
+end
+
+-- Seconds until the client should retry: remaining time when timed, else
+-- the configured default so clients keep re-knocking until `lockdown off`.
+local function retry_seconds( )
+    if state.expires_at then
+        local rem = state.expires_at - os_time( )
+        if rem < 1 then rem = 1 end
+        return rem
+    end
+    return default_retry
+end
+
+-- Refuse / kick one user: send the ISTA message, then IQUI with a TL so
+-- the client reconnects on its own once the lockdown lifts.
+local function kick_user( user )
+    user:kill(
+        "ISTA " .. ISTA_CODE .. " " .. hub_escapeto( refuse_text( ) ) .. "\n",
+        "TL" .. retry_seconds( )
+    )
+end
+
+-- Is this user exempt from the gate? Staff at/above the level pass; a
+-- whitelisted IP passes when the toggle is on.
+local function is_exempt( user )
+    if user:level( ) >= state.level then return true end
+    if exempt_whitelist and whitelist.is_whitelisted( user:ip( ) or "" ) then return true end
+    return false
+end
+
+-- Kick every online user below the level ( minus the exempt ). getusers()
+-- is humans-only ( no bots ). Snapshot the victims BEFORE killing so we
+-- never mutate the users table mid-iteration.
+local function kick_online_below( )
+    local victims = { }
+    for _, user in pairs( hub_getusers( ) ) do
+        if not is_exempt( user ) then
+            victims[ #victims + 1 ] = user
+        end
+    end
+    for _, user in ipairs( victims ) do
+        kick_user( user )
+    end
+    return #victims
+end
+
+-- Parse "[minutes] [reason]" from the tail after <level>. A leading
+-- numeric token is the intended duration ( validated: whole, >= 1 );
+-- a non-numeric leading token means no time and the whole tail is the
+-- reason. Mirrors cmd_ban's <time>-vs-<reason> split.
+-- Returns: minutes|nil, reason|nil, err_key|nil
+local function parse_time_reason( rest )
+    rest = rest or ""
+    local tok, tail = utf_match( rest, "^(%S+)%s*(.*)$" )
+    if not tok or tok == "" then return nil, nil, nil end
+    local n = tonumber( tok )
+    if n == nil then
+        return nil, rest, nil                        -- non-numeric -> reason only
+    end
+    -- A numeric first token is an intended duration: require a whole
+    -- integer in a sane range. math.type rejects floats AND inf / nan
+    -- ( "1e3", "1e999" ) - the overflow-safe form of cmd_ban's
+    -- `n ~= floor(n)` integer check.
+    if math_type( n ) ~= "integer" then return nil, nil, "notint" end
+    if n < 1 or n > MAX_MINUTES then return nil, nil, "badtime" end
+    return n, ( tail ~= "" and tail or nil ), nil    -- minutes + optional reason
+end
+
+-- Enable. `actor` is the invoking user ( already past the self-lockout
+-- guard, so >= level -> never kicked ). Returns the number kicked.
+local function enable_lockdown( level, minutes, reason, actor )
+    state = {
+        active     = true,
+        level      = level,
+        message    = reason,
+        expires_at = minutes and ( os_time( ) + minutes * 60 ) or nil,
+        by_nick    = ( actor and actor:firstnick( ) ) or "?",
+        by_level   = ( actor and actor:level( ) ) or 0,
+        started_at = os_time( ),
+    }
+    persist( )
+    return kick_online_below( )
+end
+
+-- Disable. Returns whether a lockdown was actually active.
+local function disable_lockdown( )
+    local was = state.active
+    state = { active = false }
+    persist( )
+    return was
+end
+
+local function format_status( )
+    if not is_active_now( ) then
+        return msg_status_off
+    end
+    local remaining
+    if state.expires_at then
+        -- is_active_now() above guarantees now < expires_at, so the
+        -- remainder is positive; ceil shows "1 min" for anything under a
+        -- minute.
+        remaining = math_ceil( ( state.expires_at - os_time( ) ) / 60 ) .. " min"
+    else
+        remaining = msg_indefinite
+    end
+    local m = ( state.message and state.message ~= "" ) and state.message or msg_default_kick
+    return utf_format( msg_status_on, state.level, remaining, m, state.by_nick or "?" )
+end
+
+local function send_report( msg )
+    if report then
+        report.send( report_activate, report_hubbot, report_opchat, report_llevel, msg )
+    end
+end
+
+
+------------------
+--[ADC HANDLERS]--
+------------------
+
+-- onConnect veto. Registered at load time ( no imports needed ) so the
+-- gate is live the moment the plugin loads.
+local function on_connect( user )
+    if not is_active_now( ) then return end
+    if is_exempt( user ) then return end
+    kick_user( user )
+    return PROCESSED
+end
+
+local function on_lockdown( user, command, parameters )
+    if user:level( ) < command_minlevel then
+        user:reply( msg_denied, hub_getbot( ) )
+        return PROCESSED
+    end
+
+    local first, rest = utf_match( parameters or "", "^(%S+)%s*(.*)$" )
+    first = first or ""
+    rest  = rest or ""
+    local verb = first:lower( )
+
+    if verb == "" then
+        user:reply( msg_usage, hub_getbot( ) )
+        return PROCESSED
+    end
+
+    if verb == "off" then
+        local was = disable_lockdown( )
+        if was then
+            local msg = utf_format( msg_disabled, user:firstnick( ) )
+            user:reply( msg, hub_getbot( ) )
+            send_report( msg )
+            audit.fire( audit.build( "lockdown.disable", user, nil, nil, { } ) )
+        else
+            user:reply( msg_already_off, hub_getbot( ) )
+        end
+        return PROCESSED
+    end
+
+    if verb == "status" then
+        user:reply( format_status( ), hub_getbot( ) )
+        return PROCESSED
+    end
+
+    -- Otherwise the first token must be the <level>.
+    local level = tonumber( first )
+    if not level or level ~= math_floor( level ) or level < 0 or level > 100 then
+        user:reply( msg_bad_level, hub_getbot( ) )
+        return PROCESSED
+    end
+
+    -- Self-lockout guard: never let an operator raise the bar above
+    -- their own level ( a HUBOWNER at 100 can lock everyone else out;
+    -- nobody can lock themselves out ).
+    if level > user:level( ) then
+        user:reply( utf_format( msg_self_lockout, level, user:level( ) ), hub_getbot( ) )
+        return PROCESSED
+    end
+
+    local minutes, reason, err = parse_time_reason( rest )
+    if err == "notint" then
+        user:reply( msg_notint, hub_getbot( ) )
+        return PROCESSED
+    elseif err == "badtime" then
+        user:reply( msg_badtime, hub_getbot( ) )
+        return PROCESSED
+    end
+
+    local kicked = enable_lockdown( level, minutes, reason, user )
+    local when = minutes and ( minutes .. " min" ) or msg_indefinite
+    local msg = utf_format( msg_enabled, user:firstnick( ), level, when, kicked )
+    user:reply( msg, hub_getbot( ) )
+    send_report( msg )
+    audit.fire( audit.build( "lockdown.enable", user, nil, reason, {
+        level   = level,
+        minutes = minutes,
+        kicked  = kicked,
+    } ) )
+    return PROCESSED
+end
+
+
+-----------------
+--[LIFECYCLE ]--
+-----------------
+
+hub.setlistener( "onConnect", { }, on_connect )
+
+-- Auto-expiry. onTimer fires frequently; the deadline check is cheap and
+-- lifts the lockdown at most one tick late.
+hub.setlistener( "onTimer", { },
+    function( )
+        if state.active and state.expires_at and os_time( ) >= state.expires_at then
+            local level = state.level
+            disable_lockdown( )
+            local msg = utf_format( msg_expired, level )
+            send_report( msg )
+            audit.fire( audit.build( "lockdown.expire", scriptname, nil, nil,
+                { level = level } ) )
+        end
+        return nil
+    end
+)
+
+hub.setlistener( "onStart", { },
+    function( )
+        -- A lockdown that expired while the hub was down: clear it on boot
+        -- ( no notice - nobody was here to be locked out ).
+        if state.active and state.expires_at and os_time( ) >= state.expires_at then
+            state = { active = false }
+            persist( )
+        end
+
+        local help = hub_import( "cmd_help" )
+        if help then
+            help.reg( help_title, help_usage, help_desc, command_minlevel )
+        end
+
+        local ucmd = hub_import( "etc_usercommands" )
+        if ucmd then
+            ucmd.add( ucmd_menu_status, cmd_main .. " status", { }, { "CT1" }, command_minlevel )
+            ucmd.add( ucmd_menu_off,    cmd_main .. " off",    { }, { "CT1" }, command_minlevel )
+            ucmd.add( ucmd_menu_on,
+                cmd_main .. " %[line:" .. ucmd_popup_level .. "] %[line:" .. ucmd_popup_min ..
+                "] %[line:" .. ucmd_popup_reason .. "]",
+                { }, { "CT1" }, command_minlevel )
+        end
+
+        local hubcmd = hub_import( "etc_hubcommands" )
+        assert( hubcmd )
+        assert( hubcmd.add( cmd_main, on_lockdown, command_minlevel ) )
+
+        return nil
+    end
+)
+
+hub.debug( "** Loaded " .. scriptname .. " " .. scriptversion .. " **" )
+
+--// expose internals for unit tests
+return {
+    _parse_time_reason  = parse_time_reason,
+    _is_active_now      = function( ) return is_active_now( ) end,
+    _state              = function( ) return state end,
+    _on_connect         = on_connect,
+    _on_lockdown        = on_lockdown,
+    _kick_online_below  = kick_online_below,
+    _format_status      = format_status,
+    _enable_lockdown    = enable_lockdown,
+    _disable_lockdown   = disable_lockdown,
+}

--- a/scripts/lang/etc_lockdown.lang.de
+++ b/scripts/lang/etc_lockdown.lang.de
@@ -1,0 +1,30 @@
+return {
+
+    help_title = "etc_lockdown.lua - Wartungssperre",
+    help_usage = "[+!#]lockdown <level> [minuten] [grund] | off | status",
+    help_desc  = "Laesst voruebergehend nur User ab <level> zu; kickt + weist alle darunter ab, bis du `lockdown off` ausfuehrst (oder der Timer ablaeuft).",
+
+    ucmd_menu_status = { "Hub", "Lockdown", "Status" },
+    ucmd_menu_off    = { "Hub", "Lockdown", "aus" },
+    ucmd_menu_on     = { "Hub", "Lockdown", "aktivieren" },
+    ucmd_popup_level  = "Mindestlevel zum Zulassen (z.B. 60):",
+    ucmd_popup_min    = "Minuten (leer = unbefristet):",
+    ucmd_popup_reason = "Grund (optional):",
+
+    msg_denied       = "[ LOCKDOWN ]--> Du darfst diesen Befehl nicht benutzen.",
+    msg_usage        = "Verwendung: [+!#]lockdown <level> [minuten] [grund] | off | status",
+    msg_bad_level    = "[ LOCKDOWN ]--> <level> muss eine ganze Zahl 0-100 sein, oder nutze: off / status",
+    msg_notint       = "[ LOCKDOWN ]--> Die Zeit muss eine ganze Zahl von Minuten sein.",
+    msg_badtime      = "[ LOCKDOWN ]--> Die Zeit muss zwischen 1 und 525600 Minuten liegen.",
+    msg_self_lockout = "[ LOCKDOWN ]--> Du kannst keine Sperre auf Level %d setzen - das liegt ueber deinem eigenen Level ( %d ).",
+    msg_enabled      = "[ LOCKDOWN ]--> %s hat die Sperre aktiviert: min Level %d, %s. %d Online-User gekickt.",
+    msg_disabled     = "[ LOCKDOWN ]--> %s hat die Sperre aufgehoben.",
+    msg_already_off  = "[ LOCKDOWN ]--> Die Sperre ist nicht aktiv.",
+    msg_indefinite   = "unbefristet",
+    msg_status_off   = "[ LOCKDOWN ]--> Sperre ist AUS.",
+    msg_status_on    = "[ LOCKDOWN ]--> Sperre ist AN  |  min Level: %d  |  verbleibend: %s  |  Nachricht: %s  |  von: %s",
+    msg_expired      = "[ LOCKDOWN ]--> Sperre ( min Level %d ) ist abgelaufen und wurde aufgehoben.",
+    msg_default_kick = "Der Hub befindet sich im Wartungsmodus. Bitte versuche es spaeter erneut.",
+    msg_kick         = "[ LOCKDOWN ]--> %s",
+
+}

--- a/scripts/lang/etc_lockdown.lang.en
+++ b/scripts/lang/etc_lockdown.lang.en
@@ -1,0 +1,30 @@
+return {
+
+    help_title = "etc_lockdown.lua - maintenance gate",
+    help_usage = "[+!#]lockdown <level> [minutes] [reason] | off | status",
+    help_desc  = "Temporarily admit only users at or above <level>; kick + refuse everyone below until you run `lockdown off` (or the timer expires).",
+
+    ucmd_menu_status = { "Hub", "Lockdown", "status" },
+    ucmd_menu_off    = { "Hub", "Lockdown", "off" },
+    ucmd_menu_on     = { "Hub", "Lockdown", "enable" },
+    ucmd_popup_level  = "Minimum level to admit (e.g. 60):",
+    ucmd_popup_min    = "Minutes (empty = indefinite):",
+    ucmd_popup_reason = "Reason (optional):",
+
+    msg_denied       = "[ LOCKDOWN ]--> You are not allowed to use this command.",
+    msg_usage        = "Usage: [+!#]lockdown <level> [minutes] [reason] | off | status",
+    msg_bad_level    = "[ LOCKDOWN ]--> <level> must be a whole number 0-100, or use: off / status",
+    msg_notint       = "[ LOCKDOWN ]--> Time must be a whole number of minutes.",
+    msg_badtime      = "[ LOCKDOWN ]--> Time must be between 1 and 525600 minutes.",
+    msg_self_lockout = "[ LOCKDOWN ]--> You cannot lock down at level %d - it is above your own level ( %d ).",
+    msg_enabled      = "[ LOCKDOWN ]--> %s enabled lockdown: min level %d, %s. Kicked %d online user( s ).",
+    msg_disabled     = "[ LOCKDOWN ]--> %s lifted the lockdown.",
+    msg_already_off  = "[ LOCKDOWN ]--> Lockdown is not active.",
+    msg_indefinite   = "indefinite",
+    msg_status_off   = "[ LOCKDOWN ]--> Lockdown is OFF.",
+    msg_status_on    = "[ LOCKDOWN ]--> Lockdown is ON  |  min level: %d  |  remaining: %s  |  message: %s  |  by: %s",
+    msg_expired      = "[ LOCKDOWN ]--> Lockdown ( min level %d ) expired and was lifted.",
+    msg_default_kick = "The hub is in maintenance mode. Please try again later.",
+    msg_kick         = "[ LOCKDOWN ]--> %s",
+
+}

--- a/tests/unit/etc_lockdown_test.lua
+++ b/tests/unit/etc_lockdown_test.lua
@@ -1,0 +1,367 @@
+--[[
+
+    tests/unit/etc_lockdown_test.lua
+
+    Unit tests for scripts/etc_lockdown.lua (#501 maintenance-mode gate).
+    Exercises:
+      - parse_time_reason: minutes-vs-reason split (cmd_ban grammar),
+        notint / badtime rejects, no-arg, non-numeric-first -> reason
+      - command minlevel guard + self-lockout guard (level > invoker)
+      - enable: state shape, ABSOLUTE expiry timestamp, kick-online-below
+        count (humans-only, staff untouched), persisted once
+      - onConnect veto: below-level -> ISTA 226 + IQUI TL + PROCESSED;
+        at/above-level -> nil, not killed
+      - whitelist exemption (toggle on) + no exemption (toggle off)
+      - TL: indefinite -> default_retry; timed -> remaining seconds
+      - off / already-off / status (on + off)
+      - auto-expiry via onTimer + boot-expiry clear
+      - persisted lockdown reloads on plugin load
+
+    Plugins get NO `use`; every dependency is a sandbox-global stub.
+    Run: lua5.4 tests/unit/etc_lockdown_test.lua
+
+]]--
+
+----------------------------------------------------------------------
+-- Tiny harness
+----------------------------------------------------------------------
+local _pass, _fail = 0, 0
+local function eq( what, got, want )
+    if got == want then _pass = _pass + 1
+    else _fail = _fail + 1
+        io.stderr:write( string.format( "FAIL: %s\n  got:  %s\n  want: %s\n",
+            what, tostring( got ), tostring( want ) ) ) end
+end
+local function truthy( what, v ) if v then _pass = _pass + 1
+    else _fail = _fail + 1; io.stderr:write( "FAIL: " .. what .. " got=" .. tostring( v ) .. "\n" ) end end
+local function falsy( what, v ) if not v then _pass = _pass + 1
+    else _fail = _fail + 1; io.stderr:write( "FAIL: " .. what .. " got=" .. tostring( v ) .. "\n" ) end end
+local function contains( what, hay, needle )
+    truthy( what, type( hay ) == "string" and hay:find( needle, 1, true ) ~= nil )
+end
+
+----------------------------------------------------------------------
+-- Controllable clock + capture state
+----------------------------------------------------------------------
+local _now = 1000000
+local _cfg, _persisted, _saved, _save_count, _reports, _audit, _online, _wl
+
+local function reset_cfg( )
+    _cfg = {
+        language = "en",
+        etc_lockdown_command_minlevel = 60,
+        etc_lockdown_default_retry    = 120,
+        etc_lockdown_exempt_whitelist = true,
+        etc_lockdown_report        = true,
+        etc_lockdown_report_hubbot = false,
+        etc_lockdown_report_opchat = true,
+        etc_lockdown_llevel        = 60,
+    }
+end
+local function fresh( )
+    _saved = nil; _save_count = 0; _reports = { }; _audit = { }
+    _online = { }; _wl = { }
+end
+
+----------------------------------------------------------------------
+-- Sandbox globals
+----------------------------------------------------------------------
+_G.use = nil
+_G.PROCESSED = "PROCESSED"
+_G.table, _G.string, _G.math = table, string, math
+_G.type, _G.pairs, _G.ipairs, _G.next = type, pairs, ipairs, next
+_G.tonumber, _G.tostring, _G.pcall = tonumber, tostring, pcall
+
+local _real_os = os
+_G.os = setmetatable( { time = function( ) return _now end }, { __index = _real_os } )
+
+_G.util = {
+    loadtable = function( ) return _persisted end,
+    savetable = function( t, name, path ) _saved = t; _save_count = _save_count + 1 end,
+}
+_G.cfg = {
+    get          = function( k ) return _cfg[ k ] end,
+    loadlanguage = function( ) return { } end,
+}
+_G.utf = {
+    format = function( fmt, ... ) return string.format( fmt, ... ) end,
+    match  = function( s, pat ) return string.match( s, pat ) end,
+}
+_G.audit = {
+    build = function( action, actor, target, reason, meta )
+        return { action = action, meta = meta or { } }
+    end,
+    fire = function( ev ) _audit[ #_audit + 1 ] = ev end,
+}
+_G.whitelist = { is_whitelisted = function( ip ) return _wl[ ip ] == true end }
+_G.hub = {
+    setlistener = function( ev, _opts, fn ) _G._listeners[ ev ] = fn end,
+    debug       = function( ) end,
+    getbot      = function( ) return "bot" end,
+    getusers    = function( ) return _online end,
+    escapeto    = function( s ) return s end,
+    import      = function( name )
+        if name == "etc_hubcommands" then return { add = function( ) return true end } end
+        if name == "cmd_help" then return { reg = function( ) end } end
+        if name == "etc_usercommands" then return { add = function( ) end } end
+        if name == "etc_report" then
+            return { send = function( _a, _h, _o, _l, msg ) _reports[ #_reports + 1 ] = msg end }
+        end
+        return nil
+    end,
+}
+
+local function mkuser( level, ip, sid, nick )
+    local u
+    u = {
+        level     = function( ) return level end,
+        ip        = function( ) return ip end,
+        sid       = function( ) return sid end,
+        nick      = function( ) return nick or ( "u" .. tostring( sid ) ) end,
+        firstnick = function( ) return nick or ( "u" .. tostring( sid ) ) end,
+        kill      = function( _, adc, q1 ) u._killed = adc; u._killtl = q1 end,
+        reply     = function( _, msg ) u._reply = msg end,
+    }
+    return u
+end
+
+local function load_plugin( overrides, persisted )
+    reset_cfg( )
+    if overrides then for k, v in pairs( overrides ) do _cfg[ k ] = v end end
+    fresh( )
+    _persisted = persisted
+    _G._listeners = { }
+    local p = assert( loadfile( "scripts/etc_lockdown.lua" ) )( )
+    if _G._listeners.onStart then _G._listeners.onStart( ) end
+    return p, _G._listeners
+end
+
+----------------------------------------------------------------------
+-- parse_time_reason (minutes-vs-reason split)
+----------------------------------------------------------------------
+do
+    local p = load_plugin( )
+    local function pr( s ) return p._parse_time_reason( s ) end
+
+    local m, r, e = pr( "30 maintenance" )
+    eq( "parse: '30 maintenance' minutes", m, 30 ); eq( "parse: reason", r, "maintenance" ); eq( "parse: no err", e, nil )
+
+    m, r, e = pr( "5" )
+    eq( "parse: '5' minutes", m, 5 ); eq( "parse: '5' no reason", r, nil ); eq( "parse: '5' no err", e, nil )
+
+    m, r, e = pr( "maintenance in progress" )
+    eq( "parse: non-numeric -> no minutes", m, nil ); eq( "parse: whole tail is reason", r, "maintenance in progress" )
+
+    m, r, e = pr( "" )
+    eq( "parse: empty -> no minutes", m, nil ); eq( "parse: empty -> no reason", r, nil )
+
+    m, r, e = pr( "1.5 x" )
+    eq( "parse: decimal rejected", e, "notint" ); eq( "parse: decimal no minutes", m, nil )
+
+    m, r, e = pr( "0 x" )
+    eq( "parse: zero rejected", e, "badtime" )
+
+    m, r, e = pr( "-3 x" )
+    eq( "parse: negative rejected", e, "badtime" )
+
+    -- hardening: integer-valued floats and inf must NOT slip through as
+    -- minutes (would give a float expires_at or a never-expiring "timed"
+    -- lockdown + a malformed "TL inf" reconnect hint)
+    m, r, e = pr( "1e3 x" )                          -- 1000.0, a float
+    eq( "parse: integer-valued float rejected", e, "notint" )
+    m, r, e = pr( "1e999 x" )                        -- math.huge
+    eq( "parse: inf rejected", e, "notint" )
+    m, r, e = pr( "525601 x" )                       -- over the 1-year cap
+    eq( "parse: over-cap rejected", e, "badtime" )
+    m, r, e = pr( "525600" )                         -- exactly the cap
+    eq( "parse: at-cap accepted", m, 525600 )
+
+    -- cmd_ban-style ambiguity: a reason that starts with a number is read
+    -- as minutes, exactly like +ban. Documented, operator-known behaviour.
+    m, r = pr( "2 hours downtime" )
+    eq( "parse: numeric-first taken as minutes", m, 2 ); eq( "parse: rest is reason", r, "hours downtime" )
+end
+
+----------------------------------------------------------------------
+-- command guards: minlevel + self-lockout
+----------------------------------------------------------------------
+do
+    local p = load_plugin( )
+    local low = mkuser( 40, "1.1.1.1", "S1" )      -- below command_minlevel 60
+    local r = p._on_lockdown( low, "lockdown", "60" )
+    eq( "guard: below minlevel -> PROCESSED", r, "PROCESSED" )
+    falsy( "guard: below minlevel did NOT enable", p._state( ).active )
+
+    local op = mkuser( 60, "2.2.2.2", "S2" )       -- level 60 op
+    p._on_lockdown( op, "lockdown", "80" )          -- tries to lock above own level
+    falsy( "self-lockout: level>own rejected -> not active", p._state( ).active )
+
+    p._on_lockdown( op, "lockdown", "60" )          -- own level is allowed
+    truthy( "self-lockout: level==own allowed", p._state( ).active )
+    eq( "self-lockout: level set", p._state( ).level, 60 )
+end
+
+----------------------------------------------------------------------
+-- enable: state, absolute expiry, kick-online-below, persist
+----------------------------------------------------------------------
+do
+    local p, L = load_plugin( )
+    _online = {
+        A = mkuser( 20, "10.0.0.1", "A" ),   -- kicked
+        B = mkuser( 30, "10.0.0.2", "B" ),   -- kicked
+        C = mkuser( 80, "10.0.0.3", "C" ),   -- staff, untouched
+    }
+    local owner = mkuser( 100, "9.9.9.9", "OWN", "owner" )
+    p._on_lockdown( owner, "lockdown", "60 5 scheduled maintenance" )
+
+    truthy( "enable: active", p._state( ).active )
+    eq( "enable: level", p._state( ).level, 60 )
+    eq( "enable: message", p._state( ).message, "scheduled maintenance" )
+    eq( "enable: ABSOLUTE expiry = now + 5min", p._state( ).expires_at, _now + 300 )
+    eq( "enable: by_nick", p._state( ).by_nick, "owner" )
+    truthy( "enable: persisted", _save_count >= 1 )
+    eq( "enable: persisted absolute expiry", _saved.expires_at, _now + 300 )
+
+    truthy( "enable: A (l20) kicked", _online.A._killed ~= nil )
+    truthy( "enable: B (l30) kicked", _online.B._killed ~= nil )
+    falsy( "enable: C (l80 staff) NOT kicked", _online.C._killed )
+    contains( "enable: kick uses ISTA 226", _online.A._killed, "ISTA 226" )
+    contains( "enable: reason in kick", _online.A._killed, "scheduled maintenance" )
+    contains( "enable: TL is remaining (~300)", _online.A._killtl, "TL30" ) -- "TL300" starts with TL30
+    truthy( "enable: audit fired", #_audit >= 1 )
+    eq( "enable: audit action", _audit[ #_audit ].action, "lockdown.enable" )
+end
+
+----------------------------------------------------------------------
+-- onConnect veto
+----------------------------------------------------------------------
+do
+    local p, L = load_plugin( )
+    local owner = mkuser( 100, "9.9.9.9", "OWN", "owner" )
+    p._on_lockdown( owner, "lockdown", "60" )      -- indefinite lockdown at 60
+
+    local below = mkuser( 20, "3.3.3.3", "X" )
+    local r = L.onConnect( below )
+    eq( "connect: below-level refused (PROCESSED)", r, "PROCESSED" )
+    truthy( "connect: below-level killed", below._killed ~= nil )
+    contains( "connect: ISTA 226", below._killed, "ISTA 226" )
+    contains( "connect: indefinite TL = default_retry 120", below._killtl, "TL120" )
+
+    local at = mkuser( 60, "4.4.4.4", "Y" )
+    eq( "connect: at-level admitted (nil)", L.onConnect( at ), nil )
+    falsy( "connect: at-level not killed", at._killed )
+
+    local above = mkuser( 80, "5.5.5.5", "Z" )
+    eq( "connect: above-level admitted (nil)", L.onConnect( above ), nil )
+    falsy( "connect: above-level not killed", above._killed )
+end
+
+----------------------------------------------------------------------
+-- whitelist exemption
+----------------------------------------------------------------------
+do
+    local p, L = load_plugin( )                    -- exempt_whitelist defaults true
+    p._on_lockdown( mkuser( 100, "9.9.9.9", "OWN" ), "lockdown", "60" )
+    _wl[ "7.7.7.7" ] = true
+    local pinger = mkuser( 10, "7.7.7.7", "P" )
+    eq( "whitelist: exempt IP admitted (nil)", L.onConnect( pinger ), nil )
+    falsy( "whitelist: exempt IP not killed", pinger._killed )
+
+    local other = mkuser( 10, "8.8.8.8", "Q" )     -- not whitelisted
+    eq( "whitelist: non-exempt low-level refused", L.onConnect( other ), "PROCESSED" )
+end
+
+do
+    -- toggle OFF: a whitelisted low-level user IS kicked
+    local p, L = load_plugin( { etc_lockdown_exempt_whitelist = false } )
+    p._on_lockdown( mkuser( 100, "9.9.9.9", "OWN" ), "lockdown", "60" )
+    _wl[ "7.7.7.7" ] = true
+    local pinger = mkuser( 10, "7.7.7.7", "P" )
+    eq( "whitelist-off: whitelisted low-level refused", L.onConnect( pinger ), "PROCESSED" )
+end
+
+----------------------------------------------------------------------
+-- off / already-off / status
+----------------------------------------------------------------------
+do
+    local p, L = load_plugin( )
+    local owner = mkuser( 100, "9.9.9.9", "OWN", "owner" )
+
+    p._on_lockdown( owner, "lockdown", "status" )
+    contains( "status: OFF before enable", owner._reply, "OFF" )
+
+    p._on_lockdown( owner, "lockdown", "60 nachtwartung" )
+    p._on_lockdown( owner, "lockdown", "status" )
+    contains( "status: ON after enable", owner._reply, "ON" )
+    contains( "status: shows message", owner._reply, "nachtwartung" )
+
+    p._on_lockdown( owner, "lockdown", "off" )
+    falsy( "off: not active", p._state( ).active )
+    local below = mkuser( 20, "3.3.3.3", "X" )
+    eq( "off: below-level now admitted", L.onConnect( below ), nil )
+
+    p._on_lockdown( owner, "lockdown", "off" )     -- already off
+    contains( "already-off: informs", owner._reply, "not active" )
+end
+
+----------------------------------------------------------------------
+-- auto-expiry via onTimer
+----------------------------------------------------------------------
+do
+    local p, L = load_plugin( )
+    local owner = mkuser( 100, "9.9.9.9", "OWN", "owner" )
+    p._on_lockdown( owner, "lockdown", "60 5" )    -- 5 minutes
+    truthy( "expiry: active before deadline", p._state( ).active )
+
+    -- Before deadline, onTimer is a no-op and the gate still refuses.
+    L.onTimer( )
+    truthy( "expiry: still active pre-deadline", p._state( ).active )
+    eq( "expiry: refuses pre-deadline", L.onConnect( mkuser( 20, "1.2.3.4", "X" ) ), "PROCESSED" )
+
+    _now = _now + 301                               -- past the deadline
+    L.onTimer( )
+    falsy( "expiry: cleared post-deadline", p._state( ).active )
+    eq( "expiry: admits post-deadline", L.onConnect( mkuser( 20, "1.2.3.4", "X" ) ), nil )
+    truthy( "expiry: audit fired", ( function( )
+        for _, e in ipairs( _audit ) do if e.action == "lockdown.expire" then return true end end
+    end )( ) )
+    _now = 1000000
+end
+
+----------------------------------------------------------------------
+-- persisted lockdown reloads on plugin load
+----------------------------------------------------------------------
+do
+    -- a still-valid persisted lockdown survives a reload
+    local p, L = load_plugin( nil, { active = true, level = 60, message = "persisted",
+        expires_at = _now + 600, by_nick = "op", by_level = 60, started_at = _now } )
+    truthy( "reload: persisted lockdown active", p._state( ).active )
+    eq( "reload: refuses below-level", L.onConnect( mkuser( 20, "1.2.3.4", "X" ) ), "PROCESSED" )
+end
+
+do
+    -- a persisted lockdown that already expired while the hub was down is
+    -- cleared on boot (onStart)
+    local p, L = load_plugin( nil, { active = true, level = 60, message = "stale",
+        expires_at = _now - 10, by_nick = "op", by_level = 60, started_at = _now - 100 } )
+    falsy( "reload: expired-while-down cleared on boot", p._state( ).active )
+    eq( "reload: admits after boot-clear", L.onConnect( mkuser( 20, "1.2.3.4", "X" ) ), nil )
+end
+
+do
+    -- HARDENING (review finding): a corrupt / hand-edited store with
+    -- active=true but NO numeric level must degrade to inactive, not
+    -- crash every onConnect (a level comparison against nil = hub-wide
+    -- login block).
+    local p, L = load_plugin( nil, { active = true, message = "corrupt" } )
+    falsy( "corrupt: active-without-level coerced to inactive", p._state( ).active )
+    eq( "corrupt: onConnect admits, no crash", L.onConnect( mkuser( 20, "1.2.3.4", "X" ) ), nil )
+
+    -- non-numeric expires_at is likewise coerced
+    local p2, L2 = load_plugin( nil, { active = true, level = 60, expires_at = "soon" } )
+    falsy( "corrupt: bad expires_at coerced to inactive", p2._state( ).active )
+end
+
+----------------------------------------------------------------------
+io.write( string.format( "\netc_lockdown: %d passed, %d failed\n", _pass, _fail ) )
+os.exit( _fail == 0 and 0 or 1 )


### PR DESCRIPTION
Promotes the #501 `etc_lockdown` transient maintenance-mode gate from dev to master.

`[+!#]lockdown <level> [minutes] [reason] | off | status` admits only users at/above <level>, kicks everyone below, and refuses new logins below it at onConnect (ISTA 226 + an IQUI TL reconnect hint), until lifted or a timer expires. Whitelisted IPs are exempt (keeps the hub on hublists); state persists as an absolute expiry timestamp (reload-safe); self-lockout guard rejects a level above the invoker's. Off by default.

Two-pass reviewed (independent reviewer: no critical/major; 2 minor + 1 nit addressed), 71-check unit test on both smoke legs, CI green on dev HEAD, and live-verified on a :dev testhub (kick-on-enable, real ISTA 226 refuse, op admitted, off restores).

Closes #501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)