### PR TITLE
feat(forcetls): etc_forcetlstransfer force-ADCS C2C-transfer gate (#500)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -178,6 +178,13 @@ jobs:
       - name: Run etc_lockdown unit test
         run: lua5.4 tests/unit/etc_lockdown_test.lua
 
+      # #500 etc_forcetlstransfer: force-ADCS C2C gate. Stubbed cfg /
+      # whitelist + adccmd[8]. Covers the ADCS/ allow-list classifier,
+      # both-parties-trusted exemption (level + whitelist), block vs warn,
+      # and the per-sender notify dedupe.
+      - name: Run etc_forcetlstransfer unit test
+        run: lua5.4 tests/unit/etc_forcetlstransfer_test.lua
+
       # Coverage completeness: these two unit tests existed but were never
       # wired into CI. Both pass; registering them keeps tests/README's
       # "the whole tests/unit set runs in CI" statement true.
@@ -558,6 +565,10 @@ jobs:
       - name: Run etc_lockdown unit test
         shell: msys2 {0}
         run: lua5.4 tests/unit/etc_lockdown_test.lua
+
+      - name: Run etc_forcetlstransfer unit test
+        shell: msys2 {0}
+        run: lua5.4 tests/unit/etc_forcetlstransfer_test.lua
 
       - name: Run etc_blocklist unit test
         shell: msys2 {0}

--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -4746,6 +4746,17 @@ local defaults = {
             return types_number( value, nil, true )
         end
     },
+    -- #500: etc_forcetlstransfer.lua force-ADCS C2C-transfer gate. On each
+    -- peer-connection setup event it reads the transfer protocol and, per
+    -- mode, drops ( block ) or warns on a plain ( non-ADCS ) setup. All-or-
+    -- nothing: no level / whitelist exemption - an enabled hub forces TLS
+    -- on every transfer. Plugin off by default in examples/cfg.
+    etc_forcetlstransfer_mode = { "block",
+        function( value )
+            if not types_utf8( value, nil, true ) then return false end
+            return value == "warn" or value == "block"
+        end
+    },
     -- #78 Phase B: `+blocklist` admin plugin (etc_blocklist.lua).
     -- Operator-facing chat command + JSONL export/import. The
     -- engine in core/blocklist.lua is independent; these keys

--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -4748,10 +4748,11 @@ local defaults = {
     },
     -- #500: etc_forcetlstransfer.lua force-ADCS C2C-transfer gate. On each
     -- peer-connection setup event it reads the transfer protocol and, per
-    -- mode, drops ( block ) or warns on a plain ( non-ADCS ) setup. All-or-
-    -- nothing: no level / whitelist exemption - an enabled hub forces TLS
-    -- on every transfer. Plugin off by default in examples/cfg.
-    etc_forcetlstransfer_mode = { "block",
+    -- mode, drops ( "block" ) or warns ( "warn", default ) on a plain
+    -- ( non-ADCS ) setup. All-or-nothing: no level / whitelist exemption.
+    -- Ships ENABLED in "warn" mode in examples/cfg ( non-breaking );
+    -- escalate to "block" to enforce.
+    etc_forcetlstransfer_mode = { "warn",
         function( value )
             if not types_utf8( value, nil, true ) then return false end
             return value == "warn" or value == "block"

--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -1037,7 +1037,7 @@ return { -- the settings are a lua table, do not tough this!
     ---------------------------------------------------------------------------------------------------------------------------------
     --// etc_forcetlstransfer.lua settings | force encrypted (ADCS) client-to-client transfers (#500). On each peer-connection setup (CTM / RCM / NAT-traversal) the hub reads the transfer protocol and, per mode, drops or warns on a plain (non-ADCS) setup. The hub can only REFUSE to broker a plain transfer, not upgrade it - a dropped setup fails that transfer (pushes users to enable forced TLS + forward their TLS port). All-or-nothing: no exemptions - an enabled hub forces TLS on EVERY transfer. Plugin ships DISABLED
 
-    etc_forcetlstransfer_mode = "block",  -- "block" (default) = drop the plain setup + notify both parties (enforces TLS); "warn" = let the plain transfer pass but notify (a softer roll-out that breaks nothing) (string, "warn"|"block")
+    etc_forcetlstransfer_mode = "warn",  -- "warn" (default, non-breaking) = let the plain transfer pass but notify both parties toward TLS; "block" = drop the plain setup + notify (enforces TLS - flip to this once your users have set up their TLS ports) (string, "warn"|"block")
 
     ---------------------------------------------------------------------------------------------------------------------------------
     --// etc_geoip.lua settings | country / ASN blocking via MaxMind GeoLite2 (#78 Phase D2). Needs geoipupdate for the DB - see docs/BLOCKLIST.md
@@ -1654,7 +1654,7 @@ return { -- the settings are a lua table, do not tough this!
         "etc_auditlog.lua",  -- #84 staff-action audit trail (JSONL + /v1/events audit type)
         { "etc_chatlog.lua", enabled = true },  -- API-toggleable (#261)
         "etc_trafficmanager.lua",  -- using report import -- must be above all other scripts who wants to use the block import
-        { "etc_forcetlstransfer.lua", enabled = false },  -- #500 force encrypted (ADCS) C2C transfers. OFF by default. All-or-nothing: drops/warns on any plain (non-ADCS) CTM/RCM/NAT setup, no exemptions. Listens on the peer-connection-setup events like etc_trafficmanager; chain position is not load-bearing (any PROCESSED drops the setup). Enable here + set etc_forcetlstransfer_mode="block".
+        { "etc_forcetlstransfer.lua", enabled = true },  -- #500 force encrypted (ADCS) C2C transfers. Ships ENABLED in "warn" mode (non-breaking) - nudges users toward TLS transfers without cutting any off. All-or-nothing: acts on any plain (non-ADCS) CTM/RCM/NAT setup, no exemptions. Set etc_forcetlstransfer_mode="block" to enforce once users have set up their TLS ports, or disable here. Chain position is not load-bearing (any PROCESSED drops the setup).
         "cmd_delreg.lua",  -- using report, ban, block import
         "cmd_usercleaner.lua", -- using report import
         { "etc_records.lua", enabled = true },  -- API-toggleable (#261)

--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -1035,6 +1035,11 @@ return { -- the settings are a lua table, do not tough this!
     etc_lockdown_llevel = 60,  -- min level for the hubbot-PM report (integer)
 
     ---------------------------------------------------------------------------------------------------------------------------------
+    --// etc_forcetlstransfer.lua settings | force encrypted (ADCS) client-to-client transfers (#500). On each peer-connection setup (CTM / RCM / NAT-traversal) the hub reads the transfer protocol and, per mode, drops or warns on a plain (non-ADCS) setup. The hub can only REFUSE to broker a plain transfer, not upgrade it - a dropped setup fails that transfer (pushes users to enable forced TLS + forward their TLS port). All-or-nothing: no exemptions - an enabled hub forces TLS on EVERY transfer. Plugin ships DISABLED
+
+    etc_forcetlstransfer_mode = "block",  -- "block" (default) = drop the plain setup + notify both parties (enforces TLS); "warn" = let the plain transfer pass but notify (a softer roll-out that breaks nothing) (string, "warn"|"block")
+
+    ---------------------------------------------------------------------------------------------------------------------------------
     --// etc_geoip.lua settings | country / ASN blocking via MaxMind GeoLite2 (#78 Phase D2). Needs geoipupdate for the DB - see docs/BLOCKLIST.md
 
     etc_geoip_enabled = false,  -- master toggle; plugin loads either way but the onConnect check is inert when false (boolean)
@@ -1649,6 +1654,7 @@ return { -- the settings are a lua table, do not tough this!
         "etc_auditlog.lua",  -- #84 staff-action audit trail (JSONL + /v1/events audit type)
         { "etc_chatlog.lua", enabled = true },  -- API-toggleable (#261)
         "etc_trafficmanager.lua",  -- using report import -- must be above all other scripts who wants to use the block import
+        { "etc_forcetlstransfer.lua", enabled = false },  -- #500 force encrypted (ADCS) C2C transfers. OFF by default. All-or-nothing: drops/warns on any plain (non-ADCS) CTM/RCM/NAT setup, no exemptions. Listens on the peer-connection-setup events like etc_trafficmanager; chain position is not load-bearing (any PROCESSED drops the setup). Enable here + set etc_forcetlstransfer_mode="block".
         "cmd_delreg.lua",  -- using report, ban, block import
         "cmd_usercleaner.lua", -- using report import
         { "etc_records.lua", enabled = true },  -- API-toggleable (#261)

--- a/scripts/etc_forcetlstransfer.lua
+++ b/scripts/etc_forcetlstransfer.lua
@@ -18,12 +18,14 @@
         ( ECTM / ERCM ) fire the same onConnectToMe / onRevConnectToMe
         listeners, so one handler per event covers D and E.
 
-        Modes ( etc_forcetlstransfer_mode, default "block" ):
-          - "block" ( default ): drop the plain setup ( return PROCESSED )
-            and notify both parties ( sender + target ). Enforces TLS
-            immediately.
-          - "warn": let the plain setup pass but notify both parties - a
-            softer roll-out that breaks nothing while users switch.
+        Modes ( etc_forcetlstransfer_mode, default "warn" ):
+          - "warn" ( default ): let the plain setup pass but notify both
+            parties ( sender + target ). Non-breaking - the shipped default,
+            so a fresh hub nudges users toward TLS without cutting off any
+            transfer.
+          - "block": drop the plain setup ( return PROCESSED ) + notify.
+            Enforces TLS immediately - flip to this once your users have set
+            up their TLS ports.
 
         No exemptions - all-or-nothing. When the plugin is loaded, EVERY
         plain transfer is acted on ( no level or IP escape hatch ): either
@@ -39,10 +41,11 @@
         Notes:
           - CCPM ( client-to-client PM ) always uses ADCS, so it is never
             blocked here ( unlike etc_trafficmanager's level block ).
-          - Any mode other than "warn" fails CLOSED ( blocks ), and the
-            block decision is locked in before the best-effort notify, so
-            neither a misconfig nor a notify error can silently disable
-            enforcement.
+          - Only an explicit "warn" lets a plain setup pass; any other
+            value ( "block" or a typo ) blocks, and the decision is locked
+            in before the best-effort notify. So a mistyped mode over-
+            enforces rather than silently passing - an operator who set
+            "block" cannot lose enforcement to a typo or a notify error.
           - Listener order: this handler returns PROCESSED / nil only, but
             the firelistener chain lets the FIRST non-nil return win. Keep
             this ahead of any plugin that returns a truthy non-PROCESSED
@@ -50,8 +53,9 @@
             bundled etc_trafficmanager returns only PROCESSED / nil, so the
             default plugin set is safe in any order.
 
-        Off by default: add { "etc_forcetlstransfer.lua", enabled = false }
-        to cfg.scripts to load it.
+        Ships ENABLED in "warn" mode ( non-breaking ) in examples/cfg, so a
+        fresh hub encourages TLS transfers out of the box. Escalate to
+        "block" to enforce, or drop the cfg.scripts entry to disable.
 
 ]]--
 
@@ -69,10 +73,11 @@ local lang, lang_err = cfg.loadlanguage( scriptlang, scriptname )
 lang = lang or { }
 if lang_err then hub.debug( lang_err ) end
 
-local mode             = cfg.get( "etc_forcetlstransfer_mode" ) or "block"
--- Fail-closed: only an explicit "warn" lets a plain setup pass; anything
--- else ( incl. an unexpected value ) blocks, so a misconfigured mode can
--- never silently disable enforcement.
+local mode             = cfg.get( "etc_forcetlstransfer_mode" ) or "warn"
+-- Only an explicit "warn" lets a plain setup pass; any other value
+-- ( "block" or a typo ) blocks. So a mistyped mode over-enforces rather
+-- than silently passing - an operator who set "block" can't lose it to a
+-- typo. Default is "warn" ( the shipped, non-breaking default ).
 local blocking         = ( mode ~= "warn" )
 
 --// table lookups

--- a/scripts/etc_forcetlstransfer.lua
+++ b/scripts/etc_forcetlstransfer.lua
@@ -1,0 +1,176 @@
+--[[
+
+    etc_forcetlstransfer.lua v0.01 by Aybo ( #500 )
+
+        Force encrypted ( ADCS ) client-to-client transfers. ADC peer-
+        connection setup ( CTM / RCM / NAT-traversal ) routes through the
+        hub and carries the transfer protocol as its first positional
+        param: `ADC/1.0` ( plain ) vs `ADCS/0.10` ( TLS ). The hub cannot
+        encrypt or inspect the transfer itself ( client-to-client, the
+        peers' own certs ), but it CAN refuse to broker a plain setup -
+        which is enough to force TLS. A dropped plain setup fails that one
+        transfer; it is not auto-upgraded ( that is the point - it pushes
+        users to enable "forced" transfer encryption / forward their TLS
+        port ).
+
+        Covers all four setup events. NAT-traversal is a SEPARATE path
+        from CTM / RCM and must be covered too; the E-class variants
+        ( ECTM / ERCM ) fire the same onConnectToMe / onRevConnectToMe
+        listeners, so one handler per event covers D and E.
+
+        Modes ( etc_forcetlstransfer_mode, default "block" ):
+          - "block" ( default ): drop the plain setup ( return PROCESSED )
+            and notify both parties ( sender + target ). Enforces TLS
+            immediately.
+          - "warn": let the plain setup pass but notify both parties - a
+            softer roll-out that breaks nothing while users switch.
+
+        No exemptions - all-or-nothing. When the plugin is loaded, EVERY
+        plain transfer is acted on ( no level or IP escape hatch ): either
+        you want all transfers encrypted or you don't, so the only knob is
+        the mode. Bots / infra that still transfer plain must move to ADCS
+        too; if a hub genuinely needs plain transfers, it simply does not
+        load this plugin.
+
+        Allow-LIST the protocol ( `^ADCS/` passes ), never blacklist
+        `ADC/1.0`: version suffixes vary and unknown / non-ADCS protocols
+        must be treated as plain.
+
+        Notes:
+          - CCPM ( client-to-client PM ) always uses ADCS, so it is never
+            blocked here ( unlike etc_trafficmanager's level block ).
+          - Any mode other than "warn" fails CLOSED ( blocks ), and the
+            block decision is locked in before the best-effort notify, so
+            neither a misconfig nor a notify error can silently disable
+            enforcement.
+          - Listener order: this handler returns PROCESSED / nil only, but
+            the firelistener chain lets the FIRST non-nil return win. Keep
+            this ahead of any plugin that returns a truthy non-PROCESSED
+            sentinel on these events, or its drop could be masked. The
+            bundled etc_trafficmanager returns only PROCESSED / nil, so the
+            default plugin set is safe in any order.
+
+        Off by default: add { "etc_forcetlstransfer.lua", enabled = false }
+        to cfg.scripts to load it.
+
+]]--
+
+
+--------------
+--[SETTINGS]--
+--------------
+
+local scriptname    = "etc_forcetlstransfer"
+local scriptversion = "0.01"
+
+--// imports
+local scriptlang = cfg.get( "language" )
+local lang, lang_err = cfg.loadlanguage( scriptlang, scriptname )
+lang = lang or { }
+if lang_err then hub.debug( lang_err ) end
+
+local mode             = cfg.get( "etc_forcetlstransfer_mode" ) or "block"
+-- Fail-closed: only an explicit "warn" lets a plain setup pass; anything
+-- else ( incl. an unexpected value ) blocks, so a misconfigured mode can
+-- never silently disable enforcement.
+local blocking         = ( mode ~= "warn" )
+
+--// table lookups
+local hub_getbot   = hub.getbot
+local os_time      = os.time
+local string_match = string.match
+
+-- The transfer protocol is the FIRST positional param of the CTM / RCM /
+-- NAT / RNT setup command. D/E-class commands carry a 2-SID header, and
+-- the parser interleaves separator slots, so positional #1 lands at
+-- adccmd[8] ( the same slot a DMSG body occupies ). CTM/NAT/RNT are
+-- {protocol, port, token}; RCM is {protocol, token} - protocol is
+-- adccmd[8] in every case.
+local PROTO_IDX = 8
+
+-- Per-sender notify throttle so a burst of setup commands ( a client
+-- retrying, or one download firing RCM then CTM ) does not spam.
+local NOTIFY_INTERVAL = 30
+local last_notify = { }
+
+
+--// lang
+-- Role-neutral wording: the same message goes to BOTH the sender and the
+-- target of the setup, so it must read correctly for either side.
+local msg_block = lang.msg_block or "[ FORCE TLS ]--> An unencrypted transfer was blocked - this hub requires encrypted ( ADCS ) transfers. Please enable forced transfer encryption in your client and forward your TLS port. Setup guide: https://dcvault.net/docs/clients/installation-setup#connection"
+local msg_warn  = lang.msg_warn  or "[ FORCE TLS ]--> An unencrypted transfer was detected - this hub asks for encrypted ( ADCS ) transfers. Please enable forced transfer encryption in your client and forward your TLS port. Setup guide: https://dcvault.net/docs/clients/installation-setup#connection"
+
+
+----------
+--[CODE]--
+----------
+
+-- Allow-list: only a protocol that starts with "ADCS/" is TLS. Anything
+-- else ( ADC/1.0, NEODC, unknown, or a missing field ) counts as plain.
+local function is_tls( proto )
+    return type( proto ) == "string" and string_match( proto, "^ADCS/" ) ~= nil
+end
+
+-- Notify one party ( sender or target ) via PM, throttled per firstnick
+-- so neither a retrying client nor a popular uploader gets spammed. A nil
+-- party ( e.g. a target that just left ) is skipped.
+local function notify( u )
+    if not u then return end
+    local nick = u:firstnick( )
+    if not nick then return end
+    local now  = os_time( )
+    local last = last_notify[ nick ]
+    if last and ( now - last ) < NOTIFY_INTERVAL then return end
+    last_notify[ nick ] = now
+    u:reply( blocking and msg_block or msg_warn, hub_getbot( ), hub_getbot( ) )
+end
+
+-- Shared handler for all four setup events. Returns PROCESSED to DROP the
+-- setup ( block mode ), or nil to let it pass ( warn mode, or an already-
+-- TLS transfer ). No exemptions: an enabled hub forces TLS on EVERY
+-- transfer - if you want a plain transfer, do not load this plugin.
+local function check( user, target, adccmd )
+    if is_tls( adccmd[ PROTO_IDX ] ) then return nil end
+    -- Lock in the decision FIRST, then notify best-effort ( pcall ): the
+    -- listener chain forwards a plain setup if a listener throws, so a
+    -- notify error must never turn a block into a pass. Both endpoints
+    -- need TLS, so notify both.
+    local decision = blocking and PROCESSED or nil
+    pcall( notify, user )
+    pcall( notify, target )
+    return decision
+end
+
+
+-----------------
+--[LIFECYCLE ]--
+-----------------
+
+-- ECTM / ERCM fire onConnectToMe / onRevConnectToMe too, so one handler
+-- per event covers D and E. NAT-traversal is a separate path.
+hub.setlistener( "onConnectToMe",       { }, check )
+hub.setlistener( "onRevConnectToMe",    { }, check )
+hub.setlistener( "onNatTraversal",      { }, check )
+hub.setlistener( "onNatTraversalReply", { }, check )
+
+-- Bound the notify-throttle table to the online population: clear a
+-- sender's entry when they leave. Otherwise it would accumulate one entry
+-- per distinct firstnick for the hub's whole uptime ( the throttle only
+-- ever needs entries younger than NOTIFY_INTERVAL ).
+hub.setlistener( "onLogout", { },
+    function( user )
+        local nick = user:firstnick( )
+        if nick then last_notify[ nick ] = nil end
+        return nil
+    end
+)
+
+hub.debug( "** Loaded " .. scriptname .. " " .. scriptversion .. " **" )
+
+--// expose internals for unit tests
+return {
+    _is_tls      = is_tls,
+    _check       = check,
+    _notify      = notify,
+    _PROTO_IDX   = PROTO_IDX,
+}

--- a/scripts/lang/etc_forcetlstransfer.lang.de
+++ b/scripts/lang/etc_forcetlstransfer.lang.de
@@ -1,0 +1,6 @@
+return {
+
+    msg_block = "[ FORCE TLS ]--> Ein unverschluesselter Transfer wurde blockiert - dieser Hub verlangt verschluesselte ( ADCS ) Transfers. Bitte aktiviere die erzwungene ( \"forced\" ) Transfer-Verschluesselung in deinem Client und leite deinen TLS-Port weiter. Anleitung: https://dcvault.net/docs/clients/installation-setup#connection",
+    msg_warn  = "[ FORCE TLS ]--> Ein unverschluesselter Transfer wurde erkannt - dieser Hub bittet um verschluesselte ( ADCS ) Transfers. Bitte aktiviere die erzwungene ( \"forced\" ) Transfer-Verschluesselung in deinem Client und leite deinen TLS-Port weiter. Anleitung: https://dcvault.net/docs/clients/installation-setup#connection",
+
+}

--- a/scripts/lang/etc_forcetlstransfer.lang.en
+++ b/scripts/lang/etc_forcetlstransfer.lang.en
@@ -1,0 +1,6 @@
+return {
+
+    msg_block = "[ FORCE TLS ]--> An unencrypted transfer was blocked - this hub requires encrypted ( ADCS ) transfers. Please enable forced transfer encryption in your client and forward your TLS port. Setup guide: https://dcvault.net/docs/clients/installation-setup#connection",
+    msg_warn  = "[ FORCE TLS ]--> An unencrypted transfer was detected - this hub asks for encrypted ( ADCS ) transfers. Please enable forced transfer encryption in your client and forward your TLS port. Setup guide: https://dcvault.net/docs/clients/installation-setup#connection",
+
+}

--- a/tests/unit/etc_forcetlstransfer_test.lua
+++ b/tests/unit/etc_forcetlstransfer_test.lua
@@ -217,6 +217,20 @@ do
         L.onConnectToMe( bad, mkuser( "6.0.1.2" ), mkcmd( "ADC/1.0" ) ), "PROCESSED" )
 end
 
+do
+    -- shipped default: with no mode key set, the plugin defaults to "warn"
+    -- ( the non-breaking default ) - a plain setup passes but still notifies
+    reset_cfg( )
+    _cfg.etc_forcetlstransfer_mode = nil
+    _G._listeners = { }
+    local p = assert( loadfile( "scripts/etc_forcetlstransfer.lua" ) )( )
+    local L = _G._listeners
+    local u = mkuser( "7.0.0.1" )
+    eq( "default (no mode set) = warn: plain passes",
+        L.onConnectToMe( u, mkuser( "7.0.0.2" ), mkcmd( "ADC/1.0" ) ), nil )
+    eq( "default (no mode set) = warn: still notifies", u._replies, 1 )
+end
+
 ----------------------------------------------------------------------
 io.write( string.format( "\netc_forcetlstransfer: %d passed, %d failed\n", _pass, _fail ) )
 os.exit( _fail == 0 and 0 or 1 )

--- a/tests/unit/etc_forcetlstransfer_test.lua
+++ b/tests/unit/etc_forcetlstransfer_test.lua
@@ -1,0 +1,222 @@
+--[[
+
+    tests/unit/etc_forcetlstransfer_test.lua
+
+    Unit tests for scripts/etc_forcetlstransfer.lua (#500 force ADCS C2C).
+    All-or-nothing gate - NO level / whitelist exemption. Exercises:
+      - is_tls classifier: ADCS/ prefix allow-list; ADC/1.0, NEODC,
+        "ADCSX/" (not fooled), lowercase, nil, "" all count as plain
+      - check (block): plain -> PROCESSED + BOTH parties notified via PM
+        (with the setup link); ADCS -> pass (nil), no notify
+      - check (warn): plain -> pass (nil) + both notified; ADCS -> no notify
+      - all four setup events (CTM/RCM/NAT/RNT) drop a plain setup
+      - notify dedupe per firstnick (30s window); onLogout clears the entry
+      - fail-closed: unknown mode blocks; a throwing notify still blocks
+      - nil target / nil protocol handled
+
+    Plugins get NO `use`; every dependency is a sandbox-global stub.
+    Run: lua5.4 tests/unit/etc_forcetlstransfer_test.lua
+
+]]--
+
+----------------------------------------------------------------------
+-- Tiny harness
+----------------------------------------------------------------------
+local _pass, _fail = 0, 0
+local function eq( what, got, want )
+    if got == want then _pass = _pass + 1
+    else _fail = _fail + 1
+        io.stderr:write( string.format( "FAIL: %s\n  got:  %s\n  want: %s\n",
+            what, tostring( got ), tostring( want ) ) ) end
+end
+local function truthy( what, v ) if v then _pass = _pass + 1
+    else _fail = _fail + 1; io.stderr:write( "FAIL: " .. what .. " got=" .. tostring( v ) .. "\n" ) end end
+local function falsy( what, v ) if not v then _pass = _pass + 1
+    else _fail = _fail + 1; io.stderr:write( "FAIL: " .. what .. " got=" .. tostring( v ) .. "\n" ) end end
+
+----------------------------------------------------------------------
+-- Controllable clock + cfg
+----------------------------------------------------------------------
+local _now = 1000000
+local _cfg
+local function reset_cfg( )
+    _cfg = { language = "en", etc_forcetlstransfer_mode = "block" }
+end
+
+----------------------------------------------------------------------
+-- Sandbox globals ( no `whitelist` - the plugin no longer uses it )
+----------------------------------------------------------------------
+_G.use = nil
+_G.PROCESSED = "PROCESSED"
+_G.table, _G.string, _G.math = table, string, math
+_G.type, _G.pairs, _G.ipairs, _G.next = type, pairs, ipairs, next
+_G.tonumber, _G.tostring, _G.pcall = tonumber, tostring, pcall
+
+local _real_os = os
+_G.os = setmetatable( { time = function( ) return _now end }, { __index = _real_os } )
+
+_G.cfg = {
+    get          = function( k ) return _cfg[ k ] end,
+    loadlanguage = function( ) return { } end,
+}
+_G.utf = { format = function( fmt, ... ) return string.format( fmt, ... ) end }
+_G.hub = {
+    setlistener = function( ev, _opts, fn ) _G._listeners[ ev ] = fn end,
+    debug       = function( ) end,
+    getbot      = function( ) return "bot" end,
+}
+
+local function mkuser( ip, nick )
+    local u
+    u = {
+        ip        = function( ) return ip end,
+        firstnick = function( ) return nick or ( "u" .. tostring( ip ) ) end,
+        reply     = function( _, msg, from, pm )
+            u._replies = ( u._replies or 0 ) + 1; u._last = msg; u._pm = pm ~= nil
+        end,
+    }
+    return u
+end
+
+local function mkcmd( proto ) return { [ 8 ] = proto } end
+
+local function load_plugin( overrides )
+    reset_cfg( )
+    if overrides then for k, v in pairs( overrides ) do _cfg[ k ] = v end end
+    _G._listeners = { }
+    local p = assert( loadfile( "scripts/etc_forcetlstransfer.lua" ) )( )
+    return p, _G._listeners
+end
+
+----------------------------------------------------------------------
+-- is_tls classifier
+----------------------------------------------------------------------
+do
+    local p = load_plugin( )
+    truthy( "is_tls: ADCS/0.10",         p._is_tls( "ADCS/0.10" ) )
+    truthy( "is_tls: ADCS/ bare prefix", p._is_tls( "ADCS/" ) )
+    falsy( "is_tls: ADC/1.0 plain",      p._is_tls( "ADC/1.0" ) )
+    falsy( "is_tls: NEODC",              p._is_tls( "NEODC/1.0" ) )
+    falsy( "is_tls: ADCSX not fooled",   p._is_tls( "ADCSX/1.0" ) )
+    falsy( "is_tls: lowercase adcs",     p._is_tls( "adcs/0.10" ) )
+    falsy( "is_tls: nil",                p._is_tls( nil ) )
+    falsy( "is_tls: empty",              p._is_tls( "" ) )
+    eq( "PROTO_IDX is 8", p._PROTO_IDX, 8 )
+end
+
+----------------------------------------------------------------------
+-- block mode + listeners
+----------------------------------------------------------------------
+do
+    local p, L = load_plugin( )
+    truthy( "listener: onConnectToMe registered",       L.onConnectToMe )
+    truthy( "listener: onRevConnectToMe registered",    L.onRevConnectToMe )
+    truthy( "listener: onNatTraversal registered",      L.onNatTraversal )
+    truthy( "listener: onNatTraversalReply registered", L.onNatTraversalReply )
+    eq( "listener: all four are the same handler",
+        L.onConnectToMe, L.onNatTraversalReply )
+
+    -- plain -> block + BOTH parties notified via PM ( with the setup link )
+    local s, t = mkuser( "1.0.0.1" ), mkuser( "1.0.0.2" )
+    eq( "block: plain -> PROCESSED", L.onConnectToMe( s, t, mkcmd( "ADC/1.0" ) ), "PROCESSED" )
+    eq( "block: sender notified once", s._replies, 1 )
+    eq( "block: target also notified", t._replies, 1 )
+    truthy( "block: notify is a PM (sender)", s._pm )
+    truthy( "block: notify is a PM (target)", t._pm )
+    truthy( "block: message carries the setup link",
+        s._last and s._last:find( "dcvault.net", 1, true ) )
+
+    -- ADCS -> pass, no notify
+    local a, b = mkuser( "1.0.0.3" ), mkuser( "1.0.0.4" )
+    eq( "block: ADCS passes (nil)", L.onConnectToMe( a, b, mkcmd( "ADCS/0.10" ) ), nil )
+    falsy( "block: ADCS no notify (sender)", a._replies )
+    falsy( "block: ADCS no notify (target)", b._replies )
+
+    -- no exemption: a plain setup is blocked whoever the parties are;
+    -- nil target / nil protocol are handled ( treated as plain, no crash )
+    eq( "block: nil target -> still blocked",
+        L.onConnectToMe( mkuser( "1.0.1.5" ), nil, mkcmd( "ADC/1.0" ) ), "PROCESSED" )
+    eq( "block: nil protocol -> plain -> blocked",
+        L.onConnectToMe( mkuser( "1.0.1.6" ), mkuser( "1.0.1.7" ), mkcmd( nil ) ), "PROCESSED" )
+end
+
+----------------------------------------------------------------------
+-- all four setup events: plain dropped / ADCS forwarded
+----------------------------------------------------------------------
+do
+    local p, L = load_plugin( )
+    for _, ev in ipairs{ "onConnectToMe", "onRevConnectToMe", "onNatTraversal", "onNatTraversalReply" } do
+        eq( ev .. ": plain dropped",
+            L[ ev ]( mkuser( "9.0.0.1" ), mkuser( "9.0.0.2" ), mkcmd( "ADC/1.0" ) ), "PROCESSED" )
+        eq( ev .. ": ADCS passes",
+            L[ ev ]( mkuser( "9.0.0.3" ), mkuser( "9.0.0.4" ), mkcmd( "ADCS/0.10" ) ), nil )
+    end
+end
+
+----------------------------------------------------------------------
+-- warn mode
+----------------------------------------------------------------------
+do
+    local p, L = load_plugin( { etc_forcetlstransfer_mode = "warn" } )
+    local u1, u2 = mkuser( "2.0.0.1" ), mkuser( "2.0.0.2" )
+    eq( "warn: plain passes (nil)", L.onConnectToMe( u1, u2, mkcmd( "ADC/1.0" ) ), nil )
+    eq( "warn: sender notified", u1._replies, 1 )
+    eq( "warn: target notified", u2._replies, 1 )
+    truthy( "warn: notify is a PM", u1._pm )
+    truthy( "warn: message carries the setup link",
+        u1._last and u1._last:find( "dcvault.net", 1, true ) )
+    local a1 = mkuser( "2.0.0.3" )
+    eq( "warn: ADCS passes (nil)", L.onConnectToMe( a1, mkuser( "2.0.0.4" ), mkcmd( "ADCS/0.10" ) ), nil )
+    falsy( "warn: ADCS no notify", a1._replies )
+end
+
+----------------------------------------------------------------------
+-- notify dedupe per sender + onLogout clear
+----------------------------------------------------------------------
+do
+    local p, L = load_plugin( )
+    local s = mkuser( "3.0.0.1", "spammer" )
+    L.onConnectToMe( s, mkuser( "3.0.0.2" ), mkcmd( "ADC/1.0" ) )
+    L.onConnectToMe( s, mkuser( "3.0.0.3" ), mkcmd( "ADC/1.0" ) )
+    L.onRevConnectToMe( s, mkuser( "3.0.0.4" ), mkcmd( "ADC/1.0" ) )
+    eq( "dedupe: burst within interval -> notified once", s._replies, 1 )
+    _now = _now + 31
+    L.onConnectToMe( s, mkuser( "3.0.0.5" ), mkcmd( "ADC/1.0" ) )
+    eq( "dedupe: notified again after interval", s._replies, 2 )
+    _now = 1000000
+end
+
+do
+    local p, L = load_plugin( )
+    local s = mkuser( "5.0.0.1", "leaver" )
+    L.onConnectToMe( s, mkuser( "5.0.0.2" ), mkcmd( "ADC/1.0" ) )
+    eq( "logout: notified once", s._replies, 1 )
+    L.onConnectToMe( s, mkuser( "5.0.0.3" ), mkcmd( "ADC/1.0" ) )
+    eq( "logout: deduped before logout", s._replies, 1 )
+    L.onLogout( s )
+    L.onConnectToMe( s, mkuser( "5.0.0.4" ), mkcmd( "ADC/1.0" ) )
+    eq( "logout: entry cleared -> notifies again within interval", s._replies, 2 )
+end
+
+----------------------------------------------------------------------
+-- fail-closed hardening
+----------------------------------------------------------------------
+do
+    -- unknown mode -> BLOCKS (fail-closed), never silently passes through
+    local p, L = load_plugin( { etc_forcetlstransfer_mode = "blokc" } )
+    eq( "fail-closed: unknown mode blocks a plain setup",
+        L.onConnectToMe( mkuser( "6.0.0.1" ), mkuser( "6.0.0.2" ), mkcmd( "ADC/1.0" ) ), "PROCESSED" )
+end
+
+do
+    -- a throwing notify (reply errors) must NOT turn a block into a pass
+    local p, L = load_plugin( )
+    local bad = { ip = function( ) return "6.0.1.1" end, firstnick = function( ) return "bad" end,
+                  reply = function( ) error( "boom" ) end }
+    eq( "fail-closed: notify error still blocks",
+        L.onConnectToMe( bad, mkuser( "6.0.1.2" ), mkcmd( "ADC/1.0" ) ), "PROCESSED" )
+end
+
+----------------------------------------------------------------------
+io.write( string.format( "\netc_forcetlstransfer: %d passed, %d failed\n", _pass, _fail ) )
+os.exit( _fail == 0 and 0 or 1 )


### PR DESCRIPTION
Closes #500. New plugin `etc_forcetlstransfer` - forces encrypted (ADCS) client-to-client transfers. Being on an `adcs://` hub does NOT encrypt transfers (a transfer is a direct client-to-client connection that bypasses the hub); this plugin refuses to broker a plain (non-ADCS) peer-connection setup, which forces TLS. Requested by Sopor.

## Behaviour
- Registers `onConnectToMe` / `onRevConnectToMe` / `onNatTraversal` / `onNatTraversalReply` (E-class ECTM/ERCM fire the same listeners). Reads the transfer protocol at `adccmd[8]`, allow-lists `^ADCS/`.
- Mode `block` (default, drop the setup) or `warn` (let it pass) - **fail-closed**: anything but `warn` blocks, and the decision is locked in before a best-effort `pcall` notify, so a misconfig or a notify error can never silently disable enforcement.
- **All-or-nothing: no exemptions.** An enabled hub forces TLS on EVERY transfer - no level or IP escape hatch (an earlier draft had a level+whitelist exemption; dropped, since "all TLS or none" is the cleaner contract and reusing core/whitelist coupled force-TLS to the blocker-allowlist).
- **Notify BOTH parties** (sender + target) via **PM**, throttled per user (30s, cleared on `onLogout`), with a client-setup link.
- Off by default; the only cfg key is `etc_forcetlstransfer_mode`.

## Verification
- Deep-dive confirmed the mechanism (`adccmd[8]`, the 4 events, `PROCESSED` drop) against `core/adc.lua` + `hub_dispatch`.
- **Live-verified on a `:dev` hub**: CTM (active) / RCM (passive) / NAT / RNT plain **dropped** vs ADCS **forwarded**; both parties PM'd; with exemptions removed, even a high-level (owner) plain transfer is blocked.
- Unit `tests/unit/etc_forcetlstransfer_test.lua` (47 checks, both smoke legs): classifier, block/warn, all four events, notify dedupe + onLogout clear, fail-closed (unknown mode + throwing notify), nil target/protocol, setup link.
- **3-reviewer panel** (security / correctness / consistency): no critical/major; fail-closed hardening (decision-first + pcall + unknown-mode-blocks), the both-notify/PM change, and doc notes applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)