### PR TITLE
ci(smoke): scope the push trigger to dev only

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,15 +1,22 @@
 name: Smoke
 
-# Run the Phase 6a smoke-test harness on every push and PR. Builds the
-# hub, installs into a staging tree, then runs tests/smoke/run.py which
-# starts the hub on offset test ports and exercises the protocol path
-# (plain + TLS handshake + plugin-load log scan).
+# Run the smoke-test harness on every PR (any base) plus pushes to dev.
+# Builds the hub, installs into a staging tree, then runs
+# tests/smoke/run.py which starts the hub on offset test ports and
+# exercises the protocol path (plain + TLS handshake + plugin-load scan).
 #
-# Separate from release.yml because the triggers differ: smoke runs
-# everywhere, release runs only on tag pushes and release branches.
+# Trigger scoping (CI-trim): a feature branch's push is NOT smoked - its
+# PR already is - and neither is the master push, because the dev->master
+# promotion PR and any security-backport PR already smoke via
+# pull_request. So master only ever goes green through a PR, never a
+# re-test of content dev already validated, and no coverage is lost:
+# every master-bound change lands via a PR (workflow §8). The dev push
+# stays smoked so the :dev image maps to a green run. release.yml has its
+# own tag/release-branch triggers.
 
 on:
   push:
+    branches: [dev]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Smoke currently runs on every push (any branch) and every PR, so a single feature gets smoked ~5x (feat push, feat->dev PR, dev push, dev->master PR, master push).

Restrict the `push` trigger to `branches: [dev]`:
- a feature branch's push is redundant with its PR;
- the master push is redundant with the dev->master promotion PR that already smoked the identical tree.

`pull_request` stays unfiltered, so feat->dev, dev->master, and security-backport PRs (base master) all still smoke - no coverage is lost, since every master-bound change lands via a PR (workflow section 8). Also removes the duplicate push+PR runs that occasionally orphaned/hung on feature branches.

Docker is unchanged: `:dev` and `:master` are distinct published images, each genuinely built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)