### PR TITLE
Merge dev into master: hub_cmd_manager NAT-traversal gate (#521)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -178,6 +178,12 @@ jobs:
       - name: Run etc_trafficmanager unit test
         run: lua5.4 tests/unit/etc_trafficmanager_test.lua
 
+      # hub_cmd_manager: C2C level gates. v0.03 NAT-traversal fix -
+      # onNatTraversal/onNatTraversalReply gate DNAT/DRNT by rcm/ctm
+      # level, closing a passive/CGNAT bypass of the CTM/RCM gate.
+      - name: Run hub_cmd_manager unit test
+        run: lua5.4 tests/unit/hub_cmd_manager_test.lua
+
       # #501 etc_lockdown: transient maintenance-mode gate. Stubbed
       # hub.getusers / whitelist + a controllable os.time. Covers the
       # minutes-vs-reason parser, onConnect veto (ISTA 226 + TL), kick-
@@ -571,6 +577,10 @@ jobs:
       - name: Run etc_trafficmanager unit test
         shell: msys2 {0}
         run: lua5.4 tests/unit/etc_trafficmanager_test.lua
+
+      - name: Run hub_cmd_manager unit test
+        shell: msys2 {0}
+        run: lua5.4 tests/unit/hub_cmd_manager_test.lua
 
       - name: Run etc_lockdown unit test
         shell: msys2 {0}

--- a/scripts/hub_cmd_manager.lua
+++ b/scripts/hub_cmd_manager.lua
@@ -1,8 +1,17 @@
 --[[
 
-        hub_cmd_manager.lua v0.02 by blastbeat
+        hub_cmd_manager.lua v0.03 by blastbeat
 
         - this script mangages permissions for certain adc commands
+
+        v0.03:
+            - gate NAT-traversal (DNAT / DRNT) too, closing a CTM / RCM
+              level-gate bypass: passive / CGNAT peers fall back to NAT
+              traversal, which slipped through the CTM / RCM gates.
+              DNAT (onNatTraversal) is the NAT-traversal stand-in for the
+              CTM a passive uploader cannot send, so it is gated by
+              ctmlevel; DRNT (onNatTraversalReply) is the RCM-role reply
+              from the original RCM sender, gated by rcmlevel.
 
         v0.02: by blastbeat (20170226)
             - added blacklist and onIncoming hook
@@ -10,7 +19,7 @@
 ]]--
 
 local scriptname = "hub_cmd_manager"
-local scriptversion = "0.02"
+local scriptversion = "0.03"
 
 --// min levels to use a command //--
 
@@ -73,6 +82,24 @@ hub.setlistener( "onConnectToMe", { },
 )
 
 hub.setlistener( "onRevConnectToMe", { },
+    function( user )
+        if user:level( ) < rcmlevel then
+            return PROCESSED
+        end
+        return nil
+    end
+)
+
+hub.setlistener( "onNatTraversal", { },
+    function( user )
+        if user:level( ) < ctmlevel then
+            return PROCESSED
+        end
+        return nil
+    end
+)
+
+hub.setlistener( "onNatTraversalReply", { },
     function( user )
         if user:level( ) < rcmlevel then
             return PROCESSED

--- a/tests/unit/hub_cmd_manager_test.lua
+++ b/tests/unit/hub_cmd_manager_test.lua
@@ -1,0 +1,114 @@
+--[[
+
+    tests/unit/hub_cmd_manager_test.lua
+
+    Unit tests for scripts/hub_cmd_manager.lua's C2C level gates, focused
+    on the v0.03 NAT-traversal fix.
+
+    hub_cmd_manager gates ADC commands by a minimum level. It already
+    dropped CTM (onConnectToMe, gated by ctmlevel) and RCM
+    (onRevConnectToMe, gated by rcmlevel) for below-level users, but did
+    NOT hook NAT traversal - so a below-level passive / CGNAT peer, whose
+    client falls back to DNAT / DRNT when a direct connection is
+    impossible, slipped through the gate. v0.03 adds onNatTraversal and
+    onNatTraversalReply. NATT exists because a passive uploader cannot
+    send a usable CTM, so it sends DNAT instead: DNAT is the CTM-role
+    stand-in (gated by ctmlevel) and DRNT is the RCM-role reply from the
+    original RCM sender (gated by rcmlevel).
+
+    The plugin's levels are hardcoded to 0 in-source (inert by default),
+    so the test patches ctmlevel/rcmlevel to two DIFFERENT non-zero
+    thresholds (40 / 20). The differing thresholds let the level-30 probe
+    prove the role mapping: onNatTraversal must gate by ctmlevel (40, so
+    30 is blocked) and onNatTraversalReply by rcmlevel (20, so 30 is
+    allowed) - swapping them would flip both results. The patch is
+    orthogonal to the fix and applies equally pre- and post-fix.
+
+    Run: lua5.4 tests/unit/hub_cmd_manager_test.lua
+    Exit 0 = all pass, 1 = a failure (CI-friendly).
+
+    Regression contract (CLAUDE.md §1a.7): the two "onNatTraversal /
+    onNatTraversalReply registered" checks (and the guarded gate
+    assertions) FAIL on the pre-v0.03 plugin (the listeners are
+    unregistered; the guarded calls are then skipped) and PASS patched -
+    2 RED-pre-fix registration checks. The onConnectToMe / onRevConnectToMe
+    sanity + parity checks are guards that pass on both revisions.
+    Verified by running this file with the fix stashed (2 failures
+    pre-fix, 0 post-fix).
+
+]]--
+
+local failures, checks = 0, 0
+local function eq( label, got, want )
+    checks = checks + 1
+    if got ~= want then
+        failures = failures + 1
+        io.write( string.format( "FAIL %-56s got=%q want=%q\n", label, tostring( got ), tostring( want ) ) )
+    else
+        io.write( string.format( "ok   %s\n", label ) )
+    end
+end
+
+----------------------------------------------------------------------
+-- stub the globals the plugin touches at load time + capture listeners
+----------------------------------------------------------------------
+
+local _registered = { }
+_G.PROCESSED = 1
+_G.hub = {
+    setlistener = function( event, opts, fn ) _registered[ event ] = fn end,
+    debug       = function( ) end,
+}
+
+----------------------------------------------------------------------
+-- load the plugin with the two C2C gates set to distinct thresholds
+----------------------------------------------------------------------
+
+local RCM, CTM = 20, 40
+local path = "scripts/hub_cmd_manager.lua"
+local fh = assert( io.open( path, "r" ), "cannot open " .. path )
+local src = fh:read( "*a" ); fh:close( )
+src = src:gsub( "local rcmlevel = 0", "local rcmlevel = " .. RCM )
+src = src:gsub( "local ctmlevel = 0", "local ctmlevel = " .. CTM )
+assert( src:find( "local rcmlevel = " .. RCM, 1, true ), "rcmlevel patch did not apply" )
+assert( src:find( "local ctmlevel = " .. CTM, 1, true ), "ctmlevel patch did not apply" )
+assert( load( src, "hub_cmd_manager", "t" ) )( )
+
+local function user( level ) return { level = function( ) return level end } end
+
+----------------------------------------------------------------------
+-- sanity + parity guards (pass on both pre- and post-fix revisions)
+----------------------------------------------------------------------
+
+eq( "onConnectToMe registered",    _registered.onConnectToMe    ~= nil, true )
+eq( "onRevConnectToMe registered", _registered.onRevConnectToMe ~= nil, true )
+eq( "CTM gates below ctmlevel -> PROCESSED", _registered.onConnectToMe( user( 10 ) ),    1 )
+eq( "RCM gates below rcmlevel -> PROCESSED", _registered.onRevConnectToMe( user( 10 ) ), 1 )
+
+----------------------------------------------------------------------
+-- the fix: NAT traversal gated too, with role-correct level mapping
+-- RED pre-fix: the two "registered" checks fail; guarded calls skipped.
+----------------------------------------------------------------------
+
+eq( "onNatTraversal registered",      _registered.onNatTraversal      ~= nil, true )
+eq( "onNatTraversalReply registered", _registered.onNatTraversalReply ~= nil, true )
+
+local nat = _registered.onNatTraversal
+local rnt = _registered.onNatTraversalReply
+if nat then
+    -- gated by ctmlevel (40); level 30 blocked also proves NOT rcmlevel (20)
+    eq( "NAT: below ctmlevel -> PROCESSED",  nat( user( 30 ) ), 1 )
+    eq( "NAT: at/above ctmlevel -> nil",     nat( user( 50 ) ), nil )
+end
+if rnt then
+    -- gated by rcmlevel (20); level 30 allowed also proves NOT ctmlevel (40)
+    eq( "RNT: at/above rcmlevel -> nil",     rnt( user( 30 ) ), nil )
+    eq( "RNT: below rcmlevel -> PROCESSED",  rnt( user( 10 ) ), 1 )
+end
+
+----------------------------------------------------------------------
+-- summary
+----------------------------------------------------------------------
+
+io.write( string.format( "\n%d checks, %d failures\n", checks, failures ) )
+os.exit( failures > 0 and 1 or 0 )


### PR DESCRIPTION
Promotes the single dev delta to master: `hub_cmd_manager` NAT-traversal gate (#521).

Closes a CTM/RCM level-gate bypass in the bundled, default-enabled `hub_cmd_manager`: a below-level passive/CGNAT peer bypassed the gate via NAT traversal. Adds `onNatTraversal` (gated by ctmlevel) + `onNatTraversalReply` (gated by rcmlevel). Ships inert by default (levels 0).

Verified: ADC-EXT §3.9.4 spec flow (DNAT = uploader/CTM role), RED->GREEN unit test on both smoke legs (incl. inversion-catch), and **live on the :dev hub** - a level-20 guest's raw DNAT is dropped post-fix (relayed pre-fix = the bypass), DRNT relays (role split confirmed), owner DNAT relays (control).

Already green on the #521 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)