### PR TITLE
fix(trafficmanager): stop external add()/del() leaking literal "nil" for a nil scriptname

### DIFF
--- a/scripts/etc_trafficmanager.lua
+++ b/scripts/etc_trafficmanager.lua
@@ -35,6 +35,16 @@
         the block list and accept the corresponding file-transfer
         permission.
 
+        v2.9:
+            - fix a nil-scriptname leak in the external add() / del()
+              API: a caller passing scriptname (or reason) = nil produced
+              a literal "nil" in the op report and block_tbl, because
+              tostring( nil ) is the truthy string "nil" so the intended
+              `... or msg_unknown` fallback never fired. Guarded with
+              `~= nil` before tostring at all three sites. Correct callers
+              (non-nil scriptname/reason) are unaffected. Reported by an
+              operator whose usr_upload_speed passed scriptname = nil.
+
         v2.8:
             - also block the NAT-traversal fallback (DNAT / DRNT, via the
               new onNatTraversal / onNatTraversalReply listeners), not
@@ -228,7 +238,7 @@
 --------------
 
 local scriptname = "etc_trafficmanager"
-local scriptversion = "2.8"
+local scriptversion = "2.9"
 
 local cmd = "trafficmanager"
 local cmd_b = "block"
@@ -712,10 +722,15 @@ add = function( firstnick, scriptname, reason, user )
     --  external-string path was unreachable.
     if ( not scriptname ) or ( scriptname ~= 1 ) then
         otherScript = true --> external block
-        scriptname = tostring( scriptname ) or msg_unknown
+        -- Guard `~= nil` BEFORE tostring: an external caller may pass a
+        -- nil scriptname/reason, and `tostring( nil )` is the truthy
+        -- string "nil", so a bare `tostring( x ) or msg_unknown` fallback
+        -- never fires and leaks a literal "nil" into the op report /
+        -- block_tbl (reported by an operator whose script passed nil).
+        scriptname = scriptname ~= nil and tostring( scriptname ) or msg_unknown
     end
     --> set reason msg
-    reason = tostring( reason ) or msg_unknown
+    reason = reason ~= nil and tostring( reason ) or msg_unknown
     if otherScript then reason = reason .. "  |  blocked by scriptname: " .. scriptname end
     --> Resolve target. The `firstnick` argument may be an unprefixed
     --  registered nick (e.g. from cmd_ban export) or a prefixed
@@ -837,7 +852,8 @@ del = function( firstnick, scriptname, user )
     --  nil) -> external. See add() for the #257 fix rationale.
     if ( not scriptname ) or ( scriptname ~= 1 ) then
         otherScript = true --> external unblock
-        scriptname = tostring( scriptname ) or msg_unknown
+        -- `~= nil` guard before tostring, same nil-leak fix as add().
+        scriptname = scriptname ~= nil and tostring( scriptname ) or msg_unknown
     end
     --> Resolve target (same dual-input handling as add(); closes
     --  upstream luadch/luadch#240).

--- a/tests/unit/etc_trafficmanager_test.lua
+++ b/tests/unit/etc_trafficmanager_test.lua
@@ -34,6 +34,11 @@
     (the listeners are unregistered; the guarded block/pass assertions
     are then skipped) and PASS patched - 2 more RED-pre-fix checks.
 
+    nil-scriptname section (below): external add() with scriptname=nil
+    must degrade to msg_unknown, not the literal "nil". 3 checks FAIL on
+    the pre-fix plugin (dead `tostring(nil) or msg_unknown` fallback) and
+    PASS patched.
+
 ]]--
 
 local GiB = 1024 * 1024 * 1024
@@ -46,6 +51,7 @@ local _registered = { }        -- event/listener name -> fn
 local _hubcmds = { }           -- cmd name -> handler (onbmsg)
 local _online = { }            -- sid -> stub user (hub.getusers)
 local _block_seed = nil        -- what util.loadtable returns for block_tbl
+local _last_report = nil       -- last op-report message captured from etc_report.send
 
 ----------------------------------------------------------------------
 -- stub sandbox globals the plugin reads at file scope + runtime
@@ -72,7 +78,9 @@ _G.hub = {
             }
         end
         if name == "etc_report" then
-            return { send = function( ) end }
+            -- capture the formatted op-report (last positional arg) so a
+            -- test can assert on the "User: ... | reason: ..." text.
+            return { send = function( _, _, _, _, msg ) _last_report = msg end }
         end
         return nil    -- cmd_help / etc_usercommands absent in the test
     end,
@@ -211,7 +219,7 @@ end
 
 _block_seed = { manual_guy = { "admin", "manual reason", "20260101000000" } }
 _online = { }
-assert( loadfile( "scripts/etc_trafficmanager.lua" ) )( )
+local tm = assert( loadfile( "scripts/etc_trafficmanager.lua" ) )( )
 assert( _registered.onStart, "onStart not registered" )
 _registered.onStart( )
 local onbmsg = _hubcmds.trafficmanager
@@ -351,6 +359,28 @@ do
         eq( "RNT: blocked user   -> PROCESSED", rnt( blocked, clean, { } ), 1 )
         eq( "RNT: nobody blocked -> nil",       rnt( clean,   clean, { } ), nil )
     end
+end
+
+----------------------------------------------------------------------
+-- external add() with a nil scriptname must degrade to msg_unknown,
+-- NOT leak the literal string "nil" into the op report / block_tbl.
+-- An operator's script (usr_upload_speed) called add(nick, nil, reason);
+-- pre-fix `tostring( scriptname ) or msg_unknown` never fell back because
+-- tostring(nil) is the truthy string "nil", so the report showed
+-- "User:  nil" and appended "blocked by scriptname: nil".
+-- RED pre-fix: the three assertions below FAIL (report shows "nil");
+-- PASS patched (report shows msg_unknown = "<UNKNOWN>"). Target offline
+-- so add() takes the plain external path (no target reply / desc flag).
+----------------------------------------------------------------------
+
+do
+    _online = { }                                   -- ScriptProbe is offline
+    _last_report = nil
+    tm.add( "ScriptProbe", nil, "unit reason" )     -- external path, scriptname = nil
+    local r = _last_report or ""
+    eq( "nil-scriptname add: report User is not literal 'nil'", contains( r, "User:  nil" ), false )
+    eq( "nil-scriptname add: no 'scriptname: nil' appended",    contains( r, "scriptname: nil" ), false )
+    eq( "nil-scriptname add: degrades to msg_unknown",          contains( r, "User:  <UNKNOWN>" ), true )
 end
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
`etc_trafficmanager`'s external-caller API (`add()` / `del()` via `hub.import`) mishandled a nil `scriptname`/`reason`: it did `X = tostring( X ) or msg_unknown`, but `tostring(nil)` is the truthy string `"nil"`, so the `or msg_unknown` fallback never fired. A caller passing `nil` leaked a literal `"nil"` into the op report (`User:  nil`) and into `block_tbl`.

Found via an operator report (Sopor): his `usr_upload_speed` called `block.add(nick, nil, reason)` and the traffic-manager report showed `User:  nil`. A repo-wide sweep for the dead `tostring(...) or` pattern found it only here (3 sites); the other hits are a correct `cond and tostring(...) or ...` ternary and a commented-out line.

## Fix
Guard `~= nil` before `tostring` at all three sites (add-scriptname, add-reason, del-scriptname): `X = X ~= nil and tostring( X ) or msg_unknown`. `scriptversion` -> v2.9. **Correct callers (non-nil args) are unaffected** - `tostring(x)` was already returned for any non-nil `x`.

Precise scope: this removes the literal `"nil"`. The **doubled** "blocked by scriptname" in the operator's report is caller-side - his script also baked `| blocked by scriptname: X` into its own `reason` on top of the one `add()` appends - and is fixed in his script, not here.

## Test
`tests/unit/etc_trafficmanager_test.lua` (already on both smoke legs) gains a nil-scriptname section: captures the op report via the `etc_report` stub and asserts `add(nick, nil, reason)` renders `<UNKNOWN>`, not `nil`. Verified RED (3 fails) pre-fix, GREEN (39 checks, 0) patched.

§1a.6 reviewed (independent + spot-check): no blockers; the version bump was the reviewer's one CONCERN, now applied.

Follow-up (separate repo, flagged not lost): the same dead pattern exists in `luadch-ng/scripts` `etc_wunschbrett.lua:184` (cosmetic - a nil wish-date renders `"nil"` instead of `"n.a."`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)