### PR TITLE
fix(adc): harden header-parameter parsing against malformed frames

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Run iostream unit test
         run: lua5.4 tests/unit/iostream_test.lua
 
+      - name: Run adc parse header unit test
+        run: lua5.4 tests/unit/adc_parse_header_test.lua
+
       # Phase 8 S5 BLOM bloom filter (pure Lua, same rationale as
       # the iostream test).
       - name: Run bloom unit test
@@ -497,6 +500,10 @@ jobs:
       - name: Run iostream unit test
         shell: msys2 {0}
         run: lua5.4 tests/unit/iostream_test.lua
+
+      - name: Run adc parse header unit test
+        shell: msys2 {0}
+        run: lua5.4 tests/unit/adc_parse_header_test.lua
 
       - name: Run bloom unit test
         shell: msys2 {0}

--- a/core/adc.lua
+++ b/core/adc.lua
@@ -1012,14 +1012,20 @@ parse = function( data )
 
     local len = header.len
 
-    if eol < len then
+    -- Need the fourcc plus `len` header params, i.e. eol >= len + 1.
+    -- `eol < len` accepted eol == len (fourcc + one short) for the
+    -- 2-field classes (F/D/E), letting the loop below read a nil param.
+    if eol < len + 1 then
         out_put( "adc.lua: function 'parse': adc message to short" )
         return nil
     end
 
     for i, regex in ipairs( header ) do
         local param = buffer[ i + 1 ]
-        if not regex( param ) then
+        -- param == nil guard mirrors the positional loop (F-PRS-7): the
+        -- header validators (_regex.sid / _regex.feature) throw on nil,
+        -- and that throw is uncaught up to the main loop.
+        if param == nil or not regex( param ) then
             out_put( "adc.lua: function 'parse': invalid value in header '", fourcc, "': ", param )
             return nil
         end

--- a/tests/unit/adc_parse_header_test.lua
+++ b/tests/unit/adc_parse_header_test.lua
@@ -1,0 +1,106 @@
+--[[
+
+    tests/unit/adc_parse_header_test.lua
+
+    Regression test for the ADC header-parameter parse crash.
+
+    A 2-field-header message class (F / D / E, header.len == 2) that
+    carries the fourcc plus only ONE header field slipped past the
+    length gate: `if eol < len` accepts eol == len (fourcc + 1 field),
+    then the header loop reads buffer[3] == nil and calls _regex.sid /
+    _regex.feature with nil, which throw (string.match(nil,...) / #nil).
+    That throw is uncaught all the way up (server.tick -> readbuffer ->
+    dispatch -> incoming -> adc.parse, no pcall), so a single frame such
+    as `FSCH AAAA` from an unauthenticated peer terminates the hub.
+
+    This mirrors the positional-parameter fix (Phase 8a F-PRS-7): the
+    fix requires eol >= len + 1 (fourcc + len header params) AND adds the
+    param == nil guard the positional loop already has.
+
+    Pure Lua, no hub, no sockets: stubs the `use` sandbox shim, loads the
+    module, drives adc.parse under pcall.
+
+    Run: lua tests/unit/adc_parse_header_test.lua   (any Lua 5.4)
+    Exit code 0 = all pass, 1 = a failure (CI-friendly).
+
+]]--
+
+-- minimal sandbox shim: core/adc.lua does `local x = use "x"`. Keep this
+-- in lockstep with adc.lua's `use` imports. parse() itself needs only the
+-- string libs + out.put; the rest exist so module load-time aliasing
+-- (adclib.hash, unicode.utf8.find, types.utf8, ...) does not nil-index.
+local _real = {
+    type = type, ipairs = ipairs, tostring = tostring,
+    os = os, table = table, string = string, setmetatable = setmetatable,
+    adclib = {
+        isutf8 = function( ) return true end,
+        hash = function( ) end,
+        hashpas = function( ) end,
+        random_bytes = function( n ) return string.rep( "\0", n or 0 ) end,
+    },
+    unicode = { utf8 = { find = string.find } },
+    out = { put = function( ) end },
+    types = { utf8 = function( ) end, check = function( ) end, add = function( ) end },
+}
+_G.use = function( name )
+    local v = _real[ name ]
+    assert( v ~= nil, "adc_parse_header_test shim missing dep: use \"" .. name .. "\"" )
+    return v
+end
+
+local adc = assert( loadfile( "core/adc.lua" ) )( )
+
+local failures, checks = 0, 0
+local function eq( label, got, want )
+    checks = checks + 1
+    if got ~= want then
+        failures = failures + 1
+        io.write( string.format( "FAIL %-46s got=%q want=%q\n", label, tostring( got ), tostring( want ) ) )
+    else
+        io.write( string.format( "ok   %s\n", label ) )
+    end
+end
+
+-- parse must never throw on malformed input; it returns nil on reject.
+local function safeparse( frame )
+    return pcall( adc.parse, frame )    -- ok, result
+end
+
+----------------------------------------------------------------------
+-- Regression: 2-field-header classes (F / D / E) with fourcc + only one
+-- header field. Pre-fix these crash in the header loop; post-fix they
+-- are rejected (nil) at the length gate. AAAA is a syntactically valid
+-- SID so field 1 passes and field 2 (missing) is the trigger. Covers
+-- both header validators: _regex.feature (FSCH) and _regex.sid (D/E).
+----------------------------------------------------------------------
+for _, frame in ipairs( { "FSCH AAAA", "DCTM AAAA", "ECTM AAAA", "DMSG AAAA" } ) do
+    local ok, res = safeparse( frame )
+    eq( "short-header '" .. frame .. "' does not crash parse", ok, true )
+    eq( "short-header '" .. frame .. "' rejected (nil)", ok and res, nil )
+end
+
+----------------------------------------------------------------------
+-- Positive controls: valid frames must still parse (the length gate
+-- change must not over-reject). B-class (len 1) and a full-header
+-- D-class (len 2) frame both return a parsed command table.
+----------------------------------------------------------------------
+do
+    local ok, res = safeparse( "BMSG AAAA hi" )
+    eq( "valid BMSG does not crash", ok, true )
+    eq( "valid BMSG parses (table)", ok and type( res ), "table" )
+end
+-- Header complete (B sid present) but the positional body missing: must
+-- clean-reject via the positional nil-guard (F-PRS-7), not crash.
+do
+    local ok, res = safeparse( "BMSG AAAA" )
+    eq( "BMSG missing body does not crash", ok, true )
+    eq( "BMSG missing body rejected (nil)", ok and res, nil )
+end
+do
+    local ok, res = safeparse( "DMSG AAAA BBBB hello" )
+    eq( "valid DMSG does not crash", ok, true )
+    eq( "valid DMSG parses (table)", ok and type( res ), "table" )
+end
+
+io.write( string.format( "\n%d checks, %d failures\n", checks, failures ) )
+os.exit( failures == 0 and 0 or 1 )


### PR DESCRIPTION
## Summary

`adc.parse()` could be crashed by a malformed 2-field-header frame (F/D/E classes, `header.len == 2`) carrying the fourcc plus only one header field. The length gate `if eol < len` accepted `eol == len`, so the header loop read `buffer[i+1] == nil` and passed it to `_regex.sid` / `_regex.feature`, which throw. The throw is uncaught (`server.tick -> readbuffer -> dispatch -> incoming -> adc.parse`, no pcall), so a single frame from an unauthenticated peer terminates the hub.

## Fix

- require the fourcc plus `len` header params (`eol >= len + 1`)
- add the `param == nil` guard the positional loop already carries (F-PRS-7)

Both mirror the existing positional-parameter hardening; no valid frame is affected (the minimum valid frame has `eol == len + 1`).

## Test

`tests/unit/adc_parse_header_test.lua` (registered on both smoke legs): FSCH/DCTM/ECTM/DMSG short-header frames throw pre-fix and clean-reject post-fix; valid B/D frames plus a missing-body positional case are positive controls. 14 checks, 8 fail on unpatched code.

Independent pre-merge review: APPROVE (no over-rejection, no surviving crash path). Present in `release/3.1.x` as well; backport to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)