### PR TITLE
fix(adclib): harden UTF-8 handling (overlong, sanitize crash, NUL truncation)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -434,6 +434,15 @@ jobs:
           cd build/install/luadch
           LD_LIBRARY_PATH=. lua5.4 ../../../tests/unit/adclib_hashpas_test.lua
 
+      # adclib UTF-8 handling: overlong-encoding rejection + sanitize_utf8
+      # append-not-insert (no std::terminate) + length-aware lstring ctors
+      # (no NUL truncation). Same install-tree + bundled-liblua requirement,
+      # so Linux-only.
+      - name: Run adclib_utf8 unit test
+        run: |
+          cd build/install/luadch
+          LD_LIBRARY_PATH=. lua5.4 ../../../tests/unit/adclib_utf8_test.lua
+
       # zlib_stream.gunzip() C round-trip (GeoIP auto-update precursor).
       # Same install-tree + bundled-liblua requirement as adclib above, so
       # Linux-only (msys2 lua segfaults loading our C modules).

--- a/adclib/adclib.cpp
+++ b/adclib/adclib.cpp
@@ -103,6 +103,20 @@ int utf8ToWc(const char* str, wchar_t& c) {
                         return -bytes;
                 }
 
+                // Reject overlong 2- and 3-byte encodings (e.g. C0 80 for
+                // NUL): a code point encoded in more bytes than its canonical
+                // minimum is invalid UTF-8, and left unrejected it desyncs
+                // sanitizeUtf8 (source advances by `bytes`, target by fewer).
+                // The check is bounded to 2/3 bytes on purpose: the 4-byte
+                // minimum 0x10000 does not fit a 16-bit wchar_t (Windows),
+                // where forcing it would over-reject valid 4-byte UTF-8.
+                // 4-byte overlong is exotic and the append below stops any
+                // desync crash on every platform regardless.
+                if ((bytes == 2 && c < 0x80) || (bytes == 3 && c < 0x800)) {
+                        c = 0xfffd;
+                        return -bytes;
+                }
+
                 return bytes;
         } else if ((c0 & 0x80) == 0) {             // 0xxx xxxx
                 c = static_cast<unsigned char>(str[0]);
@@ -145,7 +159,12 @@ std::string sanitizeUtf8(const std::string& str) noexcept {
                 wchar_t c = 0;
                 int x = utf8ToWc(str.c_str() + i, c);
                 if (x < 0) {
-                        tgt.insert(i, abs(x), '_');
+                        // append at the target's end, not at source index i:
+                        // i tracks the SOURCE position and can exceed
+                        // tgt.length() once any byte re-encodes shorter than it
+                        // decoded, making insert(i,...) throw std::out_of_range
+                        // across this noexcept boundary (std::terminate).
+                        tgt.append(abs(x), '_');
                 } else {
                         wcToUtf8(c, tgt);
                 }
@@ -171,7 +190,14 @@ bool validateUtf8(const std::string& str) noexcept {
 int sanitize_utf8(lua_State* L)
 {
     size_t length;
-    std::string buf = luaL_checklstring(L, 1, &length);
+    // length-aware: the const char* form stops at the first NUL and
+    // discards the fetched length, so an embedded NUL would smuggle
+    // unvalidated post-NUL bytes past this gate (F-C-3, as hash_* note).
+    // Fetch the pointer in its own statement: argument-evaluation order
+    // is unspecified, so reading `length` in the same expression that
+    // sets it would be UB (garbage length -> bad_alloc).
+    const char* raw = luaL_checklstring(L, 1, &length);
+    std::string buf(raw, length);
     std::string result = sanitizeUtf8(buf);
     lua_pushlstring(L, result.c_str(), result.length());
     return 1;
@@ -180,7 +206,11 @@ int sanitize_utf8(lua_State* L)
 int is_valid_utf8(lua_State* L)
 {
     size_t length;
-    std::string buf = luaL_checklstring(L, 1, &length);
+    // length-aware: see sanitize_utf8 (incl. the eval-order note). isutf8
+    // is the incoming-data gate (hub.lua incoming path); a NUL-truncated
+    // validation would pass a line whose post-NUL bytes were never checked.
+    const char* raw = luaL_checklstring(L, 1, &length);
+    std::string buf(raw, length);
     validateUtf8(buf) ? lua_pushboolean(L, 1) : lua_pushboolean(L, 0);
     return 1;
 }
@@ -417,7 +447,12 @@ int aes_gcm_open(lua_State* L)
 
 int escape(lua_State* L)
 {
-    std::string s = (std::string) luaL_optstring(L, 1, "");
+    // length-aware: luaL_optstring stops at the first NUL, silently
+    // dropping the rest of the value; optlstring keeps embedded NULs.
+    // Separate statement: see sanitize_utf8's eval-order note.
+    size_t s_len;
+    const char* raw = luaL_optlstring(L, 1, "", &s_len);
+    std::string s(raw, s_len);
     std::string out = "";
     out.reserve(out.length() + static_cast<size_t>(s.length()*1.1));
     std::string::const_iterator send = s.end();
@@ -447,6 +482,11 @@ int gen_self_signed_cert(lua_State* L)
 {
     ERR_clear_error();    // start with empty per-thread OpenSSL error queue
 
+    // luaL_checkstring (not the length-aware form) is correct here: cn is
+    // handed to X509_NAME_add_entry_by_txt below with len -1, i.e. OpenSSL
+    // reads it as a NUL-terminated C-string, so any embedded NUL truncates
+    // downstream regardless. cn is also operator-supplied (hub hostname),
+    // not network input.
     const char* cn = luaL_checkstring(L, 1);
     lua_Integer days_in = luaL_checkinteger(L, 2);
 
@@ -677,7 +717,11 @@ int constant_time_eq(lua_State* L)
 // trailing backslash at end-of-string (also previously dropped).
 int unescape(lua_State* L)
 {
-    std::string s = (std::string) luaL_optstring(L, 1, "");
+    // length-aware: see escape() - keep embedded NULs instead of
+    // truncating the value at the first one (incl. the eval-order note).
+    size_t s_len;
+    const char* raw = luaL_optlstring(L, 1, "", &s_len);
+    std::string s(raw, s_len);
     std::string out = "";
     out.reserve(out.length() + static_cast<size_t>(s.length()*1.1));
     std::string::const_iterator send = s.end();

--- a/tests/unit/adclib_utf8_test.lua
+++ b/tests/unit/adclib_utf8_test.lua
@@ -1,0 +1,110 @@
+--[[
+
+    tests/unit/adclib_utf8_test.lua
+
+    Regression test for the adclib UTF-8 handling hardening:
+
+      1. is_valid_utf8 / sanitize_utf8 built their std::string via the
+         const char* path, which stops at the first embedded NUL and
+         discards the fetched length. isutf8 is the incoming-data gate,
+         so a NUL-truncated validation passed a line whose post-NUL
+         bytes were never checked (F-C-3 class - the hash_* functions
+         already used the length-aware ctor).
+
+      2. utf8ToWc accepted overlong encodings (e.g. C0 80 for NUL).
+         Besides being invalid UTF-8, an overlong sequence advances the
+         source index by more bytes than it re-encodes, which desynced
+         sanitizeUtf8's target index and made a later
+         `tgt.insert(i, ...)` throw std::out_of_range across a noexcept
+         boundary -> std::terminate. Reachable via adclib.sanitize_utf8
+         (etc_webhook), and a crash on any future caller fed net data.
+
+    Coverage:
+      - isutf8 validates the WHOLE string, not the pre-NUL prefix   [NUL bypass]
+      - isutf8 rejects an overlong C0 80                             [overlong]
+      - isutf8 still accepts ASCII / 2-byte / 3-byte valid UTF-8     [no over-reject]
+      - sanitize_utf8 does not abort on an overlong+error frame      [the crash]
+      - sanitize_utf8 passes valid input through and returns a string
+
+    Pre-fix: the NUL and overlong checks return `true` (FAIL), and the
+    sanitize_utf8 overlong+error case aborts the process (std::terminate,
+    not a Lua error - pcall cannot catch it), so the run dies with a
+    non-zero exit.
+
+    Requires the built adclib shared object (and its libssl / libcrypto
+    deps loadable) plus the bundled liblua, so it runs from the install
+    tree with LD_LIBRARY_PATH=. :
+
+      cd build/install/luadch
+      LD_LIBRARY_PATH=. lua5.4 ../../../tests/unit/adclib_utf8_test.lua
+
+    CI runs this after `cmake --install build` on the Linux leg only
+    (the bundled adclib.dll segfaults under msys2 lua via ABI clash,
+    per the adclib_unescape / adclib_hashpas tests).
+
+    Exit 0 = all pass, 1 = a failure.
+
+]]--
+
+-- CWD-relative cpath - the install tree has lib/adclib/adclib.<so|dll>.
+local filetype = ( os.getenv "COMSPEC" and os.getenv "WINDIR" and ".dll" ) or ".so"
+package.cpath = "lib/?/?" .. filetype .. ";lib/?" .. filetype .. ";" .. package.cpath
+local adclib = require("adclib")
+
+-- Unbuffered: the pre-fix sanitize_utf8 case aborts the process
+-- (std::terminate), so buffered "ok"/"FAIL" lines would be lost. With
+-- no buffering a future regression still shows which checks passed
+-- before the crash.
+io.stdout:setvbuf( "no" )
+
+local failures, checks = 0, 0
+local function eq( label, got, want )
+    checks = checks + 1
+    if got ~= want then
+        failures = failures + 1
+        io.write( string.format( "FAIL %-52s got=%q want=%q\n", label, tostring( got ), tostring( want ) ) )
+    else
+        io.write( string.format( "ok   %s\n", label ) )
+    end
+end
+
+-- NUL bypass: "valid" + NUL + 0xFF (an invalid lead byte). The whole
+-- string must be validated; pre-fix the const-char* ctor truncates at
+-- the NUL and validates only "valid" -> true.
+eq( "isutf8 validates past embedded NUL", adclib.isutf8( "valid\0\255" ), false )
+
+-- Overlong: C0 80 encodes U+0000 in two bytes (canonical is one). Invalid
+-- UTF-8; pre-fix utf8ToWc accepted it -> true.
+eq( "isutf8 rejects overlong C0 80", adclib.isutf8( "\192\128" ), false )
+
+-- No over-rejection: real valid UTF-8 must still pass.
+eq( "isutf8 accepts ASCII", adclib.isutf8( "hello" ), true )
+eq( "isutf8 accepts 2-byte (C3 A9)", adclib.isutf8( "\195\169" ), true )
+eq( "isutf8 accepts 3-byte (E2 82 AC)", adclib.isutf8( "\226\130\172" ), true )
+-- Valid 4-byte UTF-8 (U+1F600) must NOT be rejected: the overlong check is
+-- deliberately bounded to 2/3 bytes so it never over-rejects here.
+eq( "isutf8 accepts 4-byte (F0 9F 98 80)", adclib.isutf8( "\240\159\152\128" ), true )
+
+-- The crash: overlong (C0 80) followed by a lone continuation byte (80).
+-- Pre-fix this aborts the process (std::terminate); post-fix it returns
+-- a sanitized string. pcall cannot catch std::terminate, so reaching the
+-- assertion at all already means no abort.
+local s = adclib.sanitize_utf8( "\192\128\128" )
+eq( "sanitize_utf8 survives overlong+error frame", type( s ), "string" )
+
+-- Valid input passes through unchanged; a lone invalid byte is replaced,
+-- not crashed on.
+eq( "sanitize_utf8 passes valid ASCII", adclib.sanitize_utf8( "hello" ), "hello" )
+eq( "sanitize_utf8 replaces lone invalid byte", type( adclib.sanitize_utf8( "\255" ) ), "string" )
+-- sanitize_utf8 must process the WHOLE value, not truncate at the NUL:
+-- "a" + NUL + 0xFF -> "a" + NUL + "_" (3 bytes). Pre-fix truncates to "a".
+eq( "sanitize_utf8 processes past embedded NUL", #adclib.sanitize_utf8( "a\0\255" ), 3 )
+
+-- escape / unescape must keep bytes past an embedded NUL (length-aware).
+-- "a\0b" has nothing to (un)escape, so both return the 3 bytes unchanged;
+-- pre-fix the const char* path truncated the value to "a" (1 byte).
+eq( "escape keeps bytes past embedded NUL", #adclib.escape( "a\0b" ), 3 )
+eq( "unescape keeps bytes past embedded NUL", #adclib.unescape( "a\0b" ), 3 )
+
+io.write( string.format( "\n%d checks, %d failures\n", checks, failures ) )
+os.exit( failures == 0 and 0 or 1 )


### PR DESCRIPTION
Three defects in adclib's UTF-8 / lstring handling, found in the pre-3.2.0 security audit.

## Fixes

1. **`sanitizeUtf8` std::terminate** - the `noexcept` function did `tgt.insert(i, ...)` with `i` the SOURCE index; once a byte re-encoded shorter than it decoded, `i` exceeded `tgt.length()` and `insert` threw `std::out_of_range` across the noexcept boundary -> `std::terminate`. Reachable via `adclib.sanitize_utf8` (etc_webhook). Fixed: `append` at the target end.
2. **overlong encodings accepted** - `utf8ToWc` accepted overlong 2/3-byte encodings (e.g. `C0 80` for NUL), invalid UTF-8 and the desync source above. Now rejected. Bounded to 2/3 bytes on purpose: the 4-byte minimum `0x10000` does not fit a 16-bit `wchar_t` (Windows), where forcing it would over-reject valid 4-byte UTF-8 (emoji).
3. **NUL truncation** - `is_valid_utf8` / `sanitize_utf8` / `escape` / `unescape` built their `std::string` via the `const char*` / `luaL_optstring` path, truncating at the first embedded NUL and discarding the fetched length. `isutf8` is the incoming-data gate, so a NUL smuggled unvalidated post-NUL bytes past it. Now length-aware, fetching the pointer in a **separate statement** before `std::string(raw, len)` (argument-evaluation order is unspecified - a one-expression form read the length before it was set -> `bad_alloc`).

`gen_self_signed_cert`'s `cn` is intentionally left on `luaL_checkstring`: OpenSSL reads it as a NUL-terminated C-string (`X509_NAME_add_entry_by_txt` len -1), so length-awareness would be a no-op; documented inline.

## Test

`tests/unit/adclib_utf8_test.lua` (Linux smoke leg, like the other C-module tests): 12 checks - overlong reject, valid 2/3/4-byte accept, no-terminate on the crash frame, NUL processed past, escape/unescape keep bytes past NUL. Verified RED->GREEN against a pre-fix build (`sanitize` aborts `std::out_of_range: __pos (which is 2) > this->size() (which is 1)`) and a standalone C++ harness. Independent pre-merge review addressed (Windows `wchar_t` width, 4-byte coverage, `cn` note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)