### PR TITLE
fix(cfg): declare ret/err local in loadcfgprofile

### DIFF
--- a/core/cfg.lua
+++ b/core/cfg.lua
@@ -620,7 +620,7 @@ end
 
 loadcfgprofile = function( profile, name )
     profile = tostring( profile or get "scripts_cfg_profile" )    -- default profile
-    ret, err = util_loadtable( get "scripts_cfg_path" .. tostring( name ) .. ".cfg." .. profile )
+    local ret, err = util_loadtable( get "scripts_cfg_path" .. tostring( name ) .. ".cfg." .. profile )
     _ = err and out_error( "cfg.lua: function 'loadcfgprofile': error while loading cfg profile: ", err )
     return ret, err
 end


### PR DESCRIPTION
`core/cfg.lua`'s `loadcfgprofile` did `ret, err = util_loadtable(...)` with no `local`. Under the restricted sandbox env every core module runs in, writing an undeclared global hits the setenv `__newindex` trap and raises "attempt to write undeclared var" - crashing the hub the moment `cfg.loadcfgprofile` is called (per-plugin cfg profiles). Latent today (no in-tree caller), but a live landmine and the same bare-global class as #353 / #358.

Fix: add `local`. Return values unchanged.

Proof (bytecode, `luac -p -l -l core/cfg.lua`): the two `SETTABUP _ENV` writes at line 623 (`ret`, `err`) drop to **0**. This was the only `_ENV` write in all of `core/` per the consistency audit, so core is now categorically clean of runtime global writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)