### PR TITLE
fix(backup): parse the archive manifest without executing it

### DIFF
--- a/core/backup_archive.lua
+++ b/core/backup_archive.lua
@@ -63,7 +63,6 @@ local error        = use "error"
 local pcall        = use "pcall"
 local tostring     = use "tostring"
 local tonumber     = use "tonumber"
-local load         = use "load"
 local pairs        = use "pairs"
 local ipairs       = use "ipairs"
 
@@ -80,10 +79,6 @@ local string_match  = string.match
 local table        = use "table"
 local table_concat = table.concat
 local table_sort   = table.sort
-
--- debug.sethook is used ONLY to bound the manifest-eval work (see
--- _manifest_parse); the standard way to cap untrusted Lua execution.
-local debug_sethook = ( use "debug" ).sethook
 
 --// extern libs //--
 
@@ -124,7 +119,6 @@ local MAX_NAME           = 100      -- ustar name field (no prefix-split yet)
 
 local MANIFEST_NAME      = "MANIFEST"
 local MANIFEST_MAX_BYTES = 65536    -- a real manifest is a handful of scalars
-local MANIFEST_MAX_INSTR = 200000   -- eval work ceiling (real parse ~dozens)
 local MODE_0644          = 420      -- rw-r--r-- (caller passes per-file modes)
 
 local ZERO_BLOCK         = string_rep( "\0", TAR_BLOCK )
@@ -320,7 +314,8 @@ end
 
 -- Serialise the flat metadata table (scalars + a string->string `kinds`
 -- map) to a deterministic `return { ... }` Lua chunk. %q keeps arbitrary
--- paths / versions safe to load back.
+-- paths / versions safe to decode back (via _manifest_parse's recogniser,
+-- which never executes the chunk).
 local function _manifest_serialize( meta )
     local keys = { }
     for k in pairs( meta ) do keys[ #keys + 1 ] = k end
@@ -347,28 +342,140 @@ local function _manifest_serialize( meta )
     return table_concat( lines, "\n" )
 end
 
--- Parse a manifest chunk in a sandboxed empty environment (text only, no
--- globals) - same protection as util.loadtable_string, PLUS a work bound.
--- The empty _ENV blocks code execution, but a crafted manifest (a foreign
--- archive whose passphrase the operator holds) could still `while true do end`
--- and hang the offline restore. An instruction-count hook aborts any chunk
--- that runs past a budget far above a real table construction; because the
--- env is empty the chunk cannot reach a long-running C call that would slip
--- the hook, so the count bound is sufficient (DEVELOPMENT.md §5: bound the
--- WORK, not just the depth).
+-- Parse a manifest WITHOUT executing it. _manifest_serialize emits a fixed
+-- grammar - `return { [<qstr>] = <scalar>, ..., kinds = { [<qstr>] = <qstr>,
+-- ... } }` - so this small hand-written recogniser rebuilds the table and
+-- rejects anything outside that grammar. A crafted manifest (a foreign
+-- archive whose passphrase the operator holds) can neither execute code nor
+-- run unbounded work: the scan is linear over the already size-capped input
+-- and every path advances `pos` or returns.
+--
+-- Replaces a load()+instruction-count-hook approach. The count hook did NOT
+-- tick inside a C-library call, and Lua's per-state string metatable is
+-- reachable from any chunk regardless of an empty _ENV, so `("x"):rep(2^30)`
+-- slipped the bound (a single huge alloc). A recogniser that never runs the
+-- input closes that class for good.
 local function _manifest_parse( str )
     if type( str ) ~= "string" or #str > MANIFEST_MAX_BYTES then
         return nil, "manifest: missing or too large"
     end
-    local fn, err = load( str, "backup_manifest", "t", { } )
-    if not fn then return nil, "manifest: " .. tostring( err ) end
-    debug_sethook( function( ) error( "manifest: instruction budget exceeded", 0 ) end, "", MANIFEST_MAX_INSTR )
-    local ok, tbl = pcall( fn )
-    debug_sethook( )   -- always clear the hook, success or not
-    if not ok or type( tbl ) ~= "table" then
-        return nil, "manifest: invalid table"
+    local n = #str
+    local pos = 1
+
+    local function skip_ws( )
+        pos = pos + #string_match( str, "^[ \t\r\n]*", pos )
     end
-    return tbl
+    local function accept( lit )
+        if string_sub( str, pos, pos + #lit - 1 ) == lit then
+            pos = pos + #lit
+            return true
+        end
+        return false
+    end
+    -- Decode one %q-quoted string at str[pos] (must start with `"`).
+    -- %q escapes: \" \\ , LF as backslash+LF, other control bytes as \ddd.
+    local function qstring( )
+        if string_sub( str, pos, pos ) ~= '"' then return nil end
+        pos = pos + 1
+        local out = { }
+        while pos <= n do
+            local ch = string_sub( str, pos, pos )
+            if ch == '"' then
+                pos = pos + 1
+                return table_concat( out )
+            elseif ch == '\\' then
+                local e = string_sub( str, pos + 1, pos + 1 )
+                if e == '"' or e == '\\' then
+                    out[ #out + 1 ] = e
+                    pos = pos + 2
+                elseif e == '\n' then
+                    out[ #out + 1 ] = '\n'
+                    pos = pos + 2
+                else
+                    local dec = string_match( str, "^\\(%d%d?%d?)", pos )
+                    if not dec then return nil end    -- unknown escape
+                    local b = tonumber( dec )
+                    if b > 255 then return nil end
+                    out[ #out + 1 ] = string_char( b )
+                    pos = pos + 1 + #dec
+                end
+            else
+                out[ #out + 1 ] = ch
+                pos = pos + 1
+            end
+        end
+        return nil    -- unterminated
+    end
+
+    skip_ws( )
+    if not accept( "return" ) then return nil, "manifest: expected 'return'" end
+    skip_ws( )
+    if not accept( "{" ) then return nil, "manifest: expected '{'" end
+
+    local result = { }
+    while true do
+        skip_ws( )
+        if accept( "}" ) then break end
+
+        -- key: [<qstr>]  OR  the bareword `kinds` (serializer's one exception)
+        local is_kinds = false
+        local key
+        if accept( "[" ) then
+            skip_ws( )
+            key = qstring( ); if key == nil then return nil, "manifest: bad key" end
+            skip_ws( ); if not accept( "]" ) then return nil, "manifest: expected ']'" end
+        elseif accept( "kinds" ) then
+            is_kinds = true
+        else
+            return nil, "manifest: unexpected token"
+        end
+
+        skip_ws( ); if not accept( "=" ) then return nil, "manifest: expected '='" end
+        skip_ws( )
+
+        if is_kinds then
+            if not accept( "{" ) then return nil, "manifest: expected kinds table" end
+            local kinds = { }
+            while true do
+                skip_ws( )
+                if accept( "}" ) then break end
+                if not accept( "[" ) then return nil, "manifest: bad kinds key" end
+                skip_ws( )
+                local kk = qstring( ); if kk == nil then return nil, "manifest: bad kinds key" end
+                skip_ws( ); if not accept( "]" ) then return nil, "manifest: expected ']'" end
+                skip_ws( ); if not accept( "=" ) then return nil, "manifest: expected '='" end
+                skip_ws( )
+                local vv = qstring( ); if vv == nil then return nil, "manifest: kinds value must be a string" end
+                kinds[ kk ] = vv
+                skip_ws( ); accept( "," )
+            end
+            result.kinds = kinds
+        elseif string_sub( str, pos, pos ) == '"' then
+            local v = qstring( ); if v == nil then return nil, "manifest: bad string value" end
+            result[ key ] = v
+        else
+            -- number or boolean bareword. `+`/`e`/`.` are allowed so
+            -- tostring's scientific form (e.g. "1e+20") round-trips;
+            -- anything tonumber rejects (and non true/false) is refused,
+            -- so an expression like `1+1` is never evaluated.
+            local word = string_match( str, "^[%w%.%+%-]+", pos )
+            if not word then return nil, "manifest: bad value" end
+            pos = pos + #word
+            if word == "true" then result[ key ] = true
+            elseif word == "false" then result[ key ] = false
+            else
+                local num = tonumber( word )
+                if num == nil then return nil, "manifest: bad value" end
+                result[ key ] = num
+            end
+        end
+
+        skip_ws( ); accept( "," )    -- comma optional (trailing allowed)
+    end
+
+    skip_ws( )
+    if pos <= n then return nil, "manifest: trailing data" end
+    return result
 end
 
 ----------------------------------// PACK / UNPACK //--

--- a/tests/unit/backup_archive_test.lua
+++ b/tests/unit/backup_archive_test.lua
@@ -132,21 +132,57 @@ eq( "manifest: bool field",    m_out.include_master_key, true )
 eq( "manifest: kinds map a",   m_out.kinds[ "__masterkey__" ], "masterkey" )
 eq( "manifest: kinds map b",   m_out.kinds[ "cfg/user.tbl" ],  "tree" )
 
--- #485: a crafted manifest must not hang the offline restore. Pre-fix this
--- spins forever (the eval had no work bound); post-fix the instruction-count
--- hook aborts it and _manifest_parse returns (nil, err). If this test ever
--- HANGS instead of failing fast, the bound regressed.
+-- %q round-trip: a value carrying every byte class %q escapes must survive
+-- the load()-free decoder intact - quote, backslash, LF (encoded as
+-- backslash+LF, which spans two physical lines and would break a line-based
+-- parser), CR (\13), a control byte followed by an ASCII digit (padded to
+-- \001), a high byte (0xFF, emitted literally by %q), and the
+-- manifest-structural bytes ] = [ { } , (literal inside the string, must not
+-- confuse the recogniser).
+local special = 'q"b\\s\nl\rr' .. string.char( 255 ) .. string.char( 1 ) .. '5]=[{},end'
+local sp_out = assert( A._manifest_parse( A._manifest_serialize( { note = special } ) ) )
+eq( "manifest: %q special/structural bytes round-trip", sp_out.note, special )
+
+-- Empty manifest and empty kinds map both parse to tables.
+eq( "manifest: empty -> table", type( A._manifest_parse( "return {}" ) ), "table" )
+local ek = assert( A._manifest_parse( A._manifest_serialize( { kinds = { } } ) ) )
+eq( "manifest: empty kinds -> table", type( ek.kinds ), "table" )
+
+-- Scientific-notation number (tostring of a large float) round-trips.
+local sci = assert( A._manifest_parse( A._manifest_serialize( { big = 1e20 } ) ) )
+eq( "manifest: sci-notation number round-trip", sci.big, 1e20 )
+
+-- #485 + F-DEP manifest hardening: a crafted manifest (foreign archive,
+-- operator-held passphrase) must neither execute code nor run unbounded work
+-- during the offline restore. The parser is a grammar recogniser that never
+-- runs the input, so every hostile case is refused as (nil, err), fast.
 do
-    local bad = A._manifest_parse( "return (function() while true do end end)()" )
-    ok( "manifest: infinite loop bounded -> nil", bad == nil )
-    -- an over-budget bounded loop is refused too, not silently accepted
-    local heavy = A._manifest_parse( "local x=0 for i=1,1e9 do x=x+1 end return {}" )
-    ok( "manifest: over-budget loop -> nil", heavy == nil )
-    -- oversized manifest rejected before load
-    local huge = A._manifest_parse( "return {}" .. string.rep( " ", 70000 ) )
-    ok( "manifest: oversized -> nil", huge == nil )
-    -- a normal manifest still parses after all that
-    ok( "manifest: normal still ok", type( A._manifest_parse( "return { a = 1 }" ) ) == "table" )
+    -- Deterministic proof the manifest is NOT evaluated: `1+1` would yield
+    -- {k=2} under the old load()-based parser; arithmetic is not part of the
+    -- grammar, so it is refused, not computed. (This is the pre-fix RED case.)
+    ok( "manifest: expression not evaluated -> nil",
+        A._manifest_parse( 'return { ["k"] = 1+1 }' ) == nil )
+    -- The exact bound-bypass that motivated the rewrite: the old instruction
+    -- count hook did not tick during the string.rep C call (reachable via the
+    -- always-present string metatable, empty _ENV notwithstanding), so this
+    -- allocated ~1 GiB. The recogniser refuses it - `(` is not a value token.
+    ok( "manifest: string-metatable rep bypass -> nil",
+        A._manifest_parse( 'return { ["k"] = ("x"):rep(2^30) }' ) == nil )
+    -- Loops / function bodies are not grammar either - refused, never run.
+    ok( "manifest: infinite loop -> nil",
+        A._manifest_parse( "return (function() while true do end end)()" ) == nil )
+    ok( "manifest: heavy loop -> nil",
+        A._manifest_parse( "local x=0 for i=1,1e9 do x=x+1 end return {}" ) == nil )
+    -- Oversized manifest rejected before any parsing.
+    ok( "manifest: oversized -> nil",
+        A._manifest_parse( "return {}" .. string.rep( " ", 70000 ) ) == nil )
+    -- Bareword scalar keys are not the serializer's shape (it emits ["k"]);
+    -- the strict recogniser refuses them.
+    ok( "manifest: bareword scalar key -> nil",
+        A._manifest_parse( "return { a = 1 }" ) == nil )
+    -- A real serializer-shaped manifest still parses after all that.
+    ok( "manifest: normal still ok",
+        type( A._manifest_parse( 'return { ["a"] = 1 }' ) ) == "table" )
 end
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
`core/backup_archive.lua`'s `_manifest_parse` loaded the MANIFEST as a Lua chunk (`load()`) bounded by a `debug.sethook` instruction-count hook. That hook does **not** tick inside a C-library call, and Lua's per-state string metatable is reachable from any chunk regardless of the empty `_ENV`, so a crafted manifest `("x"):rep(2^30)` slipped the bound and allocated ~1 GiB during the offline `--restore` of a foreign archive (the #485 threat: the operator holds the passphrase of an untrusted archive).

## Fix

Replace `load()` with a hand-written **char-stream grammar recogniser** that rebuilds the table for exactly the shape `_manifest_serialize` emits (`[<qstr>] = <scalar>`, `kinds = { [<qstr>] = <qstr> }`) and refuses everything else. It never executes the input - the scan is linear over the size-capped (64 KiB) manifest and every path advances `pos` or returns, so neither code execution nor unbounded work is possible. Includes a `%q` decoder (`\"`, `\`, LF-as-backslash+LF, `\ddd` control bytes). Format unchanged, so existing backups restore as before (verified by round-trip). Removes the now-dead `debug.sethook` import + `MANIFEST_MAX_INSTR`.

## Test (both smoke legs)

- Format round-trips: strings / numbers / booleans / kinds, plus `%q` special + structural bytes (quote, backslash, LF, CR, padded `\ddd`, 0xFF, `]=[{},`), empty manifest / empty kinds, scientific-notation numbers.
- Hostile inputs refused as `(nil, err)`: `1+1` (never evaluated), `("x"):rep(2^30)` (the motivating bypass), infinite/heavy loops, oversized, bareword key.
- **RED->GREEN**: pre-fix `1+1` evaluates to `{k=2}` (3/61 fail); post-fix 61/61.

Independent pre-merge review: APPROVE (format fidelity, %q decode, termination, no code-exec all confirmed); all nits addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)