### PR TITLE
docs: pre-3.2.0 correctness pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ promoted to `master`, so pull requests go against **`dev`** - see
 ### 3.2.x feature era (Phase 8+, on `master`)
 
 - **HTTP / JSON API** ([#82](https://github.com/luadch-ng/luadch/issues/82)) - token-authed REST surface for users, bans, registered users, config, logs, and a live `/v1/events` stream; see [`docs/HTTP_API.md`](docs/HTTP_API.md)
-- **Audit log** ([#84](https://github.com/luadch-ng/luadch/issues/84)) - structured JSONL `onAudit` records across ~20 plugins, exposed via `etc_auditlog` + the HTTP event stream
+- **Audit log** ([#84](https://github.com/luadch-ng/luadch/issues/84)) - structured JSONL `onAudit` records across the hub's staff-action plugins, exposed via `etc_auditlog` + the HTTP event stream
 - **Unified pre-handshake blocklist + in-hub GeoIP** ([#78](https://github.com/luadch-ng/luadch/issues/78) / [#79](https://github.com/luadch-ng/luadch/issues/79)) - CIDR/IPv6 blocklist with provenance, stealth mode, external feeds (Tor / Spamhaus / AbuseIPDB), MaxMind GeoLite2 country/ASN, and live proxy/VPN detection ([#352](https://github.com/luadch-ng/luadch/issues/352)); operator guide in [`docs/BLOCKLIST.md`](docs/BLOCKLIST.md)
 - **Global allowlist / whitelist** (#78 allowlist) - trusted infrastructure (hublist pingers etc.) exempt from the *automated* blockers, never from a manual ban
 - **Client blocker** ([#81](https://github.com/luadch-ng/luadch/issues/81)) - version-range client filtering

--- a/docs/BLOCKLIST.md
+++ b/docs/BLOCKLIST.md
@@ -4,7 +4,7 @@ luadch blocks unwanted connections in two complementary layers:
 
 | Layer | Fires | Handles | Managed by |
 |---|---|---|---|
-| **Pre-handshake IP/CIDR blocklist** | TCP accept, before ADC/TLS | known-bad IPs and CIDR ranges (manual + future feeds) | `+blocklist` ([`SCRIPTS.md`](SCRIPTS.md) etc_blocklist) |
+| **Pre-handshake IP/CIDR blocklist** | TCP accept, before ADC/TLS | known-bad IPs and CIDR ranges (manual + external feeds) | `+blocklist` ([`SCRIPTS.md`](SCRIPTS.md) etc_blocklist) |
 | **Post-handshake bans** | after login | nick / CID / short-term IP bans | `+ban` (cmd_ban) |
 | **GeoIP policy** | on connect, post-handshake | country / ASN policy | `etc_geoip` (this doc) |
 | **Allowlist (whitelist)** | consulted first by every automated blocker | trusted IPs / CIDRs (hublist pingers) exempted | `+whitelist` ([`SCRIPTS.md`](SCRIPTS.md) etc_whitelist) |
@@ -37,8 +37,10 @@ either logs or kicks connections matching your policy.
   after the handshake. It adds nothing to the pre-handshake accept path
   and never bloats the IP blocklist with the thousands of CIDRs a single
   country spans.
-- **Operators are exempt by default** (`etc_geoip_check_levels`) so a
-  wrong country code cannot lock your staff out.
+- **Operators are exempt by default** (`etc_geoip_check_levels` exempts
+  levels 55-80) so a wrong country code cannot lock your staff out. Note
+  the default still geo-checks level 100 (HUBOWNER) - flip `[100]=false`
+  to exempt it too (e.g. to test from a blocked region).
 - **The hub runs fine without a database.** A missing / outdated `.mmdb`
   logs one warning and leaves the checks inert.
 
@@ -204,7 +206,7 @@ snapshot is available read-only at `GET /v1/geoip`.
 | `etc_geoip_blocked_countries` | `{ }` | ISO-3166-1 alpha-2 codes (case-insensitive) |
 | `etc_geoip_blocked_asns` | `{ }` | AS numbers (needs the ASN DB) |
 | `etc_geoip_action` | `"log_only"` | `"log_only"` or `"block"` |
-| `etc_geoip_check_levels` | ops exempt | which user levels are checked |
+| `etc_geoip_check_levels` | levels 55-80 exempt (100 still checked) | which user levels are checked |
 | `etc_geoip_recheck_interval_sec` | `3600` | how often the `.mmdb` is re-read (picks up geoipupdate writes) |
 | `etc_geoip_kick_reason` | "Your region is not permitted..." | kick message (block mode); operator policy text, set it here |
 | `etc_geoip_oplevel` | `80` | min level for `+geoip` |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -26,7 +26,7 @@ After a fresh install, before opening the hub to real users:
    ```
    Pin the cert deterministically: hand users the `adcs://host:port/?kp=SHA256/<keyprint>` URL. DC++ clients trust the keyprint, not a CA chain - no Let's Encrypt or paid cert needed (see [`docs/SECURITY.md`](SECURITY.md) §6).
 
-   To regenerate later, delete `certs/servercert.pem` and `certs/serverkey.pem` and restart the hub. The `examples/certs/make_cert.{sh,bat}` scripts are still around for manual regeneration outside the hub process (e.g. for cron-based rotation).
+   To regenerate later, delete `certs/servercert.pem` and `certs/serverkey.pem` and restart the hub. The `certs/make_cert.{sh,bat}` scripts (installed alongside the cert material) are still around for manual regeneration outside the hub process (e.g. for cron-based rotation).
 
 2. **Connect with an ADC client** (AirDC++, EiskaltDC++, …):
    - Address: `adcs://127.0.0.1:5001/?kp=SHA256/<keyprint from step 1>`
@@ -138,14 +138,19 @@ do not run a public hub with `dummy / test` active.
 The hub uses an integer-based user level system. Higher levels grant
 more permissions. Bundled defaults:
 
-| Level | Name     | What it can do                                  |
-|-------|----------|-------------------------------------------------|
-| 100   | HUBOWNER | Everything (registers / deletes / shutdown)     |
-| 80    | ADMIN    | Admin operations, user + registration management |
-| 60    | OPERATOR | Moderation (ban / kick / gag / redirect)        |
-| 40    | SVIP     | Super-VIP: elevated privileges, exemptions      |
-| 20    | REG      | Registered user, basic chat / commands          |
-| 0     | UNREG    | Anonymous (unregistered) connection             |
+| Level | Name       | What it can do                                   |
+|-------|------------|--------------------------------------------------|
+| 100   | HUBOWNER   | Everything (registers / deletes / shutdown)      |
+| 80    | ADMIN      | Admin operations, user + registration management |
+| 70    | SUPERVISOR | Senior moderation, above operators               |
+| 60    | OPERATOR   | Moderation (ban / kick / gag / redirect)         |
+| 55    | SBOT       | Service-bot account level                        |
+| 50    | SERVER     | Server / linked-service account level            |
+| 40    | SVIP       | Super-VIP: elevated privileges, exemptions       |
+| 30    | VIP        | VIP user, extra privileges                       |
+| 20    | REG        | Registered user, basic chat / commands           |
+| 10    | GUEST      | Guest account, minimal privileges                |
+| 0     | UNREG      | Anonymous (unregistered) connection              |
 
 Customise per-script `minlevel` in `cfg.tbl` to grant or restrict
 specific commands.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -83,7 +83,7 @@ walk-through.
 
 ## Mount layout
 
-The compose file sets up six bind mounts:
+The compose file sets up five bind mounts:
 
 | Host path | Container path | Purpose |
 |---|---|---|
@@ -125,7 +125,7 @@ Full guide: [`docs/BACKUP.md`](BACKUP.md). The Docker essentials:
   environment:
     - LUADCH_ETC_BACKUP_PASSPHRASE=${LUADCH_ETC_BACKUP_PASSPHRASE}
   ```
-  Restart the container. `!backup status` should show "ready".
+  Restart the container. `+backup status` should show "ready".
 - **Where they land:** `./cfg/backups/` on the host (default `etc_backup_dir =
   "cfg/backups"`, inside the already-mounted `./cfg`). No extra volume needed.
 - **Off-site:** the hub only writes locally - mirror `./cfg/backups/` to a
@@ -332,7 +332,7 @@ For `vX.Y.Z` releases pin the tag in `docker-compose.yml` so you don't
 get unexpected jumps:
 
 ```yaml
-image: ghcr.io/luadch-ng/luadch:v3.1.3
+image: ghcr.io/luadch-ng/luadch:v3.1.15
 ```
 
 ### What gets updated automatically

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -75,7 +75,7 @@ Caps in the framer:
 
 The current S3 framer is a single-shot stage (`done = true` after
 the header parse; subsequent `push` returns `nil` and discards
-trailing bytes - `core/iostream.lua:469-481`). Phase 1 adds a new
+trailing bytes - `core/iostream.lua` `newhttpstage`). Phase 1 adds a new
 post-header state for collecting body bytes, plus a richer emit
 shape. The state machine becomes:
 
@@ -391,7 +391,7 @@ hub.http_register( method, path, scope, handler, meta )
 | `path` | string | URL path including version prefix, e.g. `"/v1/bans"`. Path variables in `{name}` form, e.g. `"/v1/bans/{id}"` |
 | `scope` | string | `"read"`, `"admin"`, or `"none"`. `"none"` skips the router's bearer-token gate - use ONLY when the endpoint does its OWN authentication (e.g. an HMAC-signed webhook receiver, `etc_webhook`); see the §4.4 scope table |
 | `handler` | function | `function(req) -> result` (see §6 + §7) |
-| `meta` | table or nil | Optional metadata - `{plugin=, description=, request_schema=, response_schema=, audit_redact_body=}`. `plugin` is the source plugin name, for `/v1/endpoints` + `/v1/plugins` attribution. Surfaced via `/v1/endpoints` (except `audit_redact_body`, which is router-internal). Used by WebUI for form rendering. `audit_redact_body = true` opts the route into §6.8 audit-body redaction (used by password endpoints) |
+| `meta` | table or nil | Optional metadata - `{plugin=, description=, request_schema=, response_schema=, audit_redact_body=}`. `plugin` is the source plugin name, for `/v1/endpoints` + `/v1/plugins` attribution. Surfaced via `/v1/endpoints` (except `audit_redact_body`, which is router-internal). Used by WebUI for form rendering. `audit_redact_body = true` opts the route into §8 audit-body redaction (used by password endpoints) |
 
 #### 5.1.1 Higher-level helper: `util_http.http_register_user_action`
 
@@ -1019,7 +1019,6 @@ when the named plugin is loaded; 404 `E_NOT_CONFIGURED` otherwise).
 | GET | `/v1/users/{sid}` | read | full INF + session metadata |
 | GET | `/v1/endpoints` | read | live route registry (scope-filtered) |
 | GET | `/v1/log/api` | admin | tail of this API's own audit log; query `?lines=N` (default 200, max 1000); response `{lines, returned, total_lines}` matches sibling tail endpoints |
-| GET | `/v1/log/audit` | admin | tail of today's staff-action audit log (`log/audit-YYYY-MM-DD.jsonl`, #84); query `?lines=N` (default 200, max 1000); response `{lines, returned, total_lines}` matches sibling tail endpoints; multi-day reads are filesystem-side (`jq` / `cat`) by design |
 | GET | `/v1/plugins` | read | list plugins in `cfg.scripts` + runtime state [^http-plugins-1] |
 | PUT | `/v1/plugins/{name}/enabled` | admin | toggle a manageable plugin's enabled flag [^http-plugins-2] |
 | GET | `/v1/config` | read | full cfg snapshot; sensitive keys masked as `<redacted>` [^http-config-1] |
@@ -1030,7 +1029,7 @@ when the named plugin is loaded; 404 `E_NOT_CONFIGURED` otherwise).
 
 [^http-plugins-1]: Returns 200 with `data: {plugins: [...]}`. Each entry: `{name, filename, version, manageable, enabled, loaded, order_index, listeners[], http_routes[]}`. The `enabled` / `manageable` / `order_index` fields reflect the LIVE `cfg.scripts` table (so a PUT-driven mutation is immediately visible on the next GET, without requiring a reload); `loaded` / `version` / `listeners` / `http_routes` reflect what is actually running in memory (those flip after `POST /v1/reload`). `manageable: true` means the cfg.scripts entry is in table-form `{ "name.lua", enabled = bool }` (operator opted-in for API toggling); `manageable: false` means string-form (operator-protected). `version` is extracted via source-grep of `local scriptversion = "..."` at load time; plugins can opt-in to override via `return { _version = "..." }`. Plugins not in cfg.scripts are not listed (no directory scan).
 
-[^http-config-1]: #262. Returns 200 with `data: {config: {key: value, ...}}` containing every key registered in `core/cfg_defaults.lua`. Keys on the denylist (`http_api_tokens`, `master_key_path`) are replaced with the literal string `"<redacted>"`; the actual value is never sent over the wire. No pagination - the cfg snapshot is bounded (~200 keys, ~10-30 KiB JSON). Values are returned in their native types (strings as JSON strings, integers as JSON numbers, booleans, arrays, tables) - whatever `dkjson.encode` produces. Adding a new sensitive key to the denylist is a one-line append in `core/http_router.lua`'s `_config_denylist`.
+[^http-config-1]: #262. Returns 200 with `data: {config: {key: value, ...}}` containing every key registered in `core/cfg_defaults.lua`. Keys on the denylist (`http_api_tokens`, `master_key_path`) are replaced with the literal string `"<redacted>"`; the actual value is never sent over the wire. No pagination - the cfg snapshot is bounded (~200 keys, ~10-30 KiB JSON). Values are returned in their native types (strings as JSON strings, integers as JSON numbers, booleans, arrays, tables) - whatever `dkjson.encode` produces. Redaction is driven by the secrets registry: any key for which `secrets.is_secret_key(key)` is true (see `core/secrets.lua`, populated via `secrets.register(...)`) is masked. Marking a new key sensitive means registering it there, not editing a denylist.
 
 [^http-config-2]: #262. Body `{value: <any JSON type>}`, required. Path variable `{key}` is the bare cfg key name. Mutates via `cfg.set` (validator check + atomic write to `cfg.tbl`). Response carries `apply_status` from a small lookup table in `core/http_router.lua`: `live` (effect on `cfg.set` - default for the ~200 keys not in either bucket); `reload_required` (needs `POST /v1/reload` to apply; currently `scripts`, `language`, plus the path-pointer keys `user_path` / `script_path` / `scripts_cfg_path` / `scripts_lang_path` / `core_lang_path`); `restart_required` (needs full hub restart; currently `tcp_ports`, `ssl_ports`, `tcp_ports_ipv6`, `ssl_ports_ipv6`, `http_port`, `hub_listen`, `master_key_path`, `log_path`, `ssl_params`, `use_ssl`). Returns 403 `E_FORBIDDEN` if `{key}` is on the denylist (sensitive credentials rotate via direct cfg.tbl edit + restart); 404 `E_NOT_FOUND` if the key is not registered in `cfg_defaults.lua`; 400 `E_BAD_INPUT` if body is missing the `value` field OR the validator rejected the value (the validator's err_msg is surfaced in the response). The change is NOT auto-reload-triggered - the operator chains `POST /v1/reload` for reload-required keys, or restarts the hub for restart-required keys. Per-key validator schemas are NOT exposed (the validator closures aren't designed to be introspectable); deferred to a future `GET /v1/config/{key}/schema` endpoint if a real need emerges.
 
@@ -1197,6 +1196,9 @@ is disabled in `cfg.scripts`, the endpoint returns 404
 |---|---|---|---|
 | GET | `/v1/log/error?lines=N` | admin | `cmd_errors` - **migrated (Phase 3 PR-3)** [^http-log-error-1] |
 | GET | `/v1/log/cmd?lines=N` | admin | `etc_cmdlog` - **migrated (Phase 3 PR-4)** [^http-log-cmd-1] |
+| GET | `/v1/log/audit?lines=N` | admin | `etc_auditlog` (#84) [^http-log-audit-1] |
+
+[^http-log-audit-1]: Registered by the `etc_auditlog` plugin, NOT hub-intrinsic - returns 404 `E_NOT_CONFIGURED` when that plugin is disabled. Tail of today's staff-action audit log (`log/audit-YYYY-MM-DD.jsonl`); query `?lines=N` (default 200, max 1000); response `{lines, returned, total_lines}` matches sibling tail endpoints; multi-day reads are filesystem-side (`jq` / `cat`) by design.
 
 [^http-log-error-1]: Query `?lines=N` (default 200, max 1000 per §6.4 tail-style cap). Non-numeric or out-of-range values are clamped to the default, not rejected. Returns 200 with `data: {lines:[...], returned, total_lines}`. `total_lines` is the file's full line count (operators can spot "the last 200 of 1500" at a glance). Missing log file returns 200 with `lines: []` and `total_lines: 0` (matches the ADC path's "No errors." semantic without surfacing a 404 for a file that has not been written yet). The ADC-side `cmd_errors_permission` level table does NOT apply on the HTTP path: the bearer token's `admin` scope IS the authorisation gate.
 | DELETE | `/v1/log/{name}` | admin | `etc_log_cleaner` - `{name}` ∈ `error`, `cmd` - **migrated (Phase 3 PR-5)** [^http-log-clean-1] |
@@ -1264,6 +1266,14 @@ is disabled in `cfg.scripts`, the endpoint returns 404
 
 [^http-trafficmgr-4]: No request body. Returns 200 with `data: {action: "unblocked", nick, by, removed: {by, reason, blocked_at}}` per §7.1.1; `removed` is the pre-DELETE entry snapshot for the operator's audit / undo flow. Returns **404 E_NOT_FOUND** if the nick is not manually-blocked (idempotent 200 would mask typos); the same error fires if the nick is only autoblocked by script permissions - the autoblock is a runtime classification, not a stored entry, and lifts only via cfg changes to `blocklevel_tbl` / share thresholds. Cascade on success: block_tbl -= entry, persist, opchat report.send, and if target online: target reply + description-flag removal via `cmd:setnp("DE", new_desc)` + sendtoall BINF. The ADC-side `etc_trafficmanager_masterlevel` gate does NOT apply on the HTTP path: the bearer token's `admin` scope IS the authorisation gate.
 
+#### Webhooks (inbound)
+
+| Method | Path | Scope | Plugin |
+|---|---|---|---|
+| POST | `/v1/webhook/<name>` | none | `etc_webhook` (#398) [^http-webhook-1] |
+
+[^http-webhook-1]: One route per operator-configured endpoint (`<name>` is the endpoint's configured path segment). Scope is `none` - the router does NOT gate it; the plugin authenticates each delivery itself via an HMAC-SHA256 signature over the raw body (see [`WEBHOOKS.md`](WEBHOOKS.md)). Signature mismatch returns **401** with the plugin's own `{code:"unauthorized"}` body; a body over the 64 KiB cap returns **413**; a non-JSON content type returns **415**. Registered only when `etc_webhook` is loaded and the endpoint has a resolvable secret - otherwise the path is absent and an unregistered path falls through to the router's generic 401/404.
+
 #### Shipped post-Phase-4 (#82 arc closed 2026-05-27)
 
 The four "future-scope" items below were shipped in a single day on
@@ -1280,8 +1290,8 @@ above:
   long-poll via deferred-response dispatch (NOT SSE). Listed in
   §10.1.
 - **Filter + sort** (#264 PR-A #270 + PR-B #271) - common helper
-  `core/http_filter.lua` wired into all 8 paginated list
-  endpoints. Per-endpoint allowlist documented in each footnote.
+  `core/http_filter.lua` wired into every paginated list
+  endpoint. Per-endpoint allowlist documented in each footnote.
 
 True SSE (`text/event-stream`) is still deliberately deferred -
 the long-poll handshake covers the WebUI use cases without the
@@ -1412,8 +1422,8 @@ closed; details in their respective PRs / docs.
   `GET /v1/events?since=&types=&wait=`. Polling + long-poll via
   the deferred-response dispatch handshake; NOT SSE.
 - **Filter + sort** - #264 PR-A (#270) + PR-B (#271): shared
-  helper `core/http_filter.lua` wired into all 8 paginated list
-  endpoints. Per-endpoint allowlist documented in each footnote.
+  helper `core/http_filter.lua` wired into every paginated list
+  endpoint. Per-endpoint allowlist documented in each footnote.
 
 ### Still deferred
 

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -65,8 +65,8 @@ Tighten their permissions so other local users on the host cannot read
 them:
 
 ```sh
-sudo chmod 600 /opt/luadch/cfg/user.tbl
-sudo chmod 600 /opt/luadch/cfg/cfg.tbl     # contains the dummy default password
+sudo chmod 600 /opt/luadch/cfg/user.tbl    # accounts (incl. the dummy default password)
+sudo chmod 600 /opt/luadch/cfg/cfg.tbl     # may hold bot passwords / API tokens / passphrases
 ```
 
 The `log/` directory must be writable by the service user:

--- a/docs/PLUGIN_SANDBOX_MIGRATION.md
+++ b/docs/PLUGIN_SANDBOX_MIGRATION.md
@@ -25,7 +25,11 @@ Each pattern has a copy-paste fix.
 
 ## Reference: what the new sandbox contains
 
-Plugins see ONLY these globals after #206:
+Plugins see only an explicit whitelist of globals after #206. The list
+below is **illustrative** - the `SANDBOX_GLOBALS` table in
+[`core/scripts.lua`](../core/scripts.lua) is authoritative and grows as
+new core modules are exposed; if this guide disagrees with that table,
+the code wins.
 
 | Category | Globals |
 |---|---|
@@ -33,10 +37,11 @@ Plugins see ONLY these globals after #206:
 | Lua stdlib (full) | `table`, `math`, `coroutine` |
 | Lua stdlib (curated) | `os` (only `time`, `date`, `difftime`), `io` (only `open`, path-restricted) |
 | String lib | `string` (= `utf`, UTF-8-aware), `utf` (alias for the same) |
-| luadch core | `hub`, `cfg`, `util`, `util_http`, `adc`, `adclib`, `signal`, `out`, `unicode`, `sysinfo` |
+| luadch core | `hub`, `cfg`, `util`, `util_http`, `http_filter`, `http_events`, `http_client`, `adc`, `adclib`, `signal`, `out`, `unicode`, `sysinfo`, `const`, `audit`, `secrets`, `whitelist`, `blocklist`, `mmdb`, `geoip_update`, `hmac`, `backup` |
 | Optional libs | `ssl` (with `.x509` pre-attached as a field), `socket`, `basexx`, `zlib_stream`, `dkjson` |
 
-Anything not in this list is **unreachable** from plugin code.
+Anything not on the `SANDBOX_GLOBALS` whitelist is **unreachable** from
+plugin code.
 
 ## Removed primitives
 
@@ -90,7 +95,7 @@ local n = rawlen(my_tbl)
 **Replacement:** Direct table access. The `rawX` family bypasses
 metatable traps, which is only useful in code that uses metatables for
 sandbox escape. Plain `my_tbl[k]` / `my_tbl[k] = v` / `#my_tbl` work for
-every plugin use case observed in the 96-plugin audit (bundled + companion).
+every plugin use case observed in the bundled + companion plugin audit.
 
 ### `_G` / `_ENV`
 
@@ -250,13 +255,17 @@ here's the canonical replacement template:
 local state = util.loadtable(state_path) or {}
 
 -- ON STATE CHANGE:
-util.savearray(state, state_path)
--- (savearray writes atomically; replaces the historic
+util.savetable(state, "state", state_path)
+-- (savetable writes atomically; replaces the historic
 --  `io.open(path, "w+")` + `:write(serialize(t))` + `:close()` dance)
 ```
 
-This matches the pattern used by every bundled state-bearing plugin
-post-#206 (`cmd_gag`, `cmd_ban`, `etc_msgmanager`, etc).
+Use `util.savetable(tbl, name, path)` for a **keyed** table (a map, or
+scalars like `{ counter = 0 }`): it serialises string keys. `util.savearray(tbl, path)`
+writes ONLY the array part (`ipairs`) and silently drops string keys, so
+it is for **pure array-indexed** tables only. The bundled state-bearing
+plugins pick per shape - e.g. `cmd_ban` uses `savearray` for its
+array-indexed `bans` list and `savetable` for its keyed `history`.
 
 ## See also
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -527,7 +527,7 @@ differs. `actor.sid = "<http>"` for events fired via the HTTP API
 (`target`, `reason`, `meta`, `display_nick`) are dropped when
 empty so the on-disk shape stays compact.
 
-**Action vocabulary (25 names across 20 plugins):**
+**Action vocabulary:**
 `ban.add`, `ban.remove`, `ban.clear`, `ban.history.clear`,
 `gag.add`, `gag.remove`, `user.kick`, `user.redirect`,
 `user.mass.kick`, `reg.add`, `reg.remove`, `reg.update`,

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -97,8 +97,9 @@ An `admin`-scope HTTP API token can do everything `+masteruser` can
 do, including:
 
 - Read its own and every other admin token's audit-log bodies via
-  `GET /v1/log/api`. Bodies for routes that opt into the §6.8
-  redact mechanism (`audit_redact_body = true` - currently the two
+  `GET /v1/log/api`. Bodies for routes that opt into the
+  [`HTTP_API.md`](HTTP_API.md) §8 redact mechanism
+  (`audit_redact_body = true` - currently the two
   password endpoints) log as `[redacted]` even to admin readers,
   but everything else is plaintext.
 - Issue `POST /v1/restart` / `POST /v1/shutdown` / `POST /v1/reload`.
@@ -776,7 +777,7 @@ TLS configuration in [`core/cfg_defaults.lua`](../core/cfg_defaults.lua):
 
 - Protocol: TLS 1.3 (`tlsv1_3`)
 - Cipher list: `"HIGH+kEDH:HIGH+kEECDH:HIGH:!PSK:!SRP:!3DES:!aNULL"` (excludes PSK / SRP / 3DES / anonymous suites)
-- Disabled: SSLv2, SSLv3
+- Disabled: SSLv2, SSLv3, TLS 1.0, TLS 1.1, and renegotiation (`options = { "no_sslv2", "no_sslv3", "no_tlsv1", "no_tlsv1_1", "no_renegotiation" }`)
 - Peer-cert verify: off (correct for the server-side ADC role -
   clients are unauthenticated at the TLS layer; auth happens at the
   ADC HPAS layer)

--- a/docs/WEBHOOKS.md
+++ b/docs/WEBHOOKS.md
@@ -229,7 +229,8 @@ TLS is terminated by the proxy; the hub speaks plain HTTP on loopback.
 | Symptom | Cause / fix |
 |---|---|
 | Log: `endpoint '<name>' has no secret ... skipped` | No secret resolved - set the env var, cfg key, or inline `secret`. |
-| Sender shows **401** | Signature mismatch. The secret differs between sender and hub, or `signature_header` / `signature_prefix` is wrong for that sender. |
+| Sender shows **401**, body `{code:"unauthorized"}` | Signature mismatch on a registered route. The secret differs between sender and hub, or `signature_header` / `signature_prefix` is wrong for that sender. |
+| Sender shows **401**, body `{code:"E_UNAUTHENTICATED"}` | The route is not registered (wrong `<name>` in the URL, endpoint has no resolvable secret, or `etc_webhook` disabled). The router 401s an unknown path (it presents no bearer token) rather than leaking which paths exist - fix the path / secret / plugin toggle, not the signature. |
 | Sender shows **415** | The sender isn't using `Content-Type: application/json`. |
 | **200 but no chat message** | The event isn't in your `events` filter, a `conditions` filter dropped it, there's no `templates` entry for it, or the rendered text is empty. A ping is a 200-with-no-announce by design. |
 | Sender shows **413** | The delivery body exceeds the 64 KiB cap. |

--- a/tests/README.md
+++ b/tests/README.md
@@ -114,9 +114,10 @@ Windows leg (msys2 `lua5.4`, the versioned `lua54` package - the unversioned
 `lua` rolled to Lua 5.5 and broke the suite, #388) before the build+smoke
 step. When you add a unit test you MUST add a step for it to both legs, or
 it is silent non-coverage. (The exceptions are the C-module tests -
-`adclib_unescape_test.lua` and `zlib_stream_test.lua` - which need the built
-C module and so run on the Linux leg only, after install, with
-`LD_LIBRARY_PATH=.`.)
+`adclib_unescape_test.lua`, `adclib_hashpas_test.lua`,
+`adclib_utf8_test.lua`, `zlib_stream_test.lua`, and
+`backup_archive_crypto_test.lua` - which need the built C module and so run
+on the Linux leg only, after install, with `LD_LIBRARY_PATH=.`.)
 
 The unit-test authoring contract + the regression-fail-pre-fix recipe are
 in [`../docs/DEVELOPMENT.md`](../docs/DEVELOPMENT.md) §4.


### PR DESCRIPTION
Fixes stale/wrong statements across the docs, each verified against current source. Docs only, no code change.

Highlights (most impactful first):
- **PLUGIN_SANDBOX_MIGRATION.md** state-save template used `util.savearray` (array-only, silently drops string keys) as a generic recipe -> `util.savetable` for keyed state, with the savearray-is-array-only caveat.
- **HTTP_API.md** config redaction pointer was a removed `_config_denylist` -> the secrets registry (`secrets.is_secret_key`); `/v1/log/audit` moved from core to plugin endpoints (etc_auditlog, 404 when disabled); `etc_webhook` route family added; de-numberised the paginated-endpoint count; framer symbol reference fixed.
- **DOCKER.md** `!backup`->`+backup`; six->five bind mounts; stale `:v3.1.3` pin -> `:v3.1.15`.
- **CONFIGURATION.md** `examples/certs/`->`certs/` for operators; user-levels table completed (all 11 levels).
- **SECURITY.md** TLS floor now lists TLS 1.0/1.1 + renegotiation; `§6.8` audit-redaction cross-ref -> `§8`.
- **BLOCKLIST.md**, **INSTALLING.md**, **WEBHOOKS.md**, **SCRIPTS.md**, **README.md**, **tests/README.md**: feeds-shipped, dummy-pw-in-user.tbl, 401 disambiguation, rotting counts dropped, new adclib_utf8 test listed.

Two audited findings were skipped as not holding against source (a BACKUP.md manifest-budget claim that doesn't exist there; a non-broken F-INF-2 reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)