### PR TITLE
Promote: i18n Weblate translations nl,sv (#569) + english-word fixes (#570)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ A modernised fork of [luadch](https://github.com/luadch/luadch), an ADC(S) hub f
 
 Help us translate Luadch-ng into your language. Visit our [Translation Hub](https://translate.dcvault.net/projects/luadch-ng/)
 
-🔴🔴 REPO RENAMED `luadch` → `luadch-ng` - the Docker image moved from `ghcr.io/luadch-ng/luadch` to `ghcr.io/luadch-ng/luadch-ng`. Update your `docker pull` / compose `image:` line; the old image is frozen.
-🔴🔴 BETA SOFTWARE - Please report Errors
+🔴🔴 **REPO RENAMED `luadch` → `luadch-ng` - the Docker image moved from `ghcr.io/luadch-ng/luadch` to `ghcr.io/luadch-ng/luadch-ng`.**
 
-## Features
+🔴🔴 **BETA SOFTWARE - Version 3.2.0 not released yet. Use 3.1 for stable release**
+
+## Features in 3.2
 
 - 📜 Full ADC hub protocol support, TLS 1.3, ADCS-only
 - 🥷 Private only & public hub features

--- a/lang/nl/hub.json
+++ b/lang/nl/hub.json
@@ -1,0 +1,3 @@
+{
+    "hub_cid_taken": "Je CID is al in gebruik."
+}

--- a/lang/sv/hub.json
+++ b/lang/sv/hub.json
@@ -1,0 +1,3 @@
+{
+    "hub_cid_taken": "Din CID är upptagen."
+}

--- a/scripts/lang/en/cmd_redirect.json
+++ b/scripts/lang/en/cmd_redirect.json
@@ -1,5 +1,5 @@
 {
-  "help_desc":"Redirect user to url",
+  "help_desc":"Redirect user to URL",
   "help_title":"usr_redirect.lua",
   "help_usage":"[+!#]redirect <NICK> <URL>",
   "msg_denied":"You are not allowed to use this command.",
@@ -12,5 +12,5 @@
   "msg_usage":"Usage: [+!#]redirect <NICK> <URL>",
   "ucmd_menu_ct2_1":["Redirect","default URL"],
   "ucmd_menu_ct2_2":["Redirect","custom URL"],
-  "ucmd_url":"Redirect url:"
+  "ucmd_url":"Redirect URL:"
 }

--- a/scripts/lang/nl/bot_opchat.json
+++ b/scripts/lang/nl/bot_opchat.json
@@ -1,0 +1,46 @@
+{
+    "help_desc": "Chat voor operators",
+    "help_title": "",
+    "msg_clear": "",
+    "msg_denied": "",
+    "msg_denied_2": "",
+    "msg_help_1": "",
+    "msg_help_2": "",
+    "msg_help_3": "",
+    "msg_help_4": "",
+    "msg_help_5": "",
+    "msg_help_6": "",
+    "msg_help_7": "",
+    "msg_help_8": "",
+    "msg_help_op": "",
+    "msg_history": "",
+    "msg_intro": "",
+    "ucmd_menu_ct1_help": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_history": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_historyall": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_historyclear": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ]
+}

--- a/scripts/lang/sv/bot_opchat.json
+++ b/scripts/lang/sv/bot_opchat.json
@@ -1,0 +1,46 @@
+{
+    "help_desc": "Chatt för operatörer",
+    "help_title": "",
+    "msg_clear": "",
+    "msg_denied": "",
+    "msg_denied_2": "",
+    "msg_help_1": "",
+    "msg_help_2": "",
+    "msg_help_3": "",
+    "msg_help_4": "",
+    "msg_help_5": "",
+    "msg_help_6": "",
+    "msg_help_7": "",
+    "msg_help_8": "",
+    "msg_help_op": "",
+    "msg_history": "",
+    "msg_intro": "",
+    "ucmd_menu_ct1_help": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_history": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_historyall": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_historyclear": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ]
+}

--- a/scripts/lang/sv/bot_pm2ops.json
+++ b/scripts/lang/sv/bot_pm2ops.json
@@ -1,0 +1,5 @@
+{
+    "msg_denied": "Du har inte tillåtelse att använda den här chatten.",
+    "msg_send": "",
+    "msg_toops": ""
+}

--- a/scripts/lang/sv/bot_session_chat.json
+++ b/scripts/lang/sv/bot_session_chat.json
@@ -1,0 +1,43 @@
+{
+    "chatdesc": "av: %s | medlemmar: %s",
+    "help_desc": "",
+    "help_title": "",
+    "help_usage": "",
+    "msg_already": "",
+    "msg_chatexists": "",
+    "msg_create": "",
+    "msg_create2": "",
+    "msg_create3": "",
+    "msg_del": "",
+    "msg_del_2": "",
+    "msg_delall": "",
+    "msg_denied": "",
+    "msg_denied_2": "",
+    "msg_denied_3": "",
+    "msg_help_1": "",
+    "msg_help_2": "",
+    "msg_help_3": "",
+    "msg_help_4": "",
+    "msg_help_member": "",
+    "msg_help_owner": "",
+    "msg_members": "",
+    "msg_new_member": "",
+    "msg_nomember": "",
+    "msg_notonline": "",
+    "msg_usage": "",
+    "msg_welcome": "",
+    "ucmd_menu_ct1_create": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_remove": [
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_popup": ""
+}

--- a/scripts/lang/sv/cmd_accinfo.json
+++ b/scripts/lang/sv/cmd_accinfo.json
@@ -1,0 +1,53 @@
+{
+    "help_desc": "Skickar accinfo om en registrerad användare via SID eller NICK; utan argument -> om dig själv",
+    "help_desc2": "",
+    "help_title": "",
+    "help_title2": "",
+    "help_usage": "",
+    "help_usage2": "",
+    "msg_accinfo": "",
+    "msg_accinfo2": "",
+    "msg_bans_no": "",
+    "msg_bans_yes": "",
+    "msg_days": "",
+    "msg_denied": "",
+    "msg_forever": "",
+    "msg_god": "",
+    "msg_hours": "",
+    "msg_keyprint": "",
+    "msg_minutes": "",
+    "msg_mode_both": "",
+    "msg_mode_main": "",
+    "msg_mode_pm": "",
+    "msg_msgmanager": "",
+    "msg_msgmanager_1": "",
+    "msg_msgmanager_2": "",
+    "msg_off": "",
+    "msg_online": "",
+    "msg_redacted": "",
+    "msg_seconds": "",
+    "msg_trafficmanager_1": "",
+    "msg_trafficmanager_2": "",
+    "msg_unknown": "",
+    "msg_usage": "",
+    "msg_years": "",
+    "ucmd_menu_ct0": [
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_op": [
+        "",
+        ""
+    ],
+    "ucmd_menu_ct3_op": [
+        "",
+        ""
+    ],
+    "ucmd_menu_ct4": "",
+    "ucmd_menu_ct4_op": "",
+    "ucmd_menu_ct5": "",
+    "ucmd_menu_ct5_op": "",
+    "ucmd_menu_ct6": "",
+    "ucmd_menu_ct6_op": "",
+    "ucmd_nick": ""
+}

--- a/scripts/lang/sv/cmd_delreg.json
+++ b/scripts/lang/sv/cmd_delreg.json
@@ -1,0 +1,27 @@
+{
+    "help_desc": "Avregistrerar en användare",
+    "help_title": "",
+    "help_usage": "",
+    "msg_bot": "",
+    "msg_deblacklist": "",
+    "msg_del": "",
+    "msg_del_reason": "",
+    "msg_denied": "",
+    "msg_error": "",
+    "msg_notfound": "",
+    "msg_ok": "",
+    "msg_ok2": "",
+    "msg_usage": "",
+    "ucmd_menu_ct1": [
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct2": [
+        "",
+        ""
+    ],
+    "ucmd_nick": "",
+    "ucmd_reason": ""
+}

--- a/scripts/lang/sv/cmd_disconnect.json
+++ b/scripts/lang/sv/cmd_disconnect.json
@@ -1,0 +1,25 @@
+{
+    "help_desc": "Kopplar från en användare",
+    "help_title": "",
+    "help_usage": "",
+    "msg_bot": "",
+    "msg_denied1": "",
+    "msg_denied2": "",
+    "msg_denied3": "",
+    "msg_denied4": "",
+    "msg_usage": "",
+    "report_msg": "",
+    "ucmd_menu1": [
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu2": [
+        "",
+        ""
+    ],
+    "ucmd_reason": "",
+    "ucmd_target": "",
+    "user_msg": ""
+}

--- a/scripts/lang/sv/cmd_errors.json
+++ b/scripts/lang/sv/cmd_errors.json
@@ -1,0 +1,13 @@
+{
+    "help_desc": "Visar error.log",
+    "help_title": "",
+    "help_usage": "",
+    "msg_denied": "",
+    "msg_noerrors": "",
+    "ucmd_menu": [
+        "",
+        "",
+        "",
+        ""
+    ]
+}

--- a/scripts/lang/sv/cmd_gag.json
+++ b/scripts/lang/sv/cmd_gag.json
@@ -1,0 +1,55 @@
+{
+    "help_desc": "Tysta, kennylisera, smygtysta eller återställa en användare (med valfri varaktighet); eller visa begränsade användare",
+    "help_title": "",
+    "help_usage": "",
+    "msg_add_user": "",
+    "msg_add_user_with_duration": "",
+    "msg_denied": "",
+    "msg_error_in": "",
+    "msg_error_out": "",
+    "msg_expired": "",
+    "msg_god": "",
+    "msg_invalid_duration": "",
+    "msg_isbot": "",
+    "msg_off": "",
+    "msg_remove_user": "",
+    "msg_show_users": "",
+    "msg_unit_day": "",
+    "msg_unit_hour": "",
+    "msg_unit_minute": "",
+    "msg_unit_second": "",
+    "msg_unit_year": "",
+    "msg_usage": "",
+    "msg_user_restriction_added": "",
+    "msg_user_restriction_removed": "",
+    "ucmd_duration": "",
+    "ucmd_menu_ct0": [
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1": [
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1b": [
+        "",
+        ""
+    ],
+    "ucmd_menu_ct2": [
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct3": [
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct4": [
+        "",
+        ""
+    ],
+    "ucmd_nick": ""
+}

--- a/scripts/lang/sv/cmd_help.json
+++ b/scripts/lang/sv/cmd_help.json
@@ -1,0 +1,13 @@
+{
+    "help_desc": "Visar denna hjälp för hubbkommandon",
+    "help_title": "",
+    "help_usage": "",
+    "msg_description": "",
+    "msg_minlevel": "",
+    "msg_out": "",
+    "msg_usage": "",
+    "ucmd_menu": [
+        "",
+        ""
+    ]
+}

--- a/scripts/lang/sv/cmd_hubinfo.json
+++ b/scripts/lang/sv/cmd_hubinfo.json
@@ -1,0 +1,18 @@
+{
+    "help_desc": "Skickar en lista med grundläggande information om hubben",
+    "help_title": "",
+    "help_usage": "",
+    "msg_days": "",
+    "msg_denied": "",
+    "msg_hours": "",
+    "msg_level_label": "",
+    "msg_minutes": "",
+    "msg_out": "",
+    "msg_seconds": "",
+    "msg_unknown": "",
+    "msg_years": "",
+    "ucmd_menu": [
+        "",
+        ""
+    ]
+}

--- a/scripts/lang/sv/cmd_hubstats.json
+++ b/scripts/lang/sv/cmd_hubstats.json
@@ -1,0 +1,27 @@
+{
+    "help_desc": "Visar statistik om hubben",
+    "help_title": "",
+    "help_usage": "",
+    "month_name": [
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "msg_denied": "",
+    "msg_label": "",
+    "msg_stats": "",
+    "ucmd_menu_ct1": [
+        "",
+        "",
+        ""
+    ]
+}

--- a/scripts/lang/sv/cmd_mass.json
+++ b/scripts/lang/sv/cmd_mass.json
@@ -1,0 +1,35 @@
+{
+    "help_desc": "Skickar ett PM med <MSG> till alla användare",
+    "help_desc_op": "",
+    "help_title": "",
+    "help_title_op": "",
+    "help_usage": "",
+    "help_usage_op": "",
+    "msg_allowed_levels": "",
+    "msg_denied": "",
+    "msg_lvl_exists": "",
+    "msg_ok": "",
+    "msg_out": "",
+    "msg_out_hub": "",
+    "msg_out_lvl": "",
+    "msg_usage": "",
+    "msg_usage_hub": "",
+    "msg_usage_lvl": "",
+    "ucmd_menu": [
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_1": "",
+    "ucmd_menu_2": "",
+    "ucmd_menu_3": "",
+    "ucmd_menu_4": "",
+    "ucmd_menu_hub": [
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_what": ""
+}

--- a/scripts/lang/sv/cmd_myinf.json
+++ b/scripts/lang/sv/cmd_myinf.json
@@ -1,0 +1,15 @@
+{
+    "help_desc": "Visar klient-INF från en användare eller dig själv",
+    "help_title": "",
+    "help_usage": "",
+    "msg_denied": "",
+    "msg_inf": "",
+    "ucmd_menu_ct1": [
+        "",
+        ""
+    ],
+    "ucmd_menu_ct2": [
+        "",
+        ""
+    ]
+}

--- a/scripts/lang/sv/cmd_myip.json
+++ b/scripts/lang/sv/cmd_myip.json
@@ -1,0 +1,16 @@
+{
+    "help_desc": "Visar IP-adressen från en användare eller dig själv",
+    "help_title": "",
+    "help_usage": "",
+    "msg_denied": "",
+    "msg_ip": "",
+    "msg_targetip": "",
+    "ucmd_menu_ct1": [
+        "",
+        ""
+    ],
+    "ucmd_menu_ct2": [
+        "",
+        ""
+    ]
+}

--- a/scripts/lang/sv/cmd_nickchange.json
+++ b/scripts/lang/sv/cmd_nickchange.json
@@ -1,0 +1,39 @@
+{
+    "help_desc": "Ändra användarens smeknamn",
+    "help_title": "",
+    "help_usage": "",
+    "msg_bot": "",
+    "msg_denied": "",
+    "msg_denied2": "",
+    "msg_disconnect": "",
+    "msg_length": "",
+    "msg_nicktaken": "",
+    "msg_nochange": "",
+    "msg_notfound": "",
+    "msg_ok": "",
+    "msg_op": "",
+    "msg_op2": "",
+    "msg_usage": "",
+    "ucmd_menu_ct1_0": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_1": [
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_2": "",
+    "ucmd_menu_ct1_3": "",
+    "ucmd_menu_ct1_4": "",
+    "ucmd_menu_ct1_5": "",
+    "ucmd_menu_ct1_6": "",
+    "ucmd_menu_ct2_1": [
+        "",
+        ""
+    ],
+    "ucmd_popup": "",
+    "ucmd_popup2": ""
+}

--- a/scripts/lang/sv/cmd_redirect.json
+++ b/scripts/lang/sv/cmd_redirect.json
@@ -1,0 +1,22 @@
+{
+    "help_desc": "Omdirigera användare till webbadressen",
+    "help_title": "",
+    "help_usage": "",
+    "msg_denied": "",
+    "msg_god": "",
+    "msg_isbot": "",
+    "msg_notonline": "",
+    "msg_redirect": "",
+    "msg_report": "",
+    "msg_report_redirect": "",
+    "msg_usage": "",
+    "ucmd_menu_ct2_1": [
+        "",
+        ""
+    ],
+    "ucmd_menu_ct2_2": [
+        "",
+        ""
+    ],
+    "ucmd_url": ""
+}

--- a/scripts/lang/sv/cmd_reg.json
+++ b/scripts/lang/sv/cmd_reg.json
@@ -1,0 +1,44 @@
+{
+    "help_desc": "Registrerar en ny användare / lägger till en kommentar till en befintlig användare",
+    "help_title": "",
+    "help_usage": "",
+    "msg_accinfo": "",
+    "msg_blacklist1": "",
+    "msg_blacklist2": "",
+    "msg_blacklist3": "",
+    "msg_blacklist4": "",
+    "msg_denied": "",
+    "msg_desc": "",
+    "msg_error": "",
+    "msg_keyprint": "",
+    "msg_length": "",
+    "msg_level": "",
+    "msg_nocomment": "",
+    "msg_ok": "",
+    "msg_report": "",
+    "msg_unknown": "",
+    "msg_usage": "",
+    "ucmd_desc": "",
+    "ucmd_desc2": "",
+    "ucmd_level": "",
+    "ucmd_menu_ct1_1": "",
+    "ucmd_menu_ct1_2": "",
+    "ucmd_menu_ct1_3": "",
+    "ucmd_menu_ct2": [
+        "",
+        ""
+    ],
+    "ucmd_menu_ct3": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct4": [
+        "",
+        "",
+        ""
+    ],
+    "ucmd_nick": ""
+}

--- a/scripts/lang/sv/cmd_reload.json
+++ b/scripts/lang/sv/cmd_reload.json
@@ -1,0 +1,12 @@
+{
+    "help_desc": "Laddar om komplett konfiguration: cfg.tbl, user.tbl, alla skript",
+    "help_title": "",
+    "help_usage": "",
+    "msg_denied": "",
+    "msg_ok": "",
+    "ucmd_menu": [
+        "",
+        "",
+        ""
+    ]
+}

--- a/scripts/lang/sv/cmd_restart.json
+++ b/scripts/lang/sv/cmd_restart.json
@@ -1,0 +1,17 @@
+{
+    "help_desc": "Startar om hubben",
+    "help_title": "",
+    "help_usage": "",
+    "msg_countdown": "",
+    "msg_denied": "",
+    "msg_hub_disabled": "",
+    "msg_ok": "",
+    "msg_restart": "",
+    "ucmd_menu": [
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_msg": ""
+}

--- a/scripts/lang/sv/cmd_rules.json
+++ b/scripts/lang/sv/cmd_rules.json
@@ -1,0 +1,10 @@
+{
+    "help_desc": "Visar hubbens regler",
+    "help_title": "",
+    "help_usage": "",
+    "msg_rules": "",
+    "ucmd_menu": [
+        "",
+        ""
+    ]
+}

--- a/scripts/lang/sv/cmd_setpass.json
+++ b/scripts/lang/sv/cmd_setpass.json
@@ -1,0 +1,36 @@
+{
+    "help_desc": "Ställer in lösenord för en användare eller dig själv",
+    "help_title": "",
+    "help_usage": "",
+    "msg_denied": "",
+    "msg_god": "",
+    "msg_max_length": "",
+    "msg_min_length": "",
+    "msg_nochange": "",
+    "msg_ok": "",
+    "msg_ok2": "",
+    "msg_reg": "",
+    "msg_usage": "",
+    "ucmd_menu_ct1_0": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_1": [
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_2": "",
+    "ucmd_menu_ct1_3": "",
+    "ucmd_menu_ct1_4": "",
+    "ucmd_menu_ct1_5": "",
+    "ucmd_menu_ct1_6": "",
+    "ucmd_menu_ct2_1": [
+        "",
+        ""
+    ],
+    "ucmd_nick": "",
+    "ucmd_pass": ""
+}

--- a/scripts/lang/sv/cmd_shutdown.json
+++ b/scripts/lang/sv/cmd_shutdown.json
@@ -1,0 +1,17 @@
+{
+    "help_desc": "Stänger ner hubben",
+    "help_title": "",
+    "help_usage": "",
+    "msg_countdown": "",
+    "msg_denied": "",
+    "msg_hub_disabled": "",
+    "msg_ok": "",
+    "msg_shutdown": "",
+    "ucmd_menu": [
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_msg": ""
+}

--- a/scripts/lang/sv/cmd_slots.json
+++ b/scripts/lang/sv/cmd_slots.json
@@ -1,0 +1,10 @@
+{
+    "help_desc": "Visar användare med lediga slottar",
+    "help_title": "",
+    "help_usage": "",
+    "msg_out": "",
+    "ucmd_menu": [
+        "",
+        ""
+    ]
+}

--- a/scripts/lang/sv/cmd_sslinfo.json
+++ b/scripts/lang/sv/cmd_sslinfo.json
@@ -1,0 +1,17 @@
+{
+    "help_desc": "Visar SSL-information om klient till hubb-anslutningen för dig eller andra användare",
+    "help_title": "",
+    "help_usage": "",
+    "msg_denied": "",
+    "msg_isbot": "",
+    "msg_notfound": "",
+    "msg_out": "",
+    "ucmd_menu_ct1": [
+        "",
+        ""
+    ],
+    "ucmd_menu_ct2": [
+        "",
+        ""
+    ]
+}

--- a/scripts/lang/sv/cmd_talk.json
+++ b/scripts/lang/sv/cmd_talk.json
@@ -1,0 +1,13 @@
+{
+    "help_desc": "Prata utan smeknamn",
+    "help_title": "",
+    "help_usage": "",
+    "msg_denied": "",
+    "msg_usage": "",
+    "ucmd_menu": [
+        "",
+        "",
+        ""
+    ],
+    "ucmd_what": ""
+}

--- a/scripts/lang/sv/cmd_topic.json
+++ b/scripts/lang/sv/cmd_topic.json
@@ -1,0 +1,22 @@
+{
+    "help_desc": "Ställer in ett nytt hubbämne eller återställer till standard",
+    "help_title": "",
+    "help_usage": "",
+    "msg_denied": "",
+    "msg_topic_changed": "",
+    "msg_topic_reset": "",
+    "msg_usage": "",
+    "ucmd_menu": [
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu2": [
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_popup": ""
+}

--- a/scripts/lang/sv/cmd_upgrade.json
+++ b/scripts/lang/sv/cmd_upgrade.json
@@ -1,0 +1,21 @@
+{
+    "help_desc": "Ställer in nivån för en användare",
+    "help_title": "",
+    "help_usage": "",
+    "msg_denied": "",
+    "msg_off": "",
+    "msg_out": "",
+    "msg_out_2": "",
+    "msg_reg": "",
+    "msg_same": "",
+    "msg_usage": "",
+    "ucmd_menu": "",
+    "ucmd_menu_ct1_1": "",
+    "ucmd_menu_ct1_2": "",
+    "ucmd_menu_ct1_3": "",
+    "ucmd_menu_ct1_4": "",
+    "ucmd_menu_ct1_5": "",
+    "ucmd_menu_ct1_6": "",
+    "ucmd_menu_ct1_7": "",
+    "ucmd_popup": ""
+}

--- a/scripts/lang/sv/cmd_uptime.json
+++ b/scripts/lang/sv/cmd_uptime.json
@@ -1,0 +1,13 @@
+{
+    "help_desc": "Visar drifttid för dig och för hubben",
+    "help_title": "",
+    "help_usage": "",
+    "msg_days": "",
+    "msg_denied": "",
+    "msg_hours": "",
+    "msg_minutes": "",
+    "msg_seconds": "",
+    "msg_unknown": "",
+    "msg_uptime": "",
+    "msg_years": ""
+}

--- a/scripts/lang/sv/cmd_usercleaner.json
+++ b/scripts/lang/sv/cmd_usercleaner.json
@@ -1,0 +1,108 @@
+{
+    "help_desc": "Visar och tar bort använda och oanvända konton som är frånkopplade",
+    "help_title": "",
+    "help_usage": "",
+    "msg_delreg_exception": "",
+    "msg_delreg_exception_level": "",
+    "msg_delreg_expired": "",
+    "msg_delreg_unused": "",
+    "msg_denied": "",
+    "msg_exceptions_add": "",
+    "msg_exceptions_add_taken": "",
+    "msg_exceptions_del": "",
+    "msg_exceptions_del_notfound": "",
+    "msg_exceptions_delall": "",
+    "msg_exceptions_level": "",
+    "msg_exceptions_show": "",
+    "msg_no": "",
+    "msg_nousers": "",
+    "msg_orphan_comments_cleaned": "",
+    "msg_orphan_comments_none": "",
+    "msg_out_all": "",
+    "msg_out_exceptions": "",
+    "msg_out_expired": "",
+    "msg_out_ghosts": "",
+    "msg_settings_setdays": "",
+    "msg_usage": "",
+    "msg_yes": "",
+    "ucmd_days": "",
+    "ucmd_menu_ct1_1": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_10": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_11": [
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_2": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_3": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_4": [
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_5": [
+        "",
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_6": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_7": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_8": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_ct1_9": [
+        "",
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_nick": ""
+}

--- a/scripts/lang/sv/cmd_userinfo.json
+++ b/scripts/lang/sv/cmd_userinfo.json
@@ -1,0 +1,23 @@
+{
+    "help_desc": "Skickar info om en registrerad användare via SID eller NICK; utan argument -> om dig själv",
+    "help_title": "",
+    "help_usage": "",
+    "msg_days": "",
+    "msg_god": "",
+    "msg_hours": "",
+    "msg_minutes": "",
+    "msg_off": "",
+    "msg_seconds": "",
+    "msg_unknown": "",
+    "msg_usage": "",
+    "msg_userinfo": "",
+    "msg_years": "",
+    "ucmd_menu_ct1": [
+        "",
+        ""
+    ],
+    "ucmd_menu_ct2": [
+        "",
+        ""
+    ]
+}

--- a/scripts/lang/sv/cmd_userlist.json
+++ b/scripts/lang/sv/cmd_userlist.json
@@ -1,0 +1,20 @@
+{
+    "help_desc": "Skickar lista över registrerade användare",
+    "help_title": "",
+    "help_usage": "",
+    "msg_denied": "",
+    "msg_useramount": "",
+    "msg_userlist": "",
+    "ucmd_menu": [
+        "",
+        "",
+        "",
+        ""
+    ],
+    "ucmd_menu_bydate": [
+        "",
+        "",
+        "",
+        ""
+    ]
+}


### PR DESCRIPTION
Batch promote of the two i18n commits staged on dev to master (per §8 dev->master, merge-commit).

Payload (additive language content only, already PR-reviewed into dev):
- #569 funnel Weblate translations (nl, sv) - new `scripts/lang/{nl,sv}/*.json` + `lang/{nl,sv}/hub.json`
- #570 fix some english words - `scripts/lang/en/cmd_redirect.json`

No code changes. 889 insertions / 2 deletions across 35 language files.