### PR TITLE
fix(weblate): pull Core checkout before creating linked components

### DIFF
--- a/tools/weblate_sync_components.py
+++ b/tools/weblate_sync_components.py
@@ -108,6 +108,27 @@ if core not in existing:
         f"components - create it first, or set WEBLATE_CORE_SLUG to its slug"
     )
 
+# 1b. Refresh the Core component's server-side checkout BEFORE creating linked
+# components. A linked component (repo = weblate://<project>/<core>) has its
+# `template` validated against the Core's checkout at create time; our Weblate
+# does NOT reliably auto-pull `dev` on push, so a lang file that is present on
+# dev can still 400 with `template: "File does not exist"` - even hours later
+# (the cmd_botflag #571 failure: the create races the webhook pull, and a
+# re-run 14h on still saw a stale checkout). A forced pull closes the race. It
+# is idempotent and non-destructive (git fetch + fast-forward of the checkout).
+# Best-effort: on any non-2xx we warn and fall through so the create attempts
+# still report the real state rather than masking it.
+pull_status, pull_resp = api(
+    "POST", f"{URL}/api/components/{PROJECT}/{core}/repository/",
+    {"operation": "pull"},
+)
+if pull_status in (200, 201):
+    print(f"pulled   {core} (checkout refreshed before create)")
+else:
+    print(f"warning: repository pull on {core} returned {pull_status}: "
+          f"{pull_resp} - continuing; a new component may 400 if its template "
+          f"is not yet in Weblate's checkout")
+
 # 2. Enumerate the plugins from the repo checkout.
 plugins = sorted(
     os.path.basename(p)[:-5] for p in glob("scripts/lang/en/*.json")


### PR DESCRIPTION
## Problem
The `weblate-components` workflow fails on new plugin lang files:
```
FAILED cmd_botflag (400): template: "File does not exist"
--- created=0 skipped=70 failed=1
```
`weblate_sync_components.py` creates each plugin's component **linked** to the Core component's repo (`weblate://<project>/core-hub`). Weblate validates a new linked component's `template` (`scripts/lang/en/<name>.json`) against the Core's **server-side checkout** at create time. Our instance does not reliably auto-pull `dev` on push, so a file that IS on `dev` still 400s. Confirmed not a transient race: a re-run **14h later** still failed - Weblate's checkout stayed stale.

## Fix
Force a Core repository pull before the create loop:
```
POST /api/components/<project>/core-hub/repository/  {"operation": "pull"}
```
so the checkout carries the new template. Idempotent, non-destructive (git fetch + fast-forward). Best-effort: a non-2xx warns and falls through rather than masking a real create failure.

## Test
Only testable live (the API token is a CI secret against translate.dcvault.net). Merging to `dev` runs the workflow (path filter includes this tool) - a green run that logs `pulled core-hub` + `created cmd_botflag` confirms the fix.

Surfaced by #571 (first new plugin lang file since the Weblate integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)