### PR TITLE
feat(openwrt): package definition for luadch-ng (#587)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 # Windows checkouts. Otherwise the shebang (#!/bin/sh\r) breaks the WSL build.
 *.sh        text eol=lf
 *.py        text eol=lf
+*.init      text eol=lf
 compile     text eol=lf
 cleanall    text eol=lf
 Makefile    text eol=lf

--- a/openwrt/luadch-ng/Makefile
+++ b/openwrt/luadch-ng/Makefile
@@ -1,0 +1,87 @@
+# OpenWRT package for luadch-ng (DC++ ADC hub server).
+#
+# Out-of-tree package: drop this directory into an OpenWRT SDK's package/
+# tree (or add this repo's openwrt/ as a feed) and `make package/luadch-ng/
+# compile` to produce a .apk (25.x SDK) / .ipk (<=24.10 SDK). See
+# docs/BUILDING.md (OpenWRT section) for the full recipe. Little-endian
+# targets only (adclib Tiger is LE-only); needs OpenWRT >= 22.03 (OpenSSL 3.x).
+#
+# Layout on the router:
+#   /usr/share/luadch-ng   immutable app tree (binary, liblua.so, lib/, core/,
+#                          scripts/, lang/); the mutable subdirs are symlinks
+#                          into the state dir below.
+#   /etc/luadch-ng         writable operator state (cfg/, certs/, log/, data/);
+#                          seeded on first start, preserved across upgrades.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=luadch-ng
+# CI overrides PKG_VERSION with the release tag; the default keeps a local
+# `make package/luadch-ng/compile` working against a matching source tarball.
+PKG_VERSION?=3.2.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/luadch-ng/luadch-ng/tar.gz/refs/tags
+# Our own CI-built package from a pinned tag; skip the upstream-style hash pin.
+PKG_HASH:=skip
+
+PKG_MAINTAINER:=luadch-ng <https://github.com/luadch-ng/luadch-ng>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_PARALLEL:=1
+CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/luadch-ng
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=luadch-ng - DC++ ADC hub server
+  URL:=https://github.com/luadch-ng/luadch-ng
+  # libopenssl (libcrypto/libssl 3.x) + libstdcpp (the C++ adclib) + zlib
+  # (ZLIF stream compression). libatomic: libcrypto needs it on some 32-bit
+  # arches (mips); a no-op dependency elsewhere.
+  DEPENDS:=+libopenssl +libstdcpp +zlib +libatomic
+endef
+
+define Package/luadch-ng/description
+  luadch-ng is a DC++ ADC hub server (Lua engine + a thin C launcher). It is
+  TLS-only by default and auto-generates its TLS certificate on first boot.
+  Operator state (config, registered users, the at-rest master key, logs) lives
+  in /etc/luadch-ng and is preserved across package upgrades.
+endef
+
+CMAKE_OPTIONS += -DCMAKE_BUILD_TYPE=Release
+
+APPDIR:=/usr/share/luadch-ng
+STATEDIR:=/etc/luadch-ng
+
+define Package/luadch-ng/install
+	# Immutable app tree: copy the whole CMake-installed prefix, then carve out
+	# the mutable subdirs.
+	$(INSTALL_DIR) $(1)$(APPDIR)
+	$(CP) $(PKG_INSTALL_DIR)/usr/. $(1)$(APPDIR)/
+	# Keep the pristine defaults (cfg + shipped plugin data) so first boot can
+	# seed /etc/luadch-ng. scripts/ ships a data/ dir of default .tbl files;
+	# move it out too, else the symlink below would land INSIDE it.
+	$(INSTALL_DIR) $(1)$(APPDIR)/defaults
+	mv $(1)$(APPDIR)/cfg          $(1)$(APPDIR)/defaults/cfg
+	mv $(1)$(APPDIR)/scripts/data $(1)$(APPDIR)/defaults/data
+	# docs/ is not needed on a router - drop it to save flash.
+	rm -rf $(1)$(APPDIR)/docs
+	# Redirect every writable subdir to the state dir (dangling until the init
+	# script seeds it on first start).
+	rm -rf $(1)$(APPDIR)/certs $(1)$(APPDIR)/log
+	$(LN) $(STATEDIR)/cfg   $(1)$(APPDIR)/cfg
+	$(LN) $(STATEDIR)/certs $(1)$(APPDIR)/certs
+	$(LN) $(STATEDIR)/log   $(1)$(APPDIR)/log
+	$(LN) $(STATEDIR)/data  $(1)$(APPDIR)/scripts/data
+	# procd init.
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/luadch-ng.init $(1)/etc/init.d/luadch-ng
+endef
+
+$(eval $(call BuildPackage,luadch-ng))

--- a/openwrt/luadch-ng/Makefile
+++ b/openwrt/luadch-ng/Makefile
@@ -22,7 +22,11 @@ PKG_VERSION?=3.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/luadch-ng/luadch-ng/tar.gz/refs/tags
+# codeload puts the git ref in the URL path (release tags are vX.Y.Z); the
+# trailing "?" turns the "/$(PKG_SOURCE)" that the fetcher appends into a query
+# string so the ref still resolves to the tag. CI can also pre-stage the
+# tarball in dl/ (then the download is skipped entirely).
+PKG_SOURCE_URL:=https://codeload.github.com/luadch-ng/luadch-ng/tar.gz/refs/tags/v$(PKG_VERSION)?
 # Our own CI-built package from a pinned tag; skip the upstream-style hash pin.
 PKG_HASH:=skip
 

--- a/openwrt/luadch-ng/files/luadch-ng.init
+++ b/openwrt/luadch-ng/files/luadch-ng.init
@@ -15,14 +15,18 @@ STATEDIR=/etc/luadch-ng
 
 seed_state() {
 	mkdir -p "$STATEDIR/cfg" "$STATEDIR/certs" "$STATEDIR/log" "$STATEDIR/data"
-	# First start: lay down the default config + plugin data. Never overwrite
-	# existing ones, so operator edits (and the generated master.key / user.tbl /
-	# accumulated plugin state) survive restarts and package upgrades.
-	if [ ! -f "$STATEDIR/cfg/cfg.tbl" ]; then
-		cp -a "$APPDIR/defaults/cfg/." "$STATEDIR/cfg/"
-	fi
-	if [ -z "$(ls -A "$STATEDIR/data" 2>/dev/null)" ]; then
+	# One-shot seed of the default config + plugin data, guarded by a single
+	# sentinel written LAST. Keying the whole seed on one marker (not on
+	# individual files) is crash-safe: a power loss mid-copy leaves no sentinel,
+	# so the next start re-seeds from scratch - and once seeded we never touch
+	# operator state again, so edits, the generated master.key / user.tbl and
+	# accumulated plugin data survive restarts and package upgrades. (A default
+	# data file added in a later release is not retro-seeded; bundled plugins
+	# self-seed a missing .tbl.)
+	if [ ! -f "$STATEDIR/.seeded" ]; then
+		cp -a "$APPDIR/defaults/cfg/."  "$STATEDIR/cfg/"
 		cp -a "$APPDIR/defaults/data/." "$STATEDIR/data/"
+		touch "$STATEDIR/.seeded"
 	fi
 }
 

--- a/openwrt/luadch-ng/files/luadch-ng.init
+++ b/openwrt/luadch-ng/files/luadch-ng.init
@@ -24,8 +24,11 @@ seed_state() {
 	# data file added in a later release is not retro-seeded; bundled plugins
 	# self-seed a missing .tbl.)
 	if [ ! -f "$STATEDIR/.seeded" ]; then
-		cp -a "$APPDIR/defaults/cfg/."  "$STATEDIR/cfg/"
-		cp -a "$APPDIR/defaults/data/." "$STATEDIR/data/"
+		# Chain with && so the sentinel is written ONLY if both copies
+		# succeeded - a cp that errors (e.g. ENOSPC) without killing the
+		# process then leaves no sentinel and the next start re-seeds.
+		cp -a "$APPDIR/defaults/cfg/."  "$STATEDIR/cfg/" &&
+		cp -a "$APPDIR/defaults/data/." "$STATEDIR/data/" &&
 		touch "$STATEDIR/.seeded"
 	fi
 }

--- a/openwrt/luadch-ng/files/luadch-ng.init
+++ b/openwrt/luadch-ng/files/luadch-ng.init
@@ -1,0 +1,39 @@
+#!/bin/sh /etc/rc.common
+# procd init script for luadch-ng.
+#
+# The app tree is read-only under /usr/share/luadch-ng, with its writable
+# subdirs (cfg, certs, log, scripts/data) symlinked into /etc/luadch-ng. This
+# seeds that state dir on first start, then runs the hub with its working
+# directory at the app tree so its cwd-relative paths resolve.
+
+USE_PROCD=1
+START=95
+STOP=10
+
+APPDIR=/usr/share/luadch-ng
+STATEDIR=/etc/luadch-ng
+
+seed_state() {
+	mkdir -p "$STATEDIR/cfg" "$STATEDIR/certs" "$STATEDIR/log" "$STATEDIR/data"
+	# First start: lay down the default config + plugin data. Never overwrite
+	# existing ones, so operator edits (and the generated master.key / user.tbl /
+	# accumulated plugin state) survive restarts and package upgrades.
+	if [ ! -f "$STATEDIR/cfg/cfg.tbl" ]; then
+		cp -a "$APPDIR/defaults/cfg/." "$STATEDIR/cfg/"
+	fi
+	if [ -z "$(ls -A "$STATEDIR/data" 2>/dev/null)" ]; then
+		cp -a "$APPDIR/defaults/data/." "$STATEDIR/data/"
+	fi
+}
+
+start_service() {
+	seed_state
+	procd_open_instance
+	# luadch resolves core/, cfg/, scripts/, log/ relative to its working dir,
+	# so cd into the app tree first. exec so procd tracks the hub's own pid.
+	procd_set_param command /bin/sh -c "cd '$APPDIR' && exec ./luadch"
+	procd_set_param respawn
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}


### PR DESCRIPTION
Adds `openwrt/luadch-ng/` - an OpenWRT package definition (Makefile + procd
init) so luadch-ng installs on a router as a package instead of a manual tar +
chmod + hand-picked deps. Follow-up to #568 (confirmed running on a Linksys
WRT3200ACM). First half of #587; the CI leg that builds + attaches the `.apk`
to releases is a separate PR.

## Install (once the CI leg ships the asset)

```sh
apk add --allow-untrusted ./luadch-ng-<arch>.apk     # 25.x
# opkg install ./luadch-ng-<arch>.ipk                 # <=24.10 SDK
```

`DEPENDS` pulls `libopenssl3` / `libstdcpp6` / `zlib` / `libatomic1` from
OpenWRT's own feeds - the exact step that tripped the first tester in #568.

## Layout (mirrors the Docker read-only-image + writable-mount model)

- **/usr/share/luadch-ng** - immutable app tree (binary, `liblua.so`, `lib/`,
  `core/`, `scripts/`, `lang/`).
- **/etc/luadch-ng** - writable operator state (`cfg/`, `certs/`, `log/`,
  `data/`), reached via symlinks from the app tree, **seeded on first start**
  and **preserved across upgrades** (the init never overwrites existing state).
- **/etc/init.d/luadch-ng** - procd init; runs the hub with cwd at the app tree
  so its cwd-relative paths resolve. `enable` + `start` to auto-start on boot.

## Validation (WSL lab, mvebu/cortexa9 ARMv7 SDK)

- The `.apk` builds cleanly; `DEPENDS` resolves to `libc libopenssl3
  libstdcpp6 zlib libatomic1` (correct 25.x apk names).
- The packaged tree has the right layout: app files under
  `/usr/share/luadch-ng`, all four writable subdirs are symlinks into
  `/etc/luadch-ng`, `defaults/{cfg,data}` present, init script executable.
- The packaged layout **boots under QEMU** and the hub writes its generated
  cert, `master.key` and `user.tbl` **through the symlinks** into the separate
  state dir - proving the read-only-app + writable-state split works at runtime.

## Notes

- `.gitattributes`: `*.init text eol=lf` so the shebang never becomes CRLF.
- docs/BUILDING.md already documents the manual cross-build; the `apk add` line
  will land with the CI leg (when a release actually ships the asset).
- Little-endian + OpenWRT >= 22.03 only (Tiger LE-only; OpenSSL 3.x), per #568.

Part of #587
