### PR TITLE
fix(usertbl): 0600 output perms for the offline user.tbl tool

### DIFF
--- a/tools/usertbl.py
+++ b/tools/usertbl.py
@@ -114,8 +114,17 @@ def _write_out(data, out_path, default_stream, binary):
     # icacls guidance in docs/SECURITY.md there.
     try:
         fd = os.open(out_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        if hasattr(os, "fchmod"):
+    except OSError as e:
+        _die("cannot write %s: %s" % (out_path, e))
+    # Tighten an existing looser file. Best-effort: a mount without POSIX perms
+    # (vfat / some CIFS) rejects fchmod, but it has no group/other bits to leak
+    # on anyway - so don't abort the (already O_TRUNC'd) write over it.
+    if hasattr(os, "fchmod"):
+        try:
             os.fchmod(fd, 0o600)
+        except OSError:
+            pass
+    try:
         with os.fdopen(fd, "wb") as f:
             f.write(data)
     except OSError as e:

--- a/tools/usertbl.py
+++ b/tools/usertbl.py
@@ -105,8 +105,18 @@ def _write_out(data, out_path, default_stream, binary):
     # so we allow it - but never clobber silently; warn on stderr first.
     if os.path.exists(out_path):
         sys.stderr.write("note: overwriting existing %s\n" % out_path)
+    # Create the output at 0600 on POSIX. The decrypted plaintext is
+    # password-equivalent (and a re-sealed user.tbl the hub keeps at 0600), so
+    # it must not be group/world-readable even for the brief edit window - this
+    # matches cfg_secret's chmod-600 discipline for exactly these files.
+    # os.open honors the mode on create; fchmod also tightens an existing
+    # looser target. Windows ignores the POSIX mode (no fchmod) - rely on the
+    # icacls guidance in docs/SECURITY.md there.
     try:
-        with open(out_path, "wb") as f:
+        fd = os.open(out_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "wb") as f:
             f.write(data)
     except OSError as e:
         _die("cannot write %s: %s" % (out_path, e))


### PR DESCRIPTION
Hardening follow-up to the offline `tools/usertbl.py` (merged in #583 without
the mandatory pre-merge review; a post-hoc review surfaced this).

## The gap

`usertbl.py` wrote its output with the process umask (typically `0644`). So
`decrypt -o user.plain.lua` produced a **group/world-readable file containing
every registered user's password-equivalent secret**, and a re-sealed
`user.tbl` (which the hub keeps at `0600`) had the same exposure. That
contradicts the project's own chmod-600 discipline for these files
(`cfg_secret._write_secret`, F-AUTH-1) - the plaintext is strictly more
sensitive than the encrypted blob the hub goes out of its way to lock down.

## The fix

Create the output with `os.open(..., 0o600)` and `fchmod` an existing looser
target, on POSIX. Windows ignores the POSIX mode and relies on the `icacls`
guidance already documented in docs/SECURITY.md. One-file change, no behaviour
change beyond the tightened perms.

## Validation

On POSIX (umask 022): decrypt output `0600`, encrypt output `0600`, an existing
`0644` file tightened to `0600` on overwrite, round-trip still byte-exact.

Crypto/format/error-handling were separately reviewed and confirmed correct
(byte-exact against `cfg_secret.lua` + `adclib.cpp`); this is the only
substantive finding.
