### PR TITLE
ci(openwrt): build .apk per release for 3 router arches (#587)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,10 @@ on:
         default: 'v0.0.0-test'
 
 permissions:
-  contents: write
+  # Least privilege: only the release job needs write (to create the GitHub
+  # release). The build jobs just upload artifacts - and build-openwrt runs a
+  # downloaded OpenWRT SDK toolchain, which should not carry a repo-write token.
+  contents: read
 
 env:
   # Run JavaScript-based actions on Node.js 24 instead of the default
@@ -344,10 +347,214 @@ jobs:
           path: luadch-*-windows-x86_64.zip
           if-no-files-found: error
 
+  build-openwrt:
+    name: Build OpenWRT .apk (${{ matrix.label }})
+    runs-on: ubuntu-latest
+    # Cross-build a router .apk from the OpenWRT 25.12.x SDK (per target).
+    # apk-only: the whole 25.12.x line uses apk; 24.10-and-older (opkg/.ipk)
+    # operators install manually per docs/BUILDING.md. Little-endian targets
+    # only (adclib Tiger is LE-only) - no big-endian in this matrix. Follow-up
+    # to #568 / #587. Recipe validated end-to-end under the WSL SDK lab for all
+    # three arches before this landed.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # arm_cortex-a9_vfpv3-d16 - Linksys WRT3200ACM etc. (confirmed device).
+          - target: mvebu/cortexa9
+            label: mvebu-cortexa9
+            sdk: openwrt-sdk-25.12.5-mvebu-cortexa9_gcc-14.3.0_musl_eabi.Linux-x86_64.tar.zst
+          # mipsel_24kc - the most common home-router SoC family (mt7621).
+          - target: ramips/mt7621
+            label: ramips-mt7621
+            sdk: openwrt-sdk-25.12.5-ramips-mt7621_gcc-14.3.0_musl.Linux-x86_64.tar.zst
+          # aarch64_cortex-a53 - the most common aarch64 OpenWRT base
+          # (Belkin RT3200 / Linksys E8450 and kin).
+          - target: mediatek/mt7622
+            label: mediatek-mt7622
+            sdk: openwrt-sdk-25.12.5-mediatek-mt7622_gcc-14.3.0_musl.Linux-x86_64.tar.zst
+    env:
+      # Pinned OpenWRT release. Bump alongside the SDK filenames above when a
+      # newer 25.12.x (or a future apk-based line) lands. Kept as a build input
+      # like OPENSSL_VERSION / CMAKE_VERSION elsewhere in this file.
+      OPENWRT_RELEASE: 25.12.5
+    steps:
+      - uses: actions/checkout@v4
+
+      # The OpenWRT package (openwrt/luadch-ng) is a 3.2.x+ feature and does not
+      # exist on the 3.1.x maintenance line. Detect its absence and turn every
+      # build step below into a no-op so the job stays GREEN there - otherwise a
+      # 3.1.x tag push would fail this job and, via `release: needs`, block the
+      # entire 3.1.x security release.
+      - name: Check package present
+        id: check
+        run: |
+          if [ -f openwrt/luadch-ng/Makefile ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::openwrt/luadch-ng absent on this ref - skipping the OpenWRT .apk build."
+          fi
+
+      - name: Determine version
+        id: tag
+        if: steps.check.outputs.present == 'true'
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag_name }}
+        run: |
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            TAG="${GITHUB_REF_NAME}"
+          elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="${INPUT_TAG}"
+          else
+            # Branch push: derive "vX.Y.Z-dev" from a "release/vX.Y.Z" branch.
+            BRANCH="${GITHUB_REF_NAME}"
+            TAG="${BRANCH#release/}-dev"
+          fi
+          # OpenWRT PKG_VERSION must be dashless: "-" is the reserved
+          # -r<release> delimiter and apk's version grammar rejects it. Strip the
+          # leading "v" and any pre-release suffix; the full tag is kept only for
+          # the human-facing asset filename.
+          PKGVER="${TAG#v}"; PKGVER="${PKGVER%%-*}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "pkgver=${PKGVER}" >> "$GITHUB_OUTPUT"
+
+      - name: Install SDK host dependencies
+        if: steps.check.outputs.present == 'true'
+        # The SDK bundles its own cross-toolchain, but the package build still
+        # rebuilds a few host tools and unpacks the .tar.zst. zstd handles the
+        # SDK archive; the rest is the OpenWRT-recommended host set trimmed to
+        # what a single-package build touches.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential libncurses-dev zlib1g-dev gawk gettext \
+            git libssl-dev xsltproc rsync wget unzip python3 file zstd
+
+      - name: Cache OpenWRT SDK tarball
+        if: steps.check.outputs.present == 'true'
+        # The ~200 MB SDK download dominates the job; cache it keyed on the
+        # exact filename (which pins release + gcc + target), so re-runs skip
+        # the fetch. The openssl/zlib compile is not cached (staging paths are
+        # brittle across runs) - a follow-up if job time becomes a problem.
+        uses: actions/cache@v4
+        with:
+          path: dl-cache
+          key: openwrt-sdk-${{ matrix.sdk }}
+
+      - name: Fetch + verify + extract SDK
+        if: steps.check.outputs.present == 'true'
+        env:
+          SDK: ${{ matrix.sdk }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          mkdir -p dl-cache
+          # Fetch <name> from the target dir into <out>, trying both OpenWRT
+          # mirrors (downloads first, then archive - point releases eventually
+          # move to archive.openwrt.org) with a few retries, so a transient blip
+          # does not fail the whole release (the sibling aarch64 job retries
+          # apt for the same reason).
+          fetch() {
+            local name="$1" out="$2" host t
+            for host in downloads.openwrt.org archive.openwrt.org; do
+              for t in 1 2 3; do
+                if wget -q -O "$out" \
+                    "https://${host}/releases/${OPENWRT_RELEASE}/targets/${TARGET}/${name}"; then
+                  return 0
+                fi
+                echo "fetch ${name} from ${host} failed (try ${t}); retrying in 5s..."
+                sleep 5
+              done
+            done
+            return 1
+          }
+          # Verify the SDK against the checksum OpenWRT publishes next to it -
+          # the same integrity bar the CMake/OpenSSL downloads in this file meet
+          # (this component generates the shipped machine code, so it must be
+          # checked). --ignore-missing checks only files present in dl-cache.
+          verify() { ( cd dl-cache && sha256sum --ignore-missing -c sha256sums ); }
+          fetch sha256sums dl-cache/sha256sums
+          # Re-download when the cached tarball is absent OR fails the checksum
+          # (a partial/corrupt cache entry can otherwise brick the arch forever,
+          # since actions/cache saves even on a failed run). Download to .part
+          # and rename only on success so a truncated file is never promoted.
+          if [ ! -f "dl-cache/${SDK}" ] || ! verify; then
+            fetch "${SDK}" "dl-cache/${SDK}.part"
+            mv "dl-cache/${SDK}.part" "dl-cache/${SDK}"
+          fi
+          verify
+          mkdir -p sdk
+          tar --zstd -xf "dl-cache/${SDK}" -C sdk --strip-components=1
+
+      - name: Stage package recipe + source tarball
+        if: steps.check.outputs.present == 'true'
+        env:
+          PKGVER: ${{ steps.tag.outputs.pkgver }}
+        # Copy our out-of-tree package into the SDK, pin its version in the
+        # Makefile (NOT via a global PKG_VERSION env: that leaks into every
+        # package's Makefile in the SDK tree and pulls an unbuildable
+        # package/kernel/linux), and pre-stage the source tarball into the SDK's
+        # dl/ so the Makefile's codeload fetch is skipped entirely (hermetic: we
+        # ship exactly this checkout). The tarball top dir must be
+        # luadch-ng-<ver>/ to match PKG_BUILD_DIR.
+        run: |
+          cp -r openwrt/luadch-ng sdk/package/luadch-ng
+          sed -i "s/^PKG_VERSION?=.*/PKG_VERSION:=${PKGVER}/" sdk/package/luadch-ng/Makefile
+          mkdir -p sdk/dl
+          git archive --format=tar.gz --prefix="luadch-ng-${PKGVER}/" \
+            -o "sdk/dl/luadch-ng-${PKGVER}.tar.gz" HEAD
+
+      - name: Build .apk
+        if: steps.check.outputs.present == 'true'
+        working-directory: sdk
+        env:
+          # OpenWRT's gcc wrapper refuses to run without STAGING_DIR set. (Do
+          # NOT add PKG_VERSION here - see the Stage step's note.)
+          STAGING_DIR: ${{ github.workspace }}/sdk/staging_dir
+        run: |
+          # The ncurses "build dependency" is menuconfig-only; bypass its check
+          # with an empty prereq stamp (FORCE=1 does NOT skip it). A freshly
+          # extracted SDK has no host/ dir yet, so create it first.
+          mkdir -p host && touch host/.prereq-build
+          ./scripts/feeds update base
+          ./scripts/feeds install -p base libopenssl zlib
+          make defconfig
+          echo "CONFIG_PACKAGE_luadch-ng=m" >> .config
+          make defconfig
+          make package/luadch-ng/compile -j"$(nproc)"
+
+      - name: Collect + rename .apk
+        if: steps.check.outputs.present == 'true'
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          # bin/packages/<pkgarch>/base/luadch-ng-<ver>-r<rel>.apk; the arch is
+          # not in the default name, so rename per-arch to avoid a collision
+          # when the release job merges all matrix artifacts into one dir.
+          # -print -quit stops find at the first hit (no head|SIGPIPE under the
+          # runner's pipefail).
+          BUILT=$(find sdk/bin -name 'luadch-ng-*.apk' -print -quit)
+          test -n "${BUILT}"
+          PKGARCH=$(basename "$(dirname "$(dirname "${BUILT}")")")
+          OUT="luadch-ng-${TAG}-openwrt-${PKGARCH}.apk"
+          cp "${BUILT}" "${OUT}"
+          ls -la "${OUT}"
+
+      - uses: actions/upload-artifact@v4
+        if: steps.check.outputs.present == 'true'
+        with:
+          name: luadch-ng-openwrt-${{ matrix.label }}
+          path: luadch-ng-*-openwrt-*.apk
+          if-no-files-found: error
+
   release:
     name: Create GitHub release
-    needs: [build-linux, build-linux-aarch64, build-windows]
+    needs: [build-linux, build-linux-aarch64, build-windows, build-openwrt]
     runs-on: ubuntu-latest
+    # Only this job needs write (to create the release); see the top-level
+    # `permissions: contents: read`.
+    permissions:
+      contents: write
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ docker compose up -d
 Multi-arch image (`ghcr.io/luadch-ng/luadch-ng:latest`), runs as an unprivileged user. Upon first startup, a self-signed TLS certificate is generated, and the keyprint for the `adcs://` URL is logged.
 
 ### Prebuilt binaries
-Linux/Windows x86_64 versions are included with every [release](https://github.com/luadch-ng/luadch-ng/releases/latest) - just unzip and run.
+Linux (x86_64 + aarch64) and Windows x86_64 builds are included with every [release](https://github.com/luadch-ng/luadch-ng/releases/latest) - just unzip and run. OpenWRT routers get a ready-to-install `.apk` for three common arches; see the [OpenWRT section](docs/BUILDING.md#-openwrt-routers) of the build guide.
 
 ### From source
 ```bash

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -215,11 +215,12 @@ Pi 4 / Pi 5 / Apple Silicon Linux / AWS Graviton, etc.). Verify with
 ## 📡 OpenWRT (routers)
 
 luadch runs on OpenWRT routers - confirmed on a Linksys WRT3200ACM
-(`mvebu/cortexa9`, ARMv7, OpenWRT 25.12). You **cross-compile on a PC**
-using the OpenWRT SDK and copy the result to the router; you do **not**
-build on the router (routers lack the space/RAM for a toolchain, and
-there is no cmake package for OpenWRT because it is not meant to compile
-on-device).
+(`mvebu/cortexa9`, ARMv7, OpenWRT 25.12). Every release ships a ready-to-
+install `.apk` for the three most common targets (see below); for any other
+target you **cross-compile on a PC** using the OpenWRT SDK and copy the result
+over. Either way you do **not** build on the router (routers lack the
+space/RAM for a toolchain, and there is no cmake package for OpenWRT because it
+is not meant to compile on-device).
 
 ### Will it run on my router?
 
@@ -239,6 +240,38 @@ Two hard requirements decide it:
 Flash/RAM: the runtime tree is ~6 MB plus the shared libs, so an 8/16 MB
 router needs **extroot** (USB/SD); a 128 MB+ device (like the WRT3200ACM)
 has ample room.
+
+### Install the pre-built `.apk` (easiest path)
+
+Each release attaches an OpenWRT `.apk` for the three most common
+little-endian targets, built in CI from the OpenWRT **25.12.x** SDK. Read your
+package arch with `apk --print-arch` (it prints the left-column value directly;
+`ubus call system board` names the target, which the device column maps back):
+
+| Package arch | Typical devices |
+|---|---|
+| `arm_cortex-a9_vfpv3-d16` | Linksys WRT3200ACM / WRT1900/1200 (mvebu) |
+| `mipsel_24kc` | mt7621 routers (very common) |
+| `aarch64_cortex-a53` | Belkin RT3200 / Linksys E8450 (mt7622) |
+
+```sh
+# Download luadch-ng-<ver>-openwrt-<arch>.apk from the release, then:
+apk update                                                  # populate the index
+apk add --allow-untrusted ./luadch-ng-<ver>-openwrt-<arch>.apk
+/etc/init.d/luadch-ng enable
+/etc/init.d/luadch-ng start
+```
+
+`apk` pulls the runtime deps (`libopenssl3`, `libstdcpp6`, `zlib`,
+`libatomic1`) automatically. `--allow-untrusted` is needed because the package
+is not signed by an OpenWRT feed key. It installs the app under
+`/usr/share/luadch-ng` with operator state (config, `master.key`, certs, logs)
+under `/etc/luadch-ng`, seeded on first start and preserved across package
+upgrades; first start auto-generates the TLS cert (see First-time login).
+
+This covers **25.12.x** on those three arches only. On a different arch, on
+`<=24.10` (opkg, not apk), or to build from an untagged checkout, use the
+cross-compile path below.
 
 ### Cross-compile with the OpenWRT SDK
 
@@ -338,9 +371,11 @@ cd /opt/luadch && ./luadch               # TLS-only: adcs://<router-ip>:5001
 
 First boot auto-generates the TLS cert + key (see First-time login below).
 
-> Not a native OpenWRT package yet: `apk add luadch` / `opkg install
-> luadch` (with the dependencies pulled in automatically) would need an
-> OpenWRT package Makefile + a package feed - a possible future step.
+> This manual copy is only needed for a self-cross-compiled tree. For the
+> three pre-built arches on 25.12.x, the `.apk` above installs and wires up
+> the deps + init script for you. A hosted, signed feed (the true
+> `apk add luadch-ng` with no `--allow-untrusted`) would additionally need a
+> package index + signing key - out of scope for now (#587).
 
 ---
 

--- a/openwrt/luadch-ng/files/luadch-ng.init
+++ b/openwrt/luadch-ng/files/luadch-ng.init
@@ -38,7 +38,12 @@ start_service() {
 	procd_open_instance
 	# luadch resolves core/, cfg/, scripts/, log/ relative to its working dir,
 	# so cd into the app tree first. exec so procd tracks the hub's own pid.
-	procd_set_param command /bin/sh -c "cd '$APPDIR' && exec ./luadch"
+	# umask 027 restores the hardening the daemon path applies via umask(027)
+	# in hub.c (skipped here because procd runs the hub in the foreground, not
+	# via -d): hub-written non-secret files (logs, cfg.tbl, plugin data) land
+	# 0640/0750, not world-readable. Secrets (master.key, user.tbl, serverkey)
+	# are chmod 0600 by their writers regardless.
+	procd_set_param command /bin/sh -c "umask 027; cd '$APPDIR' && exec ./luadch"
 	procd_set_param respawn
 	procd_set_param stdout 1
 	procd_set_param stderr 1


### PR DESCRIPTION
## What

Adds a `build-openwrt` matrix job to `release.yml` that cross-builds the OpenWRT `.apk` from the 25.12.x SDK for the three most common little-endian router arches and attaches them to each release. Part 2 of #587 (the package definition was #588); follow-up to #568.

| Package arch | SDK target | Typical devices |
|---|---|---|
| `arm_cortex-a9_vfpv3-d16` | mvebu/cortexa9 | Linksys WRT3200ACM (confirmed device) |
| `mipsel_24kc` | ramips/mt7621 | mt7621 routers (very common) |
| `aarch64_cortex-a53` | mediatek/mt7622 | Belkin RT3200 / Linksys E8450 |

apk-only (the whole 25.12.x line is apk); big-endian excluded (Tiger is LE-only). Operators install with `apk add --allow-untrusted ./luadch-ng-<ver>-openwrt-<arch>.apk`, which auto-pulls `libopenssl3 libstdcpp6 zlib libatomic1`.

## Validation

The exact build recipe was validated end-to-end in a local OpenWRT SDK lab for all three arches (fresh SDK -> `.apk`), and the corrected version-handling path (sanitized dashless `PKG_VERSION`, sed-into-Makefile, sha256-verified SDK) was re-validated for the `workflow_dispatch` `v0.0.0-test` case. A `workflow_dispatch` run on this branch exercised the job in real CI before merge.

## Review-driven hardening (3-agent pre-merge review)

- **Version:** pin the version in the copied package Makefile via `sed`, not a global `PKG_VERSION` env - a global export pollutes every package's Makefile in the SDK tree and pulls an unbuildable `package/kernel/linux` (would have failed every release). Sanitized to a dashless value (apk rejects `-` in the version).
- **Supply chain:** verify the SDK against OpenWRT's published `sha256sums` before use (same bar as the CMake/OpenSSL downloads in this file). This also fixes a cache-poisoning trap - a partial/corrupt cached SDK now fails the checksum and is re-fetched rather than bricking the arch.
- **Resilience:** SDK fetch retries and falls back `downloads.openwrt.org` -> `archive.openwrt.org`, so one blip does not block the whole release.
- **3.1.x safety:** green no-op when `openwrt/luadch-ng` is absent, so a 3.1.x security release is not blocked via `release: needs`.
- **Least privilege:** top-level `contents: read`; write only on the `release` job.
- **procd:** hub starts under `umask 027`, restoring the daemon path's `umask(027)` (non-secret files 0640/0750; secrets stay 0600).

## Docs

`docs/BUILDING.md` gains the pre-built `.apk` install path; `README.md` points router users there.

## Deferred follow-ups (not blocking, from the review)

- Per-asset SHA256SUMS in the release + a `sha256sum -c` verify line (release-wide, own PR; marginal since same-origin as the assets).
- `usign` signature verification of the SDK `sha256sums` against a pinned OpenWRT key (stronger than same-origin sha256).
- Drop the hub from root to a dedicated procd user / `ujail` (blast-radius reduction; the standing #587 hardening item).

Part of #587.
