### PR TITLE
feat(openwrt): run the hub as an unprivileged user, not root (#587)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 *.sh        text eol=lf
 *.py        text eol=lf
 *.init      text eol=lf
+*.keep      text eol=lf
 compile     text eol=lf
 cleanall    text eol=lf
 Makefile    text eol=lf

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -266,8 +266,11 @@ apk add --allow-untrusted ./luadch-ng-<ver>-openwrt-<arch>.apk
 `libatomic1`) automatically. `--allow-untrusted` is needed because the package
 is not signed by an OpenWRT feed key. It installs the app under
 `/usr/share/luadch-ng` with operator state (config, `master.key`, certs, logs)
-under `/etc/luadch-ng`, seeded on first start and preserved across package
-upgrades; first start auto-generates the TLS cert (see First-time login).
+under `/etc/luadch-ng`, seeded on first start and preserved across both package
+upgrades and firmware `sysupgrade` (a shipped `keep.d` entry); first start
+auto-generates the TLS cert (see First-time login). The hub runs as a dedicated
+unprivileged `luadch` user (not root); the default TLS port 5001 needs no
+privilege, but a custom port below 1024 would.
 
 This covers **25.12.x** on those three arches only. On a different arch, on
 `<=24.10` (opkg, not apk), or to build from an untagged checkout, use the
@@ -371,9 +374,10 @@ cd /opt/luadch && ./luadch               # TLS-only: adcs://<router-ip>:5001
 
 First boot auto-generates the TLS cert + key (see First-time login below).
 
-> This manual copy is only needed for a self-cross-compiled tree. For the
-> three pre-built arches on 25.12.x, the `.apk` above installs and wires up
-> the deps + init script for you. A hosted, signed feed (the true
+> This manual copy is only needed for a self-cross-compiled tree, and runs
+> the hub as whoever invokes it (typically root). For the three pre-built
+> arches on 25.12.x, the `.apk` above installs and wires up the deps + init
+> script for you and runs the hub unprivileged. A hosted, signed feed (the true
 > `apk add luadch-ng` with no `--allow-untrusted`) would additionally need a
 > package index + signing key - out of scope for now (#587).
 

--- a/openwrt/luadch-ng/Makefile
+++ b/openwrt/luadch-ng/Makefile
@@ -45,6 +45,12 @@ define Package/luadch-ng
   CATEGORY:=Network
   TITLE:=luadch-ng - DC++ ADC hub server
   URL:=https://github.com/luadch-ng/luadch-ng
+  # Create a dedicated unprivileged user:group at install (apk Require-User).
+  # The hub does not need root - it binds the default TLS port 5001 (>1024) and
+  # writes only under /etc/luadch-ng - so procd runs it as this user (see the
+  # init script), containing any compromise to the hub's own state. Names-only
+  # (no fixed uid) auto-assigns a free id, like the upstream unbound package.
+  USERID:=luadch:luadch
   # libopenssl (libcrypto/libssl 3.x) + libstdcpp (the C++ adclib) + zlib
   # (ZLIF stream compression). libatomic: libcrypto needs it on some 32-bit
   # arches (mips); a no-op dependency elsewhere.
@@ -83,9 +89,21 @@ define Package/luadch-ng/install
 	$(LN) $(STATEDIR)/certs $(1)$(APPDIR)/certs
 	$(LN) $(STATEDIR)/log   $(1)$(APPDIR)/log
 	$(LN) $(STATEDIR)/data  $(1)$(APPDIR)/scripts/data
+	# The single-instance lock is opened cwd-relative (luadch.lock in the app
+	# root, hub.c). The app root is root-owned and read-only to the runtime
+	# user, so redirect the lock into the writable, user-owned state dir too -
+	# open() follows this symlink (no O_NOFOLLOW) and flock locks the target
+	# inode, so the guard keeps working unprivileged.
+	$(LN) $(STATEDIR)/luadch.lock $(1)$(APPDIR)/luadch.lock
 	# procd init.
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/luadch-ng.init $(1)/etc/init.d/luadch-ng
+	# Preserve operator state across a firmware sysupgrade. /etc/luadch-ng is
+	# NOT package-owned (seeded at runtime), so a sysupgrade would otherwise
+	# wipe it - losing master.key, so the encrypted user.tbl can never be
+	# decrypted again (silent data loss). keep.d adds it to the backup set.
+	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
+	$(INSTALL_DATA) ./files/luadch-ng.keep $(1)/lib/upgrade/keep.d/luadch-ng
 endef
 
 $(eval $(call BuildPackage,luadch-ng))

--- a/openwrt/luadch-ng/files/luadch-ng.init
+++ b/openwrt/luadch-ng/files/luadch-ng.init
@@ -3,7 +3,8 @@
 #
 # The app tree is read-only under /usr/share/luadch-ng, with its writable
 # subdirs (cfg, certs, log, scripts/data) symlinked into /etc/luadch-ng. This
-# seeds that state dir on first start, then runs the hub with its working
+# seeds that state dir on first start, then runs the hub - as the unprivileged
+# luadch user (created at install via the Makefile's USERID) - with its working
 # directory at the app tree so its cwd-relative paths resolve.
 
 USE_PROCD=1
@@ -12,6 +13,10 @@ STOP=10
 
 APPDIR=/usr/share/luadch-ng
 STATEDIR=/etc/luadch-ng
+# Unprivileged runtime user/group, created at install (Makefile USERID). procd
+# runs the hub as this user; all writable state under $STATEDIR is chowned to it.
+RUN_USER=luadch
+RUN_GROUP=luadch
 
 seed_state() {
 	mkdir -p "$STATEDIR/cfg" "$STATEDIR/certs" "$STATEDIR/log" "$STATEDIR/data"
@@ -34,7 +39,28 @@ seed_state() {
 }
 
 start_service() {
+	# Fail VISIBLE, not open: if the unprivileged user was not created at
+	# install (USERID/Require-User not honored on some variant), refuse to
+	# start rather than let procd silently fall back to running as root - which
+	# would defeat the whole point with no signal.
+	if ! id -u "$RUN_USER" >/dev/null 2>&1; then
+		logger -t luadch-ng "runtime user '$RUN_USER' missing (USERID not applied?); refusing to start"
+		return 1
+	fi
+	# seed_state's mkdir runs in this root shell (default umask 022 -> 0755);
+	# 027 makes the state dirs 0750 instead of world-listable. The hub process
+	# gets its own umask 027 in the procd command below.
+	umask 027
 	seed_state
+	# Own all writable state by the runtime user before dropping to it. Run
+	# every start (not just first seed) so it self-heals if a reinstall
+	# re-created the user with a different auto-assigned uid. This also lets the
+	# hub create $STATEDIR/luadch.lock (the app-root lock symlink points here).
+	# -Rh uses lchown: a symlink planted in the (luadch-writable) state dir is
+	# NEVER dereferenced - without it, BusyBox chown -R follows symlink leaves,
+	# so a compromised luadch could point one at /etc/shadow and have root
+	# chown it to luadch on the next start = local root escalation.
+	chown -Rh "$RUN_USER:$RUN_GROUP" "$STATEDIR"
 	procd_open_instance
 	# luadch resolves core/, cfg/, scripts/, log/ relative to its working dir,
 	# so cd into the app tree first. exec so procd tracks the hub's own pid.
@@ -44,6 +70,9 @@ start_service() {
 	# 0640/0750, not world-readable. Secrets (master.key, user.tbl, serverkey)
 	# are chmod 0600 by their writers regardless.
 	procd_set_param command /bin/sh -c "umask 027; cd '$APPDIR' && exec ./luadch"
+	# Drop root: the hub runs unprivileged (user created at install via USERID).
+	procd_set_param user "$RUN_USER"
+	procd_set_param group "$RUN_GROUP"
 	procd_set_param respawn
 	procd_set_param stdout 1
 	procd_set_param stderr 1

--- a/openwrt/luadch-ng/files/luadch-ng.keep
+++ b/openwrt/luadch-ng/files/luadch-ng.keep
@@ -1,0 +1,1 @@
+/etc/luadch-ng


### PR DESCRIPTION
## What

The OpenWRT package started the hub as **root**. It binds TLS 5001 (>1024) and writes only under `/etc/luadch-ng`, so root is unnecessary - drop it so any hub compromise (an ADC-parsing bug, a plugin escape, ...) is contained to the hub's own state instead of the whole router. Same posture the Docker image already takes. Deferred item #3 from #587.

- **Makefile:** `USERID:=luadch:luadch` creates a dedicated unprivileged user:group at install (apk Require-User; names-only auto-assigns like upstream unbound). Verified the built `.apk` carries the `luadch-ng.rusers` metadata.
- **init:** `procd_set_param user/group luadch`; `chown -Rh luadch:luadch /etc/luadch-ng` every start (self-heals a uid change after reinstall).
- **Lock:** the single-instance lock (`luadch.lock`, opened cwd-relative in the read-only app root - hub.c) is redirected via a symlink into the writable state dir. Verified empirically: `open(O_CREAT)+flock` from a read-only cwd follows the symlink, creates the target 0640 in the writable dir, and still blocks a second instance.

Writable surface is entirely under the symlinked `cfg/certs/log/scripts-data` (-> `/etc/luadch-ng`, now user-owned), confirmed against `core/ensuredirs.lua` and every core writer.

## Validation

- Package structure validated in the OpenWRT SDK lab: `USERID` -> `luadch-ng.rusers` (14 bytes = `luadch:luadch`), all 5 app-tree symlinks incl. `luadch.lock`, `.apk` builds.
- Lock-symlink + flock mechanism validated with a C repro (read-only cwd, symlink into writable dir, second-instance blocked).
- All 3 arches rebuilt green in a real `workflow_dispatch` CI run with these changes.

## Two-pass pre-merge review (security + packaging), fixes folded in

- **[blocker] `chown -Rh`, not `-R`:** BusyBox `chown -R` dereferences symlink leaves, so a compromised luadch could plant `/etc/luadch-ng/x -> /etc/shadow` and have root chown it on the next start = local root escalation. `-h` (lchown) never follows.
- **Fail-visible, not fail-open:** refuse to start if the luadch user is missing (the two reviewers disagreed on whether procd falls back to root on a missing user - the guard is safe either way).
- **umask 027** before `seed_state` so the state dirs are 0750, not world-listable.
- **Firmware sysupgrade:** ship `/lib/upgrade/keep.d/luadch-ng` so `/etc/luadch-ng` survives a `sysupgrade` - otherwise `master.key` is lost and the encrypted `user.tbl` can never be decrypted again (silent data loss).

## Docs

BUILDING.md notes the unprivileged user, the sub-1024-port caveat, sysupgrade preservation, and that the manual copy path still runs as root.

## Note

Full on-device confirmation of the runtime drop (first boot as `luadch`, login) is welcome on a real router before dev -> master; the package-level mechanism (USERID user creation, procd user/group + chown) is the established OpenWRT idiom (unbound / transmission) and is validated at the package + CI level here.

Part of #587.
