### PR TITLE
fix(scripts): carry per-firstnick plugin stores across a nick rename

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -205,6 +205,15 @@ jobs:
       - name: Run etc_trafficmanager unit test
         run: lua5.4 tests/unit/etc_trafficmanager_test.lua
 
+      # nick-rename propagation: six plugins (etc_msgmanager,
+      # cmd_usercleaner, usr_hide_share, usr_uptime, cmd_gag, cmd_ban)
+      # re-key their per-firstnick store on a reg.nickchange onAudit
+      # event, so a +nickchange (or HTTP rename) no longer orphans the
+      # block / exception / hide flag / uptime / gag / by-nick ban.
+      # (etc_trafficmanager - the store Sopor reported - is in its own test.)
+      - name: Run nick_rename_propagation unit test
+        run: lua5.4 tests/unit/nick_rename_propagation_test.lua
+
       # hub_cmd_manager: C2C level gates. v0.03 NAT-traversal fix -
       # onNatTraversal/onNatTraversalReply gate DNAT/DRNT by rcm/ctm
       # level, closing a passive/CGNAT bypass of the CTM/RCM gate.
@@ -636,6 +645,10 @@ jobs:
       - name: Run etc_trafficmanager unit test
         shell: msys2 {0}
         run: lua5.4 tests/unit/etc_trafficmanager_test.lua
+
+      - name: Run nick_rename_propagation unit test
+        shell: msys2 {0}
+        run: lua5.4 tests/unit/nick_rename_propagation_test.lua
 
       - name: Run hub_cmd_manager unit test
         shell: msys2 {0}

--- a/scripts/cmd_ban.lua
+++ b/scripts/cmd_ban.lua
@@ -11,6 +11,16 @@
             - <time> and <reason> are optional
             - the keyword `permanent` in the <time> slot bans forever
 
+        v0.47:
+            - carry a ban over to the new nick on +nickchange / HTTP
+              rename. A by-nick ban record carries .nick = firstnick (cid /
+              ip bans are rename-invariant) and history is keyed by
+              firstnick; a rename only updated user.tbl, so a pure by-nick
+              ban was silently bypassable by renaming the account. An
+              onAudit tap on reg.nickchange now re-keys both the bans list
+              and the history map (covers the ADC self / othernick /
+              othernicku paths AND the HTTP API).
+
         v0.46:
             - feat: add a `permanent` entry to the right-click Ban submenu
               (CT2), alongside the existing 1 hour ... 1 year / other
@@ -277,7 +287,7 @@
 --------------
 
 local scriptname = "cmd_ban"
-local scriptversion = "0.46"
+local scriptversion = "0.47"
 
 local cmd = "ban"
 local cmd2 = "unban"
@@ -1299,6 +1309,37 @@ hub.setlistener( "onConnect", {},
                 user:kill( "ISTA 232 " .. hub.escapeto( message ) .. "\n", "TL" .. remaining )
                 return PROCESSED
             end
+        end
+        return nil
+    end
+)
+
+--// keep a ban attached to its user across a nick rename. A by-nick ban
+-- record carries .nick = firstnick (cid / ip bans are rename-invariant),
+-- and history is keyed by firstnick; +nickchange (and the HTTP rename)
+-- renames the user in user.tbl but not here, so without this a pure
+-- by-nick ban was silently bypassable by renaming the account. audit.fire
+-- is unconditional (core/audit.lua), so one onAudit tap catches every
+-- reg.nickchange. Returns nil (never PROCESSED) so the etc_auditlog /
+-- http_events onAudit taps still receive the event.
+hub.setlistener( "onAudit", {},
+    function( event )
+        if type( event ) ~= "table" or event.action ~= "reg.nickchange" then return nil end
+        local new_nick = event.target and event.target.nick
+        local old_nick = event.meta and event.meta.previous_nick
+        if type( old_nick ) ~= "string" or type( new_nick ) ~= "string" then return nil end
+        -- guard "": a cid/ip-only ban stores .nick = "", so an empty
+        -- old_nick (should never happen) must not match those records.
+        if old_nick == new_nick or old_nick == "" then return nil end
+        local changed = false
+        for _, b in ipairs( bans ) do
+            if b.nick == old_nick then b.nick = new_nick; changed = true end
+        end
+        if changed then util.savearray( bans, bans_path ) end
+        if history[ old_nick ] ~= nil then
+            history[ new_nick ] = history[ old_nick ]
+            history[ old_nick ] = nil
+            util.savetable( history, "history_tbl", history_path )
         end
         return nil
     end

--- a/scripts/cmd_gag.lua
+++ b/scripts/cmd_gag.lua
@@ -5,6 +5,15 @@
             - this script adds a command "gag" to mute, kennylize or shadowmute a user
             - usage: [+!#]gag mute|kennylize|shadowmute|ungag|show <NICK> [<DURATION>]
 
+            v0.14:
+                - carry a gag over to the new nick on +nickchange / HTTP
+                  rename. gag_tbl records key on .user_nick (= firstnick);
+                  a rename only updated user.tbl, so the mute was silently
+                  lifted - same class Sopor reported for etc_trafficmanager.
+                  An onAudit tap on reg.nickchange now re-keys the record
+                  (covers the ADC self / othernick / othernicku paths AND
+                  the HTTP API).
+
             v0.13:
                 - resolve an online target by firstnick when a nick-prefix
                   is active. usr_nick_prefix re-keys the hub's nick table
@@ -122,7 +131,7 @@
 --// settings begin //--
 
 local scriptname = "cmd_gag"
-local scriptversion = "0.13"
+local scriptversion = "0.14"
 
 local cmd = "gag"
 local prm_mute = "mute"
@@ -486,6 +495,34 @@ hub.setlistener("onPrivateMessage", {},
 hub.setlistener("onTimer", {},
     function()
         cleanup_expired()
+        return nil
+    end
+)
+
+--// keep a chat gag attached to its user across a nick rename. gag_tbl
+-- records key on .user_nick (= firstnick); +nickchange (and the HTTP
+-- rename) renames the user in user.tbl but not here, so without this a
+-- rename silently lifted the mute (same class Sopor reported for
+-- etc_trafficmanager). audit.fire is unconditional (core/audit.lua), so
+-- one onAudit tap catches every reg.nickchange. Returns nil (never
+-- PROCESSED) so the etc_auditlog / http_events taps still receive it.
+hub.setlistener("onAudit", {},
+    function(event)
+        if type(event) ~= "table" or event.action ~= "reg.nickchange" then return nil end
+        local new_nick = event.target and event.target.nick
+        local old_nick = event.meta and event.meta.previous_nick
+        if type(old_nick) ~= "string" or type(new_nick) ~= "string" or old_nick == new_nick then return nil end
+        local _, entry = find_entry(old_nick)
+        if not entry then return nil end
+        entry.user_nick = new_nick
+        -- drop any stale record already under the new nick so the list
+        -- keeps one entry - the renamed user's own gag wins.
+        for i = #gag_tbl, 1, -1 do
+            if gag_tbl[i] ~= entry and gag_tbl[i].user_nick == new_nick then
+                table.remove(gag_tbl, i)
+            end
+        end
+        util.savearray(gag_tbl, gag_path)
         return nil
     end
 )

--- a/scripts/cmd_usercleaner.lua
+++ b/scripts/cmd_usercleaner.lua
@@ -18,6 +18,15 @@
             [+!#]usercleaner setdays <DAYS>        -- Change the expired days (default = 365)
 
 
+        v0.9:
+            - carry a nick exception over to the new nick on +nickchange /
+              HTTP rename. exception_tbl is keyed by nick; a rename only
+              updated user.tbl, so the exception was silently orphaned -
+              the renamed account then looked "unused" and could be
+              auto-deleted (delghosts / delexpired). An onAudit tap on
+              reg.nickchange now re-keys exception_tbl (covers the ADC
+              self / othernick / othernicku paths AND the HTTP API).
+
         v0.8:
             - route the showall / showexpired / showghosts / showexceptions
               status-column "true" / "false" booleans through lang
@@ -55,7 +64,7 @@
 --------------
 
 local scriptname = "cmd_usercleaner"
-local scriptversion = "0.8"
+local scriptversion = "0.9"
 
 --// command
 local cmd = "usercleaner"
@@ -909,6 +918,31 @@ local onbmsg = function( user, command, parameters )
     user:reply( msg_usage, hub.getbot() )
     return PROCESSED
 end
+
+--// keep a nick exception attached to its user across a rename.
+-- exception_tbl is keyed by nick; +nickchange (and the HTTP rename)
+-- renames the user in user.tbl but not here, so without this the
+-- protection was silently orphaned on rename - the renamed account
+-- then looked "unused" and could be auto-deleted (delghosts /
+-- delexpired). audit.fire is unconditional (core/audit.lua), so one
+-- onAudit tap catches every reg.nickchange - the ADC self / othernick
+-- / othernicku paths AND the HTTP API. Returns nil (never PROCESSED)
+-- so the etc_auditlog / http_events onAudit taps still receive it.
+hub.setlistener( "onAudit", {},
+    function( event )
+        if type( event ) ~= "table" or event.action ~= "reg.nickchange" then return nil end
+        local new_nick = event.target and event.target.nick
+        local old_nick = event.meta and event.meta.previous_nick
+        if type( old_nick ) ~= "string" or type( new_nick ) ~= "string" then return nil end
+        if old_nick == new_nick or exception_tbl[ old_nick ] == nil then return nil end
+        -- If a stale entry already sits under the new nick, the renamed
+        -- user's own exception wins - overwrite keeps it intact.
+        exception_tbl[ new_nick ] = exception_tbl[ old_nick ]
+        exception_tbl[ old_nick ] = nil
+        util.savetable( exception_tbl, "exception_tbl", exception_file )
+        return nil
+    end
+)
 
 hub.setlistener( "onStart", {},
     function()

--- a/scripts/etc_msgmanager.lua
+++ b/scripts/etc_msgmanager.lua
@@ -13,6 +13,15 @@
         [+!#]msgmanager showusers  -- show all blocked users
         [+!#]msgmanager showsettings  -- show settings from 'cfg.tbl'
 
+        v0.12:
+            - carry a chat block over to the new nick on +nickchange /
+              HTTP rename. block_tbl is keyed by firstnick; a rename only
+              updated user.tbl, so the block was silently dropped - an
+              operator could unblock a user just by renaming them. An
+              onAudit tap on reg.nickchange now re-keys block_tbl (covers
+              the ADC self / othernick / othernicku paths AND the HTTP
+              API). Reported by Sopor.
+
         v0.11:
             - resolve an online target by firstnick when a nick-prefix is
               active: usr_nick_prefix re-keys the hub's nick table to the
@@ -73,7 +82,7 @@
 --------------
 
 local scriptname = "etc_msgmanager"
-local scriptversion = "0.11"
+local scriptversion = "0.12"
 
 local cmd = "msgmanager"
 local cmd_b1 = "blockmain"
@@ -735,6 +744,30 @@ hub.setlistener( "onStart", {},
                 },
             } )
         end
+        return nil
+    end
+)
+
+--// keep a chat block attached to its user across a nick rename.
+-- block_tbl is keyed by firstnick; +nickchange (and the HTTP rename)
+-- renames the user in user.tbl but not here, so without this the block
+-- was silently lost on rename (reported by Sopor). audit.fire is
+-- unconditional (core/audit.lua), so one onAudit tap catches every
+-- reg.nickchange - the ADC self / othernick / othernicku paths AND the
+-- HTTP API. Returns nil (never PROCESSED) so the etc_auditlog /
+-- http_events onAudit taps still receive the event.
+hub.setlistener( "onAudit", {},
+    function( event )
+        if type( event ) ~= "table" or event.action ~= "reg.nickchange" then return nil end
+        local new_nick = event.target and event.target.nick
+        local old_nick = event.meta and event.meta.previous_nick
+        if type( old_nick ) ~= "string" or type( new_nick ) ~= "string" then return nil end
+        if old_nick == new_nick or block_tbl[ old_nick ] == nil then return nil end
+        -- If a stale entry already sits under the new nick, the renamed
+        -- user's own block wins - overwrite keeps it intact.
+        block_tbl[ new_nick ] = block_tbl[ old_nick ]
+        block_tbl[ old_nick ] = nil
+        util.savetable( block_tbl, "block_tbl", block_file )
         return nil
     end
 )

--- a/scripts/etc_trafficmanager.lua
+++ b/scripts/etc_trafficmanager.lua
@@ -35,6 +35,15 @@
         the block list and accept the corresponding file-transfer
         permission.
 
+        v2.10:
+            - carry a manual block over to the new nick on +nickchange /
+              HTTP rename. block_tbl is keyed by firstnick; a rename only
+              updated user.tbl, so the block was silently dropped - an
+              operator could unblock a user just by renaming them. An
+              onAudit tap on reg.nickchange now re-keys block_tbl (covers
+              the ADC self / othernick / othernicku paths AND the HTTP
+              API). Reported by Sopor.
+
         v2.9:
             - fix a nil-scriptname leak in the external add() / del()
               API: a caller passing scriptname (or reason) = nil produced
@@ -238,7 +247,7 @@
 --------------
 
 local scriptname = "etc_trafficmanager"
-local scriptversion = "2.9"
+local scriptversion = "2.10"
 
 local cmd = "trafficmanager"
 local cmd_b = "block"
@@ -1757,6 +1766,30 @@ hub.setlistener( "onTimer", { },
             send_user_report()
             start = os.time()
         end
+        return nil
+    end
+)
+
+--// keep a manual block attached to its user across a nick rename.
+-- block_tbl is keyed by firstnick; +nickchange (and the HTTP rename)
+-- renames the user in user.tbl but not here, so without this the block
+-- was silently lost on rename (reported by Sopor). audit.fire is
+-- unconditional (core/audit.lua), so one onAudit tap catches every
+-- reg.nickchange - the ADC self / othernick / othernicku paths AND the
+-- HTTP API. Returns nil (never PROCESSED) so the etc_auditlog /
+-- http_events onAudit taps still receive the event.
+hub.setlistener( "onAudit", {},
+    function( event )
+        if type( event ) ~= "table" or event.action ~= "reg.nickchange" then return nil end
+        local new_nick = event.target and event.target.nick
+        local old_nick = event.meta and event.meta.previous_nick
+        if type( old_nick ) ~= "string" or type( new_nick ) ~= "string" then return nil end
+        if old_nick == new_nick or block_tbl[ old_nick ] == nil then return nil end
+        -- If a stale entry already sits under the new nick, the renamed
+        -- user's own block wins - overwrite keeps it intact.
+        block_tbl[ new_nick ] = block_tbl[ old_nick ]
+        block_tbl[ old_nick ] = nil
+        util.savetable( block_tbl, "block_tbl", block_file )
         return nil
     end
 )

--- a/scripts/usr_hide_share.lua
+++ b/scripts/usr_hide_share.lua
@@ -4,6 +4,15 @@
 
         Usage: [+!#]hideshare <NICK>
 
+        v0.7:
+            - carry a hidden-share flag over to the new nick on
+              +nickchange / HTTP rename. hide_share_tbl is keyed by
+              firstnick; a rename only updated user.tbl, so the flag was
+              silently dropped on rename and the user's share became
+              visible again. An onAudit tap on reg.nickchange now re-keys
+              hide_share_tbl (covers the ADC self / othernick / othernicku
+              paths AND the HTTP API).
+
         v0.6:
             - resolve an online target by firstnick when a nick-prefix is
               active: usr_nick_prefix re-keys the hub's nick table to the
@@ -44,7 +53,7 @@
 --------------
 
 local scriptname = "usr_hide_share"
-local scriptversion = "0.6"
+local scriptversion = "0.7"
 
 local cmd = "hideshare"
 
@@ -216,6 +225,30 @@ onbmsg = function( user, command, parameters )
     user:reply( msg_usage, hub.getbot() )
     return PROCESSED
 end
+
+--// keep a hidden-share flag attached to its user across a nick rename.
+-- hide_share_tbl is keyed by firstnick; +nickchange (and the HTTP
+-- rename) renames the user in user.tbl but not here, so without this
+-- the flag was silently dropped on rename and the share became visible
+-- again. audit.fire is unconditional (core/audit.lua), so one onAudit
+-- tap catches every reg.nickchange - the ADC self / othernick /
+-- othernicku paths AND the HTTP API. Returns nil (never PROCESSED) so
+-- the etc_auditlog / http_events onAudit taps still receive the event.
+hub.setlistener( "onAudit", {},
+    function( event )
+        if type( event ) ~= "table" or event.action ~= "reg.nickchange" then return nil end
+        local new_nick = event.target and event.target.nick
+        local old_nick = event.meta and event.meta.previous_nick
+        if type( old_nick ) ~= "string" or type( new_nick ) ~= "string" then return nil end
+        if old_nick == new_nick or hide_share_tbl[ old_nick ] == nil then return nil end
+        -- If a stale entry already sits under the new nick, the renamed
+        -- user's own flag wins - overwrite keeps it intact.
+        hide_share_tbl[ new_nick ] = hide_share_tbl[ old_nick ]
+        hide_share_tbl[ old_nick ] = nil
+        util.savetable( hide_share_tbl, "hide_share_tbl", path )
+        return nil
+    end
+)
 
 hub.debug( "** Loaded " .. scriptname .. " " .. scriptversion .. " **" )
 

--- a/scripts/usr_uptime.lua
+++ b/scripts/usr_uptime.lua
@@ -4,6 +4,14 @@
 
         usage: [+!#]useruptime [CT1 <FIRSTNICK> | CT2 <NICK>]
 
+        v0.13: by Aybo
+            - carry a user's accumulated uptime over to the new nick on
+              +nickchange / HTTP rename. uptime_tbl is keyed by firstnick;
+              a rename only updated user.tbl, so the stats were orphaned
+              and read as zero under the new nick. An onAudit tap on
+              reg.nickchange now re-keys the entry (covers the ADC self /
+              othernick / othernicku paths AND the HTTP API).
+
         v0.12: by Aybo
             - fix undercounting on busy hubs and across +reload
               (reported by Sopor: 24/7 users showing only a few hours
@@ -114,7 +122,7 @@
 --------------
 
 local scriptname = "usr_uptime"
-local scriptversion = "0.12"
+local scriptversion = "0.13"
 
 local cmd = { "useruptime", "uu" }
 
@@ -354,6 +362,28 @@ local onbmsg = function( user, command, parameters )
     user:reply( msg_usage, hub.getbot() )
     return PROCESSED
 end
+
+--// keep a user's accumulated uptime attached across a nick rename.
+-- uptime_tbl is keyed by firstnick; +nickchange (and the HTTP rename)
+-- renames the user in user.tbl but not here, so without this a rename
+-- orphaned the user's online-time stats (they read as zero under the new
+-- nick). audit.fire is unconditional (core/audit.lua), so one onAudit tap
+-- catches every reg.nickchange. Returns nil (never PROCESSED) so the
+-- etc_auditlog / http_events onAudit taps still receive the event.
+hub.setlistener( "onAudit", {},
+    function( event )
+        if type( event ) ~= "table" or event.action ~= "reg.nickchange" then return nil end
+        if type( uptime_tbl ) ~= "table" then return nil end
+        local new_nick = event.target and event.target.nick
+        local old_nick = event.meta and event.meta.previous_nick
+        if type( old_nick ) ~= "string" or type( new_nick ) ~= "string" then return nil end
+        if old_nick == new_nick or uptime_tbl[ old_nick ] == nil then return nil end
+        uptime_tbl[ new_nick ] = uptime_tbl[ old_nick ]
+        uptime_tbl[ old_nick ] = nil
+        util.savetable( uptime_tbl, "uptime", uptime_file )
+        return nil
+    end
+)
 
 hub.setlistener( "onStart", {},
     function()

--- a/tests/unit/etc_trafficmanager_test.lua
+++ b/tests/unit/etc_trafficmanager_test.lua
@@ -39,6 +39,14 @@
     the pre-fix plugin (dead `tostring(nil) or msg_unknown` fallback) and
     PASS patched.
 
+    nick-rename section (below): a reg.nickchange onAudit event must
+    re-key a manual block to the new nick, else +nickchange silently
+    unblocks the user (reported by Sopor). The "onAudit listener
+    registered" check FAILS on the pre-fix plugin (no listener) and PASSES
+    patched; the guarded show-blocks assertions then confirm the key moved
+    (new nick blocked, old nick gone) and that an unrelated audit event is
+    ignored.
+
 ]]--
 
 local GiB = 1024 * 1024 * 1024
@@ -397,6 +405,39 @@ do
     eq( "nil-scriptname add: report User is not literal 'nil'", contains( r, "User:  nil" ), false )
     eq( "nil-scriptname add: no 'scriptname: nil' appended",    contains( r, "scriptname: nil" ), false )
     eq( "nil-scriptname add: degrades to msg_unknown",          contains( r, "User:  <UNKNOWN>" ), true )
+end
+
+----------------------------------------------------------------------
+-- nick rename: a reg.nickchange onAudit event re-keys a manual block to
+-- the new nick. Without the listener +nickchange (and the HTTP rename)
+-- renames the user in user.tbl but leaves the block under the old
+-- firstnick, silently unblocking them (reported by Sopor).
+-- RED pre-fix: onAudit is unregistered -> the "registered" check fails
+-- and the guarded move assertions are skipped.
+----------------------------------------------------------------------
+
+do
+    eq( "rename: onAudit listener registered", _registered.onAudit ~= nil, true )
+    if _registered.onAudit then
+        -- manual_guy is in block_tbl from the initial _block_seed.
+        _registered.onAudit( { action = "reg.nickchange",
+            target = { nick = "renamed_guy" },
+            meta   = { previous_nick = "manual_guy" } } )
+        local op, replied_of = op_user( )
+        _online = { }
+        onbmsg( op, "trafficmanager", "show blocks" )
+        local out = replied_of( )
+        eq( "rename: new nick now listed as blocked", contains( out, "renamed_guy" ), true )
+        eq( "rename: old nick no longer blocked",     contains( out, "manual_guy" ),  false )
+
+        -- an unrelated audit event must not disturb the block table
+        _registered.onAudit( { action = "ban.add", target = { nick = "x" }, meta = { } } )
+        local op2, replied_of2 = op_user( )
+        _online = { }
+        onbmsg( op2, "trafficmanager", "show blocks" )
+        eq( "rename: unrelated event ignored (renamed_guy still blocked)",
+            contains( replied_of2( ), "renamed_guy" ), true )
+    end
 end
 
 ----------------------------------------------------------------------

--- a/tests/unit/nick_rename_propagation_test.lua
+++ b/tests/unit/nick_rename_propagation_test.lua
@@ -1,0 +1,273 @@
+--[[
+
+    tests/unit/nick_rename_propagation_test.lua
+
+    Regression tests for the nick-rename propagation fix. Several plugins
+    keep a per-firstnick persistent store that a +nickchange (or the HTTP
+    rename) must carry over to the new nick, else the rename silently
+    orphans the entry:
+
+      - etc_msgmanager  : a chat block (map:  store[nick] = mode)
+      - cmd_usercleaner : a delete-exception (map: store[nick] = by)
+      - usr_hide_share  : a hidden-share flag (map: store[nick] = 1)
+      - usr_uptime      : accumulated uptime (map: store[nick] = {...})
+      - cmd_gag         : a chat gag (list: record.user_nick = nick)
+      - cmd_ban         : a by-nick ban (list: record.nick) + history (map)
+
+    Each now registers an onAudit tap on reg.nickchange that re-keys its
+    store. (etc_trafficmanager - the store Sopor originally reported - is
+    covered in etc_trafficmanager_test.lua.)
+
+    The real plugin is loaded under a stubbed sandbox: the onAudit
+    listener is captured through hub.setlistener, the store(s) seeded
+    through util.loadtable, and the re-key observed through
+    util.savetable / util.savearray (captured per file).
+
+    Regression contract (CLAUDE.md §1a.7): RED pre-fix - no plugin
+    registers onAudit, so the "onAudit registered" check FAILS and the
+    guarded move assertions are skipped. GREEN patched. Verified by
+    running this file against `git show origin/dev:scripts/<plugin>.lua`.
+
+    Run: lua5.4 tests/unit/nick_rename_propagation_test.lua
+    Exit 0 = all pass, 1 = a failure (CI-friendly).
+
+]]--
+
+----------------------------------------------------------------------
+-- minimal test framework
+----------------------------------------------------------------------
+
+local failures, checks = 0, 0
+local function eq( label, got, want )
+    checks = checks + 1
+    if got ~= want then
+        failures = failures + 1
+        io.write( string.format( "FAIL %-66s got=%q want=%q\n", label, tostring( got ), tostring( want ) ) )
+    else
+        io.write( string.format( "ok   %s\n", label ) )
+    end
+end
+
+-- copy up to two levels: enough for a list-of-flat-records and a
+-- map-of-subtrees (the re-key moves a subtree wholesale by reference).
+local function dcopy( t )
+    local r = { }
+    for k, v in pairs( t ) do
+        if type( v ) == "table" then
+            local vv = { }
+            for k2, v2 in pairs( v ) do vv[ k2 ] = v2 end
+            r[ k ] = vv
+        else
+            r[ k ] = v
+        end
+    end
+    return r
+end
+
+----------------------------------------------------------------------
+-- verify factories (per store shape)
+----------------------------------------------------------------------
+
+local function map_verify( store_file, seed_val )
+    return function( saves, case )
+        local s = saves[ store_file ]
+        eq( case.name .. ": store persisted",   s ~= nil, true )
+        eq( case.name .. ": new nick present",  s and s.NewNick ~= nil, true )
+        eq( case.name .. ": old nick cleared",  s and s.OldNick == nil, true )
+        -- value-equality only for scalar-valued maps; a table value (e.g.
+        -- uptime's subtree) or an omitted seed_val skips this check.
+        if seed_val ~= nil and type( seed_val ) ~= "table" then
+            eq( case.name .. ": new nick keeps value", s and s.NewNick, seed_val )
+        end
+    end
+end
+
+local function list_verify( store_file, keyfield )
+    return function( saves, case )
+        local s = saves[ store_file ]
+        eq( case.name .. ": store persisted", s ~= nil, true )
+        local has_new, has_old = false, false
+        for _, r in ipairs( s or { } ) do
+            if r[ keyfield ] == "NewNick" then has_new = true end
+            if r[ keyfield ] == "OldNick" then has_old = true end
+        end
+        eq( case.name .. ": record now under new nick", has_new, true )
+        eq( case.name .. ": no record under old nick",  has_old, false )
+    end
+end
+
+----------------------------------------------------------------------
+-- per-plugin descriptors
+----------------------------------------------------------------------
+
+local MSG_FILE  = "scripts/data/etc_msgmanager.tbl"
+local EXC_FILE  = "scripts/data/cmd_usercleaner_exceptions.tbl"
+local HIDE_FILE = "scripts/data/usr_hide_share.tbl"
+local UPT_FILE  = "scripts/data/usr_uptime.tbl"
+local GAG_FILE  = "scripts/data/cmd_gag.tbl"
+local BAN_FILE  = "scripts/data/cmd_ban_bans.tbl"
+local BANH_FILE = "scripts/data/cmd_ban_history.tbl"
+
+local CASES = {
+    {
+        name = "etc_msgmanager", path = "scripts/etc_msgmanager.lua",
+        needs_onstart = true,     -- block_tbl is (re)loaded in onStart
+        cfg  = { language = "en", etc_msgmanager_activate = true },
+        seed = { [ MSG_FILE ] = { OldNick = "b" } },
+        verify = map_verify( MSG_FILE, "b" ),
+    },
+    {
+        name = "cmd_usercleaner", path = "scripts/cmd_usercleaner.lua",
+        needs_onstart = false,    -- exception_tbl loaded at module scope
+        cfg  = { language = "en", cmd_usercleaner_activate = true },
+        seed = { [ EXC_FILE ] = { OldNick = "op" } },
+        verify = map_verify( EXC_FILE, "op" ),
+    },
+    {
+        name = "usr_hide_share", path = "scripts/usr_hide_share.lua",
+        needs_onstart = false,
+        cfg  = {
+            language = "en", usr_hide_share_activate = true,
+            usr_hide_share_permission = { [ 60 ] = 60 },
+            usr_hide_share_restrictions = { },
+        },
+        seed = { [ HIDE_FILE ] = { OldNick = 1 } },
+        verify = map_verify( HIDE_FILE, 1 ),
+    },
+    {
+        name = "usr_uptime", path = "scripts/usr_uptime.lua",
+        needs_onstart = false,    -- uptime_tbl loaded at module scope
+        cfg  = { language = "en" },
+        seed = { [ UPT_FILE ] = { OldNick = { [ "2026" ] = { } } } },
+        verify = map_verify( UPT_FILE ),   -- table value: presence only
+    },
+    {
+        name = "cmd_gag", path = "scripts/cmd_gag.lua",
+        needs_onstart = false,    -- gag_tbl loaded at module scope
+        cfg  = { language = "en" },
+        -- the second record is a stale entry already under the new nick;
+        -- the reverse-dedup loop must drop it and keep the renamed one.
+        seed = { [ GAG_FILE ] = {
+            { user_nick = "OldNick", mode = "mute" },
+            { user_nick = "NewNick", mode = "shadowmute" },
+        } },
+        verify = function( saves, case )
+            list_verify( GAG_FILE, "user_nick" )( saves, case )
+            local n, kept_mode = 0, nil
+            for _, r in ipairs( saves[ GAG_FILE ] or { } ) do
+                if r.user_nick == "NewNick" then n = n + 1; kept_mode = r.mode end
+            end
+            eq( case.name .. ": exactly one record under new nick (dedup)", n, 1 )
+            eq( case.name .. ": renamed record survived, stale dropped", kept_mode, "mute" )
+        end,
+    },
+    {
+        name = "cmd_ban", path = "scripts/cmd_ban.lua",
+        needs_onstart = false,    -- bans + history loaded at module scope
+        cfg  = { language = "en" },
+        seed = {
+            -- the second record is a cid/ip-only ban (nick = ""); the
+            -- empty-nick guard must leave it untouched on a rename.
+            [ BAN_FILE ]  = {
+                { nick = "OldNick", ip = "", cid = "" },
+                { nick = "", ip = "1.2.3.4", cid = "CIDXYZ" },
+            },
+            [ BANH_FILE ] = { OldNick = { { date = "x" } } },
+        },
+        verify = function( saves, case )
+            list_verify( BAN_FILE, "nick" )( saves, case )
+            local ip_ok = false
+            for _, r in ipairs( saves[ BAN_FILE ] or { } ) do
+                if r.cid == "CIDXYZ" and r.ip == "1.2.3.4" and r.nick == "" then ip_ok = true end
+            end
+            eq( case.name .. ": cid/ip-only ban left untouched", ip_ok, true )
+            local h = saves[ BANH_FILE ]
+            eq( case.name .. ": history persisted",        h ~= nil, true )
+            eq( case.name .. ": history new nick present", h and h.NewNick ~= nil, true )
+            eq( case.name .. ": history old nick cleared", h and h.OldNick == nil, true )
+        end,
+    },
+}
+
+----------------------------------------------------------------------
+-- load a plugin under a stubbed sandbox, capture its onAudit listener,
+-- fire a reg.nickchange and observe the store move via save capture.
+----------------------------------------------------------------------
+
+local function run( case )
+    local registered = { }
+    local saves = { }                       -- file -> captured table
+
+    local function capture( t, file ) saves[ file ] = dcopy( t ) end
+
+    _G.PROCESSED = 1
+    _G.hub = {
+        setlistener  = function( ev, _, fn ) registered[ ev ] = fn end,
+        debug        = function( ) end,
+        getbot       = function( ) return "stub-bot" end,
+        sendtoall    = function( ) end,
+        escapeto     = function( s ) return s end,
+        escapefrom   = function( s ) return s end,
+        getusers     = function( ) return { } end,
+        isnickonline = function( ) return nil end,
+        find_online_by_firstnick = function( ) return nil end,
+        getregusers  = function( ) return { }, { }, { } end,
+        import = function( n )
+            if n == "etc_hubcommands" then
+                return { add = function( ) return true end, has = function( ) return false end, list = function( ) return { } end }
+            end
+            if n == "etc_report" then return { send = function( ) end } end
+            return nil     -- cmd_help / etc_usercommands absent
+        end,
+        http_register = function( ) end,
+    }
+    _G.cfg = {
+        loadlanguage = function( ) return { }, nil end,
+        get = function( k ) return case.cfg[ k ] end,
+    }
+    _G.util = {
+        loadtable = function( f )
+            local s = case.seed[ f ]
+            if s == nil then return nil end
+            return dcopy( s )
+        end,
+        savetable = function( t, _name, file ) capture( t, file ) end,
+        savearray = function( t, file ) capture( t, file ) end,
+        date = function( ) return "20260101000000" end,
+        strip_control_bytes = function( s ) return s end,
+        getlowestlevel = function( ) return 60 end,
+        spairs = function( t ) return pairs( t ) end,
+    }
+    _G.utf = { match = string.match, format = string.format, sub = string.sub, len = string.len }
+
+    assert( loadfile( case.path ) )( )
+    eq( case.name .. ": onAudit listener registered", registered.onAudit ~= nil, true )
+    if case.needs_onstart and registered.onStart then registered.onStart( ) end
+    if not registered.onAudit then return end
+
+    -- the rename must move the store from OldNick -> NewNick and persist
+    registered.onAudit( { action = "reg.nickchange",
+        target = { nick = "NewNick" }, meta = { previous_nick = "OldNick" } } )
+    case.verify( saves, case )
+
+    -- an unrelated audit event must not touch any store (no save)
+    saves = { }
+    registered.onAudit( { action = "ban.add", target = { nick = "x" }, meta = { } } )
+    eq( case.name .. ": unrelated event ignored (no save)", next( saves ), nil )
+
+    -- a rename of a user NOT in the store must be a no-op (no spurious
+    -- disk write on every nickchange hub-wide)
+    saves = { }
+    registered.onAudit( { action = "reg.nickchange",
+        target = { nick = "B" }, meta = { previous_nick = "not_in_store" } } )
+    eq( case.name .. ": rename of a non-stored user is a no-op", next( saves ), nil )
+end
+
+for _, c in ipairs( CASES ) do run( c ) end
+
+----------------------------------------------------------------------
+-- summary
+----------------------------------------------------------------------
+
+io.write( string.format( "\n%d checks, %d failures\n", checks, failures ) )
+os.exit( failures > 0 and 1 or 0 )


### PR DESCRIPTION
Fixes a nick-rename store-orphan bug class reported by Sopor for `etc_trafficmanager`: `+nickchange` (and the HTTP rename) renamed a user in `user.tbl` but not in plugins that keep a per-firstnick persistent store, silently orphaning the entry. An operator could unblock / unban / unmute a user just by renaming them.

Each affected plugin now taps the `reg.nickchange` audit event and re-keys its own store. `audit.fire` is unconditional, so one `onAudit` listener covers the ADC self / othernick / othernicku paths AND the HTTP API. Listeners return `nil` (never `PROCESSED`) so the `etc_auditlog` / `http_events` onAudit taps still receive the event.

Seven stores fixed:

| plugin | store | shape | tier |
|---|---|---|---|
| etc_trafficmanager | block_tbl | map | moderation |
| etc_msgmanager | block_tbl | map | moderation |
| cmd_gag | gag_tbl | list | moderation |
| cmd_ban | bans + history | list + map | access control |
| cmd_usercleaner | exception_tbl | map | data loss (auto-delete) |
| usr_hide_share | hide_share_tbl | map | visibility flag |
| usr_uptime | uptime_tbl | map | stat continuity |

Verification:
- Two independent pre-merge reviews (correctness / security / consistency), all clean. Every rename path force-disconnects the session before `audit.fire`, single-threaded hub = no race.
- Regression tests prove RED pre-fix for all seven, GREEN post-fix (`tests/unit/nick_rename_propagation_test.lua` + a section in `etc_trafficmanager_test.lua`), registered on both smoke.yml legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)