### PR TITLE
Promote dev to master: OpenWRT packaging + nick-rename store fix + compact help

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 *.sh        text eol=lf
 *.py        text eol=lf
 *.init      text eol=lf
+*.keep      text eol=lf
 compile     text eol=lf
 cleanall    text eol=lf
 Makefile    text eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,10 @@ on:
         default: 'v0.0.0-test'
 
 permissions:
-  contents: write
+  # Least privilege: only the release job needs write (to create the GitHub
+  # release). The build jobs just upload artifacts - and build-openwrt runs a
+  # downloaded OpenWRT SDK toolchain, which should not carry a repo-write token.
+  contents: read
 
 env:
   # Run JavaScript-based actions on Node.js 24 instead of the default
@@ -344,10 +347,214 @@ jobs:
           path: luadch-*-windows-x86_64.zip
           if-no-files-found: error
 
+  build-openwrt:
+    name: Build OpenWRT .apk (${{ matrix.label }})
+    runs-on: ubuntu-latest
+    # Cross-build a router .apk from the OpenWRT 25.12.x SDK (per target).
+    # apk-only: the whole 25.12.x line uses apk; 24.10-and-older (opkg/.ipk)
+    # operators install manually per docs/BUILDING.md. Little-endian targets
+    # only (adclib Tiger is LE-only) - no big-endian in this matrix. Follow-up
+    # to #568 / #587. Recipe validated end-to-end under the WSL SDK lab for all
+    # three arches before this landed.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # arm_cortex-a9_vfpv3-d16 - Linksys WRT3200ACM etc. (confirmed device).
+          - target: mvebu/cortexa9
+            label: mvebu-cortexa9
+            sdk: openwrt-sdk-25.12.5-mvebu-cortexa9_gcc-14.3.0_musl_eabi.Linux-x86_64.tar.zst
+          # mipsel_24kc - the most common home-router SoC family (mt7621).
+          - target: ramips/mt7621
+            label: ramips-mt7621
+            sdk: openwrt-sdk-25.12.5-ramips-mt7621_gcc-14.3.0_musl.Linux-x86_64.tar.zst
+          # aarch64_cortex-a53 - the most common aarch64 OpenWRT base
+          # (Belkin RT3200 / Linksys E8450 and kin).
+          - target: mediatek/mt7622
+            label: mediatek-mt7622
+            sdk: openwrt-sdk-25.12.5-mediatek-mt7622_gcc-14.3.0_musl.Linux-x86_64.tar.zst
+    env:
+      # Pinned OpenWRT release. Bump alongside the SDK filenames above when a
+      # newer 25.12.x (or a future apk-based line) lands. Kept as a build input
+      # like OPENSSL_VERSION / CMAKE_VERSION elsewhere in this file.
+      OPENWRT_RELEASE: 25.12.5
+    steps:
+      - uses: actions/checkout@v4
+
+      # The OpenWRT package (openwrt/luadch-ng) is a 3.2.x+ feature and does not
+      # exist on the 3.1.x maintenance line. Detect its absence and turn every
+      # build step below into a no-op so the job stays GREEN there - otherwise a
+      # 3.1.x tag push would fail this job and, via `release: needs`, block the
+      # entire 3.1.x security release.
+      - name: Check package present
+        id: check
+        run: |
+          if [ -f openwrt/luadch-ng/Makefile ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::openwrt/luadch-ng absent on this ref - skipping the OpenWRT .apk build."
+          fi
+
+      - name: Determine version
+        id: tag
+        if: steps.check.outputs.present == 'true'
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag_name }}
+        run: |
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            TAG="${GITHUB_REF_NAME}"
+          elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="${INPUT_TAG}"
+          else
+            # Branch push: derive "vX.Y.Z-dev" from a "release/vX.Y.Z" branch.
+            BRANCH="${GITHUB_REF_NAME}"
+            TAG="${BRANCH#release/}-dev"
+          fi
+          # OpenWRT PKG_VERSION must be dashless: "-" is the reserved
+          # -r<release> delimiter and apk's version grammar rejects it. Strip the
+          # leading "v" and any pre-release suffix; the full tag is kept only for
+          # the human-facing asset filename.
+          PKGVER="${TAG#v}"; PKGVER="${PKGVER%%-*}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "pkgver=${PKGVER}" >> "$GITHUB_OUTPUT"
+
+      - name: Install SDK host dependencies
+        if: steps.check.outputs.present == 'true'
+        # The SDK bundles its own cross-toolchain, but the package build still
+        # rebuilds a few host tools and unpacks the .tar.zst. zstd handles the
+        # SDK archive; the rest is the OpenWRT-recommended host set trimmed to
+        # what a single-package build touches.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential libncurses-dev zlib1g-dev gawk gettext \
+            git libssl-dev xsltproc rsync wget unzip python3 file zstd
+
+      - name: Cache OpenWRT SDK tarball
+        if: steps.check.outputs.present == 'true'
+        # The ~200 MB SDK download dominates the job; cache it keyed on the
+        # exact filename (which pins release + gcc + target), so re-runs skip
+        # the fetch. The openssl/zlib compile is not cached (staging paths are
+        # brittle across runs) - a follow-up if job time becomes a problem.
+        uses: actions/cache@v4
+        with:
+          path: dl-cache
+          key: openwrt-sdk-${{ matrix.sdk }}
+
+      - name: Fetch + verify + extract SDK
+        if: steps.check.outputs.present == 'true'
+        env:
+          SDK: ${{ matrix.sdk }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          mkdir -p dl-cache
+          # Fetch <name> from the target dir into <out>, trying both OpenWRT
+          # mirrors (downloads first, then archive - point releases eventually
+          # move to archive.openwrt.org) with a few retries, so a transient blip
+          # does not fail the whole release (the sibling aarch64 job retries
+          # apt for the same reason).
+          fetch() {
+            local name="$1" out="$2" host t
+            for host in downloads.openwrt.org archive.openwrt.org; do
+              for t in 1 2 3; do
+                if wget -q -O "$out" \
+                    "https://${host}/releases/${OPENWRT_RELEASE}/targets/${TARGET}/${name}"; then
+                  return 0
+                fi
+                echo "fetch ${name} from ${host} failed (try ${t}); retrying in 5s..."
+                sleep 5
+              done
+            done
+            return 1
+          }
+          # Verify the SDK against the checksum OpenWRT publishes next to it -
+          # the same integrity bar the CMake/OpenSSL downloads in this file meet
+          # (this component generates the shipped machine code, so it must be
+          # checked). --ignore-missing checks only files present in dl-cache.
+          verify() { ( cd dl-cache && sha256sum --ignore-missing -c sha256sums ); }
+          fetch sha256sums dl-cache/sha256sums
+          # Re-download when the cached tarball is absent OR fails the checksum
+          # (a partial/corrupt cache entry can otherwise brick the arch forever,
+          # since actions/cache saves even on a failed run). Download to .part
+          # and rename only on success so a truncated file is never promoted.
+          if [ ! -f "dl-cache/${SDK}" ] || ! verify; then
+            fetch "${SDK}" "dl-cache/${SDK}.part"
+            mv "dl-cache/${SDK}.part" "dl-cache/${SDK}"
+          fi
+          verify
+          mkdir -p sdk
+          tar --zstd -xf "dl-cache/${SDK}" -C sdk --strip-components=1
+
+      - name: Stage package recipe + source tarball
+        if: steps.check.outputs.present == 'true'
+        env:
+          PKGVER: ${{ steps.tag.outputs.pkgver }}
+        # Copy our out-of-tree package into the SDK, pin its version in the
+        # Makefile (NOT via a global PKG_VERSION env: that leaks into every
+        # package's Makefile in the SDK tree and pulls an unbuildable
+        # package/kernel/linux), and pre-stage the source tarball into the SDK's
+        # dl/ so the Makefile's codeload fetch is skipped entirely (hermetic: we
+        # ship exactly this checkout). The tarball top dir must be
+        # luadch-ng-<ver>/ to match PKG_BUILD_DIR.
+        run: |
+          cp -r openwrt/luadch-ng sdk/package/luadch-ng
+          sed -i "s/^PKG_VERSION?=.*/PKG_VERSION:=${PKGVER}/" sdk/package/luadch-ng/Makefile
+          mkdir -p sdk/dl
+          git archive --format=tar.gz --prefix="luadch-ng-${PKGVER}/" \
+            -o "sdk/dl/luadch-ng-${PKGVER}.tar.gz" HEAD
+
+      - name: Build .apk
+        if: steps.check.outputs.present == 'true'
+        working-directory: sdk
+        env:
+          # OpenWRT's gcc wrapper refuses to run without STAGING_DIR set. (Do
+          # NOT add PKG_VERSION here - see the Stage step's note.)
+          STAGING_DIR: ${{ github.workspace }}/sdk/staging_dir
+        run: |
+          # The ncurses "build dependency" is menuconfig-only; bypass its check
+          # with an empty prereq stamp (FORCE=1 does NOT skip it). A freshly
+          # extracted SDK has no host/ dir yet, so create it first.
+          mkdir -p host && touch host/.prereq-build
+          ./scripts/feeds update base
+          ./scripts/feeds install -p base libopenssl zlib
+          make defconfig
+          echo "CONFIG_PACKAGE_luadch-ng=m" >> .config
+          make defconfig
+          make package/luadch-ng/compile -j"$(nproc)"
+
+      - name: Collect + rename .apk
+        if: steps.check.outputs.present == 'true'
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          # bin/packages/<pkgarch>/base/luadch-ng-<ver>-r<rel>.apk; the arch is
+          # not in the default name, so rename per-arch to avoid a collision
+          # when the release job merges all matrix artifacts into one dir.
+          # -print -quit stops find at the first hit (no head|SIGPIPE under the
+          # runner's pipefail).
+          BUILT=$(find sdk/bin -name 'luadch-ng-*.apk' -print -quit)
+          test -n "${BUILT}"
+          PKGARCH=$(basename "$(dirname "$(dirname "${BUILT}")")")
+          OUT="luadch-ng-${TAG}-openwrt-${PKGARCH}.apk"
+          cp "${BUILT}" "${OUT}"
+          ls -la "${OUT}"
+
+      - uses: actions/upload-artifact@v4
+        if: steps.check.outputs.present == 'true'
+        with:
+          name: luadch-ng-openwrt-${{ matrix.label }}
+          path: luadch-ng-*-openwrt-*.apk
+          if-no-files-found: error
+
   release:
     name: Create GitHub release
-    needs: [build-linux, build-linux-aarch64, build-windows]
+    needs: [build-linux, build-linux-aarch64, build-windows, build-openwrt]
     runs-on: ubuntu-latest
+    # Only this job needs write (to create the release); see the top-level
+    # `permissions: contents: read`.
+    permissions:
+      contents: write
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -205,6 +205,15 @@ jobs:
       - name: Run etc_trafficmanager unit test
         run: lua5.4 tests/unit/etc_trafficmanager_test.lua
 
+      # nick-rename propagation: six plugins (etc_msgmanager,
+      # cmd_usercleaner, usr_hide_share, usr_uptime, cmd_gag, cmd_ban)
+      # re-key their per-firstnick store on a reg.nickchange onAudit
+      # event, so a +nickchange (or HTTP rename) no longer orphans the
+      # block / exception / hide flag / uptime / gag / by-nick ban.
+      # (etc_trafficmanager - the store Sopor reported - is in its own test.)
+      - name: Run nick_rename_propagation unit test
+        run: lua5.4 tests/unit/nick_rename_propagation_test.lua
+
       # hub_cmd_manager: C2C level gates. v0.03 NAT-traversal fix -
       # onNatTraversal/onNatTraversalReply gate DNAT/DRNT by rcm/ctm
       # level, closing a passive/CGNAT bypass of the CTM/RCM gate.
@@ -636,6 +645,10 @@ jobs:
       - name: Run etc_trafficmanager unit test
         shell: msys2 {0}
         run: lua5.4 tests/unit/etc_trafficmanager_test.lua
+
+      - name: Run nick_rename_propagation unit test
+        shell: msys2 {0}
+        run: lua5.4 tests/unit/nick_rename_propagation_test.lua
 
       - name: Run hub_cmd_manager unit test
         shell: msys2 {0}

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ docker compose up -d
 Multi-arch image (`ghcr.io/luadch-ng/luadch-ng:latest`), runs as an unprivileged user. Upon first startup, a self-signed TLS certificate is generated, and the keyprint for the `adcs://` URL is logged.
 
 ### Prebuilt binaries
-Linux/Windows x86_64 versions are included with every [release](https://github.com/luadch-ng/luadch-ng/releases/latest) - just unzip and run.
+Linux (x86_64 + aarch64) and Windows x86_64 builds are included with every [release](https://github.com/luadch-ng/luadch-ng/releases/latest) - just unzip and run. OpenWRT routers get a ready-to-install `.apk` for three common arches; see the [OpenWRT section](docs/BUILDING.md#-openwrt-routers) of the build guide.
 
 ### From source
 ```bash

--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -1234,6 +1234,18 @@ local defaults = {
     },
 
     ---------------------------------------------------------------------------------------------------------------------------------
+    --// cmd_help.lua settings
+
+    -- Command prefix shown in the +help list so each line is copy-pasteable.
+    -- The hub accepts "+", "!" and "#" (core/hub.lua "^[+!#]"); default "+"
+    -- matches the docs and the hub's own "Did you mean +X?" hints.
+    cmd_help_prefix = { "+",
+        function( value )
+            return value == "+" or value == "!" or value == "#"
+        end
+    },
+
+    ---------------------------------------------------------------------------------------------------------------------------------
     --// cmd_mass.lua settings
 
     cmd_mass_permission = { {

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -215,11 +215,12 @@ Pi 4 / Pi 5 / Apple Silicon Linux / AWS Graviton, etc.). Verify with
 ## 📡 OpenWRT (routers)
 
 luadch runs on OpenWRT routers - confirmed on a Linksys WRT3200ACM
-(`mvebu/cortexa9`, ARMv7, OpenWRT 25.12). You **cross-compile on a PC**
-using the OpenWRT SDK and copy the result to the router; you do **not**
-build on the router (routers lack the space/RAM for a toolchain, and
-there is no cmake package for OpenWRT because it is not meant to compile
-on-device).
+(`mvebu/cortexa9`, ARMv7, OpenWRT 25.12). Every release ships a ready-to-
+install `.apk` for the three most common targets (see below); for any other
+target you **cross-compile on a PC** using the OpenWRT SDK and copy the result
+over. Either way you do **not** build on the router (routers lack the
+space/RAM for a toolchain, and there is no cmake package for OpenWRT because it
+is not meant to compile on-device).
 
 ### Will it run on my router?
 
@@ -239,6 +240,38 @@ Two hard requirements decide it:
 Flash/RAM: the runtime tree is ~6 MB plus the shared libs, so an 8/16 MB
 router needs **extroot** (USB/SD); a 128 MB+ device (like the WRT3200ACM)
 has ample room.
+
+### Install the pre-built `.apk` (easiest path)
+
+Each release attaches an OpenWRT `.apk` for the three most common
+little-endian targets, built in CI from the OpenWRT **25.12.x** SDK. Read your
+package arch with `apk --print-arch` (it prints the left-column value directly;
+`ubus call system board` names the target, which the device column maps back):
+
+| Package arch | Typical devices |
+|---|---|
+| `arm_cortex-a9_vfpv3-d16` | Linksys WRT3200ACM / WRT1900/1200 (mvebu) |
+| `mipsel_24kc` | mt7621 routers (very common) |
+| `aarch64_cortex-a53` | Belkin RT3200 / Linksys E8450 (mt7622) |
+
+```sh
+# Download luadch-ng-<ver>-openwrt-<arch>.apk from the release, then:
+apk update                                                  # populate the index
+apk add --allow-untrusted ./luadch-ng-<ver>-openwrt-<arch>.apk
+/etc/init.d/luadch-ng enable
+/etc/init.d/luadch-ng start
+```
+
+`apk` pulls the runtime deps (`libopenssl3`, `libstdcpp6`, `zlib`,
+`libatomic1`) automatically. `--allow-untrusted` is needed because the package
+is not signed by an OpenWRT feed key. It installs the app under
+`/usr/share/luadch-ng` with operator state (config, `master.key`, certs, logs)
+under `/etc/luadch-ng`, seeded on first start and preserved across package
+upgrades; first start auto-generates the TLS cert (see First-time login).
+
+This covers **25.12.x** on those three arches only. On a different arch, on
+`<=24.10` (opkg, not apk), or to build from an untagged checkout, use the
+cross-compile path below.
 
 ### Cross-compile with the OpenWRT SDK
 
@@ -338,9 +371,11 @@ cd /opt/luadch && ./luadch               # TLS-only: adcs://<router-ip>:5001
 
 First boot auto-generates the TLS cert + key (see First-time login below).
 
-> Not a native OpenWRT package yet: `apk add luadch` / `opkg install
-> luadch` (with the dependencies pulled in automatically) would need an
-> OpenWRT package Makefile + a package feed - a possible future step.
+> This manual copy is only needed for a self-cross-compiled tree. For the
+> three pre-built arches on 25.12.x, the `.apk` above installs and wires up
+> the deps + init script for you. A hosted, signed feed (the true
+> `apk add luadch-ng` with no `--allow-untrusted`) would additionally need a
+> package index + signing key - out of scope for now (#587).
 
 ---
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -266,8 +266,11 @@ apk add --allow-untrusted ./luadch-ng-<ver>-openwrt-<arch>.apk
 `libatomic1`) automatically. `--allow-untrusted` is needed because the package
 is not signed by an OpenWRT feed key. It installs the app under
 `/usr/share/luadch-ng` with operator state (config, `master.key`, certs, logs)
-under `/etc/luadch-ng`, seeded on first start and preserved across package
-upgrades; first start auto-generates the TLS cert (see First-time login).
+under `/etc/luadch-ng`, seeded on first start and preserved across both package
+upgrades and firmware `sysupgrade` (a shipped `keep.d` entry); first start
+auto-generates the TLS cert (see First-time login). The hub runs as a dedicated
+unprivileged `luadch` user (not root); the default TLS port 5001 needs no
+privilege, but a custom port below 1024 would.
 
 This covers **25.12.x** on those three arches only. On a different arch, on
 `<=24.10` (opkg, not apk), or to build from an untagged checkout, use the
@@ -371,9 +374,10 @@ cd /opt/luadch && ./luadch               # TLS-only: adcs://<router-ip>:5001
 
 First boot auto-generates the TLS cert + key (see First-time login below).
 
-> This manual copy is only needed for a self-cross-compiled tree. For the
-> three pre-built arches on 25.12.x, the `.apk` above installs and wires up
-> the deps + init script for you. A hosted, signed feed (the true
+> This manual copy is only needed for a self-cross-compiled tree, and runs
+> the hub as whoever invokes it (typically root). For the three pre-built
+> arches on 25.12.x, the `.apk` above installs and wires up the deps + init
+> script for you and runs the hub unprivileged. A hosted, signed feed (the true
 > `apk add luadch-ng` with no `--allow-untrusted`) would additionally need a
 > package index + signing key - out of scope for now (#587).
 

--- a/openwrt/luadch-ng/Makefile
+++ b/openwrt/luadch-ng/Makefile
@@ -45,6 +45,12 @@ define Package/luadch-ng
   CATEGORY:=Network
   TITLE:=luadch-ng - DC++ ADC hub server
   URL:=https://github.com/luadch-ng/luadch-ng
+  # Create a dedicated unprivileged user:group at install (apk Require-User).
+  # The hub does not need root - it binds the default TLS port 5001 (>1024) and
+  # writes only under /etc/luadch-ng - so procd runs it as this user (see the
+  # init script), containing any compromise to the hub's own state. Names-only
+  # (no fixed uid) auto-assigns a free id, like the upstream unbound package.
+  USERID:=luadch:luadch
   # libopenssl (libcrypto/libssl 3.x) + libstdcpp (the C++ adclib) + zlib
   # (ZLIF stream compression). libatomic: libcrypto needs it on some 32-bit
   # arches (mips); a no-op dependency elsewhere.
@@ -83,9 +89,21 @@ define Package/luadch-ng/install
 	$(LN) $(STATEDIR)/certs $(1)$(APPDIR)/certs
 	$(LN) $(STATEDIR)/log   $(1)$(APPDIR)/log
 	$(LN) $(STATEDIR)/data  $(1)$(APPDIR)/scripts/data
+	# The single-instance lock is opened cwd-relative (luadch.lock in the app
+	# root, hub.c). The app root is root-owned and read-only to the runtime
+	# user, so redirect the lock into the writable, user-owned state dir too -
+	# open() follows this symlink (no O_NOFOLLOW) and flock locks the target
+	# inode, so the guard keeps working unprivileged.
+	$(LN) $(STATEDIR)/luadch.lock $(1)$(APPDIR)/luadch.lock
 	# procd init.
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/luadch-ng.init $(1)/etc/init.d/luadch-ng
+	# Preserve operator state across a firmware sysupgrade. /etc/luadch-ng is
+	# NOT package-owned (seeded at runtime), so a sysupgrade would otherwise
+	# wipe it - losing master.key, so the encrypted user.tbl can never be
+	# decrypted again (silent data loss). keep.d adds it to the backup set.
+	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
+	$(INSTALL_DATA) ./files/luadch-ng.keep $(1)/lib/upgrade/keep.d/luadch-ng
 endef
 
 $(eval $(call BuildPackage,luadch-ng))

--- a/openwrt/luadch-ng/files/luadch-ng.init
+++ b/openwrt/luadch-ng/files/luadch-ng.init
@@ -3,7 +3,8 @@
 #
 # The app tree is read-only under /usr/share/luadch-ng, with its writable
 # subdirs (cfg, certs, log, scripts/data) symlinked into /etc/luadch-ng. This
-# seeds that state dir on first start, then runs the hub with its working
+# seeds that state dir on first start, then runs the hub - as the unprivileged
+# luadch user (created at install via the Makefile's USERID) - with its working
 # directory at the app tree so its cwd-relative paths resolve.
 
 USE_PROCD=1
@@ -12,6 +13,10 @@ STOP=10
 
 APPDIR=/usr/share/luadch-ng
 STATEDIR=/etc/luadch-ng
+# Unprivileged runtime user/group, created at install (Makefile USERID). procd
+# runs the hub as this user; all writable state under $STATEDIR is chowned to it.
+RUN_USER=luadch
+RUN_GROUP=luadch
 
 seed_state() {
 	mkdir -p "$STATEDIR/cfg" "$STATEDIR/certs" "$STATEDIR/log" "$STATEDIR/data"
@@ -34,7 +39,28 @@ seed_state() {
 }
 
 start_service() {
+	# Fail VISIBLE, not open: if the unprivileged user was not created at
+	# install (USERID/Require-User not honored on some variant), refuse to
+	# start rather than let procd silently fall back to running as root - which
+	# would defeat the whole point with no signal.
+	if ! id -u "$RUN_USER" >/dev/null 2>&1; then
+		logger -t luadch-ng "runtime user '$RUN_USER' missing (USERID not applied?); refusing to start"
+		return 1
+	fi
+	# seed_state's mkdir runs in this root shell (default umask 022 -> 0755);
+	# 027 makes the state dirs 0750 instead of world-listable. The hub process
+	# gets its own umask 027 in the procd command below.
+	umask 027
 	seed_state
+	# Own all writable state by the runtime user before dropping to it. Run
+	# every start (not just first seed) so it self-heals if a reinstall
+	# re-created the user with a different auto-assigned uid. This also lets the
+	# hub create $STATEDIR/luadch.lock (the app-root lock symlink points here).
+	# -Rh uses lchown: a symlink planted in the (luadch-writable) state dir is
+	# NEVER dereferenced - without it, BusyBox chown -R follows symlink leaves,
+	# so a compromised luadch could point one at /etc/shadow and have root
+	# chown it to luadch on the next start = local root escalation.
+	chown -Rh "$RUN_USER:$RUN_GROUP" "$STATEDIR"
 	procd_open_instance
 	# luadch resolves core/, cfg/, scripts/, log/ relative to its working dir,
 	# so cd into the app tree first. exec so procd tracks the hub's own pid.
@@ -44,6 +70,9 @@ start_service() {
 	# 0640/0750, not world-readable. Secrets (master.key, user.tbl, serverkey)
 	# are chmod 0600 by their writers regardless.
 	procd_set_param command /bin/sh -c "umask 027; cd '$APPDIR' && exec ./luadch"
+	# Drop root: the hub runs unprivileged (user created at install via USERID).
+	procd_set_param user "$RUN_USER"
+	procd_set_param group "$RUN_GROUP"
 	procd_set_param respawn
 	procd_set_param stdout 1
 	procd_set_param stderr 1

--- a/openwrt/luadch-ng/files/luadch-ng.init
+++ b/openwrt/luadch-ng/files/luadch-ng.init
@@ -38,7 +38,12 @@ start_service() {
 	procd_open_instance
 	# luadch resolves core/, cfg/, scripts/, log/ relative to its working dir,
 	# so cd into the app tree first. exec so procd tracks the hub's own pid.
-	procd_set_param command /bin/sh -c "cd '$APPDIR' && exec ./luadch"
+	# umask 027 restores the hardening the daemon path applies via umask(027)
+	# in hub.c (skipped here because procd runs the hub in the foreground, not
+	# via -d): hub-written non-secret files (logs, cfg.tbl, plugin data) land
+	# 0640/0750, not world-readable. Secrets (master.key, user.tbl, serverkey)
+	# are chmod 0600 by their writers regardless.
+	procd_set_param command /bin/sh -c "umask 027; cd '$APPDIR' && exec ./luadch"
 	procd_set_param respawn
 	procd_set_param stdout 1
 	procd_set_param stderr 1

--- a/openwrt/luadch-ng/files/luadch-ng.keep
+++ b/openwrt/luadch-ng/files/luadch-ng.keep
@@ -1,0 +1,1 @@
+/etc/luadch-ng

--- a/scripts/cmd_ban.lua
+++ b/scripts/cmd_ban.lua
@@ -11,6 +11,16 @@
             - <time> and <reason> are optional
             - the keyword `permanent` in the <time> slot bans forever
 
+        v0.47:
+            - carry a ban over to the new nick on +nickchange / HTTP
+              rename. A by-nick ban record carries .nick = firstnick (cid /
+              ip bans are rename-invariant) and history is keyed by
+              firstnick; a rename only updated user.tbl, so a pure by-nick
+              ban was silently bypassable by renaming the account. An
+              onAudit tap on reg.nickchange now re-keys both the bans list
+              and the history map (covers the ADC self / othernick /
+              othernicku paths AND the HTTP API).
+
         v0.46:
             - feat: add a `permanent` entry to the right-click Ban submenu
               (CT2), alongside the existing 1 hour ... 1 year / other
@@ -277,7 +287,7 @@
 --------------
 
 local scriptname = "cmd_ban"
-local scriptversion = "0.46"
+local scriptversion = "0.47"
 
 local cmd = "ban"
 local cmd2 = "unban"
@@ -1299,6 +1309,37 @@ hub.setlistener( "onConnect", {},
                 user:kill( "ISTA 232 " .. hub.escapeto( message ) .. "\n", "TL" .. remaining )
                 return PROCESSED
             end
+        end
+        return nil
+    end
+)
+
+--// keep a ban attached to its user across a nick rename. A by-nick ban
+-- record carries .nick = firstnick (cid / ip bans are rename-invariant),
+-- and history is keyed by firstnick; +nickchange (and the HTTP rename)
+-- renames the user in user.tbl but not here, so without this a pure
+-- by-nick ban was silently bypassable by renaming the account. audit.fire
+-- is unconditional (core/audit.lua), so one onAudit tap catches every
+-- reg.nickchange. Returns nil (never PROCESSED) so the etc_auditlog /
+-- http_events onAudit taps still receive the event.
+hub.setlistener( "onAudit", {},
+    function( event )
+        if type( event ) ~= "table" or event.action ~= "reg.nickchange" then return nil end
+        local new_nick = event.target and event.target.nick
+        local old_nick = event.meta and event.meta.previous_nick
+        if type( old_nick ) ~= "string" or type( new_nick ) ~= "string" then return nil end
+        -- guard "": a cid/ip-only ban stores .nick = "", so an empty
+        -- old_nick (should never happen) must not match those records.
+        if old_nick == new_nick or old_nick == "" then return nil end
+        local changed = false
+        for _, b in ipairs( bans ) do
+            if b.nick == old_nick then b.nick = new_nick; changed = true end
+        end
+        if changed then util.savearray( bans, bans_path ) end
+        if history[ old_nick ] ~= nil then
+            history[ new_nick ] = history[ old_nick ]
+            history[ old_nick ] = nil
+            util.savetable( history, "history_tbl", history_path )
         end
         return nil
     end

--- a/scripts/cmd_gag.lua
+++ b/scripts/cmd_gag.lua
@@ -5,6 +5,15 @@
             - this script adds a command "gag" to mute, kennylize or shadowmute a user
             - usage: [+!#]gag mute|kennylize|shadowmute|ungag|show <NICK> [<DURATION>]
 
+            v0.14:
+                - carry a gag over to the new nick on +nickchange / HTTP
+                  rename. gag_tbl records key on .user_nick (= firstnick);
+                  a rename only updated user.tbl, so the mute was silently
+                  lifted - same class Sopor reported for etc_trafficmanager.
+                  An onAudit tap on reg.nickchange now re-keys the record
+                  (covers the ADC self / othernick / othernicku paths AND
+                  the HTTP API).
+
             v0.13:
                 - resolve an online target by firstnick when a nick-prefix
                   is active. usr_nick_prefix re-keys the hub's nick table
@@ -122,7 +131,7 @@
 --// settings begin //--
 
 local scriptname = "cmd_gag"
-local scriptversion = "0.13"
+local scriptversion = "0.14"
 
 local cmd = "gag"
 local prm_mute = "mute"
@@ -486,6 +495,34 @@ hub.setlistener("onPrivateMessage", {},
 hub.setlistener("onTimer", {},
     function()
         cleanup_expired()
+        return nil
+    end
+)
+
+--// keep a chat gag attached to its user across a nick rename. gag_tbl
+-- records key on .user_nick (= firstnick); +nickchange (and the HTTP
+-- rename) renames the user in user.tbl but not here, so without this a
+-- rename silently lifted the mute (same class Sopor reported for
+-- etc_trafficmanager). audit.fire is unconditional (core/audit.lua), so
+-- one onAudit tap catches every reg.nickchange. Returns nil (never
+-- PROCESSED) so the etc_auditlog / http_events taps still receive it.
+hub.setlistener("onAudit", {},
+    function(event)
+        if type(event) ~= "table" or event.action ~= "reg.nickchange" then return nil end
+        local new_nick = event.target and event.target.nick
+        local old_nick = event.meta and event.meta.previous_nick
+        if type(old_nick) ~= "string" or type(new_nick) ~= "string" or old_nick == new_nick then return nil end
+        local _, entry = find_entry(old_nick)
+        if not entry then return nil end
+        entry.user_nick = new_nick
+        -- drop any stale record already under the new nick so the list
+        -- keeps one entry - the renamed user's own gag wins.
+        for i = #gag_tbl, 1, -1 do
+            if gag_tbl[i] ~= entry and gag_tbl[i].user_nick == new_nick then
+                table.remove(gag_tbl, i)
+            end
+        end
+        util.savearray(gag_tbl, gag_path)
         return nil
     end
 )

--- a/scripts/cmd_help.lua
+++ b/scripts/cmd_help.lua
@@ -6,6 +6,13 @@
         - it exports also a module to reg a help text which will be shown by help
         - usage: [+!#]help
 
+        v0.07: (#591)
+            - compact one-line-per-command layout: "[level]  <prefix><cmd> <args>
+              <description>", command column aligned, drops the .lua-name title.
+              Level shown first so it stays aligned even for very long commands.
+            - the command is shown with a single copyable prefix (cfg
+              cmd_help_prefix, default "+"); + ! # all work at the hub.
+
         v0.06: by pulsar
             - small typo fix
             - some small code changes
@@ -28,7 +35,7 @@
 
 
 local scriptname = "cmd_help"
-local scriptversion = "0.06"
+local scriptversion = "0.07"
 
 local cmd = "help"
 
@@ -44,6 +51,8 @@ local hub_debug = hub.debug
 local utf_match = utf.match
 local utf_format = utf.format
 local table_concat = table.concat
+local string_rep = string.rep
+local string_format = string.format
 
 --// imports
 local scriptlang = cfg_get( "language" )
@@ -54,18 +63,25 @@ local help_title = lang.help_title or "cmd_help.lua"
 local help_usage = lang.help_usage or "[+!#]help"
 local help_desc = lang.help_desc or "Shows this help for hub commands"
 
-local msg_usage = lang.msg_usage or "Usage:"
-local msg_description = lang.msg_description or "Description:"
-local msg_minlevel = lang.msg_minlevel or "Min. Level:"
 local msg_out = lang.msg_out or [[
 
 
-=== AVAILABLE COMMANDS =================================================================================
+=== HUB COMMANDS ======================================================================================
+(leading [number] = minimum level; a command also works with ! or #)
 %s
-================================================================================= AVAILABLE COMMANDS ===
+====================================================================================== HUB COMMANDS ===
   ]]
 
 local ucmd_menu = lang.ucmd_menu or { "General", "Help" }
+
+--// The single, copyable command prefix shown in the list. +, ! and # are all
+--// valid at the hub (core/hub.lua matches "^[+!#]"); default to "+", luadch's
+--// convention (the docs and the hub's own "Did you mean +X?" hints use it).
+local help_prefix = tostring( cfg_get( "cmd_help_prefix" ) or "+" )
+--// Align the command column up to this width; the few very long multi-verb
+--// commands overflow it (their description just starts later) instead of
+--// padding every row out to their length.
+local CMD_COL = 40
 
 --// code
 local help = {}
@@ -77,19 +93,38 @@ local reghelp = function( title, usage, desc, level )
 end
 
 local onbmsg = function( user, command, parameters )
-    local tmp = {}
     local level = user:level()
-    for id, tbl in ipairs( help ) do
+    --// pass 1: keep the entries this user may see, normalize each to a single
+    --// copyable "<prefix><command> <args>" form, and find the width to align
+    --// the (capped) command column.
+    local rows, width = {}, 0
+    for _, tbl in ipairs( help ) do
         if level >= tbl.level then
-            tmp[ #tmp + 1 ] = "\n" ..
-                              tbl.title .. "\n" ..
-                              msg_usage .. "\t\t" .. tbl.usage .. "\n" ..
-                              msg_description .. "\t" .. tbl.desc .. "\n" ..
-                              msg_minlevel .. "\t" .. tbl.level .. "\n"
+            local c = tbl.usage
+            c = c:gsub( "^%[%+!#%]", "" )   -- strip the leading "[+!#]" marker ...
+            c = c:gsub( "^[%+!#]", "" )     -- ... or a single leading + ! #
+            c = help_prefix .. c
+            c = c:gsub( "%[%+!#%]", help_prefix )   -- and any further "[+!#]" a
+                                                    -- second usage form carries
+                                                    -- ("+cmd a  /  [+!#]cmd b")
+            local w = #c
+            if w > width and w <= CMD_COL then width = w end
+            rows[ #rows + 1 ] = { cmd = c, desc = tbl.desc, level = tbl.level }
         end
     end
-    tmp = table_concat( tmp )
-    local msg = utf_format( msg_out, tmp )
+    --// pass 2: one aligned line per command - "[level]  command  description".
+    --// Level first so it stays aligned even when a long command overflows the
+    --// command column.
+    local tmp = {}
+    for _, r in ipairs( rows ) do
+        local pad = width - #r.cmd
+        if pad < 0 then pad = 0 end
+        -- %3.0f, not %3d: tolerate a plugin that ever registers a fractional
+        -- level (%d errors on a non-integer in Lua 5.4); real levels are ints.
+        tmp[ #tmp + 1 ] = string_format( "  [%3.0f]  %s%s  %s",
+            r.level, r.cmd, string_rep( " ", pad ), r.desc )
+    end
+    local msg = utf_format( msg_out, table_concat( tmp, "\n" ) )
     user:reply( msg, hub_getbot(), hub_getbot() )
     return PROCESSED
 end

--- a/scripts/cmd_usercleaner.lua
+++ b/scripts/cmd_usercleaner.lua
@@ -18,6 +18,15 @@
             [+!#]usercleaner setdays <DAYS>        -- Change the expired days (default = 365)
 
 
+        v0.9:
+            - carry a nick exception over to the new nick on +nickchange /
+              HTTP rename. exception_tbl is keyed by nick; a rename only
+              updated user.tbl, so the exception was silently orphaned -
+              the renamed account then looked "unused" and could be
+              auto-deleted (delghosts / delexpired). An onAudit tap on
+              reg.nickchange now re-keys exception_tbl (covers the ADC
+              self / othernick / othernicku paths AND the HTTP API).
+
         v0.8:
             - route the showall / showexpired / showghosts / showexceptions
               status-column "true" / "false" booleans through lang
@@ -55,7 +64,7 @@
 --------------
 
 local scriptname = "cmd_usercleaner"
-local scriptversion = "0.8"
+local scriptversion = "0.9"
 
 --// command
 local cmd = "usercleaner"
@@ -909,6 +918,31 @@ local onbmsg = function( user, command, parameters )
     user:reply( msg_usage, hub.getbot() )
     return PROCESSED
 end
+
+--// keep a nick exception attached to its user across a rename.
+-- exception_tbl is keyed by nick; +nickchange (and the HTTP rename)
+-- renames the user in user.tbl but not here, so without this the
+-- protection was silently orphaned on rename - the renamed account
+-- then looked "unused" and could be auto-deleted (delghosts /
+-- delexpired). audit.fire is unconditional (core/audit.lua), so one
+-- onAudit tap catches every reg.nickchange - the ADC self / othernick
+-- / othernicku paths AND the HTTP API. Returns nil (never PROCESSED)
+-- so the etc_auditlog / http_events onAudit taps still receive it.
+hub.setlistener( "onAudit", {},
+    function( event )
+        if type( event ) ~= "table" or event.action ~= "reg.nickchange" then return nil end
+        local new_nick = event.target and event.target.nick
+        local old_nick = event.meta and event.meta.previous_nick
+        if type( old_nick ) ~= "string" or type( new_nick ) ~= "string" then return nil end
+        if old_nick == new_nick or exception_tbl[ old_nick ] == nil then return nil end
+        -- If a stale entry already sits under the new nick, the renamed
+        -- user's own exception wins - overwrite keeps it intact.
+        exception_tbl[ new_nick ] = exception_tbl[ old_nick ]
+        exception_tbl[ old_nick ] = nil
+        util.savetable( exception_tbl, "exception_tbl", exception_file )
+        return nil
+    end
+)
 
 hub.setlistener( "onStart", {},
     function()

--- a/scripts/etc_msgmanager.lua
+++ b/scripts/etc_msgmanager.lua
@@ -13,6 +13,15 @@
         [+!#]msgmanager showusers  -- show all blocked users
         [+!#]msgmanager showsettings  -- show settings from 'cfg.tbl'
 
+        v0.12:
+            - carry a chat block over to the new nick on +nickchange /
+              HTTP rename. block_tbl is keyed by firstnick; a rename only
+              updated user.tbl, so the block was silently dropped - an
+              operator could unblock a user just by renaming them. An
+              onAudit tap on reg.nickchange now re-keys block_tbl (covers
+              the ADC self / othernick / othernicku paths AND the HTTP
+              API). Reported by Sopor.
+
         v0.11:
             - resolve an online target by firstnick when a nick-prefix is
               active: usr_nick_prefix re-keys the hub's nick table to the
@@ -73,7 +82,7 @@
 --------------
 
 local scriptname = "etc_msgmanager"
-local scriptversion = "0.11"
+local scriptversion = "0.12"
 
 local cmd = "msgmanager"
 local cmd_b1 = "blockmain"
@@ -735,6 +744,30 @@ hub.setlistener( "onStart", {},
                 },
             } )
         end
+        return nil
+    end
+)
+
+--// keep a chat block attached to its user across a nick rename.
+-- block_tbl is keyed by firstnick; +nickchange (and the HTTP rename)
+-- renames the user in user.tbl but not here, so without this the block
+-- was silently lost on rename (reported by Sopor). audit.fire is
+-- unconditional (core/audit.lua), so one onAudit tap catches every
+-- reg.nickchange - the ADC self / othernick / othernicku paths AND the
+-- HTTP API. Returns nil (never PROCESSED) so the etc_auditlog /
+-- http_events onAudit taps still receive the event.
+hub.setlistener( "onAudit", {},
+    function( event )
+        if type( event ) ~= "table" or event.action ~= "reg.nickchange" then return nil end
+        local new_nick = event.target and event.target.nick
+        local old_nick = event.meta and event.meta.previous_nick
+        if type( old_nick ) ~= "string" or type( new_nick ) ~= "string" then return nil end
+        if old_nick == new_nick or block_tbl[ old_nick ] == nil then return nil end
+        -- If a stale entry already sits under the new nick, the renamed
+        -- user's own block wins - overwrite keeps it intact.
+        block_tbl[ new_nick ] = block_tbl[ old_nick ]
+        block_tbl[ old_nick ] = nil
+        util.savetable( block_tbl, "block_tbl", block_file )
         return nil
     end
 )

--- a/scripts/etc_trafficmanager.lua
+++ b/scripts/etc_trafficmanager.lua
@@ -35,6 +35,15 @@
         the block list and accept the corresponding file-transfer
         permission.
 
+        v2.10:
+            - carry a manual block over to the new nick on +nickchange /
+              HTTP rename. block_tbl is keyed by firstnick; a rename only
+              updated user.tbl, so the block was silently dropped - an
+              operator could unblock a user just by renaming them. An
+              onAudit tap on reg.nickchange now re-keys block_tbl (covers
+              the ADC self / othernick / othernicku paths AND the HTTP
+              API). Reported by Sopor.
+
         v2.9:
             - fix a nil-scriptname leak in the external add() / del()
               API: a caller passing scriptname (or reason) = nil produced
@@ -238,7 +247,7 @@
 --------------
 
 local scriptname = "etc_trafficmanager"
-local scriptversion = "2.9"
+local scriptversion = "2.10"
 
 local cmd = "trafficmanager"
 local cmd_b = "block"
@@ -1757,6 +1766,30 @@ hub.setlistener( "onTimer", { },
             send_user_report()
             start = os.time()
         end
+        return nil
+    end
+)
+
+--// keep a manual block attached to its user across a nick rename.
+-- block_tbl is keyed by firstnick; +nickchange (and the HTTP rename)
+-- renames the user in user.tbl but not here, so without this the block
+-- was silently lost on rename (reported by Sopor). audit.fire is
+-- unconditional (core/audit.lua), so one onAudit tap catches every
+-- reg.nickchange - the ADC self / othernick / othernicku paths AND the
+-- HTTP API. Returns nil (never PROCESSED) so the etc_auditlog /
+-- http_events onAudit taps still receive the event.
+hub.setlistener( "onAudit", {},
+    function( event )
+        if type( event ) ~= "table" or event.action ~= "reg.nickchange" then return nil end
+        local new_nick = event.target and event.target.nick
+        local old_nick = event.meta and event.meta.previous_nick
+        if type( old_nick ) ~= "string" or type( new_nick ) ~= "string" then return nil end
+        if old_nick == new_nick or block_tbl[ old_nick ] == nil then return nil end
+        -- If a stale entry already sits under the new nick, the renamed
+        -- user's own block wins - overwrite keeps it intact.
+        block_tbl[ new_nick ] = block_tbl[ old_nick ]
+        block_tbl[ old_nick ] = nil
+        util.savetable( block_tbl, "block_tbl", block_file )
         return nil
     end
 )

--- a/scripts/lang/de/cmd_help.json
+++ b/scripts/lang/de/cmd_help.json
@@ -2,9 +2,6 @@
   "help_desc":"Zeigt diese Auflistung der verfügbaren Hubbefehle",
   "help_title":"cmd_help.lua",
   "help_usage":"[+!#]help",
-  "msg_description":"Beschreibung:",
-  "msg_minlevel":"Min. Level:",
-  "msg_out":"\n\n=== VERFÜGBARE BEFEHLE =================================================================================\n%s\n================================================================================= VERFÜGBARE BEFEHLE ===\n  ",
-  "msg_usage":"Gebrauch:",
+  "msg_out":"\n\n=== HUB-BEFEHLE =================================================================================\n(führende [Zahl] = Mindest-Level; ein Befehl geht auch mit ! oder #)\n%s\n================================================================================= HUB-BEFEHLE ===\n  ",
   "ucmd_menu":["Allgemein","Hilfe"]
 }

--- a/scripts/lang/en/cmd_help.json
+++ b/scripts/lang/en/cmd_help.json
@@ -2,9 +2,6 @@
   "help_desc":"Shows this help for hub commands",
   "help_title":"cmd_help.lua",
   "help_usage":"[+!#]help",
-  "msg_description":"Description:",
-  "msg_minlevel":"Min. Level:",
-  "msg_out":"\n\n=== AVAILABLE COMMANDS =================================================================================\n%s\n================================================================================= AVAILABLE COMMANDS ===\n  ",
-  "msg_usage":"Usage:",
+  "msg_out":"\n\n=== HUB COMMANDS =================================================================================\n(leading [number] = minimum level; a command also works with ! or #)\n%s\n================================================================================= HUB COMMANDS ===\n  ",
   "ucmd_menu":["General","Help"]
 }

--- a/scripts/lang/sv/cmd_help.json
+++ b/scripts/lang/sv/cmd_help.json
@@ -2,10 +2,7 @@
     "help_desc": "Visar denna hjälp för hubbkommandon",
     "help_title": "",
     "help_usage": "",
-    "msg_description": "",
-    "msg_minlevel": "",
     "msg_out": "",
-    "msg_usage": "",
     "ucmd_menu": [
         "",
         ""

--- a/scripts/usr_hide_share.lua
+++ b/scripts/usr_hide_share.lua
@@ -4,6 +4,15 @@
 
         Usage: [+!#]hideshare <NICK>
 
+        v0.7:
+            - carry a hidden-share flag over to the new nick on
+              +nickchange / HTTP rename. hide_share_tbl is keyed by
+              firstnick; a rename only updated user.tbl, so the flag was
+              silently dropped on rename and the user's share became
+              visible again. An onAudit tap on reg.nickchange now re-keys
+              hide_share_tbl (covers the ADC self / othernick / othernicku
+              paths AND the HTTP API).
+
         v0.6:
             - resolve an online target by firstnick when a nick-prefix is
               active: usr_nick_prefix re-keys the hub's nick table to the
@@ -44,7 +53,7 @@
 --------------
 
 local scriptname = "usr_hide_share"
-local scriptversion = "0.6"
+local scriptversion = "0.7"
 
 local cmd = "hideshare"
 
@@ -216,6 +225,30 @@ onbmsg = function( user, command, parameters )
     user:reply( msg_usage, hub.getbot() )
     return PROCESSED
 end
+
+--// keep a hidden-share flag attached to its user across a nick rename.
+-- hide_share_tbl is keyed by firstnick; +nickchange (and the HTTP
+-- rename) renames the user in user.tbl but not here, so without this
+-- the flag was silently dropped on rename and the share became visible
+-- again. audit.fire is unconditional (core/audit.lua), so one onAudit
+-- tap catches every reg.nickchange - the ADC self / othernick /
+-- othernicku paths AND the HTTP API. Returns nil (never PROCESSED) so
+-- the etc_auditlog / http_events onAudit taps still receive the event.
+hub.setlistener( "onAudit", {},
+    function( event )
+        if type( event ) ~= "table" or event.action ~= "reg.nickchange" then return nil end
+        local new_nick = event.target and event.target.nick
+        local old_nick = event.meta and event.meta.previous_nick
+        if type( old_nick ) ~= "string" or type( new_nick ) ~= "string" then return nil end
+        if old_nick == new_nick or hide_share_tbl[ old_nick ] == nil then return nil end
+        -- If a stale entry already sits under the new nick, the renamed
+        -- user's own flag wins - overwrite keeps it intact.
+        hide_share_tbl[ new_nick ] = hide_share_tbl[ old_nick ]
+        hide_share_tbl[ old_nick ] = nil
+        util.savetable( hide_share_tbl, "hide_share_tbl", path )
+        return nil
+    end
+)
 
 hub.debug( "** Loaded " .. scriptname .. " " .. scriptversion .. " **" )
 

--- a/scripts/usr_uptime.lua
+++ b/scripts/usr_uptime.lua
@@ -4,6 +4,14 @@
 
         usage: [+!#]useruptime [CT1 <FIRSTNICK> | CT2 <NICK>]
 
+        v0.13: by Aybo
+            - carry a user's accumulated uptime over to the new nick on
+              +nickchange / HTTP rename. uptime_tbl is keyed by firstnick;
+              a rename only updated user.tbl, so the stats were orphaned
+              and read as zero under the new nick. An onAudit tap on
+              reg.nickchange now re-keys the entry (covers the ADC self /
+              othernick / othernicku paths AND the HTTP API).
+
         v0.12: by Aybo
             - fix undercounting on busy hubs and across +reload
               (reported by Sopor: 24/7 users showing only a few hours
@@ -114,7 +122,7 @@
 --------------
 
 local scriptname = "usr_uptime"
-local scriptversion = "0.12"
+local scriptversion = "0.13"
 
 local cmd = { "useruptime", "uu" }
 
@@ -354,6 +362,28 @@ local onbmsg = function( user, command, parameters )
     user:reply( msg_usage, hub.getbot() )
     return PROCESSED
 end
+
+--// keep a user's accumulated uptime attached across a nick rename.
+-- uptime_tbl is keyed by firstnick; +nickchange (and the HTTP rename)
+-- renames the user in user.tbl but not here, so without this a rename
+-- orphaned the user's online-time stats (they read as zero under the new
+-- nick). audit.fire is unconditional (core/audit.lua), so one onAudit tap
+-- catches every reg.nickchange. Returns nil (never PROCESSED) so the
+-- etc_auditlog / http_events onAudit taps still receive the event.
+hub.setlistener( "onAudit", {},
+    function( event )
+        if type( event ) ~= "table" or event.action ~= "reg.nickchange" then return nil end
+        if type( uptime_tbl ) ~= "table" then return nil end
+        local new_nick = event.target and event.target.nick
+        local old_nick = event.meta and event.meta.previous_nick
+        if type( old_nick ) ~= "string" or type( new_nick ) ~= "string" then return nil end
+        if old_nick == new_nick or uptime_tbl[ old_nick ] == nil then return nil end
+        uptime_tbl[ new_nick ] = uptime_tbl[ old_nick ]
+        uptime_tbl[ old_nick ] = nil
+        util.savetable( uptime_tbl, "uptime", uptime_file )
+        return nil
+    end
+)
 
 hub.setlistener( "onStart", {},
     function()

--- a/tests/unit/etc_trafficmanager_test.lua
+++ b/tests/unit/etc_trafficmanager_test.lua
@@ -39,6 +39,14 @@
     the pre-fix plugin (dead `tostring(nil) or msg_unknown` fallback) and
     PASS patched.
 
+    nick-rename section (below): a reg.nickchange onAudit event must
+    re-key a manual block to the new nick, else +nickchange silently
+    unblocks the user (reported by Sopor). The "onAudit listener
+    registered" check FAILS on the pre-fix plugin (no listener) and PASSES
+    patched; the guarded show-blocks assertions then confirm the key moved
+    (new nick blocked, old nick gone) and that an unrelated audit event is
+    ignored.
+
 ]]--
 
 local GiB = 1024 * 1024 * 1024
@@ -397,6 +405,39 @@ do
     eq( "nil-scriptname add: report User is not literal 'nil'", contains( r, "User:  nil" ), false )
     eq( "nil-scriptname add: no 'scriptname: nil' appended",    contains( r, "scriptname: nil" ), false )
     eq( "nil-scriptname add: degrades to msg_unknown",          contains( r, "User:  <UNKNOWN>" ), true )
+end
+
+----------------------------------------------------------------------
+-- nick rename: a reg.nickchange onAudit event re-keys a manual block to
+-- the new nick. Without the listener +nickchange (and the HTTP rename)
+-- renames the user in user.tbl but leaves the block under the old
+-- firstnick, silently unblocking them (reported by Sopor).
+-- RED pre-fix: onAudit is unregistered -> the "registered" check fails
+-- and the guarded move assertions are skipped.
+----------------------------------------------------------------------
+
+do
+    eq( "rename: onAudit listener registered", _registered.onAudit ~= nil, true )
+    if _registered.onAudit then
+        -- manual_guy is in block_tbl from the initial _block_seed.
+        _registered.onAudit( { action = "reg.nickchange",
+            target = { nick = "renamed_guy" },
+            meta   = { previous_nick = "manual_guy" } } )
+        local op, replied_of = op_user( )
+        _online = { }
+        onbmsg( op, "trafficmanager", "show blocks" )
+        local out = replied_of( )
+        eq( "rename: new nick now listed as blocked", contains( out, "renamed_guy" ), true )
+        eq( "rename: old nick no longer blocked",     contains( out, "manual_guy" ),  false )
+
+        -- an unrelated audit event must not disturb the block table
+        _registered.onAudit( { action = "ban.add", target = { nick = "x" }, meta = { } } )
+        local op2, replied_of2 = op_user( )
+        _online = { }
+        onbmsg( op2, "trafficmanager", "show blocks" )
+        eq( "rename: unrelated event ignored (renamed_guy still blocked)",
+            contains( replied_of2( ), "renamed_guy" ), true )
+    end
 end
 
 ----------------------------------------------------------------------

--- a/tests/unit/nick_rename_propagation_test.lua
+++ b/tests/unit/nick_rename_propagation_test.lua
@@ -1,0 +1,273 @@
+--[[
+
+    tests/unit/nick_rename_propagation_test.lua
+
+    Regression tests for the nick-rename propagation fix. Several plugins
+    keep a per-firstnick persistent store that a +nickchange (or the HTTP
+    rename) must carry over to the new nick, else the rename silently
+    orphans the entry:
+
+      - etc_msgmanager  : a chat block (map:  store[nick] = mode)
+      - cmd_usercleaner : a delete-exception (map: store[nick] = by)
+      - usr_hide_share  : a hidden-share flag (map: store[nick] = 1)
+      - usr_uptime      : accumulated uptime (map: store[nick] = {...})
+      - cmd_gag         : a chat gag (list: record.user_nick = nick)
+      - cmd_ban         : a by-nick ban (list: record.nick) + history (map)
+
+    Each now registers an onAudit tap on reg.nickchange that re-keys its
+    store. (etc_trafficmanager - the store Sopor originally reported - is
+    covered in etc_trafficmanager_test.lua.)
+
+    The real plugin is loaded under a stubbed sandbox: the onAudit
+    listener is captured through hub.setlistener, the store(s) seeded
+    through util.loadtable, and the re-key observed through
+    util.savetable / util.savearray (captured per file).
+
+    Regression contract (CLAUDE.md §1a.7): RED pre-fix - no plugin
+    registers onAudit, so the "onAudit registered" check FAILS and the
+    guarded move assertions are skipped. GREEN patched. Verified by
+    running this file against `git show origin/dev:scripts/<plugin>.lua`.
+
+    Run: lua5.4 tests/unit/nick_rename_propagation_test.lua
+    Exit 0 = all pass, 1 = a failure (CI-friendly).
+
+]]--
+
+----------------------------------------------------------------------
+-- minimal test framework
+----------------------------------------------------------------------
+
+local failures, checks = 0, 0
+local function eq( label, got, want )
+    checks = checks + 1
+    if got ~= want then
+        failures = failures + 1
+        io.write( string.format( "FAIL %-66s got=%q want=%q\n", label, tostring( got ), tostring( want ) ) )
+    else
+        io.write( string.format( "ok   %s\n", label ) )
+    end
+end
+
+-- copy up to two levels: enough for a list-of-flat-records and a
+-- map-of-subtrees (the re-key moves a subtree wholesale by reference).
+local function dcopy( t )
+    local r = { }
+    for k, v in pairs( t ) do
+        if type( v ) == "table" then
+            local vv = { }
+            for k2, v2 in pairs( v ) do vv[ k2 ] = v2 end
+            r[ k ] = vv
+        else
+            r[ k ] = v
+        end
+    end
+    return r
+end
+
+----------------------------------------------------------------------
+-- verify factories (per store shape)
+----------------------------------------------------------------------
+
+local function map_verify( store_file, seed_val )
+    return function( saves, case )
+        local s = saves[ store_file ]
+        eq( case.name .. ": store persisted",   s ~= nil, true )
+        eq( case.name .. ": new nick present",  s and s.NewNick ~= nil, true )
+        eq( case.name .. ": old nick cleared",  s and s.OldNick == nil, true )
+        -- value-equality only for scalar-valued maps; a table value (e.g.
+        -- uptime's subtree) or an omitted seed_val skips this check.
+        if seed_val ~= nil and type( seed_val ) ~= "table" then
+            eq( case.name .. ": new nick keeps value", s and s.NewNick, seed_val )
+        end
+    end
+end
+
+local function list_verify( store_file, keyfield )
+    return function( saves, case )
+        local s = saves[ store_file ]
+        eq( case.name .. ": store persisted", s ~= nil, true )
+        local has_new, has_old = false, false
+        for _, r in ipairs( s or { } ) do
+            if r[ keyfield ] == "NewNick" then has_new = true end
+            if r[ keyfield ] == "OldNick" then has_old = true end
+        end
+        eq( case.name .. ": record now under new nick", has_new, true )
+        eq( case.name .. ": no record under old nick",  has_old, false )
+    end
+end
+
+----------------------------------------------------------------------
+-- per-plugin descriptors
+----------------------------------------------------------------------
+
+local MSG_FILE  = "scripts/data/etc_msgmanager.tbl"
+local EXC_FILE  = "scripts/data/cmd_usercleaner_exceptions.tbl"
+local HIDE_FILE = "scripts/data/usr_hide_share.tbl"
+local UPT_FILE  = "scripts/data/usr_uptime.tbl"
+local GAG_FILE  = "scripts/data/cmd_gag.tbl"
+local BAN_FILE  = "scripts/data/cmd_ban_bans.tbl"
+local BANH_FILE = "scripts/data/cmd_ban_history.tbl"
+
+local CASES = {
+    {
+        name = "etc_msgmanager", path = "scripts/etc_msgmanager.lua",
+        needs_onstart = true,     -- block_tbl is (re)loaded in onStart
+        cfg  = { language = "en", etc_msgmanager_activate = true },
+        seed = { [ MSG_FILE ] = { OldNick = "b" } },
+        verify = map_verify( MSG_FILE, "b" ),
+    },
+    {
+        name = "cmd_usercleaner", path = "scripts/cmd_usercleaner.lua",
+        needs_onstart = false,    -- exception_tbl loaded at module scope
+        cfg  = { language = "en", cmd_usercleaner_activate = true },
+        seed = { [ EXC_FILE ] = { OldNick = "op" } },
+        verify = map_verify( EXC_FILE, "op" ),
+    },
+    {
+        name = "usr_hide_share", path = "scripts/usr_hide_share.lua",
+        needs_onstart = false,
+        cfg  = {
+            language = "en", usr_hide_share_activate = true,
+            usr_hide_share_permission = { [ 60 ] = 60 },
+            usr_hide_share_restrictions = { },
+        },
+        seed = { [ HIDE_FILE ] = { OldNick = 1 } },
+        verify = map_verify( HIDE_FILE, 1 ),
+    },
+    {
+        name = "usr_uptime", path = "scripts/usr_uptime.lua",
+        needs_onstart = false,    -- uptime_tbl loaded at module scope
+        cfg  = { language = "en" },
+        seed = { [ UPT_FILE ] = { OldNick = { [ "2026" ] = { } } } },
+        verify = map_verify( UPT_FILE ),   -- table value: presence only
+    },
+    {
+        name = "cmd_gag", path = "scripts/cmd_gag.lua",
+        needs_onstart = false,    -- gag_tbl loaded at module scope
+        cfg  = { language = "en" },
+        -- the second record is a stale entry already under the new nick;
+        -- the reverse-dedup loop must drop it and keep the renamed one.
+        seed = { [ GAG_FILE ] = {
+            { user_nick = "OldNick", mode = "mute" },
+            { user_nick = "NewNick", mode = "shadowmute" },
+        } },
+        verify = function( saves, case )
+            list_verify( GAG_FILE, "user_nick" )( saves, case )
+            local n, kept_mode = 0, nil
+            for _, r in ipairs( saves[ GAG_FILE ] or { } ) do
+                if r.user_nick == "NewNick" then n = n + 1; kept_mode = r.mode end
+            end
+            eq( case.name .. ": exactly one record under new nick (dedup)", n, 1 )
+            eq( case.name .. ": renamed record survived, stale dropped", kept_mode, "mute" )
+        end,
+    },
+    {
+        name = "cmd_ban", path = "scripts/cmd_ban.lua",
+        needs_onstart = false,    -- bans + history loaded at module scope
+        cfg  = { language = "en" },
+        seed = {
+            -- the second record is a cid/ip-only ban (nick = ""); the
+            -- empty-nick guard must leave it untouched on a rename.
+            [ BAN_FILE ]  = {
+                { nick = "OldNick", ip = "", cid = "" },
+                { nick = "", ip = "1.2.3.4", cid = "CIDXYZ" },
+            },
+            [ BANH_FILE ] = { OldNick = { { date = "x" } } },
+        },
+        verify = function( saves, case )
+            list_verify( BAN_FILE, "nick" )( saves, case )
+            local ip_ok = false
+            for _, r in ipairs( saves[ BAN_FILE ] or { } ) do
+                if r.cid == "CIDXYZ" and r.ip == "1.2.3.4" and r.nick == "" then ip_ok = true end
+            end
+            eq( case.name .. ": cid/ip-only ban left untouched", ip_ok, true )
+            local h = saves[ BANH_FILE ]
+            eq( case.name .. ": history persisted",        h ~= nil, true )
+            eq( case.name .. ": history new nick present", h and h.NewNick ~= nil, true )
+            eq( case.name .. ": history old nick cleared", h and h.OldNick == nil, true )
+        end,
+    },
+}
+
+----------------------------------------------------------------------
+-- load a plugin under a stubbed sandbox, capture its onAudit listener,
+-- fire a reg.nickchange and observe the store move via save capture.
+----------------------------------------------------------------------
+
+local function run( case )
+    local registered = { }
+    local saves = { }                       -- file -> captured table
+
+    local function capture( t, file ) saves[ file ] = dcopy( t ) end
+
+    _G.PROCESSED = 1
+    _G.hub = {
+        setlistener  = function( ev, _, fn ) registered[ ev ] = fn end,
+        debug        = function( ) end,
+        getbot       = function( ) return "stub-bot" end,
+        sendtoall    = function( ) end,
+        escapeto     = function( s ) return s end,
+        escapefrom   = function( s ) return s end,
+        getusers     = function( ) return { } end,
+        isnickonline = function( ) return nil end,
+        find_online_by_firstnick = function( ) return nil end,
+        getregusers  = function( ) return { }, { }, { } end,
+        import = function( n )
+            if n == "etc_hubcommands" then
+                return { add = function( ) return true end, has = function( ) return false end, list = function( ) return { } end }
+            end
+            if n == "etc_report" then return { send = function( ) end } end
+            return nil     -- cmd_help / etc_usercommands absent
+        end,
+        http_register = function( ) end,
+    }
+    _G.cfg = {
+        loadlanguage = function( ) return { }, nil end,
+        get = function( k ) return case.cfg[ k ] end,
+    }
+    _G.util = {
+        loadtable = function( f )
+            local s = case.seed[ f ]
+            if s == nil then return nil end
+            return dcopy( s )
+        end,
+        savetable = function( t, _name, file ) capture( t, file ) end,
+        savearray = function( t, file ) capture( t, file ) end,
+        date = function( ) return "20260101000000" end,
+        strip_control_bytes = function( s ) return s end,
+        getlowestlevel = function( ) return 60 end,
+        spairs = function( t ) return pairs( t ) end,
+    }
+    _G.utf = { match = string.match, format = string.format, sub = string.sub, len = string.len }
+
+    assert( loadfile( case.path ) )( )
+    eq( case.name .. ": onAudit listener registered", registered.onAudit ~= nil, true )
+    if case.needs_onstart and registered.onStart then registered.onStart( ) end
+    if not registered.onAudit then return end
+
+    -- the rename must move the store from OldNick -> NewNick and persist
+    registered.onAudit( { action = "reg.nickchange",
+        target = { nick = "NewNick" }, meta = { previous_nick = "OldNick" } } )
+    case.verify( saves, case )
+
+    -- an unrelated audit event must not touch any store (no save)
+    saves = { }
+    registered.onAudit( { action = "ban.add", target = { nick = "x" }, meta = { } } )
+    eq( case.name .. ": unrelated event ignored (no save)", next( saves ), nil )
+
+    -- a rename of a user NOT in the store must be a no-op (no spurious
+    -- disk write on every nickchange hub-wide)
+    saves = { }
+    registered.onAudit( { action = "reg.nickchange",
+        target = { nick = "B" }, meta = { previous_nick = "not_in_store" } } )
+    eq( case.name .. ": rename of a non-stored user is a no-op", next( saves ), nil )
+end
+
+for _, c in ipairs( CASES ) do run( c ) end
+
+----------------------------------------------------------------------
+-- summary
+----------------------------------------------------------------------
+
+io.write( string.format( "\n%d checks, %d failures\n", checks, failures ) )
+os.exit( failures > 0 and 1 or 0 )


### PR DESCRIPTION
Routine dev -> master promotion. All four changes landed on dev with review + green CI:

- #593 ci(openwrt): build .apk per release for 3 router arches (#587)
- #594 feat(openwrt): run the hub as an unprivileged user, not root (#587)
- #596 fix(scripts): carry per-firstnick plugin stores across a nick rename
- #595 feat(cmd_help): compact one-line-per-command help layout (#591)

Merged as a merge commit (not squash) per branch-hygiene so dev history is preserved on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)