### PR TITLE
http: array-body reject, handler-error tracebacks, per-entry token validation

### DIFF
--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -311,17 +311,41 @@ local defaults = {
     http_api_tokens = { { },
         function( value )
             if not types_table( value ) then return false end
+            -- Per-entry validation, NOT whole-table. A single malformed
+            -- entry (a scope typo, a non-string key, ...) must not
+            -- invalidate the ENTIRE table: that path returned false here,
+            -- the cfg loader reset the key to the default {}, and the HTTP
+            -- listener then refused to bind at all - one typo locked the
+            -- operator out of an otherwise-healthy hub. Instead drop only
+            -- the offending entries, keep the valid tokens, and log each
+            -- drop so a vanished token is explained rather than silent.
+            -- `use "out"` is resolved lazily (out.lua loads AFTER cfg in
+            -- the _core order, so it cannot be imported at file top); this
+            -- validator only runs at checkcfg / reload time, long after
+            -- out is up. Setting an existing field to nil during a pairs()
+            -- walk is explicitly permitted by Lua.
+            local dropped = 0
             for token, spec in pairs( value ) do
+                local ok = true
                 if type( token ) ~= "string" or #token == 0 then
-                    return false
+                    ok = false
+                elseif type( spec ) ~= "table" then
+                    ok = false
+                elseif spec.scope ~= "read" and spec.scope ~= "admin" then
+                    ok = false
+                elseif spec.comment ~= nil and type( spec.comment ) ~= "string" then
+                    ok = false
                 end
-                if type( spec ) ~= "table" then return false end
-                if spec.scope ~= "read" and spec.scope ~= "admin" then
-                    return false
+                if not ok then
+                    value[ token ] = nil
+                    dropped = dropped + 1
                 end
-                if spec.comment ~= nil and type( spec.comment ) ~= "string" then
-                    return false
-                end
+            end
+            if dropped > 0 then
+                use( "out" ).error(
+                    "cfg.lua: http_api_tokens: dropped ", dropped,
+                    " invalid token entr", ( dropped == 1 and "y" or "ies" ),
+                    " (bad scope or shape); the remaining valid tokens are kept" )
             end
             return true
         end

--- a/core/http_router.lua
+++ b/core/http_router.lua
@@ -43,8 +43,10 @@ local ipairs = use "ipairs"
 local tostring = use "tostring"
 local tonumber = use "tonumber"
 local type = use "type"
-local pcall = use "pcall"
+local xpcall = use "xpcall"
 local error = use "error"
+local getmetatable = use "getmetatable"
+local debug = use "debug"
 
 local string = use "string"
 local table = use "table"
@@ -852,6 +854,18 @@ dispatch = function( framer_unit, source_ip )
             audit_log( req, 400 )
             return 400, envelope_error( "E_BAD_JSON", "body must be a JSON object" ), resp_headers
         end
+        -- Top-level MUST be a JSON object, never an array (§6.1). dkjson
+        -- tags a decoded array with a metatable {__jsontype="array"} and
+        -- an object with {__jsontype="object"}. Without this check a bare
+        -- array passes the type()=="table" test above and reaches the
+        -- handler as a body whose every named-field lookup silently reads
+        -- nil - so a client sending `[...]` gets misleading validation
+        -- errors instead of "not an object". Reject it explicitly.
+        local pmeta = getmetatable( parsed )
+        if pmeta and pmeta.__jsontype == "array" then
+            audit_log( req, 400 )
+            return 400, envelope_error( "E_BAD_JSON", "body must be a JSON object, not a JSON array" ), resp_headers
+        end
         req.body = parsed
 
         -- Schema validation, if the route declared one.
@@ -864,8 +878,14 @@ dispatch = function( framer_unit, source_ip )
         end
     end
 
-    -- Dispatch.
-    local ok, result_or_err = pcall( matched_route.handler, req )
+    -- Dispatch. xpcall (not pcall) so an uncaught handler error carries
+    -- its Lua traceback into error.log - a bare pcall discards the stack,
+    -- leaving only the message with no line to look at. `debug` is a core
+    -- import (never handed to the plugin sandbox); the message handler
+    -- runs at the point of the error, so the traceback is meaningful.
+    local ok, result_or_err = xpcall( matched_route.handler, function( err )
+        return debug.traceback( tostring( err ), 2 )
+    end, req )
     if not ok then
         out_error( "http_router.dispatch: handler raised on ",
             method, " ", path, ": ", tostring( result_or_err ) )

--- a/tests/unit/cfg_defaults_test.lua
+++ b/tests/unit/cfg_defaults_test.lua
@@ -48,12 +48,17 @@ local _real = {
     ipairs = ipairs,
     -- const.CONFIG_PATH is read into an upvalue at load; any string is fine.
     const  = { CONFIG_PATH = "cfg/" },
-    -- types.utf8 + types.get "<name>" are captured into upvalues at load;
-    -- the returned validators are never called here, so identity stubs work.
+    -- types.utf8 + types.get "<name>" are captured into upvalues at load.
+    -- The identity stub (always true) is exercised by the http_api_tokens
+    -- validator test below (it calls types_table(value)); returning true
+    -- lets that test drive the per-entry filter path.
     types  = {
         utf8 = function() return true end,
         get  = function() return function() return true end end,
     },
+    -- http_api_tokens validator resolves `use "out"` lazily to log dropped
+    -- entries; a no-op error sink keeps that path silent under test.
+    out    = { error = function() end },
 }
 
 _G.use = function( name )
@@ -130,6 +135,54 @@ for _, key in ipairs( {
     local sok, sval = pcall( cfg_get, key )
     assert_true( key .. ": registered + resolves without crash", sok )
     assert_true( key .. ": default is a boolean", type( sval ) == "boolean" )
+end
+
+----------------------------------------------------------------------
+-- http_api_tokens validator: per-entry (NOT whole-table) validation.
+-- A single malformed entry must not invalidate the whole map - that
+-- path returned false, the cfg loader reset the key to {}, and the HTTP
+-- listener then refused to bind: one scope typo locked the operator out.
+-- The validator now drops only the bad entries, keeps the valid tokens,
+-- and returns true.
+-- RED pre-fix: a mixed good/bad map returned false (whole-table reject)
+-- and left the map unmutated.
+----------------------------------------------------------------------
+
+do
+    local validator = settings.http_api_tokens[ 2 ]
+
+    -- mixed: one valid admin token + one bad-scope typo.
+    local mixed = {
+        [ "goodtoken-long-enough-000001" ] = { scope = "admin", comment = "ops" },
+        [ "typoscope-long-enough-000002" ] = { scope = "administrator" },   -- bad
+    }
+    assert_eq( "http_api_tokens: mixed map validates true (per-entry)",
+        validator( mixed ), true )
+    assert_true( "http_api_tokens: valid token survives",
+        mixed[ "goodtoken-long-enough-000001" ] ~= nil )
+    assert_eq( "http_api_tokens: valid token scope intact",
+        mixed[ "goodtoken-long-enough-000001" ]
+            and mixed[ "goodtoken-long-enough-000001" ].scope, "admin" )
+    assert_true( "http_api_tokens: bad-scope entry dropped",
+        mixed[ "typoscope-long-enough-000002" ] == nil )
+
+    -- all-valid: unchanged, true.
+    local allgood = {
+        [ "aaaa-long-enough-token-0001" ] = { scope = "read" },
+        [ "bbbb-long-enough-token-0002" ] = { scope = "admin", comment = "x" },
+    }
+    assert_eq( "http_api_tokens: all-valid validates true",
+        validator( allgood ), true )
+    assert_true( "http_api_tokens: all-valid keeps both",
+        allgood[ "aaaa-long-enough-token-0001" ] ~= nil
+        and allgood[ "bbbb-long-enough-token-0002" ] ~= nil )
+
+    -- all-bad: everything dropped, still true (empty map -> listener
+    -- simply won't bind, same as no tokens; NOT a hard reject).
+    local allbad = { [ "onlytoken-long-enough-0003" ] = { scope = "nope" } }
+    assert_eq( "http_api_tokens: all-bad validates true",
+        validator( allbad ), true )
+    assert_true( "http_api_tokens: all-bad map emptied", next( allbad ) == nil )
 end
 
 ----------------------------------------------------------------------

--- a/tests/unit/http_router_test.lua
+++ b/tests/unit/http_router_test.lua
@@ -4,8 +4,10 @@
 
     Unit tests for the pure-Lua-bit functions of core/http_router.lua
     (constant_time_eq, validate_schema, envelope helpers, token
-    resolution, schema validator, request-id shape). Dispatch is
-    smoke-tested end-to-end against a real hub.
+    resolution, schema validator, request-id shape) plus targeted
+    dispatch() coverage (OPTIONS introspection, the top-level body-shape
+    guard, handler-crash traceback logging). Full end-to-end request
+    paths are smoke-tested against a real hub.
 
     The router uses `use "cfg"` and `use "out"` and `use "dkjson"`
     at file scope; we stub them here so the module can load in a
@@ -26,6 +28,7 @@
 local _stub_cfg_tokens = { }
 local _stub_cfg_idem_cap = nil    -- nil = use default; integer overrides
 local _last_audit_args = nil
+local _last_error_args = nil
 local _mock_cfg = {
     get = function( key )
         if key == "http_api_tokens" then return _stub_cfg_tokens end
@@ -37,7 +40,11 @@ local _mock_cfg = {
 }
 local _mock_out = {
     put       = function() end,
-    error     = function() end,
+    -- capture so the Fix-B handler-crash test can assert the logged
+    -- text carries a Lua traceback (xpcall + debug.traceback), not just
+    -- the bare error message. out_error is snapshotted to a local at
+    -- module load, so this capturing closure must exist BEFORE loadfile.
+    error     = function( ... ) _last_error_args = { ... } end,
     api_audit = function( ... ) _last_audit_args = { ... } end,
 }
 local _mock_dkjson = {
@@ -60,7 +67,17 @@ local _mock_dkjson = {
             if not ok then return nil, nil, t end
             return t
         end
-        return nil, nil, "stub: only OBJ:{...} accepted"
+        -- "ARR:" mirrors real dkjson tagging a decoded JSON array with the
+        -- metatable {__jsontype="array"} - the body-shape guard's signal.
+        if s:sub( 1, 4 ) == "ARR:" then
+            local fn = loadstring and loadstring( "return " .. s:sub( 5 ) )
+                or load( "return " .. s:sub( 5 ) )
+            if not fn then return nil, nil, "stub: bad ARR body" end
+            local ok, t = pcall( fn )
+            if not ok then return nil, nil, t end
+            return setmetatable( t, { __jsontype = "array" } )
+        end
+        return nil, nil, "stub: only OBJ:{...} / ARR:{...} accepted"
     end,
 }
 
@@ -73,12 +90,22 @@ local _mock_dkjson = {
 -- a real build.
 local _mock_socket = { gettime = function( ) return os.time( ) end }
 
+-- dispatch() resolves `use "ratelimit"` at request time for any non-
+-- X-Confirm route; a permissive stub lets the body-shape + handler-crash
+-- dispatch tests run without a real token bucket. (Bucket behaviour is
+-- covered by ratelimit_test.lua + smoke.)
+local _mock_ratelimit = {
+    http_token             = function( ) return true end,
+    http_token_retry_after = function( ) return 60 end,
+}
+
 local _real = {
     string = string, table = table, os = os, io = io, math = math,
     pairs = pairs, ipairs = ipairs, tostring = tostring, tonumber = tonumber,
-    type = type, pcall = pcall, select = select, error = error,
+    type = type, pcall = pcall, xpcall = xpcall, select = select, error = error,
+    getmetatable = getmetatable, debug = debug,
     cfg = _mock_cfg, out = _mock_out, dkjson = _mock_dkjson,
-    socket = _mock_socket, adclib = false,
+    socket = _mock_socket, adclib = false, ratelimit = _mock_ratelimit,
 }
 _G.use = function( name )
     local v = _real[ name ]
@@ -408,6 +435,101 @@ do
     -- anonymous OPTIONS on an unknown path: 401 (unchanged).
     eq( "OPTIONS anon unknown path -> 401", ( opt( "/v1/unknown", nil ) ), 401 )
 
+    router.unregister_all( )
+    _stub_cfg_tokens = { }
+end
+
+----------------------------------------------------------------------
+-- dispatch body-shape guard (§6.1): a top-level JSON *array* must be
+-- rejected, not silently accepted as a body whose named fields all read
+-- nil. Real dkjson tags a decoded array with metatable
+-- {__jsontype="array"}; the router rejects on that tag (the mock mirrors
+-- the tag via its "ARR:" prefix; the real tag is pinned below).
+-- RED pre-fix: the array body reached the handler and returned 200.
+----------------------------------------------------------------------
+
+do
+    router.unregister_all( )
+    local seen_body
+    local h = function( req )
+        seen_body = req.body
+        return { status = 200, data = { got = "ok" } }
+    end
+    router.register( "POST", "/v1/body", "admin", h )
+    _stub_cfg_tokens = { [ "ADMINTOKEN00000001" ] = { scope = "admin" } }
+
+    local function post( raw )
+        return router.dispatch( {
+            method  = "POST",
+            target  = "/v1/body",
+            headers = {
+                [ "authorization" ] = "Bearer ADMINTOKEN00000001",
+                [ "content-type" ]  = "application/json; charset=utf-8",
+            },
+            body = raw,
+        }, "127.0.0.1" )
+    end
+
+    -- object body: accepted, handler runs, body reaches it.
+    seen_body = nil
+    local st_ok = post( "OBJ:{ topic = 'hello' }" )
+    eq( "body-guard: object body -> 200", st_ok, 200 )
+    eq( "body-guard: object body reaches handler", seen_body and seen_body.topic, "hello" )
+
+    -- array body: rejected 400 BEFORE the handler; distinct message.
+    seen_body = nil
+    local st_arr, body_arr = post( "ARR:{ 1, 2, 3 }" )
+    eq( "body-guard: array body -> 400", st_arr, 400 )
+    local arr_err = body_arr and body_arr._encoded and body_arr._encoded.error
+    eq( "body-guard: array body code E_BAD_JSON", arr_err and arr_err.code, "E_BAD_JSON" )
+    eq( "body-guard: array body message names array",
+        arr_err and arr_err.message, "body must be a JSON object, not a JSON array" )
+    eq( "body-guard: array body never reached handler", seen_body, nil )
+
+    router.unregister_all( )
+    _stub_cfg_tokens = { }
+end
+
+----------------------------------------------------------------------
+-- Pin the external assumption Fix A relies on: the BUNDLED dkjson tags a
+-- decoded top-level array with __jsontype="array" and an object with
+-- "object". If a future dkjson bump drops the tag, the body-shape guard
+-- above silently stops rejecting arrays; catch that here, not in prod.
+----------------------------------------------------------------------
+
+do
+    local realdk = assert( loadfile( "dkjson/dkjson.lua" ) )( )
+    local arr = realdk.decode( "[1,2,3]" )
+    local obj = realdk.decode( "{\"a\":1}" )
+    eq( "dkjson: decoded array tagged __jsontype=array",
+        getmetatable( arr ) and getmetatable( arr ).__jsontype, "array" )
+    eq( "dkjson: decoded object tagged __jsontype=object",
+        getmetatable( obj ) and getmetatable( obj ).__jsontype, "object" )
+end
+
+----------------------------------------------------------------------
+-- dispatch handler-crash logging (Fix B): an uncaught handler error is
+-- caught (500 E_INTERNAL) AND logged WITH its Lua traceback (xpcall +
+-- debug.traceback), not just the bare message (pcall).
+-- RED pre-fix (pcall): the logged text carried the message but no
+-- "stack traceback:" section.
+----------------------------------------------------------------------
+
+do
+    router.unregister_all( )
+    router.register( "GET", "/v1/boom", "read", function( ) error( "kaboom" ) end )
+    _stub_cfg_tokens = { [ "READTOKEN000000001" ] = { scope = "read" } }
+    _last_error_args = nil
+    local st = router.dispatch( {
+        method  = "GET",
+        target  = "/v1/boom",
+        headers = { [ "authorization" ] = "Bearer READTOKEN000000001" },
+        body    = nil,
+    }, "127.0.0.1" )
+    eq( "handler-crash: 500 E_INTERNAL", st, 500 )
+    local logged = _last_error_args and table.concat( _last_error_args, "" ) or ""
+    eq( "handler-crash: message logged", logged:find( "kaboom", 1, true ) ~= nil, true )
+    eq( "handler-crash: traceback logged", logged:find( "stack traceback", 1, true ) ~= nil, true )
     router.unregister_all( )
     _stub_cfg_tokens = { }
 end


### PR DESCRIPTION
Three HTTP-API correctness fixes surfaced by a `docs/HTTP_API.md`-vs-code audit. Each makes the code match a contract the spec already documented.

- **Top-level JSON array body** is now rejected with `400 E_BAD_JSON` instead of silently reaching handlers as a body whose every named field reads `nil` (spec 6.1). Detected via dkjson's `{__jsontype="array"}` tag, post-auth.
- **Handler crashes** now log a Lua traceback (`xpcall` + `debug.traceback`) instead of only the message (spec 5.4). `debug` is a core import; it is **not** exposed to the plugin sandbox. The `500` response body is unchanged.
- **`http_api_tokens` validation is now per-entry.** One malformed entry (a scope typo) used to fail the whole validator, the loader reset the key to `{}`, and the HTTP listener then refused to bind - a full operator lockout on a single typo. Now only the bad entries are dropped, the valid tokens are kept, and each drop is logged.

### Tests
New `dispatch()` coverage in `http_router_test` (body-shape guard, handler-crash traceback, real-dkjson array/object tag pin) and per-entry cases in `cfg_defaults_test`. All proven **RED on the unpatched code** (9 targeted failures), green patched; both files already run on both `smoke.yml` legs.

### Review
Independent pre-merge review: **SHIP-WITH-NITS**. The one actionable nit (a dead `local pcall` after the `xpcall` swap) is folded in. Sandbox boundary (`debug` absent from the plugin whitelist), cfg reference-semantics (in-place filter survives `checkcfg`), and secret-key protection (`http_api_tokens` unreachable via `PUT /v1/config`) all verified clean.

Companion doc PR reconciles the remaining ~15 drifted spec statements: #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)
