### PR TITLE
Promote dev to master: HTTP API doc + impl reconciliation (#598, #599)

### DIFF
--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -311,17 +311,41 @@ local defaults = {
     http_api_tokens = { { },
         function( value )
             if not types_table( value ) then return false end
+            -- Per-entry validation, NOT whole-table. A single malformed
+            -- entry (a scope typo, a non-string key, ...) must not
+            -- invalidate the ENTIRE table: that path returned false here,
+            -- the cfg loader reset the key to the default {}, and the HTTP
+            -- listener then refused to bind at all - one typo locked the
+            -- operator out of an otherwise-healthy hub. Instead drop only
+            -- the offending entries, keep the valid tokens, and log each
+            -- drop so a vanished token is explained rather than silent.
+            -- `use "out"` is resolved lazily (out.lua loads AFTER cfg in
+            -- the _core order, so it cannot be imported at file top); this
+            -- validator only runs at checkcfg / reload time, long after
+            -- out is up. Setting an existing field to nil during a pairs()
+            -- walk is explicitly permitted by Lua.
+            local dropped = 0
             for token, spec in pairs( value ) do
+                local ok = true
                 if type( token ) ~= "string" or #token == 0 then
-                    return false
+                    ok = false
+                elseif type( spec ) ~= "table" then
+                    ok = false
+                elseif spec.scope ~= "read" and spec.scope ~= "admin" then
+                    ok = false
+                elseif spec.comment ~= nil and type( spec.comment ) ~= "string" then
+                    ok = false
                 end
-                if type( spec ) ~= "table" then return false end
-                if spec.scope ~= "read" and spec.scope ~= "admin" then
-                    return false
+                if not ok then
+                    value[ token ] = nil
+                    dropped = dropped + 1
                 end
-                if spec.comment ~= nil and type( spec.comment ) ~= "string" then
-                    return false
-                end
+            end
+            if dropped > 0 then
+                use( "out" ).error(
+                    "cfg.lua: http_api_tokens: dropped ", dropped,
+                    " invalid token entr", ( dropped == 1 and "y" or "ies" ),
+                    " (bad scope or shape); the remaining valid tokens are kept" )
             end
             return true
         end

--- a/core/http_router.lua
+++ b/core/http_router.lua
@@ -43,8 +43,10 @@ local ipairs = use "ipairs"
 local tostring = use "tostring"
 local tonumber = use "tonumber"
 local type = use "type"
-local pcall = use "pcall"
+local xpcall = use "xpcall"
 local error = use "error"
+local getmetatable = use "getmetatable"
+local debug = use "debug"
 
 local string = use "string"
 local table = use "table"
@@ -852,6 +854,18 @@ dispatch = function( framer_unit, source_ip )
             audit_log( req, 400 )
             return 400, envelope_error( "E_BAD_JSON", "body must be a JSON object" ), resp_headers
         end
+        -- Top-level MUST be a JSON object, never an array (§6.1). dkjson
+        -- tags a decoded array with a metatable {__jsontype="array"} and
+        -- an object with {__jsontype="object"}. Without this check a bare
+        -- array passes the type()=="table" test above and reaches the
+        -- handler as a body whose every named-field lookup silently reads
+        -- nil - so a client sending `[...]` gets misleading validation
+        -- errors instead of "not an object". Reject it explicitly.
+        local pmeta = getmetatable( parsed )
+        if pmeta and pmeta.__jsontype == "array" then
+            audit_log( req, 400 )
+            return 400, envelope_error( "E_BAD_JSON", "body must be a JSON object, not a JSON array" ), resp_headers
+        end
         req.body = parsed
 
         -- Schema validation, if the route declared one.
@@ -864,8 +878,14 @@ dispatch = function( framer_unit, source_ip )
         end
     end
 
-    -- Dispatch.
-    local ok, result_or_err = pcall( matched_route.handler, req )
+    -- Dispatch. xpcall (not pcall) so an uncaught handler error carries
+    -- its Lua traceback into error.log - a bare pcall discards the stack,
+    -- leaving only the message with no line to look at. `debug` is a core
+    -- import (never handed to the plugin sandbox); the message handler
+    -- runs at the point of the error, so the traceback is meaningful.
+    local ok, result_or_err = xpcall( matched_route.handler, function( err )
+        return debug.traceback( tostring( err ), 2 )
+    end, req )
     if not ok then
         out_error( "http_router.dispatch: handler raised on ",
             method, " ", path, ": ", tostring( result_or_err ) )

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -35,8 +35,9 @@ the authoritative spec; it is kept in lockstep with the implementation.
 - **Plugin-extensible** - bundled and third-party plugins register
   their own endpoints via a hub-side API. Core only ships the router
   + a handful of hub-intrinsic endpoints; everything else is plugin-
-  owned. If a plugin is not loaded, its endpoints return
-  `404 E_NOT_CONFIGURED`.
+  owned. If a plugin is not loaded, its path is not registered and
+  the router answers `404 E_NOT_FOUND` ("no such endpoint") - there
+  is no code that distinguishes "not configured" from "unknown".
 - Designed to underpin a future WebUI (live monitoring + plugin
   management) - discoverable, versioned, machine-readable error shape.
 - Inherits the Phase-8 S3 hardened HTTP framer (`core/iostream.lua:
@@ -105,10 +106,9 @@ shape. The state machine becomes:
                  ╲── any smuggling-defence trigger (TE, multi-CL, ...) ─►  emit{reject = 400}; done
 
 [collecting-body]  ── enough bytes received ─►  emit{method, target, version, headers, body=<CL bytes>}; done
-                ╲
-                 ╲── socket EOF before CL bytes ─►  emit{reject = 400}; done
-                ╲
-                 ╲── per-push limit / overflow guard tripped ─►  emit{reject = 413}; done
+                (mid-body socket EOF emits NOTHING: no close-hook, the connection is torn
+                 down and the framer state is GC'd - there is no per-push 413 guard here,
+                 413 fires only on the declared Content-Length during header parse)
 
 [done]  any further push  ─►  returns nil, false  (trailing bytes discarded)
 ```
@@ -192,7 +192,11 @@ the core router does everything else.
 
 ## 4. Auth model
 
-Token-based bearer auth with two scopes: `read` and `admin`.
+Token-based bearer auth with three scopes: `none`, `read`, and
+`admin`. `none` marks routes that skip the router's bearer gate -
+unauthenticated routes like `/health` and plugin-self-auth routes
+like the webhook receiver (the handler does its own auth); `read`
+and `admin` are token-gated. §4.4 details each.
 
 ### 4.1 cfg shape
 
@@ -206,9 +210,12 @@ http_api_tokens = {
 - Map key = token (opaque string, operator-generated). Any non-empty
   string works syntactically; recommended ≥32 bytes from
   `/dev/urandom` base64-encoded for adequate entropy.
-- `scope`: required, exactly one of `"read"` or `"admin"`. Any other
-  value rejects the entry at startup with a logged error and the
-  token does not become active.
+- `scope`: required, exactly one of `"read"` or `"admin"`. A
+  malformed entry (bad scope or wrong shape) is dropped per-entry at
+  startup: only the offending entry is removed, the remaining valid
+  tokens stay active, and a warning is logged. (An earlier version
+  invalidated the WHOLE table on a single bad entry and left the
+  listener unbound; that is fixed.)
 - `comment`: optional, free-form; surfaced in `api_audit.log` for
   attribution.
 - Empty table or missing key = API is reachable but answers `401`
@@ -230,20 +237,21 @@ http_api_tokens = {
 - No query-string fallback (tokens in URLs leak into proxy logs).
 - Constant-time comparison required: Lua's `==` on strings short-
   circuits at first mismatch byte, leaking length and prefix-match
-  timing. Phase 1 ships a small `adclib.constant_time_eq( a, b )`
-  in C (XOR-accumulate over equal-length strings, single branch on
-  final accumulator). Interim Lua fallback while the C function is
-  in review: same algorithm in pure Lua with Lua 5.4 native bitwise
-  (`~`/`|`) / `string.byte` (timing-leak-free at the Lua level; the JIT may
-  still optimize, but our hub uses plain Lua 5.4 interpreter, not
-  LuaJIT, so the constant-time property holds).
+  timing. The hub ships `adclib.constant_time_eq( a, b )` in C
+  (XOR-accumulate over equal-length strings, single branch on the
+  final accumulator); it is the active path whenever `adclib` is
+  loaded - the normal case. A pure-Lua fallback (same algorithm with
+  Lua 5.4 native bitwise `~`/`|` / `string.byte`) runs ONLY in
+  stripped builds without `adclib`. Both are timing-leak-free at the
+  Lua level; our hub uses the plain Lua 5.4 interpreter, not LuaJIT,
+  so the constant-time property holds.
 
 ### 4.4 Scope semantics
 
 | Scope | Can | Cannot |
 |---|---|---|
 | `none` | Reached without a bearer token; the route is part of the route table and listed by `/v1/endpoints`. Used by `/health` and by plugins that do their OWN authentication (e.g. `etc_webhook`'s HMAC-signed webhook routes - the handler verifies the signature over `req.raw_body`). | n/a (no router auth gate; the handler authenticates) |
-| `read` | GET endpoints + `GET /v1/endpoints` filtered to {`none`, `read`} routes | Any non-GET; admin-scoped GETs (none planned but reserved) |
+| `read` | GET endpoints + `GET /v1/endpoints` filtered to {`none`, `read`} routes | Any non-GET; admin-scoped GETs (these DO ship - e.g. `GET /v1/log/api`, `/v1/log/error`, `/v1/log/cmd`, `/v1/log/audit`) |
 | `admin` | Everything `read` + all writes (POST/PUT/PATCH/DELETE) + admin-scoped GETs | n/a |
 
 The dispatcher checks scope BEFORE invoking the handler. A scope
@@ -474,9 +482,11 @@ symmetric:
   at registration time and the second plugin's `onStart` returns
   false. Operator sees a startup error in `error.log`; hub continues
   with the first registration.
-- Registration is single-shot per plugin per route; idempotent re-
-  registration in the same `onStart` (same method + path + handler)
-  is a no-op.
+- Registration is single-shot per plugin per route: a duplicate
+  method + path always raises "duplicate route" at registration
+  time, regardless of handler identity. There is no same-handler
+  no-op - a second `register` for an already-claimed method + path
+  is an error.
 
 ### 5.3 Naming convention
 
@@ -536,9 +546,12 @@ Supported field-spec keys: `type` (`"string"` / `"integer"` /
 (strings), `pattern` (Lua pattern - NOT PCRE; `%d` is digit, `.`
 matches any char, no `\d` / `\w`; WebUI builders MUST be told this).
 
-For `type = "array"` and `"object"` the router validates ONLY the
-top-level shape (is-array vs is-object, is-present). Nested item
-or property validation is the handler's job. Rationale: phase 1
+For `type = "array"` and `"object"` the router validates ONLY that
+the value is a table and is present - it does NOT distinguish array
+from object (both collapse to a `type == "table"` check), so
+`type = "array"` accepts an object and vice-versa. Array-vs-object,
+plus nested item or property validation, is the handler's job.
+Rationale: phase 1
 endpoints (see catalog §10) all have flat request bodies; a full
 recursive validator is bloat we don't pay for until a real
 nested-body endpoint shows up. The schema mini-spec is
@@ -586,7 +599,8 @@ req = {
     token_scope = "admin",
     source_ip   = "127.0.0.1",                 -- for audit log
     idempotency_key = nil,                     -- string if client sent X-Idempotency-Key
-    request_id  = "01HKE7...",                 -- client-sent X-Request-ID, or auto-generated UUIDv4
+    request_id  = "01HKE7...",                 -- client-sent X-Request-ID, or an auto-generated
+                                               -- UUIDv4-SHAPED id (NOT a real UUIDv4 - see §6.5)
     confirm     = false,                       -- true iff client sent X-Confirm: yes
 }
 ```
@@ -651,10 +665,11 @@ req = {
   the WebUI polls.
 - Exceeded ⇒ `429 E_RATE_LIMITED` with `Retry-After: <seconds>` header.
 - Buckets share `core/ratelimit.lua` infrastructure with the ADC
-  side. Per-token buckets are keyed on the resolved token *label*
-  (non-secret comment + first4...last4); the full token never
-  enters the bucket map, so the rate-limit state cannot leak
-  secrets even if dumped.
+  side. Per-token buckets are keyed on an internal `bucket_id`
+  (first 8 + last 8 chars of the token = 16 chars, or the whole
+  token when it is shorter than 16); no comment is included. The
+  full token never enters the bucket map, so the rate-limit state
+  cannot leak secrets even if dumped.
 - The failed-auth bucket (§4.8) is checked BEFORE the token bucket:
   an attacker grinding tokens hits the failed-auth defences first.
 - `/health` is NOT rate-limited (probes are noisy by design;
@@ -699,7 +714,10 @@ GET /v1/users?limit=100&offset=0
 }
 ```
 
-- `next_offset` is `null` when the page is the last one.
+- `next_offset` is OMITTED (the JSON key is absent, not `null`) on
+  the last page - dkjson does not serialise a nil field. Clients
+  MUST treat a MISSING `next_offset` as "no more pages" rather than
+  testing for `null`.
 
 ### Filtering and sorting (#264)
 
@@ -752,9 +770,13 @@ through it. Cap `max_lines = 1000`; clamping rules follow §6.4.
 
 - If the client sends `X-Request-ID: <opaque>`, the router echoes it
   in the response header and in the audit log.
-- If the client does NOT send one, the router generates a UUIDv4 and
-  echoes it back. The client can then correlate its log line with
-  the audit log entry without having to invent IDs.
+- If the client does NOT send one, the router generates a
+  UUIDv4-shaped id (8-4-4-4-12 hex with the version nibble pinned to
+  4) and echoes it back. It is NOT a real UUIDv4 - the variant nibble
+  is unconstrained and `math.random` is not a CSPRNG - so it is a
+  log-correlation handle, not a cryptographic uniqueness guarantee.
+  The client can then correlate its log line with the audit log entry
+  without having to invent IDs.
 
 ### 6.6 OPTIONS + HEAD auto-support
 
@@ -870,11 +892,10 @@ discriminator. WebUI / clients pattern-match on `code`, surface
 | `E_CONFIRMATION_REQUIRED` | 400 | Endpoint requires `X-Confirm: yes` header (§4.6) |
 | `E_UNAUTHENTICATED` | 401 | No / bad bearer token |
 | `E_FORBIDDEN` | 403 | Token scope insufficient for endpoint |
-| `E_NOT_FOUND` | 404 | Resource does not exist (e.g. sid not online) |
-| `E_NOT_CONFIGURED` | 404 | Endpoint path exists in spec but plugin is not loaded |
+| `E_NOT_FOUND` | 404 | Resource does not exist (e.g. sid not online), or the path is not registered at all ("no such endpoint" - e.g. the plugin that would own it is not loaded) |
 | `E_METHOD_NOT_ALLOWED` | 405 | Method not implemented for path; `Allow` header lists what is |
 | `E_CONFLICT` | 409 | State conflict (e.g. user already banned) |
-| `E_PAYLOAD_TOO_LARGE` | 413 | Body exceeds `MAXBODY` (64 KiB) |
+| `E_PAYLOAD_TOO_LARGE` | 413 | Reserved only. A 413 is emitted by the framer as transport-level `text/plain` ("413 Payload Too Large") with NO JSON envelope, so it carries no machine-readable `error.code` - unlike every routed error above |
 | `E_UNSUPPORTED_MEDIA_TYPE` | 415 | Request body present but Content-Type is not JSON |
 | `E_RATE_LIMITED` | 429 | Token bucket or failed-auth bucket empty; check `Retry-After` |
 | `E_INTERNAL` | 500 | Handler raised; details in `error.log` only |
@@ -927,11 +948,13 @@ New cfg key `log_api_audit` (default `true`) gates the stream;
 operators can disable via cfg + reload. One line per non-GET request:
 
 ```
-[2026-05-22 | 14:32:11] POST /v1/bans 200 token=operator-3k...kd2 (ops cli) src=127.0.0.1 idem=- body={"target_type":"nick","target":"baduser","duration_minutes":60}
+[2026-05-22 | 14:32:11] POST /v1/bans 200 token=ops cli (oper...3kd2) src=127.0.0.1 idem=- req_id=8f14a2c0-1b3d-4e5a-9c7f-2a6b1d0e4f88 body={"target_type":"nick","target":"baduser","duration_minutes":60}
 ```
 
 - Token field shows first + last 4 chars (full token never in logs).
-- `comment` field from cfg appears in parens.
+- `comment` field from cfg (when set) appears BEFORE the parens; the
+  parens hold the `first4...last4` token fragment. A `req_id=` field
+  always sits between `idem=` and `body=`.
 - Body is JSON-serialised, max 512 bytes (truncated to 509 plus `...`
   if longer), control-bytes replaced with `?` (see
   `core/http_router.lua:logsafe_body`). **The 512-byte truncation is a log-
@@ -1009,8 +1032,9 @@ scope-filtered to what the calling token can reach:
 }
 ```
 
-- A `read` token sees only `read`-scoped endpoints.
-- An `admin` token sees both.
+- A `read` token sees `none`- and `read`-scoped endpoints (e.g.
+  `/health`).
+- An `admin` token sees all scopes.
 - The `/v1/endpoints` route is itself listed in its own output (the
   registry is self-describing).
 - Plugin authors who omit `meta` get `description=null`, schemas
@@ -1022,7 +1046,8 @@ scope-filtered to what the calling token can reach:
 
 Distinguishes **core endpoints** (hub-intrinsic, always available
 when the listener is bound) from **plugin endpoints** (registered
-when the named plugin is loaded; 404 `E_NOT_CONFIGURED` otherwise).
+when the named plugin is loaded; a disabled plugin has no registered
+route, so it answers 404 `E_NOT_FOUND` like any unknown path).
 
 > **Authorisation on the HTTP path.** Across every endpoint below, the
 > ADC-side level / permission guards (an operator's `permission[level]`
@@ -1063,7 +1088,8 @@ when the named plugin is loaded; 404 `E_NOT_CONFIGURED` otherwise).
 Mapped from existing `+cmd` operations. Each row's `plugin` column
 names the bundled plugin that registers the endpoint; if that plugin
 is disabled in `cfg.scripts`, the endpoint returns 404
-`E_NOT_CONFIGURED`.
+`E_NOT_FOUND` (the router does not distinguish a disabled plugin from
+an unknown path).
 
 #### User control
 
@@ -1221,7 +1247,7 @@ is disabled in `cfg.scripts`, the endpoint returns 404
 | GET | `/v1/log/cmd?lines=N` | admin | `etc_cmdlog` [^http-log-cmd-1] |
 | GET | `/v1/log/audit?lines=N` | admin | `etc_auditlog` (#84) [^http-log-audit-1] |
 
-[^http-log-audit-1]: Registered by the `etc_auditlog` plugin, NOT hub-intrinsic - returns 404 `E_NOT_CONFIGURED` when that plugin is disabled. Tail of today's staff-action audit log (`log/audit-YYYY-MM-DD.jsonl`); query `?lines=N` (default 200, max 1000); response `{lines, returned, total_lines}` matches sibling tail endpoints; multi-day reads are filesystem-side (`jq` / `cat`) by design.
+[^http-log-audit-1]: Registered by the `etc_auditlog` plugin, NOT hub-intrinsic - returns 404 `E_NOT_FOUND` when that plugin is disabled. Tail of today's staff-action audit log (`log/audit-YYYY-MM-DD.jsonl`); query `?lines=N` (default 200, max 1000); response `{lines, returned, total_lines}` matches sibling tail endpoints; multi-day reads are filesystem-side (`jq` / `cat`) by design.
 
 [^http-log-error-1]: Query `?lines=N` (default 200, max 1000 per §6.4 tail-style cap). Non-numeric or out-of-range values are clamped to the default, not rejected. Returns 200 with `data: {lines:[...], returned, total_lines}`. `total_lines` is the file's full line count (operators can spot "the last 200 of 1500" at a glance). Missing log file returns 200 with `lines: []` and `total_lines: 0` (matches the ADC path's "No errors." semantic without surfacing a 404 for a file that has not been written yet).
 | DELETE | `/v1/log/{name}` | admin | `etc_log_cleaner` - `{name}` ∈ `error`, `cmd` [^http-log-clean-1] |
@@ -1363,7 +1389,7 @@ reviewable and shippable.
   header for method mismatch (§6.6).
 - New module `core/http_router.lua` (or extend `core/http.lua`):
   route table, dispatch, auth, scope, envelope, JSON marshalling,
-  error mapping, rate-limit (token + per-IP failed-auth), idempotency-
+  error mapping, rate-limit (token + per-prefix failed-auth), idempotency-
   key cache, audit log, X-Request-ID generation, schema validation.
 - New plugin API global `hub.http_register(...)` with optional `meta`
   (description + request_schema + response_schema).
@@ -1476,8 +1502,9 @@ closed; details in their respective PRs / docs.
   current; a `/v2` rollout overlaps with `/v1` for one full minor
   version before `/v1` is removed.
 - **Schema validation depth.** Phase 1 ships the minimal type +
-  required + enum + min/max validator. Full JSON-Schema is out of
-  scope unless a real client demand surfaces.
+  required + enum + min/max + min_length/max_length/pattern
+  validator. Full JSON-Schema is out of scope unless a real client
+  demand surfaces.
 
 ---
 

--- a/tests/unit/cfg_defaults_test.lua
+++ b/tests/unit/cfg_defaults_test.lua
@@ -48,12 +48,17 @@ local _real = {
     ipairs = ipairs,
     -- const.CONFIG_PATH is read into an upvalue at load; any string is fine.
     const  = { CONFIG_PATH = "cfg/" },
-    -- types.utf8 + types.get "<name>" are captured into upvalues at load;
-    -- the returned validators are never called here, so identity stubs work.
+    -- types.utf8 + types.get "<name>" are captured into upvalues at load.
+    -- The identity stub (always true) is exercised by the http_api_tokens
+    -- validator test below (it calls types_table(value)); returning true
+    -- lets that test drive the per-entry filter path.
     types  = {
         utf8 = function() return true end,
         get  = function() return function() return true end end,
     },
+    -- http_api_tokens validator resolves `use "out"` lazily to log dropped
+    -- entries; a no-op error sink keeps that path silent under test.
+    out    = { error = function() end },
 }
 
 _G.use = function( name )
@@ -130,6 +135,54 @@ for _, key in ipairs( {
     local sok, sval = pcall( cfg_get, key )
     assert_true( key .. ": registered + resolves without crash", sok )
     assert_true( key .. ": default is a boolean", type( sval ) == "boolean" )
+end
+
+----------------------------------------------------------------------
+-- http_api_tokens validator: per-entry (NOT whole-table) validation.
+-- A single malformed entry must not invalidate the whole map - that
+-- path returned false, the cfg loader reset the key to {}, and the HTTP
+-- listener then refused to bind: one scope typo locked the operator out.
+-- The validator now drops only the bad entries, keeps the valid tokens,
+-- and returns true.
+-- RED pre-fix: a mixed good/bad map returned false (whole-table reject)
+-- and left the map unmutated.
+----------------------------------------------------------------------
+
+do
+    local validator = settings.http_api_tokens[ 2 ]
+
+    -- mixed: one valid admin token + one bad-scope typo.
+    local mixed = {
+        [ "goodtoken-long-enough-000001" ] = { scope = "admin", comment = "ops" },
+        [ "typoscope-long-enough-000002" ] = { scope = "administrator" },   -- bad
+    }
+    assert_eq( "http_api_tokens: mixed map validates true (per-entry)",
+        validator( mixed ), true )
+    assert_true( "http_api_tokens: valid token survives",
+        mixed[ "goodtoken-long-enough-000001" ] ~= nil )
+    assert_eq( "http_api_tokens: valid token scope intact",
+        mixed[ "goodtoken-long-enough-000001" ]
+            and mixed[ "goodtoken-long-enough-000001" ].scope, "admin" )
+    assert_true( "http_api_tokens: bad-scope entry dropped",
+        mixed[ "typoscope-long-enough-000002" ] == nil )
+
+    -- all-valid: unchanged, true.
+    local allgood = {
+        [ "aaaa-long-enough-token-0001" ] = { scope = "read" },
+        [ "bbbb-long-enough-token-0002" ] = { scope = "admin", comment = "x" },
+    }
+    assert_eq( "http_api_tokens: all-valid validates true",
+        validator( allgood ), true )
+    assert_true( "http_api_tokens: all-valid keeps both",
+        allgood[ "aaaa-long-enough-token-0001" ] ~= nil
+        and allgood[ "bbbb-long-enough-token-0002" ] ~= nil )
+
+    -- all-bad: everything dropped, still true (empty map -> listener
+    -- simply won't bind, same as no tokens; NOT a hard reject).
+    local allbad = { [ "onlytoken-long-enough-0003" ] = { scope = "nope" } }
+    assert_eq( "http_api_tokens: all-bad validates true",
+        validator( allbad ), true )
+    assert_true( "http_api_tokens: all-bad map emptied", next( allbad ) == nil )
 end
 
 ----------------------------------------------------------------------

--- a/tests/unit/http_router_test.lua
+++ b/tests/unit/http_router_test.lua
@@ -4,8 +4,10 @@
 
     Unit tests for the pure-Lua-bit functions of core/http_router.lua
     (constant_time_eq, validate_schema, envelope helpers, token
-    resolution, schema validator, request-id shape). Dispatch is
-    smoke-tested end-to-end against a real hub.
+    resolution, schema validator, request-id shape) plus targeted
+    dispatch() coverage (OPTIONS introspection, the top-level body-shape
+    guard, handler-crash traceback logging). Full end-to-end request
+    paths are smoke-tested against a real hub.
 
     The router uses `use "cfg"` and `use "out"` and `use "dkjson"`
     at file scope; we stub them here so the module can load in a
@@ -26,6 +28,7 @@
 local _stub_cfg_tokens = { }
 local _stub_cfg_idem_cap = nil    -- nil = use default; integer overrides
 local _last_audit_args = nil
+local _last_error_args = nil
 local _mock_cfg = {
     get = function( key )
         if key == "http_api_tokens" then return _stub_cfg_tokens end
@@ -37,7 +40,11 @@ local _mock_cfg = {
 }
 local _mock_out = {
     put       = function() end,
-    error     = function() end,
+    -- capture so the Fix-B handler-crash test can assert the logged
+    -- text carries a Lua traceback (xpcall + debug.traceback), not just
+    -- the bare error message. out_error is snapshotted to a local at
+    -- module load, so this capturing closure must exist BEFORE loadfile.
+    error     = function( ... ) _last_error_args = { ... } end,
     api_audit = function( ... ) _last_audit_args = { ... } end,
 }
 local _mock_dkjson = {
@@ -60,7 +67,17 @@ local _mock_dkjson = {
             if not ok then return nil, nil, t end
             return t
         end
-        return nil, nil, "stub: only OBJ:{...} accepted"
+        -- "ARR:" mirrors real dkjson tagging a decoded JSON array with the
+        -- metatable {__jsontype="array"} - the body-shape guard's signal.
+        if s:sub( 1, 4 ) == "ARR:" then
+            local fn = loadstring and loadstring( "return " .. s:sub( 5 ) )
+                or load( "return " .. s:sub( 5 ) )
+            if not fn then return nil, nil, "stub: bad ARR body" end
+            local ok, t = pcall( fn )
+            if not ok then return nil, nil, t end
+            return setmetatable( t, { __jsontype = "array" } )
+        end
+        return nil, nil, "stub: only OBJ:{...} / ARR:{...} accepted"
     end,
 }
 
@@ -73,12 +90,22 @@ local _mock_dkjson = {
 -- a real build.
 local _mock_socket = { gettime = function( ) return os.time( ) end }
 
+-- dispatch() resolves `use "ratelimit"` at request time for any non-
+-- X-Confirm route; a permissive stub lets the body-shape + handler-crash
+-- dispatch tests run without a real token bucket. (Bucket behaviour is
+-- covered by ratelimit_test.lua + smoke.)
+local _mock_ratelimit = {
+    http_token             = function( ) return true end,
+    http_token_retry_after = function( ) return 60 end,
+}
+
 local _real = {
     string = string, table = table, os = os, io = io, math = math,
     pairs = pairs, ipairs = ipairs, tostring = tostring, tonumber = tonumber,
-    type = type, pcall = pcall, select = select, error = error,
+    type = type, pcall = pcall, xpcall = xpcall, select = select, error = error,
+    getmetatable = getmetatable, debug = debug,
     cfg = _mock_cfg, out = _mock_out, dkjson = _mock_dkjson,
-    socket = _mock_socket, adclib = false,
+    socket = _mock_socket, adclib = false, ratelimit = _mock_ratelimit,
 }
 _G.use = function( name )
     local v = _real[ name ]
@@ -408,6 +435,101 @@ do
     -- anonymous OPTIONS on an unknown path: 401 (unchanged).
     eq( "OPTIONS anon unknown path -> 401", ( opt( "/v1/unknown", nil ) ), 401 )
 
+    router.unregister_all( )
+    _stub_cfg_tokens = { }
+end
+
+----------------------------------------------------------------------
+-- dispatch body-shape guard (§6.1): a top-level JSON *array* must be
+-- rejected, not silently accepted as a body whose named fields all read
+-- nil. Real dkjson tags a decoded array with metatable
+-- {__jsontype="array"}; the router rejects on that tag (the mock mirrors
+-- the tag via its "ARR:" prefix; the real tag is pinned below).
+-- RED pre-fix: the array body reached the handler and returned 200.
+----------------------------------------------------------------------
+
+do
+    router.unregister_all( )
+    local seen_body
+    local h = function( req )
+        seen_body = req.body
+        return { status = 200, data = { got = "ok" } }
+    end
+    router.register( "POST", "/v1/body", "admin", h )
+    _stub_cfg_tokens = { [ "ADMINTOKEN00000001" ] = { scope = "admin" } }
+
+    local function post( raw )
+        return router.dispatch( {
+            method  = "POST",
+            target  = "/v1/body",
+            headers = {
+                [ "authorization" ] = "Bearer ADMINTOKEN00000001",
+                [ "content-type" ]  = "application/json; charset=utf-8",
+            },
+            body = raw,
+        }, "127.0.0.1" )
+    end
+
+    -- object body: accepted, handler runs, body reaches it.
+    seen_body = nil
+    local st_ok = post( "OBJ:{ topic = 'hello' }" )
+    eq( "body-guard: object body -> 200", st_ok, 200 )
+    eq( "body-guard: object body reaches handler", seen_body and seen_body.topic, "hello" )
+
+    -- array body: rejected 400 BEFORE the handler; distinct message.
+    seen_body = nil
+    local st_arr, body_arr = post( "ARR:{ 1, 2, 3 }" )
+    eq( "body-guard: array body -> 400", st_arr, 400 )
+    local arr_err = body_arr and body_arr._encoded and body_arr._encoded.error
+    eq( "body-guard: array body code E_BAD_JSON", arr_err and arr_err.code, "E_BAD_JSON" )
+    eq( "body-guard: array body message names array",
+        arr_err and arr_err.message, "body must be a JSON object, not a JSON array" )
+    eq( "body-guard: array body never reached handler", seen_body, nil )
+
+    router.unregister_all( )
+    _stub_cfg_tokens = { }
+end
+
+----------------------------------------------------------------------
+-- Pin the external assumption Fix A relies on: the BUNDLED dkjson tags a
+-- decoded top-level array with __jsontype="array" and an object with
+-- "object". If a future dkjson bump drops the tag, the body-shape guard
+-- above silently stops rejecting arrays; catch that here, not in prod.
+----------------------------------------------------------------------
+
+do
+    local realdk = assert( loadfile( "dkjson/dkjson.lua" ) )( )
+    local arr = realdk.decode( "[1,2,3]" )
+    local obj = realdk.decode( "{\"a\":1}" )
+    eq( "dkjson: decoded array tagged __jsontype=array",
+        getmetatable( arr ) and getmetatable( arr ).__jsontype, "array" )
+    eq( "dkjson: decoded object tagged __jsontype=object",
+        getmetatable( obj ) and getmetatable( obj ).__jsontype, "object" )
+end
+
+----------------------------------------------------------------------
+-- dispatch handler-crash logging (Fix B): an uncaught handler error is
+-- caught (500 E_INTERNAL) AND logged WITH its Lua traceback (xpcall +
+-- debug.traceback), not just the bare message (pcall).
+-- RED pre-fix (pcall): the logged text carried the message but no
+-- "stack traceback:" section.
+----------------------------------------------------------------------
+
+do
+    router.unregister_all( )
+    router.register( "GET", "/v1/boom", "read", function( ) error( "kaboom" ) end )
+    _stub_cfg_tokens = { [ "READTOKEN000000001" ] = { scope = "read" } }
+    _last_error_args = nil
+    local st = router.dispatch( {
+        method  = "GET",
+        target  = "/v1/boom",
+        headers = { [ "authorization" ] = "Bearer READTOKEN000000001" },
+        body    = nil,
+    }, "127.0.0.1" )
+    eq( "handler-crash: 500 E_INTERNAL", st, 500 )
+    local logged = _last_error_args and table.concat( _last_error_args, "" ) or ""
+    eq( "handler-crash: message logged", logged:find( "kaboom", 1, true ) ~= nil, true )
+    eq( "handler-crash: traceback logged", logged:find( "stack traceback", 1, true ) ~= nil, true )
     router.unregister_all( )
     _stub_cfg_tokens = { }
 end


### PR DESCRIPTION
Promote `dev` to `master`. Brings the HTTP API implementation + spec reconciliation (groundwork for the upcoming WebUI):

- **#598** - http correctness fixes: top-level JSON array body reject, handler-error tracebacks (xpcall + debug.traceback), per-entry `http_api_tokens` validation. New RED-proven regression tests; CI Smoke green on both legs.
- **#599** - `docs/HTTP_API.md` reconciled with the code (~16 prose/contract corrections; endpoint catalog was already in lockstep).

Both squash-landed on `dev` and CI-green there (Smoke Linux + Windows, Analyze, Docker build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
