### PR TITLE
http: X-Actor audit attribution for the HTTP API (#82 WebUI)

### DIFF
--- a/core/http_router.lua
+++ b/core/http_router.lua
@@ -494,6 +494,28 @@ local function logsafe_body( raw_body )
     return ( s:gsub( "%c", "?" ) )
 end
 
+-- X-Actor is a CLIENT-ASSERTED correlation hint (#82 WebUI): the BFF
+-- holds one hub token and sets X-Actor to the operator nick behind
+-- each call, so api_audit can show WHO acted, not just which token.
+-- It is audit-only and NEVER an authorization input - the bearer
+-- token stays the authenticated principal. Sanitised like any other
+-- attacker-supplied header value: control bytes AND whitespace AND `=`
+-- all become `?` (so the value can never introduce an audit-line field
+-- boundary - a `src=`/`body=` forged ahead of the real one), then
+-- capped at 64 (the auth-verify nick contract). A reguser nick that
+-- legitimately contains a space therefore renders `foo?bar` in the
+-- hint - acceptable: `token=` remains the authoritative identity, and
+-- a space-free field keeps the log machine-parseable. Returns nil for
+-- absent/empty so the caller renders `-`.
+local function logsafe_actor( raw_actor )
+    if not raw_actor or raw_actor == "" then return nil end
+    local s = raw_actor
+    if string_len( s ) > 64 then
+        s = string_sub( s, 1, 64 )
+    end
+    return ( s:gsub( "[%c%s=]", "?" ) )
+end
+
 -- Per-route audit-body redaction (§6.8). Routes that ingest secrets
 -- (password rotation, reguser POST) declare `audit_redact_body =
 -- true` in their meta; dispatch sets req._audit_redact_body after
@@ -511,9 +533,19 @@ audit_log = function( req, status )
     else
         body_field = logsafe_body( req.raw_body )
     end
+    -- actor is recorded ONLY for a request that carries a real
+    -- authenticated bearer principal (req.token_label set by the auth
+    -- block) and is not a rejected probe (_audit_skip_body). Both
+    -- guards are needed: the 429-prefix brute-force path sets a
+    -- SYNTHETIC token_label yet is unauthenticated (skip_body set), and
+    -- an anonymous call to a scope="none" route (the webhook receiver)
+    -- has no token_label yet does not set skip_body. Either alone would
+    -- let an anonymous caller spoof a chosen actor= string in the file.
+    local actor_field = ( not req._audit_skip_body and req.token_label and req.actor ) or "-"
     out_api_audit(
         req.method, " ", req.path, " ", tostring( status ),
         " token=", ( req.token_label or "-" ),
+        " actor=", actor_field,
         " src=", ( req.source_ip or "-" ),
         " idem=", ( req.idempotency_key or "-" ),
         " req_id=", ( req.request_id or "-" ),
@@ -624,6 +656,7 @@ dispatch = function( framer_unit, source_ip )
                      or generate_request_id( ),
         idempotency_key = framer_unit.headers[ "x-idempotency-key" ],
         confirm    = ( framer_unit.headers[ "x-confirm" ] == "yes" ),
+        actor      = logsafe_actor( framer_unit.headers[ "x-actor" ] ),
     }
 
     -- Headers we always echo regardless of outcome.

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -602,6 +602,8 @@ req = {
     request_id  = "01HKE7...",                 -- client-sent X-Request-ID, or an auto-generated
                                                -- UUIDv4-SHAPED id (NOT a real UUIDv4 - see §6.5)
     confirm     = false,                       -- true iff client sent X-Confirm: yes
+    actor       = "alice",                     -- client-sent X-Actor (§6.7), sanitised; nil if
+                                               -- absent. Audit-only correlation hint, NOT authz.
 }
 ```
 
@@ -805,6 +807,40 @@ through it. Cap `max_lines = 1000`; clamping rules follow §6.4.
   at all". Anonymous callers do NOT see 405 - they get 401 first
   (no path-existence leak to unauthenticated callers).
 
+### 6.7 X-Actor (audit attribution)
+
+Some deployments front the API with a service that holds ONE hub
+token and acts on behalf of many operators - the WebUI BFF (#82) is
+the reference case: it authenticates the operator itself, then calls
+the hub with its single admin token. Without extra information the
+audit log would attribute every such call to that one token, losing
+"who actually did this".
+
+- If the caller sends `X-Actor: <nick>`, the router records it in the
+  audit log as an `actor=` field (§8), alongside the authenticated
+  `token=` field. The token remains the authenticated principal; the
+  actor is the caller's CLAIM about who is behind the call.
+- **X-Actor is never an authorization input.** It does not affect
+  routing, scope, rate-limit buckets, or any handler decision - it is
+  purely an audit-correlation hint. A token holder can set it to any
+  string, so treat `actor=` as "the token holder asserted this nick",
+  not as a verified identity. The trust boundary is the token; the
+  actor is only as trustworthy as whoever holds it (for the WebUI,
+  the BFF, which verified the operator via `POST /v1/auth/verify`).
+- The value is sanitised exactly like any attacker-supplied header:
+  control bytes, whitespace, and `=` all become `?` (so the value can
+  never introduce an audit-line field boundary - e.g. forge a `src=`
+  ahead of the real one), then it is capped at 64 chars (the
+  auth-verify nick contract). A reguser nick that legitimately contains
+  a space therefore appears as `foo?bar` in the hint; `token=` remains
+  the authoritative identity. Absent/empty renders as `-`.
+- It is recorded ONLY when the request carried a valid bearer token
+  (an authenticated principal). Every request without one renders
+  `actor=-`: the rejected probes (`401 / 404 / 405 / 429-prefix`) AND
+  anonymous calls to `scope="none"` routes such as the webhook
+  receiver. So an anonymous caller can never put a chosen `actor=`
+  string in the file - the authenticated `token=` is the gate.
+
 ---
 
 ## 7. Response shape
@@ -948,13 +984,21 @@ New cfg key `log_api_audit` (default `true`) gates the stream;
 operators can disable via cfg + reload. One line per non-GET request:
 
 ```
-[2026-05-22 | 14:32:11] POST /v1/bans 200 token=ops cli (oper...3kd2) src=127.0.0.1 idem=- req_id=8f14a2c0-1b3d-4e5a-9c7f-2a6b1d0e4f88 body={"target_type":"nick","target":"baduser","duration_minutes":60}
+[2026-05-22 | 14:32:11] POST /v1/bans 200 token=ops cli (oper...3kd2) actor=alice src=127.0.0.1 idem=- req_id=8f14a2c0-1b3d-4e5a-9c7f-2a6b1d0e4f88 body={"target_type":"nick","target":"baduser","duration_minutes":60}
 ```
 
 - Token field shows first + last 4 chars (full token never in logs).
 - `comment` field from cfg (when set) appears BEFORE the parens; the
-  parens hold the `first4...last4` token fragment. A `req_id=` field
-  always sits between `idem=` and `body=`.
+  parens hold the `first4...last4` token fragment. An `actor=` field
+  always sits between `token=` and `src=`; a `req_id=` field always
+  sits between `idem=` and `body=`.
+- `actor=` is the client-asserted operator nick from `X-Actor` (§6.7),
+  a correlation hint for services that front the API with one token
+  (the WebUI BFF). It is NEVER an authorization input - the `token=`
+  field remains the authenticated principal. It is `-` whenever there
+  is no authenticated bearer principal (rejected probes AND anonymous
+  `scope="none"` calls) or when no `X-Actor` header was sent, so an
+  anonymous caller cannot inject a chosen actor.
 - Body is JSON-serialised, max 512 bytes (truncated to 509 plus `...`
   if longer), control-bytes replaced with `?` (see
   `core/http_router.lua:logsafe_body`). **The 512-byte truncation is a log-

--- a/tests/unit/http_router_test.lua
+++ b/tests/unit/http_router_test.lua
@@ -626,6 +626,130 @@ do
 end
 
 ----------------------------------------------------------------------
+-- X-Actor audit field (#82 WebUI unified audit): the BFF holds one hub
+-- token and sets X-Actor to the operator nick behind each call so
+-- api_audit shows WHO acted, not just which token. actor is a client-
+-- asserted correlation hint, sanitised (control -> ?, capped 64) and
+-- suppressed on unauth/probe paths (never an authz input). Assertions
+-- run through the real dispatch() and inspect the variadic passed to
+-- out.api_audit (_last_audit_args). RED pre-feature: no actor= field
+-- exists at all, so every find below returns nil.
+----------------------------------------------------------------------
+
+do
+    router.unregister_all( )
+    router.register( "POST", "/v1/actortest", "admin",
+        function( ) return { status = 200, data = { ok = true } } end )
+    _stub_cfg_tokens = { [ "ADMINTOKEN00000001" ] = { scope = "admin" } }
+    local TOK = "ADMINTOKEN00000001"
+
+    local function audit_line_for( actor_hdr, tok )
+        _last_audit_args = nil
+        local headers = { [ "content-type" ] = "application/json; charset=utf-8" }
+        if tok then headers[ "authorization" ] = "Bearer " .. tok end
+        if actor_hdr ~= nil then headers[ "x-actor" ] = actor_hdr end
+        local st = router.dispatch( {
+            method  = "POST",
+            target  = "/v1/actortest",
+            headers = headers,
+            body    = "OBJ:{ }",
+        }, "127.0.0.1" )
+        local line = _last_audit_args and table.concat( _last_audit_args, "" ) or ""
+        return st, line
+    end
+
+    -- 1. present + authenticated: nick recorded, token still present,
+    --    actor sits between token= and src=.
+    local st1, l1 = audit_line_for( "alice", TOK )
+    eq( "actor: authenticated write -> 200", st1, 200 )
+    eq( "actor: nick recorded", l1:find( "actor=alice", 1, true ) ~= nil, true )
+    eq( "actor: token still present", l1:find( "token=", 1, true ) ~= nil, true )
+    local it, ia, is = l1:find( "token=", 1, true ),
+                       l1:find( "actor=", 1, true ),
+                       l1:find( " src=", 1, true )
+    eq( "actor: sits between token and src",
+        ( it and ia and is and it < ia and ia < is ) and true or false, true )
+
+    -- 2. absent -> actor=-
+    local _, l2 = audit_line_for( nil, TOK )
+    eq( "actor: absent -> dash", l2:find( "actor=-", 1, true ) ~= nil, true )
+
+    -- 3. control bytes sanitised to ?
+    local _, l3 = audit_line_for( "al\tice\n", TOK )
+    eq( "actor: control bytes -> ?", l3:find( "actor=al?ice?", 1, true ) ~= nil, true )
+
+    -- 3b. space and `=` neutralised too, so the value cannot forge an
+    --     audit-line field boundary (e.g. a spurious src=) ahead of the
+    --     real one. RED against a control-bytes-only sanitiser.
+    local _, l3b = audit_line_for( "a b=c src=9.9.9.9", TOK )
+    eq( "actor: space+= -> ?", l3b:find( "actor=a?b?c?src?9.9.9.9 src=", 1, true ) ~= nil, true )
+    eq( "actor: no forged src= survives in actor value",
+        l3b:find( "actor=a b=c src=9.9.9.9", 1, true ) == nil, true )
+
+    -- 3c. CONTRAST: logsafe_body (the body= field) must NOT be broadened
+    --     the way logsafe_actor is - a JSON body legitimately contains
+    --     spaces and `=`, and mangling them would corrupt the audit
+    --     record. Guards the two sanitisers against being unified.
+    _last_audit_args = nil
+    router.dispatch( {
+        method  = "POST",
+        target  = "/v1/actortest",
+        headers = {
+            [ "content-type" ] = "application/json; charset=utf-8",
+            [ "authorization" ] = "Bearer " .. TOK,
+        },
+        body = "OBJ:{ a = 'b c' }",
+    }, "127.0.0.1" )
+    local lbody = _last_audit_args and table.concat( _last_audit_args, "" ) or ""
+    eq( "body: spaces and = preserved (logsafe_body stays %c-only)",
+        lbody:find( "body=OBJ:{ a = 'b c' }", 1, true ) ~= nil, true )
+
+    -- 4. over 64 chars truncated to exactly 64 (no 65th)
+    local _, l4 = audit_line_for( string.rep( "x", 100 ), TOK )
+    eq( "actor: capped at 64",
+        l4:find( "actor=" .. string.rep( "x", 64 ) .. " src=", 1, true ) ~= nil, true )
+    eq( "actor: not 65",
+        l4:find( "actor=" .. string.rep( "x", 65 ), 1, true ) == nil, true )
+
+    -- 5. unauth probe (401): actor suppressed even though header present,
+    --    so an attacker cannot inject an actor string via 401/404 probes.
+    local st5, l5 = audit_line_for( "evil", nil )
+    eq( "actor: unauth probe -> 401", st5, 401 )
+    eq( "actor: probe suppresses actor", l5:find( "actor=-", 1, true ) ~= nil, true )
+    eq( "actor: probe drops attacker actor",
+        l5:find( "actor=evil", 1, true ) == nil, true )
+    eq( "actor: probe skips body", l5:find( "body=[skipped]", 1, true ) ~= nil, true )
+
+    -- 6. anonymous call to a scope="none" route (the webhook-receiver
+    --    class): auth is skipped so the handler runs (200) and the body
+    --    is NOT skipped, yet there is no authenticated principal - actor
+    --    MUST render `-`, never the caller-supplied string. This is the
+    --    path _audit_skip_body does NOT cover, so the gate keys on
+    --    token_label too.
+    router.register( "POST", "/v1/nonetest", "none",
+        function( ) return { status = 200, data = { ok = true } } end )
+    _last_audit_args = nil
+    local st6 = router.dispatch( {
+        method  = "POST",
+        target  = "/v1/nonetest",
+        headers = {
+            [ "content-type" ] = "application/json; charset=utf-8",
+            [ "x-actor" ]      = "evil",
+        },
+        body = "OBJ:{ }",
+    }, "127.0.0.1" )
+    local l6 = _last_audit_args and table.concat( _last_audit_args, "" ) or ""
+    eq( "actor: scope=none anon -> 200 (auth skipped)", st6, 200 )
+    eq( "actor: scope=none anon renders dash",
+        l6:find( "actor=-", 1, true ) ~= nil, true )
+    eq( "actor: scope=none anon drops attacker actor",
+        l6:find( "actor=evil", 1, true ) == nil, true )
+
+    router.unregister_all( )
+    _stub_cfg_tokens = { }
+end
+
+----------------------------------------------------------------------
 
 io.write( string.format( "\n%d checks, %d failures\n", checks, failures ) )
 os.exit( failures == 0 and 0 or 1 )


### PR DESCRIPTION
## What

Adds `X-Actor: <nick>` request-header support to the HTTP API audit log. A service that fronts the API with a single hub token - the WebUI BFF (#82) is the reference case - can now name the operator behind each call. The router records it as an `actor=` field in `api_audit.log`, between `token=` and `src=`.

`actor` is **audit-only**: it never affects routing, scope, rate-limit buckets, or any handler decision. The bearer `token=` stays the authenticated principal; `actor=` is a client-asserted correlation hint.

This is the 3rd and final hub-side deliverable for the WebUI unified-audit trail (after `POST /v1/auth/verify` #601 and its rate-limit).

## Security properties

Both hardened during pre-merge review (independent reviewer + maintainer spot-check):

- **Anonymous callers can never spoof an actor.** `actor` is emitted only when the request carries a real authenticated bearer principal (`req.token_label`) AND is not a rejected probe (`_audit_skip_body`). Both guards are needed: the 429-prefix brute-force path sets a *synthetic* `token_label` while unauthenticated, and an anonymous call to a `scope="none"` route (the webhook receiver) has *no* `token_label` yet does *not* set `_audit_skip_body`. Either guard alone leaks. (This was a real finding, caught + fixed in review.)
- **No audit-line field injection.** `logsafe_actor` neutralises control bytes, whitespace, and `=` (all -> `?`) then caps at 64 chars, so a valid-token holder cannot forge a `src=`/`body=` field ahead of the real one. `logsafe_body` stays `%c`-only (a JSON body legitimately contains spaces and `=`); a contrast test guards the two sanitisers against being unified.

## Tests

18 checks through the real `dispatch()` path, inspecting the variadic passed to `out.api_audit`. Every substantive assertion was proven **RED on the corresponding weaker code** (no emit line / skip-body-only gate / `%c`-only sanitiser). Full suite: 115 checks, 0 failures on Lua 5.4.8. No `smoke.yml` change (existing test file).

## Docs

New §6.7 X-Actor; the `req` struct, the §8 audit example line, and the field-position note updated. §6.x numbering is non-breaking (OPTIONS+HEAD stays §6.6; no code cross-reference touched).

Part of #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)