### PR TITLE
http: fix /v1/auth/verify crashing (getregusers on hub module, not hub.object())

### DIFF
--- a/core/http_router.lua
+++ b/core/http_router.lua
@@ -1665,7 +1665,10 @@ local function auth_verify_handler( req )
     end
     -- Reguser lookup. Nicks with spaces are stored escaped, so escape the
     -- incoming nick exactly as the ADC login path does before indexing.
-    local hub = use "hub"
+    -- getregusers/escapeto live on the hub OBJECT (core/hub.lua returns
+    -- { init, loop, object }), so resolve via .object() like every other
+    -- endpoint handler here - `use "hub"` alone has no getregusers.
+    local hub = ( use "hub" ).object( )
     local _, regs_by_nick = hub.getregusers( )
     local profile = regs_by_nick[ hub.escapeto( nick ) ]
     -- Treat an empty stored password as ABSENT: the reg/setpass paths

--- a/tests/unit/http_router_test.lua
+++ b/tests/unit/http_router_test.lua
@@ -37,9 +37,18 @@ local function _stub_hashpas( pw, salt )   -- deterministic stand-in for adclib.
     _hashpas_calls[ #_hashpas_calls + 1 ] = { pw = pw, salt = salt }
     return "H:" .. tostring( pw ) .. ":" .. tostring( salt )
 end
+-- Mirror the real hub module shape: core/hub.lua returns { init, loop, object },
+-- so getregusers/escapeto live on hub.object(), NOT on the module directly. A
+-- flat mock (getregusers on the top level) masked the auth-verify handler
+-- calling `use "hub".getregusers()` instead of `.object().getregusers()`, which
+-- 500s on a real hub. Keeping the mock faithful makes that class fail here.
 local _mock_hub = {
-    getregusers = function( ) return { }, _mock_regusers_by_nick, { } end,
-    escapeto    = function( s ) return s end,   -- identity: test nicks have no spaces
+    object = function( )
+        return {
+            getregusers = function( ) return { }, _mock_regusers_by_nick, { } end,
+            escapeto    = function( s ) return s end,   -- identity: test nicks have no spaces
+        }
+    end,
 }
 local _mock_cfg = {
     get = function( key )


### PR DESCRIPTION
## Problem

`POST /v1/auth/verify` (WebUI operator login, #82) returned **500 on every call** on a real hub - no login could ever succeed. The handler resolved the hub via `use "hub"` and called `hub.getregusers()` / `hub.escapeto()` directly on the module. Those functions live on the hub **object**: `core/hub.lua` returns `{ init, loop, object }`, and `getregusers`/`escapeto` are fields of `createhub()`'s table, reached via `hub.object()`. Both calls hit `nil` -> the handler raised -> 500.

Present on **master and dev**.

## Fix

Resolve via `( use "hub" ).object()` like every other endpoint handler in this file (e.g. `users_list_handler`).

## Why the tests missed it

`http_router_test.lua`'s `_mock_hub` exposed `getregusers`/`escapeto` flat on the module, so the handler's wrong access passed against the mock. This PR makes the mock faithful to the real module shape (both functions under `object()`), which **fails on the old handler and passes on the fixed one** (fail-first, demonstrated locally: buggy handler -> suite errors out; fixed -> 115 checks / 0 failures).

## Validation

- `http_router_test.lua`: 115/0 green with the fix; provably red without it.
- Live end-to-end on the devlab (`:dev` image + current core overlaid): real `dummy/test` login through the WebUI BFF -> hub -> `200 / level 100 / session`; direct `POST /v1/auth/verify` returns `{ok:true,data:{ok:true,level:100}}`, wrong password `{ok:true,data:{ok:false}}`.

Found by live testlab validation while building the WebUI login flow; unit tests with a mocked hub could not catch the module-vs-object mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)