### PR TITLE
Promote dev -> master: /v1/auth/verify hub.object() fix (#605)

### DIFF
--- a/core/http_router.lua
+++ b/core/http_router.lua
@@ -1665,7 +1665,10 @@ local function auth_verify_handler( req )
     end
     -- Reguser lookup. Nicks with spaces are stored escaped, so escape the
     -- incoming nick exactly as the ADC login path does before indexing.
-    local hub = use "hub"
+    -- getregusers/escapeto live on the hub OBJECT (core/hub.lua returns
+    -- { init, loop, object }), so resolve via .object() like every other
+    -- endpoint handler here - `use "hub"` alone has no getregusers.
+    local hub = ( use "hub" ).object( )
     local _, regs_by_nick = hub.getregusers( )
     local profile = regs_by_nick[ hub.escapeto( nick ) ]
     -- Treat an empty stored password as ABSENT: the reg/setpass paths

--- a/tests/unit/http_router_test.lua
+++ b/tests/unit/http_router_test.lua
@@ -37,9 +37,18 @@ local function _stub_hashpas( pw, salt )   -- deterministic stand-in for adclib.
     _hashpas_calls[ #_hashpas_calls + 1 ] = { pw = pw, salt = salt }
     return "H:" .. tostring( pw ) .. ":" .. tostring( salt )
 end
+-- Mirror the real hub module shape: core/hub.lua returns { init, loop, object },
+-- so getregusers/escapeto live on hub.object(), NOT on the module directly. A
+-- flat mock (getregusers on the top level) masked the auth-verify handler
+-- calling `use "hub".getregusers()` instead of `.object().getregusers()`, which
+-- 500s on a real hub. Keeping the mock faithful makes that class fail here.
 local _mock_hub = {
-    getregusers = function( ) return { }, _mock_regusers_by_nick, { } end,
-    escapeto    = function( s ) return s end,   -- identity: test nicks have no spaces
+    object = function( )
+        return {
+            getregusers = function( ) return { }, _mock_regusers_by_nick, { } end,
+            escapeto    = function( s ) return s end,   -- identity: test nicks have no spaces
+        }
+    end,
 }
 local _mock_cfg = {
     get = function( key )


### PR DESCRIPTION
Promotes the `/v1/auth/verify` fix (#605) to master.

The endpoint 500'd on every login (handler called `getregusers`/`escapeto` on `use "hub"` instead of `( use "hub" ).object()`), so the WebUI operator login could never work. Fix validated live end-to-end on the devlab (`dummy/test` -> 200 / level 100 / session) and via a fail-first unit test.

dev == master + this one squash commit; no other delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)