### PR TITLE
http: percent-decode captured path variables in match_path

### DIFF
--- a/core/http_router.lua
+++ b/core/http_router.lua
@@ -61,6 +61,7 @@ local string_match = string.match
 local string_gmatch = string.gmatch
 local string_lower = string.lower
 local string_byte = string.byte
+local string_char = string.char
 local table_concat = table.concat
 local table_insert = table.insert
 local table_remove = table.remove
@@ -288,12 +289,24 @@ local function compile_path_pattern( template )
     return pattern, vars
 end
 
+-- Percent-decode a captured path-variable value (RFC 3986 §2.1). Applied to
+-- the {var} captures ONLY, and AFTER route matching, so a %2F inside a value
+-- can never split a segment or re-route - it just yields a literal '/' in the
+-- value. Standard clients percent-encode path values (Go's net/http does), and
+-- reg nicks can carry non-ASCII / escaped chars, so without this the stored
+-- (un-encoded) key never matches. A lone/invalid '%' is left as-is.
+local function percent_decode( s )
+    return ( s:gsub( "%%(%x%x)", function( h )
+        return string_char( tonumber( h, 16 ) )
+    end ) )
+end
+
 match_path = function( route, path )
     local matches = { string_match( path, route.pattern ) }
     if matches[ 1 ] == nil then return nil end
     local path_vars = { }
     for i, name in ipairs( route.vars ) do
-        path_vars[ name ] = matches[ i ]
+        path_vars[ name ] = percent_decode( matches[ i ] )
     end
     return path_vars
 end
@@ -1794,6 +1807,8 @@ return {
     _resolve_token        = resolve_token,
     _generate_request_id  = generate_request_id,
     _auth_verify_handler  = auth_verify_handler,
+    _compile_path_pattern = compile_path_pattern,
+    _match_path           = match_path,
     _idem_lookup          = function( ... ) return idem_lookup( ... ) end,
     _idem_store           = function( ... ) return idem_store( ... ) end,
     _idem_clear           = function( ... ) return idem_clear( ... ) end,

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -586,7 +586,9 @@ struct passed to the handler:
 req = {
     method      = "POST",                      -- uppercase
     path        = "/v1/bans",                  -- with version prefix
-    path_vars   = { id = "abc" },              -- {} if no {name} segments
+    path_vars   = { id = "abc" },              -- {} if no {name} segments; values ARE
+                                               -- percent-decoded (a {name} nick may carry
+                                               -- non-ASCII / escaped chars)
     query       = { lines = "100" },           -- query-string parsed; values are RAW URL-encoded strings
                                                -- (the router does NOT %-decode; handlers do so per-endpoint)
     headers     = { ["content-type"] = "..." },-- lowercased keys

--- a/tests/unit/http_router_test.lua
+++ b/tests/unit/http_router_test.lua
@@ -758,6 +758,30 @@ do
     _stub_cfg_tokens = { }
 end
 
+-- ============================================================
+-- match_path percent-decodes captured path variables. The hub compares the raw
+-- path bytes against ADC-escaped reg keys, so a non-ASCII / escaped nick sent
+-- percent-encoded by a standard client (Go's net/http always encodes) must be
+-- decoded before lookup. Decoding is post-routing, so a %2F cannot split a
+-- segment - it just yields a literal '/' in the value.
+-- ============================================================
+do
+    local pat, vars = router._compile_path_pattern( "/v1/x/{nick}" )
+    local route = { pattern = pat, vars = vars }
+    local umlaut = "M" .. string.char( 0xC3, 0xBC ) .. "ller"   -- UTF-8 "Mueller" with u-umlaut
+
+    eq( "path-decode: plain value unchanged",
+        ( router._match_path( route, "/v1/x/dummy" ) or { } ).nick, "dummy" )
+    eq( "path-decode: non-ASCII %C3%BC -> UTF-8",
+        ( router._match_path( route, "/v1/x/M%C3%BCller" ) or { } ).nick, umlaut )
+    eq( "path-decode: %5C -> backslash (ADC \\s nick)",
+        ( router._match_path( route, "/v1/x/Bob%5CsSmith" ) or { } ).nick, "Bob\\sSmith" )
+    eq( "path-decode: %2F -> literal slash in value (no segment split)",
+        ( router._match_path( route, "/v1/x/a%2Fb" ) or { } ).nick, "a/b" )
+    eq( "path-decode: lone % left as-is",
+        ( router._match_path( route, "/v1/x/50%off" ) or { } ).nick, "50%off" )
+end
+
 ----------------------------------------------------------------------
 
 io.write( string.format( "\n%d checks, %d failures\n", checks, failures ) )


### PR DESCRIPTION
## Problem
`match_path` stored the raw captured `{var}` bytes. But the hub compares path-var values **literally** against stored keys (reg nicks are keyed by the ADC-escaped nick, `http_router.lua` auth_verify uses `regs_by_nick[hub.escapeto(nick)]`). A standard client percent-encodes path values (Go's `net/http` always does), so any `{var}` that is a nick with **non-ASCII / a space / a backslash** - or a config key with a reserved char - never matched. `GET /v1/registered/{nick}` returned **404** for those operators.

Confirmed against the running hub before the fix: `GET /v1/registered/du%6Dmy` (`%6D`=`m`) -> 404 (no decode).

## Fix
Percent-decode each captured value **after** route matching, so a `%2F` cannot split a segment or re-route - it only yields a literal `/` in the value. Plain values and a lone/invalid `%` are unchanged. Query values stay raw (documented, unchanged).

## Why it surfaced
The WebUI live-level gate (#82) looks up an operator's current level by nick over `GET /v1/registered/{nick}`; without the decode a non-ASCII-nick operator is locked out of the WebUI after the level cache expires.

## Validation
- `http_router_test.lua`: 120/0 green; fail-first proven (3 failures without the decode: non-ASCII / backslash / `%2F`).
- Live on the devlab (overlaid): `GET /v1/registered/du%6Dmy` -> **200** (nick=dummy, level=100).

Docs: HTTP_API.md §5 req struct now notes path vars are percent-decoded (vs raw query values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)