### PR TITLE
Promote dev -> master: percent-decode path variables (#607)

### DIFF
--- a/core/http_router.lua
+++ b/core/http_router.lua
@@ -61,6 +61,7 @@ local string_match = string.match
 local string_gmatch = string.gmatch
 local string_lower = string.lower
 local string_byte = string.byte
+local string_char = string.char
 local table_concat = table.concat
 local table_insert = table.insert
 local table_remove = table.remove
@@ -288,12 +289,24 @@ local function compile_path_pattern( template )
     return pattern, vars
 end
 
+-- Percent-decode a captured path-variable value (RFC 3986 §2.1). Applied to
+-- the {var} captures ONLY, and AFTER route matching, so a %2F inside a value
+-- can never split a segment or re-route - it just yields a literal '/' in the
+-- value. Standard clients percent-encode path values (Go's net/http does), and
+-- reg nicks can carry non-ASCII / escaped chars, so without this the stored
+-- (un-encoded) key never matches. A lone/invalid '%' is left as-is.
+local function percent_decode( s )
+    return ( s:gsub( "%%(%x%x)", function( h )
+        return string_char( tonumber( h, 16 ) )
+    end ) )
+end
+
 match_path = function( route, path )
     local matches = { string_match( path, route.pattern ) }
     if matches[ 1 ] == nil then return nil end
     local path_vars = { }
     for i, name in ipairs( route.vars ) do
-        path_vars[ name ] = matches[ i ]
+        path_vars[ name ] = percent_decode( matches[ i ] )
     end
     return path_vars
 end
@@ -1794,6 +1807,8 @@ return {
     _resolve_token        = resolve_token,
     _generate_request_id  = generate_request_id,
     _auth_verify_handler  = auth_verify_handler,
+    _compile_path_pattern = compile_path_pattern,
+    _match_path           = match_path,
     _idem_lookup          = function( ... ) return idem_lookup( ... ) end,
     _idem_store           = function( ... ) return idem_store( ... ) end,
     _idem_clear           = function( ... ) return idem_clear( ... ) end,

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -586,7 +586,9 @@ struct passed to the handler:
 req = {
     method      = "POST",                      -- uppercase
     path        = "/v1/bans",                  -- with version prefix
-    path_vars   = { id = "abc" },              -- {} if no {name} segments
+    path_vars   = { id = "abc" },              -- {} if no {name} segments; values ARE
+                                               -- percent-decoded (a {name} nick may carry
+                                               -- non-ASCII / escaped chars)
     query       = { lines = "100" },           -- query-string parsed; values are RAW URL-encoded strings
                                                -- (the router does NOT %-decode; handlers do so per-endpoint)
     headers     = { ["content-type"] = "..." },-- lowercased keys

--- a/tests/unit/http_router_test.lua
+++ b/tests/unit/http_router_test.lua
@@ -758,6 +758,30 @@ do
     _stub_cfg_tokens = { }
 end
 
+-- ============================================================
+-- match_path percent-decodes captured path variables. The hub compares the raw
+-- path bytes against ADC-escaped reg keys, so a non-ASCII / escaped nick sent
+-- percent-encoded by a standard client (Go's net/http always encodes) must be
+-- decoded before lookup. Decoding is post-routing, so a %2F cannot split a
+-- segment - it just yields a literal '/' in the value.
+-- ============================================================
+do
+    local pat, vars = router._compile_path_pattern( "/v1/x/{nick}" )
+    local route = { pattern = pat, vars = vars }
+    local umlaut = "M" .. string.char( 0xC3, 0xBC ) .. "ller"   -- UTF-8 "Mueller" with u-umlaut
+
+    eq( "path-decode: plain value unchanged",
+        ( router._match_path( route, "/v1/x/dummy" ) or { } ).nick, "dummy" )
+    eq( "path-decode: non-ASCII %C3%BC -> UTF-8",
+        ( router._match_path( route, "/v1/x/M%C3%BCller" ) or { } ).nick, umlaut )
+    eq( "path-decode: %5C -> backslash (ADC \\s nick)",
+        ( router._match_path( route, "/v1/x/Bob%5CsSmith" ) or { } ).nick, "Bob\\sSmith" )
+    eq( "path-decode: %2F -> literal slash in value (no segment split)",
+        ( router._match_path( route, "/v1/x/a%2Fb" ) or { } ).nick, "a/b" )
+    eq( "path-decode: lone % left as-is",
+        ( router._match_path( route, "/v1/x/50%off" ) or { } ).nick, "50%off" )
+end
+
 ----------------------------------------------------------------------
 
 io.write( string.format( "\n%d checks, %d failures\n", checks, failures ) )


### PR DESCRIPTION
Promotes the path-var percent-decode fix (#607) to master.

`match_path` now percent-decodes captured `{var}` values (post-routing), so `GET /v1/registered/{nick}` (and any `{param}` endpoint) matches nicks/keys with non-ASCII / escaped / reserved chars instead of 404ing. Fail-first unit test + live-validated (`/v1/registered/du%6Dmy` -> 200). Unblocks the WebUI live-level gate for non-ASCII-nick operators.

dev == master + this one squash commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)