### PR TITLE
http: url-decode query-string keys and values in parse_query (#609)

### DIFF
--- a/core/http_router.lua
+++ b/core/http_router.lua
@@ -301,6 +301,16 @@ local function percent_decode( s )
     end ) )
 end
 
+-- Url-decode a query-string key or value (application/x-www-form-urlencoded).
+-- Unlike path vars, query components also encode space as '+', so '+' -> ' '
+-- runs BEFORE the %XX pass (a literal '+' arrives as %2B and survives the '+'
+-- pass to be decoded here). Applied by parse_query AFTER the &/= split, so a
+-- %26/%3D inside a value can never forge an extra pair/assignment boundary. A
+-- lone/invalid '%' is left as-is, matching percent_decode.
+local function query_decode( s )
+    return percent_decode( ( s:gsub( "%+", " " ) ) )
+end
+
 match_path = function( route, path )
     local matches = { string_match( path, route.pattern ) }
     if matches[ 1 ] == nil then return nil end
@@ -604,9 +614,9 @@ parse_query = function( s )
     for pair in string_gmatch( s, "([^&]+)" ) do
         local k, v = string_match( pair, "^([^=]+)=(.*)$" )
         if k then
-            q[ k ] = v
+            q[ query_decode( k ) ] = query_decode( v )
         else
-            q[ pair ] = ""
+            q[ query_decode( pair ) ] = ""
         end
     end
     return q
@@ -1825,6 +1835,7 @@ return {
     _user_to_json         = _user_to_json,
     _compile_path_pattern = compile_path_pattern,
     _match_path           = match_path,
+    _parse_query          = parse_query,
     _idem_lookup          = function( ... ) return idem_lookup( ... ) end,
     _idem_store           = function( ... ) return idem_store( ... ) end,
     _idem_clear           = function( ... ) return idem_clear( ... ) end,

--- a/tests/unit/http_router_test.lua
+++ b/tests/unit/http_router_test.lua
@@ -806,6 +806,47 @@ do
 end
 
 -- ============================================================
+-- parse_query url-decodes query keys AND values (application/x-www-form-urlencoded).
+-- Unlike path vars, query components use '+' for space, so '+' -> ' ' precedes the
+-- %XX pass (a literal '+' arrives as %2B and survives the '+' pass). Decoding is
+-- POST-split, so a %26/%3D inside a value can never forge an extra &/= boundary.
+-- RED pre-fix: parse_query stored values verbatim, so a filter term with a space /
+-- non-ASCII (browser URLSearchParams encodes both) never matched the decoded field.
+-- ============================================================
+do
+    local umlaut = "M" .. string.char( 0xC3, 0xBC ) .. "ller"   -- UTF-8 "Mueller" with u-umlaut
+
+    eq( "query: %20 -> space in value",
+        ( router._parse_query( "nick=John%20Doe" ) ).nick, "John Doe" )
+    eq( "query: + -> space in value",
+        ( router._parse_query( "nick=John+Doe" ) ).nick, "John Doe" )
+    eq( "query: non-ASCII %C3%BC -> UTF-8",
+        ( router._parse_query( "nick=M%C3%BCller" ) ).nick, umlaut )
+    eq( "query: %2B -> literal '+' (survives the + pass)",
+        ( router._parse_query( "x=a%2Bb" ) ).x, "a+b" )
+    eq( "query: %26 in value is not a pair boundary (post-split decode)",
+        ( router._parse_query( "a=1%262" ) ).a, "1&2" )
+    eq( "query: %3D in value is not an assignment boundary",
+        ( router._parse_query( "q=a%3Db" ) ).q, "a=b" )
+    eq( "query: lone % left as-is",
+        ( router._parse_query( "x=50%off" ) ).x, "50%off" )
+    eq( "query: key is decoded too",
+        ( router._parse_query( "ni%63k=x" ) ).nick, "x" )
+    eq( "query: bare key (no '=') yields empty value, key decoded",
+        ( router._parse_query( "fo%6f" ) ).foo, "" )
+    eq( "query: empty value preserved",
+        ( router._parse_query( "nick=" ) ).nick, "" )
+    -- multiple pairs, and a '-' sort prefix must pass through untouched.
+    do
+        local q = router._parse_query( "nick=a&sort=-nick" )
+        eq( "query: multi-pair key 1", q.nick, "a" )
+        eq( "query: multi-pair key 2 (sort '-' untouched)", q.sort, "-nick" )
+    end
+    eq( "query: empty string -> empty table (no keys)",
+        next( router._parse_query( "" ) ), nil )
+end
+
+-- ============================================================
 -- _user_to_json ADC-unescapes free-text INF fields (NI/DE/EM/AP/VE) so the JSON
 -- API returns plain UTF-8, not the raw wire form. getnp() hands back the escaped
 -- bytes (a nick "John Doe" arrives as "John\sDoe", a description "[ ADMIN ]" as


### PR DESCRIPTION
## Problem
`parse_query` in `core/http_router.lua` stored query params verbatim - it never url-decoded them. Path vars were decoded (#607); query values were not. A browser filter like `?nick=John Doe` arrives as `nick=John+Doe` / `John%20Doe` and never substring-matches the decoded field; non-ASCII nicks (percent-encoded on the wire) never match. Affects every query filter (`/v1/users?nick=`, `/v1/registered?nick=`, `/v1/bans/history?nick=`, ...).

## Fix
Add `query_decode` (application/x-www-form-urlencoded: `+` -> space, then `%XX`), applied AFTER the `&`/`=` split so a `%26`/`%3D` inside a value cannot forge an extra pair/assignment boundary. Decodes both key and value; a lone/invalid `%` is preserved, matching the path-var `percent_decode` it mirrors.

## Tests
`tests/unit/http_router_test.lua` gains a `parse_query` block, proven RED pre-fix (8 failures) / GREEN post-fix (142 checks, 0 failures). Covers `%20`, `+`, non-ASCII, `%2B` (literal `+` survives the `+` pass), `%26`/`%3D` non-forgery, lone `%`, key-decode, bare-key, empty value, multi-pair, `-`-sort passthrough.

## Review + validation
- Independent pre-merge review (security / new-bugs / breaking / consistency): SHIP, no blockers. Traced every `req.query` consumer - plain-string `find` (no pattern injection), dkjson-escaped error bodies (no JSON injection), positive-allowlist key handling, correct decode order, nil-safe, no double-decode, restricted-env clean.
- Live-validated on a `:dev` hub: `?nick=dumm%79` matched `dummy` (0 pre-fix), controls intact.
- `luac -p -l -l` clean (no bare globals / #353 class).

Closes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)