### PR TITLE
fix(etc_clientblocker): reject "." / ".." patterns (undeletable via HTTP)

### DIFF
--- a/scripts/etc_clientblocker.lua
+++ b/scripts/etc_clientblocker.lua
@@ -67,7 +67,7 @@
 --------------
 
 local scriptname = "etc_clientblocker"
-local scriptversion = "0.11"
+local scriptversion = "0.12"
 
 local cmd_add  = "addblocker"
 local cmd_del  = "delblocker"
@@ -181,6 +181,12 @@ local patterns_tbl = { }
 --     404). Real-world DC client AP/VE strings are alphanumeric
 --     + `+`/`.`/`-`, so disallowing these four chars rules out
 --     zero legitimate use. Fail loud at edit time instead.
+--   - not a bare `.` / `..` dot-segment: these are collapsed by URL
+--     path normalization (the browser AND a server-side path.Clean
+--     rewrite `/v1/clientblocker/..` before it reaches the route), so
+--     such a pattern is likewise undeletable via HTTP (#617). Same
+--     class as the char check above; a lone `.`/`..` also matches
+--     nearly every VE tag, so it is never a legitimate pattern.
 --   - compile-probe via pcall(string.find, "", pat) so we fail
 --     loud at edit time, never silent at onConnect kick time
 -- Returns: true | nil, err_msg.
@@ -192,6 +198,9 @@ local function validate_pattern( pat )
         return nil, msg_bad_pattern
     end
     if pat:find( "[/?#&]" ) then
+        return nil, msg_bad_pattern
+    end
+    if pat == "." or pat == ".." then    -- #617: dot-segment, undeletable via HTTP path
         return nil, msg_bad_pattern
     end
     local ok = pcall( string_find, "", pat )

--- a/tests/unit/etc_clientblocker_test.lua
+++ b/tests/unit/etc_clientblocker_test.lua
@@ -280,6 +280,30 @@ do
 end
 
 ----------------------------------------------------------------------
+-- 5c. POST reject: bad_pattern (dot-segment "." / "..", #617)
+--     A bare "." or ".." is collapsed by URL path normalization so
+--     DELETE /v1/clientblocker/{pattern} can never reach the route -
+--     the entry would be un-removable via HTTP. Reject at POST time.
+--     Regression per CLAUDE.md 1a.7: on the unpatched validate_pattern
+--     these POSTs returned 201 (accepted); they now return 400. The
+--     "a.b" case guards that we reject ONLY the exact dot-segments,
+--     not every pattern containing a dot (real VE tags carry dots).
+----------------------------------------------------------------------
+
+do
+    for _, seg in ipairs( { ".", ".." } ) do
+        local r = POST{ body = { pattern = seg }, token_label = "alice" }
+        eq( "dot-segment " .. seg .. ": status", r.status,     400 )
+        eq( "dot-segment " .. seg .. ": code",   r.error.code, "bad_pattern" )
+    end
+    -- a dot elsewhere is still a legitimate pattern (must be accepted)
+    local ok = POST{ body = { pattern = "a.b", reason = "x" }, token_label = "alice" }
+    eq( "dotted pattern a.b: accepted", ok.status, 201 )
+    -- cleanup so later count-based assertions are unaffected
+    DELETE{ path_vars = { pattern = "a.b" }, token_label = "alice" }
+end
+
+----------------------------------------------------------------------
 -- 6. POST reject: exists
 ----------------------------------------------------------------------
 


### PR DESCRIPTION
Rejects a client-blocker pattern of exactly `.` or `..` in `validate_pattern`.

Such a pattern passed validation but could never be removed via `DELETE /v1/clientblocker/{pattern}` - URL path normalization (browser + the Go BFF `path.Clean`) collapses the dot-segment so the DELETE never reaches the route. Same class as the existing `[/?#&]` reject. A lone `.`/`..` also matches nearly every VE tag, so it is never a legitimate pattern.

Covers both entry paths (ADC `+addblocker` + `POST /v1/clientblocker`) via the shared `validate_pattern` chokepoint. Fail-first regression test (5c): `.`/`..` -> 400, `a.b` still -> 201 (only exact dot-segments rejected). Proven RED on the unpatched validator (201), green after.

Independent review: SHIP (no security/correctness/consistency issues).

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)