### PR TITLE
fix(http-api): coerce JSON string keys to int keys on PUT /v1/config level-maps (#630)

### DIFF
--- a/core/http_router.lua
+++ b/core/http_router.lua
@@ -67,6 +67,7 @@ local table_insert = table.insert
 local table_remove = table.remove
 local table_sort = table.sort
 local math_floor = math.floor
+local math_tointeger = math.tointeger
 
 local cfg = use "cfg"
 local out = use "out"
@@ -1546,6 +1547,38 @@ local function config_get_handler( req )
     return { status = 200, data = { config = snapshot } }
 end
 
+-- A JSON object always decodes (dkjson) to a Lua table with STRING
+-- keys, but a level-keyed cfg map (e.g. cmd_ban_permission =
+-- { [ 0 ] = 0, ... , [ 100 ] = 100 }) is validated with INTEGER keys
+-- (cfg_defaults validators call types_number( k ), which is
+-- type( k ) == "number"). So a PUT of such a map arrives as
+-- { [ "0" ] = 0, ... } and the validator rejects it - level-maps were
+-- effectively read-only over the HTTP API. When (and ONLY when) EVERY
+-- key of a table is an integer-looking string, rebuild it with integer
+-- keys so the level-map validators accept it. A table with any
+-- non-numeric-string key (e.g. a token map keyed by the token string)
+-- or a mixed table returns nil -> the caller keeps the value as-is and
+-- does not retry, so this can never corrupt a legitimately
+-- string-keyed map. Values are copied verbatim; only top-level keys are
+-- converted (cfg level-maps are flat). Returns the coerced table, or
+-- nil when nothing should be coerced.
+local function coerce_numeric_string_keys( value )
+    if type( value ) ~= "table" then return nil end
+    -- not named `out` - that local is the logging module at file scope.
+    local result, n = { }, 0
+    for k, v in pairs( value ) do
+        if type( k ) ~= "string" or not string_match( k, "^%-?%d+$" ) then
+            return nil  -- a non-integer-string key -> not a level-map
+        end
+        local ik = math_tointeger( tonumber( k ) )
+        if not ik then return nil end  -- out of 64-bit integer range -> bail
+        result[ ik ] = v
+        n = n + 1
+    end
+    if n == 0 then return nil end  -- empty table: nothing to coerce
+    return result
+end
+
 -- #262 PUT /v1/config/{key}: admin-scoped. Body `{ "value": <any
 -- JSON type> }`. Denylisted keys -> 403. Unknown keys -> 404.
 -- Validator-rejected values -> 400 with the validator's err_msg.
@@ -1574,6 +1607,17 @@ local function config_put_handler( req )
             message = "missing required body field: value" } }
     end
     local ok, err = cfg_mod.set( key, body.value )
+    if not ok then
+        -- A level-keyed map (cmd_ban_permission etc.) arrives from JSON with
+        -- string keys that the integer-key validator rejects; retry once with
+        -- the keys coerced to integers. Only an all-integer-string-keyed table
+        -- is coerced, so a legitimately string-keyed map still surfaces its
+        -- original validator error rather than being silently rewritten.
+        local coerced = coerce_numeric_string_keys( body.value )
+        if coerced then
+            ok, err = cfg_mod.set( key, coerced )
+        end
+    end
     if not ok then
         return { status = 400, error = { code = "E_BAD_INPUT",
             message = err or "cfg.set rejected the value" } }

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -10700,6 +10700,9 @@ def test_http_config_api(staging_dir: Path, proc=None):
       7.  PUT missing body field -> 400 E_BAD_INPUT.
       8.  PUT validator-rejected value (max_users = "notanumber")
           -> 400 E_BAD_INPUT with validator hint.
+      9.  PUT a level-keyed map (cmd_ban_permission) - JSON string keys
+          are coerced to integer keys so the level-map validator accepts
+          it and it round-trips; a mixed-key map is NOT coerced (400).
 
     Restores the bare-key cfg.tbl format at the end (matches the #261
     plugins-api test pattern) so downstream regex-based cfg flips
@@ -10808,6 +10811,35 @@ def test_http_config_api(staging_dir: Path, proc=None):
             raise TestFailure(f"PUT invalid: expected 400, got {status(r)!r}")
         if "validator rejected" not in body_of(r):
             raise TestFailure(f"PUT invalid: missing 'validator rejected' hint; body={body_of(r)!r}")
+
+        # 9. PUT a level-keyed permission map. A JSON object always carries
+        #    STRING keys ({"0":0,...}), but the cfg validator requires INTEGER
+        #    keys (types_number(k) == type(k)=="number"); pre-fix the PUT 400s
+        #    ("validator rejected") and level-maps were read-only over the API.
+        #    config_put_handler now retries once with the keys coerced to
+        #    integers. The DEFAULT values are re-sent (no semantic change): a
+        #    200 proves the integer-key validator accepted the coerced map (it
+        #    rejects string keys), and the readback confirms the round-trip.
+        r = put_value(
+            "cmd_ban_permission",
+            '{"value": {"0":0,"10":0,"20":0,"30":0,"40":0,"50":0,'
+            '"55":0,"60":50,"70":60,"80":70,"100":100}}',
+        )
+        if "200 OK" not in status(r):
+            raise TestFailure(f"PUT level-map: expected 200 (int-key coercion), got {status(r)!r} / body={body_of(r)!r}")
+        j = json.loads(body_of(r))
+        if j["data"].get("apply_status") not in ("live", "reload_required", "restart_required"):
+            raise TestFailure(f"PUT level-map: missing apply_status; got {j['data']!r}")
+        got = get_json("/v1/config")["data"]["config"].get("cmd_ban_permission")
+        if not isinstance(got, dict) or str(got.get("60")) != "50" or str(got.get("100")) != "100":
+            raise TestFailure(f"PUT level-map: readback wrong; cmd_ban_permission={got!r}")
+
+        # 9b. A table with any non-integer key is NOT a level-map: coercion
+        #     bails and the original 400 stands - never silently rewrite a
+        #     legitimately string-keyed map.
+        r = put_value("cmd_ban_permission", '{"value": {"0":0,"nope":1}}')
+        if "400 Bad Request" not in status(r):
+            raise TestFailure(f"PUT mixed-key map: expected 400, got {status(r)!r} / body={body_of(r)!r}")
     finally:
         # Restore cfg.tbl to bare-key format so downstream
         # BLOM/ZLIF/hub_listen regex flips keep working.


### PR DESCRIPTION
Closes #630.

`PUT /v1/config/{key}` could not save any **level-keyed cfg map** (`cmd_ban_permission`, `etc_trafficmanager_blocklevel_tbl`, the `usr_*_prefix_table` maps, `max_share`, ...). A JSON object always decodes (dkjson) to a Lua table with **string** keys (`{"0":0}` -> `{["0"]=0}`), but the `cfg_defaults` validators check the key with `types_number(k)` = `type(k)=="number"` -> a string key fails -> `400 "validator rejected value"`. So level-maps were effectively **read-only** over the API (latent bug since #262).

## Fix
`config_put_handler` tries `cfg.set` as-is first; only if that fails **and** every key of the value is an integer-looking string does it retry once with the keys coerced to integer keys. Non-level-map values (arrays, string-keyed maps, non-tables, empty) are never coerced - the original error stands. The retry-only-on-failure shape is the safety property: a value the validator already accepts never reaches coercion.

## Validation
- **Fail-first regression**: `tests/smoke/run.py` `test_http_config_api` case 9 PUTs a level-map (default values re-sent) expecting 200 + readback; provably RED on the unpatched hub (400). Case 9b: mixed-key map -> 400 (never coerced).
- **Restricted-env clean**: `math.tointeger` localized; `luac -p -l -l` shows the same 2 `_ENV` refs as before (no new global; #353/#358 class).
- **Live in the devlab**: the PUT that returned 400 pre-fix now returns 200; on-disk `cfg.tbl` stores **integer** keys (`[ 0 ] = 0` ... `[ 100 ] = 100`); mixed-key still 400s; `ssl_ports` (array) still 200s.
- Independent review: SHIP (no blocker/concern); the one NIT (a shadowed `out` local) folded.

Unblocks a structured level-map editor in the WebUI (luadch-ng/webui#166 arc). No security impact (admin-scoped write that previously failed closed); **not** a 3.1.x backport candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)