### PR TITLE
fix(scripts): report the real version for disabled plugins, not "unknown" (#635)

### DIFF
--- a/core/scripts.lua
+++ b/core/scripts.lua
@@ -393,10 +393,17 @@ startscripts = function( hub )
         if not scriptname then
             out_error( "scripts.lua: invalid entry in cfg.scripts at index ", cfg_index )
         elseif not enabled then
+            -- #635: read the source so a disabled plugin still reports its real
+            -- version (registry / +scripts / WebUI) instead of a bare "unknown".
+            -- checkfile is path-guarded + UTF-8-checked + READ-ONLY - the plugin is
+            -- NOT loaded or executed (that only happens in the enabled branch below).
+            -- A genuinely missing / unreadable file falls back to "unknown"
+            -- (_extract_version returns "unknown" on a nil source).
+            local src = checkfile( cfg_get( "script_path" ) .. scriptname )
             _plugin_meta[ scriptname ] = {
                 name          = scriptname:gsub( "%.lua$", "" ),
                 filename      = scriptname,
-                version       = "unknown",
+                version       = _extract_version( src ),
                 manageable    = manageable,
                 enabled       = false,
                 loaded        = false,

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -10205,6 +10205,10 @@ def test_http_plugins_api(staging_dir: Path, proc=None):
         raise TestFailure(f"baseline: etc_motd.enabled expected true, got {motd!r}")
     if not motd.get("loaded"):
         raise TestFailure(f"baseline: etc_motd.loaded expected true, got {motd!r}")
+    # #635: capture the version reported for the ENABLED plugin (a real version).
+    motd_version = motd.get("version")
+    if not motd_version or motd_version == "unknown":
+        raise TestFailure(f"baseline: etc_motd.version should be a real version, got {motd_version!r}")
     cmd_help = plugins.get("cmd_help")
     if not cmd_help:
         raise TestFailure(f"baseline: cmd_help not in listing")
@@ -10240,6 +10244,10 @@ def test_http_plugins_api(staging_dir: Path, proc=None):
         raise TestFailure(f"after reload: enabled expected false, got {motd!r}")
     if motd.get("loaded"):
         raise TestFailure(f"after reload: loaded expected false, got {motd!r}")
+    # #635: a disabled plugin still reports its real version - the loader source-greps
+    # the version even for an entry it does not load (pre-fix it hardcoded "unknown").
+    if motd.get("version") != motd_version:
+        raise TestFailure(f"after reload (disabled): version should stay {motd_version!r}, got {motd.get('version')!r}")
 
     # 6. PUT enable (restore path)
     r = put_enabled("etc_motd", True)


### PR DESCRIPTION
Closes #635.

`GET /v1/plugins` (and `+scripts` / the WebUI Plugins page) reported `version: "unknown"` for **disabled** plugins (`etc_lockdown` ships disabled #501; `etc_webhook` when disabled), although they declare a `scriptversion`.

## Root cause
`startscripts` source-greps the version, but only read the file for ENABLED plugins (it loads them). The `elseif not enabled then` branch hardcoded `version = "unknown"`.

## Fix
The disabled branch now reads the source via `checkfile` (path-guarded, UTF-8-checked, **read-only - NOT loaded/executed**) and runs the same `_extract_version` grep; a missing/unreadable file falls back to "unknown". No new global (sandbox-clean).

## Validation
Fail-first smoke case in `test_http_plugins_api` (etc_motd's version stays its real value after disable+reload - RED pre-fix). Live in the devlab: `etc_lockdown` (disabled) `"unknown"` -> `"0.01"`; **no plugin reports "unknown" anymore**. Independent review = SHIP (one logging NIT, reviewer's + my call: keep - a missing disabled-plugin file is a real misconfig worth one log line). 3.2.x only, no security impact, not backported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)