### PR TITLE
Promote to master: disabled-plugin version reporting (#636)

### DIFF
--- a/core/scripts.lua
+++ b/core/scripts.lua
@@ -393,10 +393,17 @@ startscripts = function( hub )
         if not scriptname then
             out_error( "scripts.lua: invalid entry in cfg.scripts at index ", cfg_index )
         elseif not enabled then
+            -- #635: read the source so a disabled plugin still reports its real
+            -- version (registry / +scripts / WebUI) instead of a bare "unknown".
+            -- checkfile is path-guarded + UTF-8-checked + READ-ONLY - the plugin is
+            -- NOT loaded or executed (that only happens in the enabled branch below).
+            -- A genuinely missing / unreadable file falls back to "unknown"
+            -- (_extract_version returns "unknown" on a nil source).
+            local src = checkfile( cfg_get( "script_path" ) .. scriptname )
             _plugin_meta[ scriptname ] = {
                 name          = scriptname:gsub( "%.lua$", "" ),
                 filename      = scriptname,
-                version       = "unknown",
+                version       = _extract_version( src ),
                 manageable    = manageable,
                 enabled       = false,
                 loaded        = false,

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -10205,6 +10205,10 @@ def test_http_plugins_api(staging_dir: Path, proc=None):
         raise TestFailure(f"baseline: etc_motd.enabled expected true, got {motd!r}")
     if not motd.get("loaded"):
         raise TestFailure(f"baseline: etc_motd.loaded expected true, got {motd!r}")
+    # #635: capture the version reported for the ENABLED plugin (a real version).
+    motd_version = motd.get("version")
+    if not motd_version or motd_version == "unknown":
+        raise TestFailure(f"baseline: etc_motd.version should be a real version, got {motd_version!r}")
     cmd_help = plugins.get("cmd_help")
     if not cmd_help:
         raise TestFailure(f"baseline: cmd_help not in listing")
@@ -10240,6 +10244,10 @@ def test_http_plugins_api(staging_dir: Path, proc=None):
         raise TestFailure(f"after reload: enabled expected false, got {motd!r}")
     if motd.get("loaded"):
         raise TestFailure(f"after reload: loaded expected false, got {motd!r}")
+    # #635: a disabled plugin still reports its real version - the loader source-greps
+    # the version even for an entry it does not load (pre-fix it hardcoded "unknown").
+    if motd.get("version") != motd_version:
+        raise TestFailure(f"after reload (disabled): version should stay {motd_version!r}, got {motd.get('version')!r}")
 
     # 6. PUT enable (restore path)
     r = put_enabled("etc_motd", True)


### PR DESCRIPTION
Promote dev -> master. One change since the last promotion:

- **#636** (Closes #635) - `GET /v1/plugins` now reports the real version for **disabled** plugins (source-grepped read-only, no execution) instead of a bare "unknown". Fixes the WebUI Plugins-page "unknown" on `etc_lockdown` / `etc_webhook` etc. Fail-first smoke case (both legs green), sandbox-clean, devlab-validated (`etc_lockdown` "unknown" -> "0.01"). No security impact, not backported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)