### PR TITLE
feat(usr_hubs): add kick-only mode (block_time <= 0 disconnects, no ban)

### DIFF
--- a/examples/cfg/cfg.tbl
+++ b/examples/cfg/cfg.tbl
@@ -360,7 +360,7 @@ return { -- the settings are a lua table, do not tough this!
         [ 100 ] = true,  -- hubowner
     },
 
-    usr_hubs_block_time = 360,  -- ban time in minutes (integer)
+    usr_hubs_block_time = 360,  -- ban time in minutes (integer); 0 or less = kick only (disconnect, no ban). Ignored when usr_hubs_redirect is set (redirect wins).
 
     usr_hubs_report = true,  -- send status report? (boolean)
     usr_hubs_report_hubbot = false,  -- send report as hubbot msg? (boolean)

--- a/scripts/lang/de/usr_hubs.json
+++ b/scripts/lang/de/usr_hubs.json
@@ -9,5 +9,6 @@
   "msg_seconds":" Sekunden",
   "msg_years":" Jahre, ",
   "report_msg":"[ USER HUBS ]--> User:  %s  |  IP:  %s  |  CID:  %s  |  wurde gebannt für:  %s  |  Grund: Überschreiten des User Hub Limits. Hubs:  %s  (Gesamt:  %s Hubs)  |  Erlaubt:  %s  (max.  %s  Hubs gesamt)",
+  "report_msg_kick":"[ USER HUBS ]--> User:  %s  |  IP:  %s  |  CID:  %s  |  wurde getrennt  |  Grund: Überschreiten des User Hub Limits. Hubs:  %s  (Gesamt:  %s Hubs)  |  Erlaubt:  %s  (max.  %s  Hubs gesamt)",
   "report_msg_redirect":"[ USER HUBS ]--> User:  %s  |  IP:  %s  |  CID:  %s  |  wurde redirected  |  Grund: Überschreiten des User Hub Limits. Hubs:  %s  (Gesamt:  %s Hubs)  |  Erlaubt:  %s  (max.  %s  Hubs gesamt)"
 }

--- a/scripts/lang/en/usr_hubs.json
+++ b/scripts/lang/en/usr_hubs.json
@@ -9,5 +9,6 @@
   "msg_seconds":" seconds",
   "msg_years":" years, ",
   "report_msg":"[ USER HUBS ]--> User:  %s  |  IP:  %s  |  CID:  %s  |  was banned for:  %s  |  reason: exceeded users hub limit. Hubs:  %s  (total:  %s hubs)  |  allowed:  %s  (max.  %s  hubs total)",
+  "report_msg_kick":"[ USER HUBS ]--> User:  %s  |  IP:  %s  |  CID:  %s  |  was disconnected  |  reason: exceeded users hub limit. Hubs:  %s  (total:  %s hubs)  |  allowed:  %s  (max.  %s  hubs total)",
   "report_msg_redirect":"[ USER HUBS ]--> User:  %s  |  IP:  %s  |  CID:  %s  |  was redirected  |  reason: exceeded users hub limit. Hubs:  %s  (total:  %s hubs)  |  allowed:  %s  (max.  %s  hubs total)"
 }

--- a/scripts/usr_hubs.lua
+++ b/scripts/usr_hubs.lua
@@ -4,6 +4,21 @@
 
         - this script checks the hub count of a user
 
+        v0.15: by Aybo (#638)
+            - add a kick-only mode: usr_hubs_block_time <= 0 now disconnects
+              the offender WITHOUT recording a ban (no cmd_ban entry), using
+              TL-1 so the client does not auto-reconnect - the user has to
+              reduce their hub count client-side, same rationale as the
+              invalid-hubcount kick. Previously block_time = 0 still called
+              ban.add with a 0 bantime, writing a time-0 ban entry that only
+              self-cleared on the next cmd_ban sweep. Redirect still wins when
+              usr_hubs_redirect is set; block_time > 0 keeps the temp-ban
+              behaviour unchanged. New report line report_msg_kick (en + de).
+            - consistency: ADC-escape the reason on the invalid-hubcount kill
+              too (hub.escapeto), matching the new kick path. Unescaped, the
+              space in "Invalid hubcount." split the ISTA description into a
+              stray param on the wire, truncating the client-shown message.
+
         v0.14: by Aybo
             - kill TL on the hub-count-limit / invalid-tag path changed
               from TL300 to TL-1 (don't auto-reconnect). The user cannot
@@ -75,7 +90,7 @@
 --------------
 
 local scriptname = "usr_hubs"
-local scriptversion = "0.14"
+local scriptversion = "0.15"
 
 --// imports
 local scriptlang = cfg.get( "language" )
@@ -99,6 +114,7 @@ local usr_hubs_redirect = cfg.get( "usr_hubs_redirect" )
 local msg_reason = lang.msg_reason or "Exceeded users hub limit"
 local report_msg = lang.report_msg or "[ USER HUBS ]--> User:  %s  |  IP:  %s  |  CID:  %s  |  was banned for:  %s  |  reason: exceeded users hub limit. Hubs:  %s  (total:  %s hubs)  |  allowed:  %s  (max.  %s  hubs total)"
 local report_msg_redirect = lang.report_msg_redirect or "[ USER HUBS ]--> User:  %s  |  IP:  %s  |  CID:  %s  |  was redirected  |  reason: exceeded users hub limit. Hubs:  %s  (total:  %s hubs)  |  allowed:  %s  (max.  %s  hubs total)"
+local report_msg_kick = lang.report_msg_kick or "[ USER HUBS ]--> User:  %s  |  IP:  %s  |  CID:  %s  |  was disconnected  |  reason: exceeded users hub limit. Hubs:  %s  (total:  %s hubs)  |  allowed:  %s  (max.  %s  hubs total)"
 local msg_redirect = lang.msg_redirect or "[ USER HUBS ]--> You got redirected because: exceeded users hub limit. Hubs: "
 local msg_invalid = lang.msg_invalid or "Invalid hubcount"
 local msg_years = lang.msg_years or " years, "
@@ -142,16 +158,13 @@ local check = function( user )
     -- value" before the nil-check below could fire. Reorder so the
     -- nil-check rejects first.
     if not ( hn and hr and ho ) then
-        user:kill( "ISTA 120 " .. msg_invalid .. "\n", "TL-1" )
+        user:kill( "ISTA 120 " .. hub.escapeto( msg_invalid ) .. "\n", "TL-1" )
         return PROCESSED
     end
     local hm = hn + hr + ho
     if ( hn > user_max ) or ( hr > reg_max ) or ( ho > op_max ) or ( hm > hubs_max ) then
         local hubs = hn .. "/" .. hr .. "/" .. ho
         local hubs_allowed = user_max .. "/" .. reg_max .. "/" .. op_max
-        local bantime = block_time * 60
-        local y, d, h, m, s = util.formatseconds( bantime )
-        local msg_bantime =  y .. msg_years .. d .. msg_days .. h .. msg_hours .. m .. msg_minutes .. s .. msg_seconds
         if usr_hubs_redirect then
             local redirect_msg = hub.escapeto( msg_redirect .. hubs )
             user:redirect( redirect_url, redirect_msg )
@@ -159,7 +172,22 @@ local check = function( user )
             local msg_out = utf.format( report_msg_redirect, user_nick, user_ip, user_cid, hubs, hm, hubs_allowed, hubs_max )
             report.send( report_activate, report_hubbot, report_opchat, llevel, msg_out )
             return PROCESSED
+        elseif block_time <= 0 then
+            -- #638 kick-only: disconnect without recording a ban. TL-1 so the
+            -- client does not auto-reconnect (the offender must reduce their
+            -- hub count client-side, same as the invalid-hubcount kick above).
+            -- Only reached when usr_hubs_redirect is off (redirect wins).
+            local msg = utf.format( msg_max, user_max, hn, reg_max, hr, op_max, ho, hubs_max, hm )
+            user:reply( msg, hub.getbot() )
+            user:kill( "ISTA 120 " .. hub.escapeto( msg_reason ) .. "\n", "TL-1" )
+            --// report
+            local msg_out = utf.format( report_msg_kick, user_nick, user_ip, user_cid, hubs, hm, hubs_allowed, hubs_max )
+            report.send( report_activate, report_hubbot, report_opchat, llevel, msg_out )
+            return PROCESSED
         else
+            local bantime = block_time * 60
+            local y, d, h, m, s = util.formatseconds( bantime )
+            local msg_bantime =  y .. msg_years .. d .. msg_days .. h .. msg_hours .. m .. msg_minutes .. s .. msg_seconds
             local msg = utf.format( msg_max, user_max, hn, reg_max, hr, op_max, ho, hubs_max, hm )
             user:reply( msg, hub.getbot() )
             ban.add( nil, user, bantime, msg_reason, "USER HUBS CHECK" )


### PR DESCRIPTION
Closes #638

## Problem

`usr_hubs`'s over-limit path offered only **redirect** or **temp-ban**. `usr_hubs_block_time = 0` still called `ban.add( ..., 0, ... )`, writing a degenerate time-0 ban entry and killing with `TL0` - which permits immediate auto-reconnect, so the client reconnected and was re-kicked on its next INF (a reconnect/re-kick loop) while a phantom 0-second ban lingered until the cmd_ban sweep. An operator who wants "kick, don't ban" had no clean option.

## Change

Treat `usr_hubs_block_time <= 0` as **kick-only** in the non-redirect branch: disconnect with `TL-1` (no auto-reconnect; the offender must reduce their hub count client-side, same rationale as the invalid-hubcount kick and the v0.14 `TL300 -> TL-1` change) and record **no** ban.

- Redirect still wins when `usr_hubs_redirect` is set.
- `block_time > 0` keeps the temp-ban path unchanged.
- New report line `report_msg_kick` (en + de), worded as a disconnect.
- cfg validator already accepts 0 (`types_number`, no lower bound); documented `0 = kick only` in the example cfg comment.
- Also ADC-escape the reason on the sibling invalid-hubcount kill (`hub.escapeto`), matching the new kick path (a space in the reason otherwise split the ISTA description on the wire). Broader same-pattern cohort in other plugins tracked separately.

## Validation

Live RED/GREEN on `:dev` (`usr_hubs_block_time = 0`, a level-10 test user bumped past the limit via a post-login INF):

- **RED** (old v0.14): writes a ban - `ISTA 232`, `ban_seconds = 0`.
- **GREEN** (v0.15): disconnects - `ISTA 120 ... + TL-1` - with **zero** ban entries.

`plugin_lang_test` 4416/4416, luac syntax clean, hub healthy after reload, independent review = SHIP.