### PR TITLE
feat(cfg): comment-preserving single-key cfg.tbl writer - core/cfg_write.lua (PR-1, part of #644)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -89,6 +89,11 @@ jobs:
       - name: Run util_makedir unit test
         run: lua5.4 tests/unit/util_makedir_test.lua
 
+      # core/cfg_write.lua (#644): surgical comment/layout-preserving
+      # single-key cfg.tbl writer - lexer/scanner + round-trip safety gate.
+      - name: Run cfg_write unit test
+        run: lua5.4 tests/unit/cfg_write_test.lua
+
       # core/ensuredirs.lua (#78 follow-up): boot-time runtime-directory
       # self-heal (log/, cfg/, certs/, scripts/data/, cfg/geoip/).
       - name: Run ensuredirs unit test
@@ -593,6 +598,10 @@ jobs:
       - name: Run util_makedir unit test
         shell: msys2 {0}
         run: lua5.4 tests/unit/util_makedir_test.lua
+
+      - name: Run cfg_write unit test
+        shell: msys2 {0}
+        run: lua5.4 tests/unit/cfg_write_test.lua
 
       - name: Run ensuredirs unit test
         shell: msys2 {0}

--- a/core/cfg_write.lua
+++ b/core/cfg_write.lua
@@ -1,0 +1,506 @@
+--[==[
+
+    core/cfg_write.lua - surgical, comment/layout-preserving single-key
+    cfg.tbl writer (#644).
+
+    The wholesale save path (cfg.set -> util.savetable -> sortserialize)
+    rebuilds the ENTIRE cfg.tbl from the in-memory _settings table on every
+    change: it strips the operator's comments, re-sorts the keys, quotes
+    bare keys (`key = v` -> `[ "key" ] = v`) and swaps the `return { ... }`
+    envelope for `local settings; settings = { ... }; return settings`. An
+    operator who edits one setting via the WebUI loses their whole
+    hand-annotated file. This module preserves it.
+
+    Mechanism (single-key change):
+      1. read the existing cfg.tbl TEXT,
+      2. a char-stream scanner (never executes the file - it is a pure
+         lexer, cf. the untrusted-config recogniser #531) locates the
+         target key's VALUE span in the top-level table, skipping strings,
+         comments and nested braces, matching both bare `key =` and
+         `[ "key" ] =` forms,
+      3. splice the newly serialised value (via util.serialize_value, the
+         SAME serialiser the wholesale path uses, so the result round-trips
+         identically) into that span; when the key is absent, append
+         `    key = value,` before the table's closing brace,
+      4. SAFETY GATE: re-parse the spliced text sandboxed (util.loadtable_
+         string, env = {}, non-executing) and accept it ONLY if it
+         deep-equals the authoritative _settings table,
+      5. atomic_write.
+
+    Any failure (unreadable file, lexer bail, key ambiguous, parse
+    mismatch, write error) returns nil so the caller (cfg.set) falls back
+    to the proven wholesale util.savetable. The accept-gate is what makes
+    this safe: a mis-scan can only ever produce text that fails to parse or
+    parses to a DIFFERENT table, both of which are rejected. The worst case
+    is the current behaviour (comments lost), never a corrupted config.
+
+    Scope: only the cfg.set save path. Other util.savetable users (plugin
+    state, user.tbl) are untouched.
+
+    Known limitations (each degrades SAFELY to the wholesale fallback, or is
+    a cosmetic-only normalisation of the ONE edited key - never a data risk):
+      - a `\z` (skip-whitespace) escape spanning a newline inside a short
+        string makes the lexer bail -> wholesale save (no cfg value uses it);
+      - inner-table rows are re-indented at 4 spaces, so editing a table
+        value in a tab-/2-space-indented file does not match its indent unit;
+      - editing a `[[ long-bracket ]]` string value rewrites it to a "%q"
+        quoted literal (one serialiser); the value round-trips identically.
+
+    Passive at load (no init(), no file I/O at require time).
+
+]==]
+
+local use = use
+
+local type     = use "type"
+local pairs    = use "pairs"
+local pcall    = use "pcall"
+local string   = use "string"
+local io       = use "io"
+local util     = use "util"
+
+local string_sub   = string.sub
+local string_byte  = string.byte
+local string_find  = string.find
+
+local io_open = io.open
+
+local util_serialize_value  = util.serialize_value
+local util_loadtable_string = util.loadtable_string
+local util_atomic_write     = util.atomic_write
+
+-- Lua reserved words: a cfg key equal to one cannot be written as a bare
+-- identifier key (`key = v`) - it must use the bracketed form. cfg keys
+-- are never reserved words in practice; this is defence for the append
+-- path only.
+local RESERVED = {
+    ["and"] = true, ["break"] = true, ["do"] = true, ["else"] = true,
+    ["elseif"] = true, ["end"] = true, ["false"] = true, ["for"] = true,
+    ["function"] = true, ["goto"] = true, ["if"] = true, ["in"] = true,
+    ["local"] = true, ["nil"] = true, ["not"] = true, ["or"] = true,
+    ["repeat"] = true, ["return"] = true, ["then"] = true, ["true"] = true,
+    ["until"] = true, ["while"] = true,
+}
+
+----------------------------------// LEXER //--
+
+-- Byte-class helpers over string.byte (avoids per-char string allocations).
+local B_SPACE, B_TAB, B_NL, B_CR = 32, 9, 10, 13
+local B_MINUS, B_LBRACK, B_RBRACK, B_LBRACE, B_RBRACE = 45, 91, 93, 123, 125
+local B_EQ, B_COMMA, B_DQUOTE, B_SQUOTE = 61, 44, 34, 39
+local B_0, B_9 = 48, 57
+local B_a, B_z, B_A, B_Z, B_UNDER, B_DOT = 97, 122, 65, 90, 95, 46
+
+local function is_ws( b )
+    return b == B_SPACE or b == B_TAB or b == B_NL or b == B_CR
+end
+
+local function is_digit( b )
+    return b and b >= B_0 and b <= B_9
+end
+
+local function is_alpha( b )
+    return b and ( ( b >= B_a and b <= B_z ) or ( b >= B_A and b <= B_Z ) or b == B_UNDER )
+end
+
+local function is_alnum( b )
+    return b and ( is_alpha( b ) or is_digit( b ) )
+end
+
+-- Long-bracket opener at position i? Returns the level (0 for `[[`, 1 for
+-- `[=[`, ...) or nil. Does not consume.
+local function long_bracket_level( s, i )
+    if string_byte( s, i ) ~= B_LBRACK then return nil end
+    local k = 0
+    local j = i + 1
+    while string_byte( s, j ) == B_EQ do
+        k = k + 1
+        j = j + 1
+    end
+    if string_byte( s, j ) == B_LBRACK then return k end
+    return nil
+end
+
+-- Skip a long bracket (string or comment body) whose opener starts at i
+-- with the given level. Returns the index one PAST the closing `]=*]`, or
+-- nil if unterminated.
+local function skip_long_bracket( s, i, level )
+    -- opener is `[` + level `=` + `[`  => 2 + level chars
+    local p = i + 2 + level
+    local len = #s
+    while p <= len do
+        if string_byte( s, p ) == B_RBRACK then
+            local q = p + 1
+            local k = 0
+            while string_byte( s, q ) == B_EQ do
+                k = k + 1
+                q = q + 1
+            end
+            if k == level and string_byte( s, q ) == B_RBRACK then
+                return q + 1
+            end
+        end
+        p = p + 1
+    end
+    return nil
+end
+
+-- Skip a short string opened at i by quote byte q. Returns the index one
+-- PAST the closing quote, or nil if unterminated / contains a raw newline.
+local function skip_short_string( s, i, q )
+    local len = #s
+    local p = i + 1
+    while p <= len do
+        local b = string_byte( s, p )
+        if b == 92 then           -- backslash: skip the escaped byte (covers
+            p = p + 2             -- \" \' \\ and \<newline> line continuation)
+        elseif b == q then
+            return p + 1
+        elseif b == B_NL then
+            return nil            -- raw newline in a short string = invalid
+        else
+            p = p + 1
+        end
+    end
+    return nil
+end
+
+-- Tokenise `s` into a flat list of structural tokens, skipping whitespace
+-- and comments. Each token = { t = <type>, i = <start byte>, j = <end byte> }
+-- where type is "punct" | "name" | "string" | "number". Returns the token
+-- list, or nil on a lexical error (unterminated string / long bracket).
+local function tokenize( s )
+    local tokens = { }
+    local n = 0
+    local i = 1
+    local len = #s
+    while i <= len do
+        local b = string_byte( s, i )
+        if is_ws( b ) then
+            i = i + 1
+        elseif b == B_MINUS and string_byte( s, i + 1 ) == B_MINUS then
+            -- comment
+            local after = i + 2
+            local level = long_bracket_level( s, after )
+            if level then
+                local nx = skip_long_bracket( s, after, level )
+                if not nx then return nil end
+                i = nx
+            else
+                -- line comment to end of line (or EOF)
+                local nl = string_find( s, "\n", after, true )
+                i = nl and ( nl + 1 ) or ( len + 1 )
+            end
+        elseif b == B_LBRACK then
+            local level = long_bracket_level( s, i )
+            if level then
+                local nx = skip_long_bracket( s, i, level )
+                if not nx then return nil end
+                n = n + 1
+                tokens[ n ] = { t = "string", i = i, j = nx - 1 }
+                i = nx
+            else
+                n = n + 1
+                tokens[ n ] = { t = "punct", i = i, j = i, v = "[" }
+                i = i + 1
+            end
+        elseif b == B_DQUOTE or b == B_SQUOTE then
+            local nx = skip_short_string( s, i, b )
+            if not nx then return nil end
+            n = n + 1
+            tokens[ n ] = { t = "string", i = i, j = nx - 1 }
+            i = nx
+        elseif is_digit( b ) or ( b == B_DOT and is_digit( string_byte( s, i + 1 ) ) ) then
+            -- number: consume a run of alnum / '.' / sign-after-exponent.
+            -- Over-consuming is harmless - number tokens are only matched
+            -- structurally (never decoded), and the safety gate validates.
+            local j = i + 1
+            while j <= len do
+                local c = string_byte( s, j )
+                if is_alnum( c ) or c == B_DOT
+                    or ( ( c == B_MINUS or c == 43 ) and ( string_byte( s, j - 1 ) == 101 or string_byte( s, j - 1 ) == 69 ) ) then
+                    j = j + 1
+                else
+                    break
+                end
+            end
+            n = n + 1
+            tokens[ n ] = { t = "number", i = i, j = j - 1 }
+            i = j
+        elseif is_alpha( b ) then
+            local j = i + 1
+            while is_alnum( string_byte( s, j ) ) do j = j + 1 end
+            n = n + 1
+            tokens[ n ] = { t = "name", i = i, j = j - 1 }
+            i = j
+        elseif b == B_EQ then
+            if string_byte( s, i + 1 ) == B_EQ then
+                n = n + 1
+                tokens[ n ] = { t = "punct", i = i, j = i + 1, v = "==" }
+                i = i + 2
+            else
+                n = n + 1
+                tokens[ n ] = { t = "punct", i = i, j = i, v = "=" }
+                i = i + 1
+            end
+        else
+            -- single-char punctuation ({ } ] , . : ( ) etc.). Only a small
+            -- set is meaningful to the parser; the rest are consumed as
+            -- generic punct so depth/entry tracking stays correct.
+            local ch = string_sub( s, i, i )
+            n = n + 1
+            tokens[ n ] = { t = "punct", i = i, j = i, v = ch }
+            i = i + 1
+        end
+    end
+    return tokens
+end
+
+----------------------------------// PARSER //--
+
+local function is_punct( tk, v )
+    return tk ~= nil and tk.t == "punct" and tk.v == v
+end
+
+-- The indent (leading whitespace of the line) of the byte at offset `pos`.
+local function indent_at( s, pos )
+    local ls = pos
+    while ls > 1 and string_byte( s, ls - 1 ) ~= B_NL do
+        ls = ls - 1
+    end
+    local e = ls
+    while e < pos do
+        local b = string_byte( s, e )
+        if b == B_SPACE or b == B_TAB then e = e + 1 else break end
+    end
+    return string_sub( s, ls, e - 1 )
+end
+
+-- Decode a simple string-literal token to its key name. Only handles a
+-- plain SHORT string (the escape-free case; cfg keys are plain identifiers);
+-- returns nil for a long-bracket literal (`[[k]]`) or one with a backslash,
+-- since neither can equal a plain target key - a nil just means "not this
+-- key" (the gate still guarantees correctness).
+local function simple_key_of_string( s, tk )
+    local first = string_byte( s, tk.i )
+    if first ~= B_DQUOTE and first ~= B_SQUOTE then return nil end
+    local raw = string_sub( s, tk.i, tk.j )
+    if string_find( raw, "\\", 1, true ) then return nil end
+    -- strip the surrounding quote bytes
+    return string_sub( raw, 2, #raw - 1 )
+end
+
+-- Scan the top-level table of cfg text `s` for `key`. Returns a record:
+--   { ok = true, found = true,  value_i, value_j, indent }   key present
+--   { ok = true, found = false, close_i, indent }            key absent
+--   { ok = false }                                           bail -> fallback
+-- value_i..value_j is the inclusive byte span of the key's value; close_i
+-- is the byte offset of the config table's closing brace (append anchor).
+local function scan_table( s, key )
+    local tokens = tokenize( s )
+    if not tokens then return { ok = false } end
+    local n = #tokens
+
+    -- The config table is the first structural `{`.
+    local p = 1
+    while p <= n and not is_punct( tokens[ p ], "{" ) do p = p + 1 end
+    if p > n then return { ok = false } end
+    p = p + 1   -- first token inside the table
+
+    local found_i, found_j, found_indent
+    local found_count = 0
+    local first_indent
+
+    -- Build the result record for a config table whose closing `}` is at
+    -- token index `close_p`. `needs_sep` is true when the last field before
+    -- the brace has no trailing separator (`,`/`;`), so the APPEND path must
+    -- insert a comma right after that field's value (byte `sep_at`) to keep
+    -- the file valid Lua. An empty table (prev token is the opening `{`) or
+    -- a trailing separator both leave needs_sep false.
+    local function make_rec( close_p )
+        local prev = tokens[ close_p - 1 ]
+        local sep_present = prev ~= nil and prev.t == "punct"
+            and ( prev.v == "," or prev.v == ";" or prev.v == "{" )
+        return {
+            ok = true,
+            found = found_count == 1,
+            value_i = found_i,
+            value_j = found_j,
+            indent = found_indent or first_indent or "    ",
+            close_i = tokens[ close_p ].i,
+            needs_sep = not sep_present,
+            sep_at = ( not sep_present and prev ) and prev.j or nil,
+        }
+    end
+
+    while p <= n do
+        local tk = tokens[ p ]
+        if is_punct( tk, "}" ) then
+            if found_count > 1 then return { ok = false } end   -- ambiguous
+            return make_rec( p )
+        elseif is_punct( tk, "," ) or is_punct( tk, ";" ) then
+            p = p + 1   -- stray / trailing separator
+        else
+            -- Parse one entry: optional key, then a value.
+            local entry_indent = indent_at( s, tk.i )
+            if not first_indent then first_indent = entry_indent end
+            local this_key = nil
+            if tk.t == "name" and is_punct( tokens[ p + 1 ], "=" ) then
+                this_key = string_sub( s, tk.i, tk.j )
+                p = p + 2
+            elseif is_punct( tk, "[" ) and tokens[ p + 1 ] and tokens[ p + 1 ].t == "string"
+                and is_punct( tokens[ p + 2 ], "]" ) and is_punct( tokens[ p + 3 ], "=" ) then
+                this_key = simple_key_of_string( s, tokens[ p + 1 ] )
+                p = p + 4
+            elseif is_punct( tk, "[" ) and tokens[ p + 1 ] and tokens[ p + 1 ].t == "number"
+                and is_punct( tokens[ p + 2 ], "]" ) and is_punct( tokens[ p + 3 ], "=" ) then
+                this_key = nil   -- numeric key: never a targeted cfg key
+                p = p + 4
+            end
+            -- p now sits at the first token of the VALUE (positional entries
+            -- start here directly with this_key == nil).
+            local vtk = tokens[ p ]
+            if not vtk or is_punct( vtk, "}" ) then return { ok = false } end
+            local value_i = vtk.i
+            local value_j = nil
+            local depth = 0
+            local terminator = nil
+            while p <= n do
+                local t = tokens[ p ]
+                if is_punct( t, "{" ) then
+                    depth = depth + 1; value_j = t.j; p = p + 1
+                elseif is_punct( t, "}" ) then
+                    if depth == 0 then terminator = "}"; break end
+                    depth = depth - 1; value_j = t.j; p = p + 1
+                elseif ( is_punct( t, "," ) or is_punct( t, ";" ) ) and depth == 0 then
+                    terminator = t.v; break    -- Lua allows both , and ; as field seps
+                else
+                    value_j = t.j; p = p + 1
+                end
+            end
+            if not value_j then return { ok = false } end
+            if this_key == key then
+                found_count = found_count + 1
+                found_i, found_j, found_indent = value_i, value_j, entry_indent
+            end
+            if terminator == "}" then
+                if found_count > 1 then return { ok = false } end
+                return make_rec( p )
+            elseif terminator == "," or terminator == ";" then
+                p = p + 1
+            else
+                return { ok = false }   -- ran off the end without a terminator
+            end
+        end
+    end
+    return { ok = false }
+end
+
+----------------------------------// SAFETY GATE //--
+
+-- Deep structural equality of two Lua data values (cfg tables: scalars +
+-- nested tables). Integer/float key normalisation is handled by Lua (t[0]
+-- and t[0.0] are the same slot), and `==` treats 3 == 3.0.
+local function deep_equal( a, b )
+    if type( a ) ~= type( b ) then return false end
+    if type( a ) ~= "table" then return a == b end
+    for k, v in pairs( a ) do
+        if not deep_equal( v, b[ k ] ) then return false end
+    end
+    for k in pairs( b ) do
+        if a[ k ] == nil then return false end
+    end
+    return true
+end
+
+-- Textual form of `key` as a table-constructor key for the APPEND path:
+-- a bare identifier when it is a valid, non-reserved Lua name, else the
+-- bracketed quoted form.
+local function key_repr( key )
+    if type( key ) == "string" and not RESERVED[ key ]
+        and string_find( key, "^[%a_][%w_]*$" ) then
+        return key
+    end
+    return "[ " .. util_serialize_value( key ) .. " ]"
+end
+
+----------------------------------// PUBLIC //--
+
+local function build_new_text( old_text, settings, key )
+    local rec = scan_table( old_text, key )
+    if not rec.ok then return nil end
+    if rec.found then
+        local value_text = util_serialize_value( settings[ key ], rec.indent )
+        return string_sub( old_text, 1, rec.value_i - 1 )
+            .. value_text
+            .. string_sub( old_text, rec.value_j + 1 )
+    else
+        -- Absent key: append `<indent>key = value,` on its own line just
+        -- before the closing brace, preserving every existing comment. A
+        -- leading newline is added ONLY when the byte before the brace is
+        -- not already one, so the common `...,\n\n}` tail gains no double
+        -- blank line yet a one-line `{ }` / `{}` still splits correctly.
+        local value_text = util_serialize_value( settings[ key ], rec.indent )
+        local lead = ( string_byte( old_text, rec.close_i - 1 ) == B_NL ) and "" or "\n"
+        local field = lead .. rec.indent .. key_repr( key ) .. " = " .. value_text .. ",\n"
+        if rec.needs_sep and rec.sep_at then
+            -- The last existing field has no trailing separator. Add a comma
+            -- right after its value (before any inline comment on that line)
+            -- so the appended field is a syntactically distinct field.
+            return string_sub( old_text, 1, rec.sep_at )
+                .. ","
+                .. string_sub( old_text, rec.sep_at + 1, rec.close_i - 1 )
+                .. field
+                .. string_sub( old_text, rec.close_i )
+        end
+        return string_sub( old_text, 1, rec.close_i - 1 )
+            .. field
+            .. string_sub( old_text, rec.close_i )
+    end
+end
+
+-- Attempt a comment-preserving in-place rewrite of a single cfg key.
+--   path     - cfg.tbl path
+--   settings - the authoritative in-memory settings table (post-set)
+--   key      - the single key that changed
+-- Returns true when the surgical write succeeded and was verified; returns
+-- nil (never raises) on ANY failure, so the caller falls back to the
+-- wholesale util.savetable.
+local function save_key( path, settings, key )
+    local ok, result = pcall( function( )
+        local f = io_open( path, "rb" )
+        if not f then return nil end
+        local old_text = f:read( "*a" )
+        f:close( )
+        if not old_text or old_text == "" then return nil end
+
+        local new_text = build_new_text( old_text, settings, key )
+        if not new_text then return nil end
+
+        -- SAFETY GATE: the surgically rewritten text must parse (sandboxed,
+        -- non-executing) to a table deep-equal to the authoritative
+        -- settings. This is what makes a scanner bug non-catastrophic - a
+        -- bad splice can only fail to parse or parse to a different table,
+        -- both rejected here.
+        --
+        -- INVARIANT: the gate's loader (util.loadtable_string) must read the
+        -- written bytes EXACTLY as the runtime loader (util.loadtable ->
+        -- loadfile) will, or the proof breaks. The one known divergence -
+        -- loadfile skips a leading UTF-8 BOM, load() does not - is closed in
+        -- util.loadtable_string (the shipped cfg.tbl is BOM-headed). Any new
+        -- divergence would be a real corruption channel: keep the two in sync.
+        local parsed = util_loadtable_string( new_text, "cfg_write_verify" )
+        if type( parsed ) ~= "table" then return nil end
+        if not deep_equal( parsed, settings ) then return nil end
+
+        local wok = util_atomic_write( path, new_text )
+        if not wok then return nil end
+        return true
+    end )
+    if ok and result == true then return true end
+    return nil
+end
+
+return {
+    save_key = save_key,
+}

--- a/core/util.lua
+++ b/core/util.lua
@@ -149,6 +149,7 @@ local makedir
 
 local serialize
 local sortserialize
+local serialize_value
 
 local loadtable
 local loadtable_string
@@ -379,6 +380,40 @@ sortserialize = function( tbl, name, file, tab, r )
         end
     end
     file:write( "\n", tab, "}" )
+end
+
+-- Serialize a single Lua VALUE to its cfg.tbl textual form, reusing the
+-- exact escaping/sorting of the wholesale savetable path (sortserialize)
+-- so a surgical single-key rewrite (core/cfg_write.lua, #644) round-trips
+-- through loadtable identically to a full savetable. There is deliberately
+-- ONE serializer: a second, divergent value-formatter would be a defect
+-- (CLAUDE.md 1a.1).
+--
+-- `indent` is the run of spaces the CLOSING brace of a TABLE value sits at
+-- (= the column of the key being written); nested entries indent one
+-- 4-space level deeper. Scalars ignore it. The returned text carries NO
+-- leading indent on the opening brace (it follows `<key> = ` inline) and
+-- NO trailing comma.
+serialize_value = function( value, indent )
+    if type( value ) ~= "table" then
+        return ( type( value ) == "string" ) and utf_format( "%q", value ) or tostring( value )
+    end
+    indent = indent or ""
+    local sb = { buf = { }, n = 0 }
+    function sb:write( ... )
+        local n = select( "#", ... )
+        for i = 1, n do
+            self.n = self.n + 1
+            self.buf[ self.n ] = tostring( ( select( i, ... ) ) or "" )
+        end
+    end
+    -- r = true makes sortserialize emit `<indent>{ ... }` (a bare value, no
+    -- `name = ` prefix), inner entries at indent + 4, closing brace at indent.
+    sortserialize( value, "", sb, indent, true )
+    local s = table_concat( sb.buf, "", 1, sb.n )
+    -- Strip the leading indent sortserialize wrote before the opening brace
+    -- so the brace follows `= ` inline; the inner indentation is untouched.
+    return ( s:gsub( "^%s+", "" ) )
 end
 
 --// loads a local table from file
@@ -650,6 +685,17 @@ end
 -- of an encrypted user.tbl, and we want the same empty-_ENV protection
 -- as loadtable). Same return-shape as loadtable.
 loadtable_string = function( content, name )
+    -- Lua's load() on a STRING does not skip a leading UTF-8 BOM, unlike
+    -- loadfile()/luaL_loadfilex (which loadtable uses). Strip it so this
+    -- string-loader interprets bytes exactly as the file-loader does. This
+    -- is load-bearing for core/cfg_write.lua's safety gate (#644): the gate
+    -- re-parses the surgically rewritten cfg text with this function and
+    -- must read it EXACTLY as the runtime loadfile will - the shipped
+    -- cfg.tbl carries a BOM, so without this a BOM'd file would fail the
+    -- gate and silently fall back to the comment-stripping wholesale save.
+    if type( content ) == "string" then
+        content = content:gsub( "^\239\187\191", "" )
+    end
     local fn, err = load( content, name or "tbl_string", "t", { } )
     if not fn then return nil, err end
     local ok, ret = pcall( fn )
@@ -1033,6 +1079,7 @@ return {
     loadtable_string = loadtable_string,
     loadjsontable = loadjsontable,
     serialize = serialize,
+    serialize_value = serialize_value,
     savearray = savearray,
     arraytostring = arraytostring,
     tabletostring = tabletostring,

--- a/tests/unit/cfg_write_test.lua
+++ b/tests/unit/cfg_write_test.lua
@@ -1,0 +1,429 @@
+--[==[
+
+    tests/unit/cfg_write_test.lua
+
+    Unit tests for core/cfg_write.lua (#644) - the surgical,
+    comment/layout-preserving single-key cfg.tbl writer that cfg.set uses
+    in place of the wholesale util.savetable, falling back to it on any
+    failure.
+
+    What matters, and why:
+
+      1. A single-key change replaces ONLY that key's value; every comment,
+         blank line, other key and the operator's bare-key `key = value`
+         format is byte-preserved. This is the entire point of the module
+         (an operator who edits one setting via the WebUI must not lose
+         their hand-annotated cfg.tbl).
+      2. A nested-table value (a level-keyed permission map) is replaced
+         correctly and re-indented under its key.
+      3. A key ABSENT from the file is appended before the closing brace,
+         preserving every existing comment.
+      4. The canonical already-rewritten form (`[ "key" ] = v`) is handled
+         too, so a second edit of a previously wholesale-saved file still
+         works.
+      5. A `[[ long string ]]` value, and comments containing braces /
+         commas / fake `key = value` text, do NOT fool the lexer - a
+         neighbouring edit leaves them intact.
+      6. THE SAFETY GATE: the rewritten text is accepted only if it
+         re-parses (sandboxed) to a table deep-equal to the authoritative
+         settings. A change the splice cannot reproduce, a duplicate
+         top-level key (ambiguous), a lexically broken file, and an
+         unreadable file each return nil (so cfg.set falls back to the
+         proven wholesale save) and write NOTHING.
+
+    Provably fails pre-fix (CLAUDE.md 1a.7): on master core/cfg_write.lua
+    does not exist, so loadfile returns nil and the assert aborts - RED.
+    Patched, all checks pass - GREEN. The behavioural assertions below
+    would also fail a no-op or a mis-splicing implementation.
+
+    Run: lua5.4 tests/unit/cfg_write_test.lua   (from repo root)
+    Exit 0 = all pass, 1 = a failure (CI-friendly).
+
+]==]
+
+----------------------------------------------------------------------
+-- shim layer 1: load the REAL core/util.lua so serialize_value +
+-- loadtable_string are genuine (the module reuses util's serialiser and
+-- its sandboxed parser - a fake would not prove round-trip parity).
+----------------------------------------------------------------------
+
+local _dkjson = assert( loadfile( "dkjson/dkjson.lua" ) )( )
+
+local _io_stub = {
+    open = function( ) return nil, "no such file" end,   -- util never opens in these tests
+}
+local _adclib_stub = {
+    isutf8 = function( ) return true end,
+    random_bytes = function( ) return "x" end,
+}
+local _unicode_stub = {
+    ascii = { sub = string.sub, gsub = string.gsub },
+    utf8  = { format = string.format },
+}
+local _out_stub = { put = function( ) end, error = function( ) end }
+local _mem_stub = { free = function( ) end }
+
+local _util_deps = {
+    type = type, load = load, table = table, pairs = pairs,
+    pcall = pcall, select = select, ipairs = ipairs,
+    tostring = tostring, tonumber = tonumber, loadfile = loadfile,
+    setmetatable = setmetatable, getmetatable = getmetatable,
+    io = _io_stub, math = math, string = string, os = os,
+    package = package,
+    adclib = _adclib_stub, unicode = _unicode_stub,
+    out = _out_stub, mem = _mem_stub, dkjson = _dkjson,
+}
+_G.use = function( name )
+    local v = _util_deps[ name ]
+    assert( v ~= nil, "cfg_write_test util shim missing dep: use \"" .. name .. "\"" )
+    return v
+end
+
+local util = assert( loadfile( "core/util.lua" ) )( )
+util.init( )
+
+----------------------------------------------------------------------
+-- shim layer 2: load core/cfg_write.lua. util is a FACADE - real
+-- serialize_value + loadtable_string, but atomic_write is captured and io
+-- serves a virtual file - so the whole scan / splice / safety-gate path
+-- runs in memory and we assert on the exact text that WOULD be written.
+----------------------------------------------------------------------
+
+local captured        -- content the module handed to atomic_write (nil = none)
+local virtual_file    -- text the io stub serves as the existing cfg.tbl
+
+local _cfgw_io = {
+    open = function( )
+        if virtual_file == nil then return nil, "no such file" end
+        return {
+            read  = function( ) return virtual_file end,
+            close = function( ) end,
+        }
+    end,
+}
+local _util_facade = {
+    serialize_value  = util.serialize_value,
+    loadtable_string = util.loadtable_string,
+    atomic_write     = function( _path, content ) captured = content; return true end,
+}
+local _cfgw_deps = {
+    type = type, pairs = pairs, pcall = pcall, string = string,
+    io = _cfgw_io, util = _util_facade,
+}
+_G.use = function( name )
+    local v = _cfgw_deps[ name ]
+    assert( v ~= nil, "cfg_write_test shim missing dep: use \"" .. name .. "\"" )
+    return v
+end
+
+local cfgw = assert( loadfile( "core/cfg_write.lua" ) )( )
+
+----------------------------------------------------------------------
+-- minimal test framework
+----------------------------------------------------------------------
+
+local failures, checks = 0, 0
+local function report( pass, label, extra )
+    checks = checks + 1
+    if pass then
+        io.write( string.format( "ok   %s\n", label ) )
+    else
+        failures = failures + 1
+        io.write( string.format( "FAIL %-58s %s\n", label, extra or "" ) )
+    end
+end
+local function eq( label, got, want )
+    report( got == want, label, "got=" .. tostring( got ) .. " want=" .. tostring( want ) )
+end
+local function has( label, hay, needle )
+    report( type( hay ) == "string" and string.find( hay, needle, 1, true ) ~= nil,
+        label, "missing: " .. needle )
+end
+local function hasnot( label, hay, needle )
+    report( type( hay ) == "string" and string.find( hay, needle, 1, true ) == nil,
+        label, "unexpectedly present: " .. needle )
+end
+
+-- Deep equality for the round-trip assertions (independent of the
+-- module's own internal deep_equal).
+local function deep_equal( a, b )
+    if type( a ) ~= type( b ) then return false end
+    if type( a ) ~= "table" then return a == b end
+    for k, v in pairs( a ) do if not deep_equal( v, b[ k ] ) then return false end end
+    for k in pairs( b ) do if a[ k ] == nil then return false end end
+    return true
+end
+
+-- A representative operator-style cfg.tbl: bare keys, inline comments, a
+-- scalar-array, a level-keyed map, a long-bracket multi-line value, and a
+-- nasty comment carrying braces / commas / a fake `key = value`.
+local CFG = [==[
+return { -- root table, do not touch this line
+
+    ---- Basic ----
+    language = "en",  -- your language (string)
+    hub_name = "My Hub",  -- name of the hub
+
+    -- danger: a comment with { braces }, commas, and a fake key = value pair
+    hub_owner = "me",  -- owner (string)
+
+    ssl_ports = { 5001 },  -- ssl ports (integer array)
+
+    cmd_ban_permission = {
+
+        [ 0 ] = 0,
+        [ 60 ] = 50,
+        [ 100 ] = 100,
+
+    },  -- ban up to level, by level
+
+    msg_banner = [[
+line one
+line two
+]],
+
+}
+]==]
+
+local function parse( text )
+    local fn = assert( load( text, "cfg", "t", { } ) )
+    return fn( )
+end
+
+local function fresh( )    -- an independent parse of CFG per test
+    return parse( CFG )
+end
+
+local function run( old_text, settings, key )
+    virtual_file = old_text
+    captured = nil
+    local ret = cfgw.save_key( "cfg/cfg.tbl", settings, key )
+    return ret, captured
+end
+
+----------------------------------------------------------------------
+-- 1. change a scalar: only that value changes; comments + format kept
+----------------------------------------------------------------------
+
+do
+    local s = fresh( )
+    s.hub_name = "New Name"
+    local ret, out = run( CFG, s, "hub_name" )
+    eq( "scalar: save_key returned true", ret, true )
+    has( "scalar: new value present",         out or "", 'hub_name = "New Name"' )
+    has( "scalar: language comment kept",     out or "", "-- your language (string)" )
+    has( "scalar: other key untouched",       out or "", 'language = "en"' )
+    has( "scalar: own inline comment kept",   out or "", "-- name of the hub" )
+    hasnot( "scalar: stays bare-key (no quoting)", out or "", '[ "hub_name" ]' )
+    has( "scalar: root comment preserved",    out or "", "root table, do not touch this line" )
+    if out then eq( "scalar: round-trips to settings", deep_equal( parse( out ), s ), true ) end
+end
+
+----------------------------------------------------------------------
+-- 2. change a nested level-map value
+----------------------------------------------------------------------
+
+do
+    local s = fresh( )
+    s.cmd_ban_permission[ 60 ] = 99
+    local ret, out = run( CFG, s, "cmd_ban_permission" )
+    eq( "map: save_key returned true", ret, true )
+    has( "map: changed entry present",        out or "", "[ 60 ] = 99" )
+    has( "map: sibling entry present",        out or "", "[ 100 ] = 100" )
+    has( "map: unrelated comment kept",       out or "", "-- your language (string)" )
+    has( "map: banner long-string intact",    out or "", "line one\nline two" )
+    if out then eq( "map: round-trips to settings", deep_equal( parse( out ), s ), true ) end
+end
+
+----------------------------------------------------------------------
+-- 3. append an ABSENT key before the closing brace
+----------------------------------------------------------------------
+
+do
+    local s = fresh( )
+    s.max_users = 500
+    local ret, out = run( CFG, s, "max_users" )
+    eq( "append: save_key returned true", ret, true )
+    has( "append: new key present (bare)",    out or "", "max_users = 500" )
+    has( "append: existing comment kept",     out or "", "-- owner (string)" )
+    has( "append: banner intact",             out or "", "line one\nline two" )
+    if out then
+        eq( "append: round-trips to settings", deep_equal( parse( out ), s ), true )
+        -- the appended key must sit INSIDE the table (before the final brace)
+        local body = string.match( out, "return%s*(%b{})" )
+        has( "append: key is inside the root table", body or "", "max_users = 500" )
+    end
+end
+
+----------------------------------------------------------------------
+-- 4. canonical already-rewritten form ([ "key" ] = v) is handled
+----------------------------------------------------------------------
+
+do
+    local CANON = 'local settings\n\nsettings = {\n\n    [ "a" ] = 1,\n    [ "b" ] = "x",\n\n}\n\nreturn settings\n'
+    local s = { a = 2, b = "x" }
+    local ret, out = run( CANON, s, "a" )
+    eq( "canonical: save_key returned true", ret, true )
+    has( "canonical: changed value present",  out or "", '[ "a" ] = 2' )
+    has( "canonical: sibling preserved",      out or "", '[ "b" ] = "x"' )
+    has( "canonical: envelope preserved",     out or "", "return settings" )
+    if out then eq( "canonical: round-trips", deep_equal( parse( out ), s ), true ) end
+end
+
+----------------------------------------------------------------------
+-- 4b. a leading UTF-8 BOM (the SHIPPED cfg.tbl carries one) must NOT
+--     defeat the surgical path. The scanner tolerates the BOM; the trap
+--     is the safety gate - load() does not skip a BOM, loadfile() does,
+--     so util.loadtable_string must strip it or the gate rejects every
+--     BOM'd file and silently falls back to the comment-stripping save.
+--     Provably RED before that fix (save_key returns nil on BOM'd input).
+----------------------------------------------------------------------
+
+do
+    local BOM = "\239\187\191"
+    local s = fresh( )
+    s.hub_name = "Bom Name"
+    local ret, out = run( BOM .. CFG, s, "hub_name" )
+    eq( "bom: save_key returned true", ret, true )
+    has( "bom: new value present",       out or "", 'hub_name = "Bom Name"' )
+    has( "bom: comment preserved",       out or "", "-- your language (string)" )
+    if out then
+        eq( "bom: BOM retained in output", string.sub( out, 1, 3 ), BOM )
+        -- the written bytes (BOM included) must load to settings exactly as
+        -- the runtime loadfile (which strips the BOM) will.
+        local stripped = string.gsub( out, "^\239\187\191", "" )
+        eq( "bom: round-trips (BOM-stripped parse)", deep_equal( parse( stripped ), s ), true )
+    end
+end
+
+----------------------------------------------------------------------
+-- 5. lexer robustness: a comment with braces/commas/fake-key does not
+--    derail a neighbouring edit
+----------------------------------------------------------------------
+
+do
+    local s = fresh( )
+    s.hub_owner = "someone else"
+    local ret, out = run( CFG, s, "hub_owner" )
+    eq( "comment-trap: save_key returned true", ret, true )
+    has( "comment-trap: value changed",        out or "", 'hub_owner = "someone else"' )
+    has( "comment-trap: nasty comment intact", out or "", "a fake key = value pair" )
+    if out then eq( "comment-trap: round-trips", deep_equal( parse( out ), s ), true ) end
+end
+
+----------------------------------------------------------------------
+-- 6. SAFETY GATE: a change the single-key splice cannot reproduce is
+--    rejected (deep-equal fails) -> nil, nothing written
+----------------------------------------------------------------------
+
+do
+    local s = fresh( )
+    s.hub_name = "New Name"
+    s.language = "de"                 -- a SECOND divergence the splice of hub_name won't reflect
+    local ret, out = run( CFG, s, "hub_name" )
+    eq( "gate-mismatch: save_key returned nil", ret, nil )
+    eq( "gate-mismatch: nothing written",       out, nil )
+end
+
+----------------------------------------------------------------------
+-- 7. ambiguous: editing a key that appears TWICE at top level -> the
+--    scan bails (which value span is authoritative is undecidable) ->
+--    nil, nothing written. (Editing a NON-duplicated key in the same
+--    file stays fine - the splice is unambiguous and the gate verifies -
+--    so ambiguity is only rejected for the TARGET key.)
+----------------------------------------------------------------------
+
+do
+    local DUP = "return {\n    x = 1,\n    y = 2,\n    x = 3,\n}\n"
+    local s = parse( DUP )    -- Lua keeps the last x -> { x = 3, y = 2 }
+    s.x = 5
+    local ret, out = run( DUP, s, "x" )
+    eq( "ambiguous: save_key returned nil", ret, nil )
+    eq( "ambiguous: nothing written",       out, nil )
+end
+
+----------------------------------------------------------------------
+-- 8. lexically broken file (unterminated string) -> nil, nothing written
+----------------------------------------------------------------------
+
+do
+    local BROKEN = 'return {\n    hub_name = "unterminated,\n    x = 1,\n}\n'
+    local ret, out = run( BROKEN, { hub_name = "y", x = 1 }, "x" )
+    eq( "broken: save_key returned nil", ret, nil )
+    eq( "broken: nothing written",       out, nil )
+end
+
+----------------------------------------------------------------------
+-- 9. unreadable file -> nil, nothing written
+----------------------------------------------------------------------
+
+do
+    local ret, out = run( nil, { x = 1 }, "x" )   -- virtual_file nil => io.open returns nil
+    eq( "unreadable: save_key returned nil", ret, nil )
+    eq( "unreadable: nothing written",       out, nil )
+end
+
+----------------------------------------------------------------------
+-- 10. append when the LAST field has NO trailing comma: a comma must be
+--     added after that field's value (before its inline comment) so the
+--     result is valid Lua. Provably RED before the trailing-comma fix
+--     (append produced two adjacent fields with no separator -> gate nil).
+----------------------------------------------------------------------
+
+do
+    local NOCOMMA = "return {\n\n    a = 1,  -- first\n    b = 2  -- last (no trailing comma)\n}\n"
+    local s = parse( NOCOMMA )
+    s.c = 3
+    local ret, out = run( NOCOMMA, s, "c" )
+    eq( "nocomma: save_key returned true", ret, true )
+    has( "nocomma: comma added after last field", out or "", "b = 2,  -- last (no trailing comma)" )
+    has( "nocomma: appended key present",         out or "", "c = 3" )
+    has( "nocomma: first comment preserved",      out or "", "-- first" )
+    if out then eq( "nocomma: round-trips", deep_equal( parse( out ), s ), true ) end
+end
+
+----------------------------------------------------------------------
+-- 11. append edge cases: an empty table, and a reserved-word key
+--     (must fall back to the bracketed [ "end" ] = ... form)
+----------------------------------------------------------------------
+
+do
+    local s = { only = 1 }
+    local ret, out = run( "return {}\n", s, "only" )
+    eq( "empty-table: save_key returned true", ret, true )
+    has( "empty-table: key inserted", out or "", "only = 1" )
+    if out then eq( "empty-table: round-trips", deep_equal( parse( out ), s ), true ) end
+end
+
+do
+    local s = fresh( )
+    s[ "end" ] = 7            -- a Lua reserved word: bare `end = 7` is illegal
+    local ret, out = run( CFG, s, "end" )
+    eq( "reserved-key: save_key returned true", ret, true )
+    has( "reserved-key: bracketed form used", out or "", '[ "end" ] = 7' )
+    if out then eq( "reserved-key: round-trips", deep_equal( parse( out ), s ), true ) end
+end
+
+----------------------------------------------------------------------
+-- 12. edit a key in a SEMICOLON-separated table (Lua allows ; as a field
+--     separator). Provably RED before the ';' terminator fix (the value
+--     span over-ran to the closing brace -> gate mismatch -> nil).
+----------------------------------------------------------------------
+
+do
+    local SEMI = "return {\n    a = 1;\n    b = 2;\n}\n"
+    local s = parse( SEMI )
+    s.a = 9
+    local ret, out = run( SEMI, s, "a" )
+    eq( "semicolon: save_key returned true", ret, true )
+    has( "semicolon: value changed",   out or "", "a = 9" )
+    has( "semicolon: sibling intact",   out or "", "b = 2" )
+    if out then eq( "semicolon: round-trips", deep_equal( parse( out ), s ), true ) end
+end
+
+----------------------------------------------------------------------
+-- summary
+----------------------------------------------------------------------
+
+io.write( string.format( "\n%d checks, %d failures\n", checks, failures ) )
+os.exit( failures > 0 and 1 or 0 )


### PR DESCRIPTION
PR-1 of 2 for the comment-preserving cfg-save arc (#644). Ships the module + serialiser helper + tests; the `cfg.set` wiring + `_core` registration land in PR-2, so nothing is active on the boot path yet.

## What

`core/cfg_write.lua` surgically rewrites ONE cfg.tbl key in place, preserving comments/layout, instead of the wholesale rebuild `util.savetable` does (which strips comments, re-sorts keys, quotes bare keys, swaps the `return { }` envelope). Flow:

1. read the existing cfg.tbl text,
2. a char-stream lexer (never executes the file, cf. the #531 recogniser) locates the target key's value byte-span in the top-level table - matches both bare `key =` and `[ "key" ] =`, skips strings/comments/nested braces,
3. splice the newly serialised value (via the new `util.serialize_value`, the SAME serialiser the wholesale path uses -> identical round-trip),
4. **safety gate**: re-parse the spliced text sandboxed (`util.loadtable_string`, `env={}`, non-executing) and accept it ONLY if it deep-equals the authoritative `settings`,
5. `atomic_write`.

Absent keys are appended before the closing brace (adding a trailing comma to the prior field when it lacks one). Any failure returns nil -> caller falls back to the proven wholesale save. The accept-gate is what makes it safe: a mis-scan can only fail to parse or parse to a different table, both rejected - worst case is today's behaviour (comments lost), never a corrupted config. The whole entry point is `pcall`-wrapped and restricted-env clean (every global via `use`; `luac` shows only the `use` bootstrap `_ENV` ref).

## Helper changes in core/util.lua

- `serialize_value`: reuses `sortserialize` + `%q`/`tostring` so there is ONE value serialiser shared with `savetable` (no divergent second escaper).
- `loadtable_string`: strips a leading UTF-8 BOM, matching `loadfile` (which `loadtable` uses). The shipped `cfg.tbl` is BOM-headed; without this the gate's `load()` rejects every BOM'd file and silently falls back to the comment-stripping save - defeating the feature on the default install. Also benefits the `cfg_users` decrypt path.

## Tests

`tests/unit/cfg_write_test.lua` (registered on both smoke.yml legs), 57 checks: scalar / level-map / append / canonical-form / comment-trap / BOM / no-trailing-comma-append / reserved-word-key / empty-table / semicolon-separated, plus the four safe-degrade paths (gate-mismatch / ambiguous / broken / unreadable). The BOM and trailing-comma cases are proven RED on the unpatched code, GREEN after.

## Review

Two independent reviewers (lexer+gate-bypass; safety+integration). Both cleared the gate-bypass and restricted-env axes. Findings folded: the BOM gate defect (was HIGH), the append-trailing-comma defect (was MEDIUM), a `;`-separator handling gap, and a long-bracket-key decode guard; remaining LOWs (`\z` escape, non-4-space indent, `[[]]`->`%q` normalisation) documented as safe-degrade known-limitations.

Known pre-existing (NOT introduced here): `util.atomic_write`'s Windows remove-then-rename fallback can leave the file deleted if the rename fails - shared by every savetable caller; can file a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)