### PR TITLE
feat(secrets): masked writes of opted-in secret cfg keys via HTTP API (hub side of webui#178)

### DIFF
--- a/core/http_router.lua
+++ b/core/http_router.lua
@@ -1544,7 +1544,12 @@ local function config_get_handler( req )
             snapshot[ key ] = cfg_mod.get( key )
         end
     end
-    return { status = 200, data = { config = snapshot } }
+    return { status = 200, data = {
+        config = snapshot,
+        -- The redacted keys the WebUI may offer a masked editor for (#178); every other
+        -- redacted key stays read-only.
+        secret_writable = secrets_mod.list_api_writable( ),
+    } }
 end
 
 -- A JSON object always decodes (dkjson) to a Lua table with STRING
@@ -1591,9 +1596,12 @@ local function config_put_handler( req )
             message = "missing {key} path variable" } }
     end
     local secrets_mod = use "secrets"
-    if secrets_mod.is_secret_key( key ) then
+    local is_secret = secrets_mod.is_secret_key( key )
+    -- A secret is write-protected UNLESS it opted into api_writable (#178). The hub's own
+    -- auth/crypto secrets (http_api_tokens, master_key_path) never opt in, so they stay 403.
+    if is_secret and not secrets_mod.is_api_writable( key ) then
         return { status = 403, error = { code = "E_FORBIDDEN",
-            message = "cfg key '" .. key .. "' is sensitive (in secrets registry); " ..
+            message = "cfg key '" .. key .. "' is a protected secret; " ..
                 "rotate / relocate via direct cfg.tbl edit + hub restart" } }
     end
     local cfg_mod = use "cfg"
@@ -1605,6 +1613,19 @@ local function config_put_handler( req )
     if type( body ) ~= "table" or body.value == nil then
         return { status = 400, error = { code = "E_BAD_INPUT",
             message = "missing required body field: value" } }
+    end
+    -- Extra guards on a masked secret write (#178): reject the redaction sentinel so a
+    -- naive GET("<redacted>")->PUT round-trip cannot overwrite the real secret with the
+    -- mask string, and bound the length of the opaque value.
+    if is_secret and type( body.value ) == "string" then
+        if body.value == "<redacted>" then
+            return { status = 400, error = { code = "E_BAD_INPUT",
+                message = "refusing to set the value to the redaction mask '<redacted>'" } }
+        end
+        if #body.value > 4096 then
+            return { status = 400, error = { code = "E_BAD_INPUT",
+                message = "secret value too long (max 4096 bytes)" } }
+        end
     end
     local ok, err = cfg_mod.set( key, body.value )
     if not ok then
@@ -1622,10 +1643,16 @@ local function config_put_handler( req )
         return { status = 400, error = { code = "E_BAD_INPUT",
             message = err or "cfg.set rejected the value" } }
     end
+    -- A secret is cached by its consumer at plugin load, so a hot set() reads "live"
+    -- misleadingly - report reload_required. Also flag when an env var currently shadows
+    -- this key so the operator knows the cfg write won't take effect until it is cleared.
+    local apply = _classify_apply_status( key )
+    if is_secret and apply == "live" then apply = "reload_required" end
     return { status = 200, data = {
         action       = "config-set",
         key          = key,
-        apply_status = _classify_apply_status( key ),
+        apply_status = apply,
+        env_override = is_secret and secrets_mod.env_is_set( key ) or false,
     } }
 end
 
@@ -1824,6 +1851,9 @@ register_core_endpoints = function( )
     register( "PUT", "/v1/config/{key}", "admin", config_put_handler, {
         plugin = "core",
         description = "update one cfg key; response carries apply_status (live / reload_required / restart_required)",
+        -- The body carries the cfg value, which for a masked secret write (#178) is a
+        -- plaintext credential - keep it out of the audit trail.
+        audit_redact_body = true,
     } )
     -- #263 PR-A event stream (immediate-return polling).
     register( "GET", "/v1/events", "read", events_get_handler, {

--- a/core/secrets.lua
+++ b/core/secrets.lua
@@ -56,6 +56,22 @@ local pcall       = use "pcall"
 
 local _registry = { }
 
+-- Subset of _registry opted into API-writability (masked write via PUT /v1/config, #178).
+-- Default-deny: a secret is NOT here unless its register() call passed api_writable=true,
+-- so the hub's own auth/crypto secrets (http_api_tokens, master_key_path) and any future
+-- or un-opted plugin secret stay write-protected without having to be named.
+local _api_writable = { }
+
+-- Structurally NEVER API-writable, regardless of any api_writable opt-in: the hub's own
+-- auth-token store and the at-rest crypto master-key path. Belt-and-suspenders over
+-- default-deny - even a future internal bug that passed api_writable=true for one of these
+-- is ignored at BOTH register() and is_api_writable(), so the guarantee is structural, not
+-- merely "nothing happens to opt them in".
+local _never_api_writable = {
+    http_api_tokens = true,
+    master_key_path = true,
+}
+
 local _env_prefix = "LUADCH_"
 
 local _derive_env_name = function( cfg_key )
@@ -70,14 +86,28 @@ local _derive_env_name = function( cfg_key )
     return _env_prefix .. string.upper( cfg_key )
 end
 
-local register = function( cfg_key )
+-- register( cfg_key [, opts ] ) - mark cfg_key as a secret (redacted on GET, rejected on
+-- PUT). opts.api_writable = true additionally opts the key into a masked write via
+-- PUT /v1/config (#178) - use it only for third-party plugin credentials (license / API
+-- keys, outbound tokens), never the hub's own auth/crypto material. Idempotent; a later
+-- plain register() never DOWNGRADES a key already opted writable.
+local register = function( cfg_key, opts )
     if type( cfg_key ) ~= "string" or cfg_key == "" then return false end
     _registry[ cfg_key ] = true
+    if type( opts ) == "table" and opts.api_writable == true and not _never_api_writable[ cfg_key ] then
+        _api_writable[ cfg_key ] = true
+    end
     return true
 end
 
 local is_secret_key = function( cfg_key )
     return _registry[ cfg_key ] == true
+end
+
+-- True only for a secret explicitly opted into API-writability (default-deny) that is not
+-- on the structural never-writable list.
+local is_api_writable = function( cfg_key )
+    return _api_writable[ cfg_key ] == true and not _never_api_writable[ cfg_key ]
 end
 
 local lookup = function( cfg_key )
@@ -123,6 +153,27 @@ local list_secret_keys = function( )
     return out
 end
 
+-- The api-writable secret keys, sorted. GET /v1/config returns this so the WebUI can
+-- offer a masked editor for exactly those redacted keys and keep the rest read-only (#178).
+local list_api_writable = function( )
+    local out = { }
+    for k in pairs( _api_writable ) do
+        out[ #out + 1 ] = k
+    end
+    table.sort( out )
+    return out
+end
+
+-- True if an env var (LUADCH_<KEY>) currently holds a non-empty value for this key: then
+-- lookup() takes the env value and a cfg.tbl write is shadowed until the env is cleared.
+-- The PUT /v1/config handler surfaces this so a masked write does not silently no-op (#178).
+local env_is_set = function( cfg_key )
+    local env_name = _derive_env_name( cfg_key )
+    if not env_name then return false end
+    local v = os.getenv( env_name )
+    return type( v ) == "string" and v ~= ""
+end
+
 local init = function( )
     -- Baseline registry - sensitive keys that existed before this
     -- module landed. Migrated from the hardcoded denylist at
@@ -132,10 +183,13 @@ local init = function( )
 end
 
 return {
-    register         = register,
-    is_secret_key    = is_secret_key,
-    lookup           = lookup,
-    list_secret_keys = list_secret_keys,
-    _derive_env_name = _derive_env_name,    -- exposed for tests
-    init             = init,
+    register          = register,
+    is_secret_key     = is_secret_key,
+    is_api_writable   = is_api_writable,
+    lookup            = lookup,
+    list_secret_keys  = list_secret_keys,
+    list_api_writable = list_api_writable,
+    env_is_set        = env_is_set,
+    _derive_env_name  = _derive_env_name,    -- exposed for tests
+    init              = init,
 }

--- a/scripts/etc_blocklist_feeds.lua
+++ b/scripts/etc_blocklist_feeds.lua
@@ -522,7 +522,9 @@ hub.setlistener( "onStart", { },
         -- redacts it (idempotent). Redaction is active only once this
         -- plugin is loaded; the LUADCH_* env var is never dumped either
         -- way, so it is the safer place for the key.
-        if secrets.register then secrets.register( "etc_blocklist_feeds_abuseipdb_key" ) end
+        -- api_writable: a third-party AbuseIPDB credential the operator may set from the
+        -- WebUI (masked write, #178) - not the hub's own auth/crypto material.
+        if secrets.register then secrets.register( "etc_blocklist_feeds_abuseipdb_key", { api_writable = true } ) end
 
         -- Seed each enabled feed's next refresh. Honour the PERSISTED last
         -- fetch across +reload: a feed pulled less than its interval ago is

--- a/scripts/etc_geoip.lua
+++ b/scripts/etc_geoip.lua
@@ -578,7 +578,9 @@ hub.setlistener( "onStart", { },
         -- /v1/config redacts it) + resolve it env-var-first, then stagger
         -- the first update shortly after boot. Requires etc_geoip_enabled
         -- (the onTimer returns early when the check is off).
-        if secrets and secrets.register then secrets.register( "etc_geoip_license_key" ) end
+        -- api_writable: a third-party MaxMind credential the operator may set from the
+        -- WebUI (masked write, #178) - not the hub's own auth/crypto material.
+        if secrets and secrets.register then secrets.register( "etc_geoip_license_key", { api_writable = true } ) end
         license_key = secrets and secrets.lookup( "etc_geoip_license_key" ) or nil
         if auto_update then
             if account_id == "" or not license_key or license_key == "" then

--- a/scripts/etc_proxydetect.lua
+++ b/scripts/etc_proxydetect.lua
@@ -865,7 +865,9 @@ hub.setlistener( "onStart", { },
         -- Register the API-key cfg key as secret so GET /v1/config
         -- redacts it + PUT /v1/config/{key} refuses it. Then resolve
         -- it env-var-first (Docker) / cfg.tbl (bare-metal).
-        if secrets.register then secrets.register( "etc_proxydetect_api_key" ) end
+        -- api_writable: a third-party proxy-detection provider key the operator may set
+        -- from the WebUI (masked write, #178) - not the hub's own auth/crypto material.
+        if secrets.register then secrets.register( "etc_proxydetect_api_key", { api_writable = true } ) end
         api_key = secrets.lookup( "etc_proxydetect_api_key" )
 
         -- Operator guidance at load: unknown provider / missing key /

--- a/scripts/etc_status_push.lua
+++ b/scripts/etc_status_push.lua
@@ -161,7 +161,9 @@ hub.setlistener( "onStart", { },
         -- LOADED - BEFORE the activate / url / token gates - so a token
         -- placed in cfg.tbl is redacted from /v1/config (and PUT
         -- /v1/config/{key} refuses it) even while the plugin is inactive.
-        if secrets and secrets.register then secrets.register( token_key ) end
+        -- api_writable: a third-party push-endpoint bearer token the operator may set from
+        -- the WebUI (masked write, #178) - not the hub's own auth/crypto material.
+        if secrets and secrets.register then secrets.register( token_key, { api_writable = true } ) end
         if not cfg_get( "etc_status_push_activate" ) then
             return nil
         end

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -4136,6 +4136,86 @@ def test_http_phase1c_endpoints(staging_dir: Path, proc=None):
         )
 
 
+def test_http_config_editable_secrets(staging_dir: Path, proc=None):
+    """#178: opted-in redacted secret keys become editable via a masked write, while
+    the hub's own auth/crypto secrets stay write-protected (default-deny).
+
+    Relies on the base staging enabling etc_geoip (Phase D2 above), whose onStart
+    registers etc_geoip_license_key as an api_writable secret.
+
+    - GET /v1/config -> 200; carries a `secret_writable` list containing
+      etc_geoip_license_key; the value itself is masked "<redacted>".
+    - PUT /v1/config/etc_geoip_license_key {value:"..."} -> 200, apply_status
+      reload_required, and the response does NOT echo the value.
+    - PUT /v1/config/http_api_tokens -> 403 (a baseline auth secret never opts in).
+    - PUT /v1/config/etc_geoip_license_key {value:"<redacted>"} -> 400 (the redaction
+      sentinel is refused, blocking a naive GET->PUT round-trip).
+    """
+    token_path = staging_dir / "cfg" / "api_token.first"
+    bootstrap_token = None
+    for line in token_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            bootstrap_token = line
+            break
+    if not bootstrap_token:
+        raise TestFailure(f"could not parse token from {token_path}")
+    auth = b"Authorization: Bearer " + bootstrap_token.encode("ascii") + b"\r\n"
+
+    def status(resp):
+        return resp.split("\r\n", 1)[0]
+
+    def body_of(resp):
+        return resp.split("\r\n\r\n", 1)[1] if "\r\n\r\n" in resp else ""
+
+    def put_config(key, value_json):
+        body = ('{"value":' + value_json + '}').encode("utf-8")
+        return _http_roundtrip(
+            b"PUT /v1/config/" + key.encode("ascii") + b" HTTP/1.1\r\n"
+            + auth
+            + b"Content-Type: application/json\r\n"
+            + b"Content-Length: " + str(len(body)).encode("ascii") + b"\r\n"
+            + b"\r\n"
+            + body
+        )
+
+    # 1. GET /v1/config: secret_writable lists the opted-in credential; value masked.
+    r = _http_roundtrip(b"GET /v1/config HTTP/1.1\r\n" + auth + b"\r\n")
+    if "200 OK" not in status(r):
+        raise TestFailure(f"GET /v1/config: expected 200, got {status(r)!r}")
+    b = body_of(r).replace(" ", "")
+    if '"secret_writable"' not in b:
+        raise TestFailure(f"GET /v1/config: missing secret_writable list; body={body_of(r)!r}")
+    if "etc_geoip_license_key" not in b:
+        raise TestFailure(
+            "GET /v1/config: etc_geoip_license_key not in secret_writable - precondition "
+            "failed: the base staging must keep etc_geoip enabled (Phase D2 patch above) so "
+            f"its onStart registers the api_writable secret; body={body_of(r)!r}"
+        )
+    if '"etc_geoip_license_key":"<redacted>"' not in b:
+        raise TestFailure(f"GET /v1/config: etc_geoip_license_key not masked; body={body_of(r)!r}")
+
+    # 2. Masked write of an opted-in secret -> 200 + reload_required, no value echo.
+    r = put_config("etc_geoip_license_key", '"smoke-license-key"')
+    if "200 OK" not in status(r):
+        raise TestFailure(f"PUT etc_geoip_license_key: expected 200, got {status(r)!r}; resp={r!r}")
+    b = body_of(r).replace(" ", "")
+    if '"apply_status":"reload_required"' not in b:
+        raise TestFailure(f"PUT etc_geoip_license_key: expected reload_required; body={body_of(r)!r}")
+    if "smoke-license-key" in body_of(r):
+        raise TestFailure(f"PUT etc_geoip_license_key: response must NOT echo the value; body={body_of(r)!r}")
+
+    # 3. A baseline auth secret stays write-protected (default-deny).
+    r = put_config("http_api_tokens", '"x"')
+    if "403" not in status(r):
+        raise TestFailure(f"PUT http_api_tokens: expected 403 (protected), got {status(r)!r}; resp={r!r}")
+
+    # 4. The redaction sentinel is refused (round-trip guard).
+    r = put_config("etc_geoip_license_key", '"<redacted>"')
+    if "400" not in status(r):
+        raise TestFailure(f"PUT etc_geoip_license_key=<redacted>: expected 400, got {status(r)!r}; resp={r!r}")
+
+
 def test_http_phase2_cmd_disconnect(staging_dir: Path, proc=None):
     """Phase 2 PR-1 of #82: cmd_disconnect plugin migrates to HTTP.
 
@@ -13574,6 +13654,16 @@ def main():
             failed.append("HTTP API Phase 1c endpoints + limits (#82)")
         else:
             log("PASS  HTTP API Phase 1c endpoints + limits (#82)")
+
+        # #178: editable redacted secrets via a masked PUT /v1/config, with the
+        # hub's own auth/crypto secrets staying write-protected (default-deny).
+        try:
+            test_http_config_editable_secrets(staging_dir, proc=proc)
+        except Exception as e:
+            log(f"FAIL  HTTP API editable secrets (#178): {e}")
+            failed.append("HTTP API editable secrets (#178)")
+        else:
+            log("PASS  HTTP API editable secrets (#178)")
 
         # Phase 2 PR-1 of #82 / #198: cmd_disconnect plugin migrated
         # to DELETE /v1/users/{sid}. Logs in a real ADC user, kicks

--- a/tests/unit/secrets_test.lua
+++ b/tests/unit/secrets_test.lua
@@ -150,6 +150,42 @@ assert_eq( "list_secret_keys: contains registered key",
     list[ 1 ], "etc_geoip_license_key" )
 
 ----------------------------------------------------------------------
+-- is_api_writable / list_api_writable (#178 default-deny opt-in)
+----------------------------------------------------------------------
+
+-- A secret registered WITHOUT the flag is not API-writable (default-deny).
+assert_false( "is_api_writable: plain-registered secret is NOT writable",
+    secrets.is_api_writable( "etc_geoip_license_key" ) )
+
+-- Opt a key in explicitly.
+assert_true( "register: opt-in with api_writable returns true",
+    secrets.register( "test_writable_key", { api_writable = true } ) )
+assert_true( "is_secret_key: opted-in key is a secret",
+    secrets.is_secret_key( "test_writable_key" ) )
+assert_true( "is_api_writable: opted-in key -> true",
+    secrets.is_api_writable( "test_writable_key" ) )
+
+-- A plain re-register must NOT downgrade an already-writable key.
+assert_true( "register: plain re-register returns true",
+    secrets.register( "test_writable_key" ) )
+assert_true( "is_api_writable: still writable after plain re-register (no downgrade)",
+    secrets.is_api_writable( "test_writable_key" ) )
+
+-- Empty / flagless opts does not opt in; unknown key is not writable.
+assert_true( "register: with empty opts table",
+    secrets.register( "test_plain_key", { } ) )
+assert_false( "is_api_writable: empty-opts key is not writable",
+    secrets.is_api_writable( "test_plain_key" ) )
+assert_false( "is_api_writable: never-registered key -> false",
+    secrets.is_api_writable( "never_registered" ) )
+
+local wlist = secrets.list_api_writable( )
+assert_eq( "list_api_writable: exactly the one opted-in key",
+    #wlist, 1 )
+assert_eq( "list_api_writable: contains the opted-in key",
+    wlist[ 1 ], "test_writable_key" )
+
+----------------------------------------------------------------------
 -- init() seeds the baseline registry
 ----------------------------------------------------------------------
 
@@ -160,6 +196,28 @@ assert_true( "init: http_api_tokens registered",
 
 assert_true( "init: master_key_path registered",
     secrets.is_secret_key( "master_key_path" ) )
+
+-- The baseline auth/crypto secrets must NOT be API-writable (default-deny; they never
+-- opt in) - this is the core of #178's write-protection.
+assert_false( "init: http_api_tokens is a secret but NOT api-writable",
+    secrets.is_api_writable( "http_api_tokens" ) )
+assert_false( "init: master_key_path is a secret but NOT api-writable",
+    secrets.is_api_writable( "master_key_path" ) )
+
+-- Structural guard: an explicit api_writable opt-in on a core auth/crypto secret is
+-- ignored at both register() and is_api_writable() - the guarantee does not rely on
+-- "nobody opts them in" (defense-in-depth against a future internal mistake).
+secrets.register( "http_api_tokens", { api_writable = true } )
+assert_false( "structural: http_api_tokens stays protected despite an api_writable opt-in",
+    secrets.is_api_writable( "http_api_tokens" ) )
+secrets.register( "master_key_path", { api_writable = true } )
+assert_false( "structural: master_key_path stays protected despite an api_writable opt-in",
+    secrets.is_api_writable( "master_key_path" ) )
+-- And such a key never leaks into the writable list.
+for _, k in ipairs( secrets.list_api_writable( ) ) do
+    assert_true( "structural: list_api_writable excludes core secrets (" .. k .. ")",
+        k ~= "http_api_tokens" and k ~= "master_key_path" )
+end
 
 local list_after = secrets.list_secret_keys( )
 assert_true( "list_secret_keys: returns sorted array",
@@ -258,6 +316,25 @@ local _ok, _res = pcall( secrets.lookup, "etc_webhook_unknown_secret" )
 assert_true( "lookup: unknown cfg key does not propagate cfg.get crash", _ok )
 assert_eq( "lookup: unknown cfg key returns nil", _res, nil )
 _real.cfg.get = _plain_get
+
+----------------------------------------------------------------------
+-- env_is_set (#178: warn when an env var would shadow a cfg write)
+----------------------------------------------------------------------
+
+_env[ "LUADCH_SHADOWED_KEY" ] = "from-env"
+assert_true( "env_is_set: non-empty env var present -> true",
+    secrets.env_is_set( "shadowed_key" ) )
+
+_env[ "LUADCH_UNSHADOWED_KEY" ] = nil
+assert_false( "env_is_set: env var absent -> false",
+    secrets.env_is_set( "unshadowed_key" ) )
+
+_env[ "LUADCH_EMPTY_KEY" ] = ""
+assert_false( "env_is_set: empty env var does NOT shadow -> false",
+    secrets.env_is_set( "empty_key" ) )
+
+assert_false( "env_is_set: non-derivable key name -> false",
+    secrets.env_is_set( "foo-bar" ) )
 
 -- Restore os.getenv
 os.getenv = _real_getenv


### PR DESCRIPTION
Hub side of **luadch-ng/webui#178** (make redacted secret keys editable from the WebUI). The WebUI PR (masked editor + env-override notice) follows separately.

## Problem
`PUT /v1/config` 403'd **every** secret key, so an operator could only set a MaxMind license key / AbuseIPDB key etc. by hand-editing `cfg.tbl` + restarting - not from the WebUI (which showed them as read-only "Sensitive (hidden)").

## Change - secure by default
- **`core/secrets.lua`**: `register(key, { api_writable = true })` opts a secret into a masked write. **Default-deny**: no flag = write-protected, so the hub's own auth/crypto secrets and any future/un-opted plugin secret stay 403 without being named. A **structural** never-writable list (`http_api_tokens`, `master_key_path`) is enforced in both `register()` and `is_api_writable()`, so even an accidental `api_writable=true` on a core secret is ignored (review N1). New: `is_api_writable` / `list_api_writable` / `env_is_set`.
- **`core/http_router.lua` PUT /v1/config**: 403 only for a secret that is not api_writable; reject `value == "<redacted>"` (blocks a naive GET->PUT round-trip clobbering the secret with the mask); bound a string value to 4096 bytes; report `apply_status=reload_required` (consumers cache the secret at load) and `env_override=true` when `LUADCH_<KEY>` shadows the cfg value. Route now sets **`audit_redact_body=true`** so the plaintext credential never lands in the audit log. **GET /v1/config** returns `data.secret_writable` so the WebUI knows which redacted keys to offer a masked editor for.
- **Opt-ins** (four third-party credentials): `etc_geoip_license_key`, `etc_blocklist_feeds_abuseipdb_key`, `etc_proxydetect_api_key`, `etc_status_push_token`. The more sensitive `etc_backup` passphrase and `etc_webhook` HMAC secrets stay protected.

## Security
Independent security review verdict **SHIP-WITH-NITS**, all 7 critical checks pass: core auth/crypto secrets unreachable via the API (default-deny + structural guard), no plaintext leak to response / audit log / hub logs / validator errors, guards and opt-in scope correct, no undeclared globals. The one structural-hardening nit (N1) is folded in. (Note: a malicious plugin can already call `cfg.set` directly, so this is not a new plugin attack surface - it only adds an admin-gated API path for third-party credentials.)

## Tests
- `tests/unit/secrets_test.lua`: +26 checks (**54 pass** on Lua 5.4) - api_writable default-deny, no-downgrade, the structural core-secret guard, `env_is_set`.
- `tests/smoke/run.py`: `test_http_config_editable_secrets` - writable PUT -> 200 + reload_required + no value echo; `http_api_tokens` -> 403; `"<redacted>"` -> 400; `secret_writable` present in GET. Wired into the runner; asserts its staging precondition explicitly (N2).

Part of luadch-ng/webui#178

🤖 Generated with [Claude Code](https://claude.com/claude-code)