### PR TITLE
docs(cfg): correct the ratelimit_handshake_sweep_interval comment (#648 follow-up)

### DIFF
--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -4895,13 +4895,19 @@ local defaults = {
         end
     },
     -- #207: cadence of the dedicated "kill stuck TLS handshakes"
-    -- sweep. Decoupled from the broader _checkinterval (120s) so a
-    -- handshake whose `ratelimit_handshake_timeout` expired gets
-    -- reaped within roughly `sweep_interval` seconds rather than
-    -- waiting for the next 120s sweep. Worst-case stuck-handshake
-    -- lifetime = handshake_timeout + sweep_interval (default
-    -- 10 + 10 = ~20s). Setting to 0 effectively disables the fast
-    -- sweep and falls back to the broader 120s cadence.
+    -- sweep, a DoS mitigation - a stuck handshake pins a handler +
+    -- coroutine until it is reaped. A handshake whose
+    -- `ratelimit_handshake_timeout` expired gets reaped within roughly
+    -- `sweep_interval` seconds; worst-case stuck-handshake lifetime =
+    -- handshake_timeout + sweep_interval (default 10 + 10 = ~20s).
+    -- server.lua reads this live (apply_status "live", #648 follow-up)
+    -- and clamps it to a >= 1s floor - the validator below only
+    -- type-checks the value, so the clamp is the floor. It CANNOT be
+    -- disabled: 0 or a negative becomes a 1s sweep, not "off". That is
+    -- deliberate - nothing else reaps stuck handshakes (the 120s
+    -- _checkinterval loop does idle-timeout + bucket cleanup, not a
+    -- handshake sweep), so a disable path would open a memory-pinning
+    -- DoS hole. Do not add one.
     ratelimit_handshake_sweep_interval = { 10,
         function( value )
             return types_number( value, nil, true )


### PR DESCRIPTION
Option X from the #660 independent review (NIT 2). Comment-only, no behaviour change.

The `cfg_defaults.lua` comment claimed *"Setting to 0 effectively disables the fast sweep and falls back to the broader 120s cadence."* Both halves are wrong:

- `core/server.lua` clamps the value to a `>= 1s` floor, so `0` becomes a **1s** sweep (the most aggressive setting), not "off".
- Nothing else reaps stuck handshakes: the 120s `_checkinterval` loop does idle-timeout + bucket cleanup, **not** a handshake sweep. There is no 120s fallback.

So an operator who set `0` to "disable" the sweep would get the opposite. Since the sweep is a DoS mitigation (a stuck handshake pins a handler + coroutine), disabling it is not a feature we want - the rewritten comment records that it is deliberately always-on (clamp = floor, cannot be disabled) so nobody adds a disable path later.

Verified by the #660 review, which independently confirmed the clamp-is-the-floor and no-120s-fallback facts. `luac54 -p` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)