### PR TITLE
feat(chat): POST /v1/chat - post to main chat as the hubbot (#669)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -185,6 +185,12 @@ jobs:
       - name: Run cmd_gag gags-endpoint unit test
         run: lua5.4 tests/unit/cmd_gag_endpoint_test.lua
 
+      # cmd_talk POST /v1/chat (webui#177 A): posts to main chat as the
+      # hubbot, mirrors into etc_chatlog's new log_line export, audits
+      # the real operator, response sender = hubbot nick (no token leak).
+      - name: Run cmd_talk chat-endpoint unit test
+        run: lua5.4 tests/unit/cmd_talk_endpoint_test.lua
+
       # cmd_ban periodic sweep: an expired non-permanent ban is pruned on
       # a 60s onTimer (not just lazily on the banned user's reconnect);
       # permanent bans are never swept, and a no-op sweep does not save.
@@ -655,6 +661,10 @@ jobs:
       - name: Run cmd_gag gags-endpoint unit test
         shell: msys2 {0}
         run: lua5.4 tests/unit/cmd_gag_endpoint_test.lua
+
+      - name: Run cmd_talk chat-endpoint unit test
+        shell: msys2 {0}
+        run: lua5.4 tests/unit/cmd_talk_endpoint_test.lua
 
       - name: Run cmd_ban sweep unit test
         shell: msys2 {0}

--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -1267,6 +1267,7 @@ an unknown path).
 | Method | Path | Scope | Plugin |
 |---|---|---|---|
 | POST | `/v1/announce` | admin | `cmd_mass` [^http-announce-1] |
+| POST | `/v1/chat` | admin | `cmd_talk` [^http-chat-1] |
 | POST | `/v1/topic` | admin | `cmd_topic` [^http-topic-1] |
 | GET | `/v1/aliases` | read | `etc_aliases` [^http-aliases-1] |
 | POST | `/v1/aliases` | admin | `etc_aliases` [^http-aliases-2] |
@@ -1276,6 +1277,8 @@ an unknown path).
 | POST | `/v1/shutdown` | admin | `cmd_shutdown` - requires `X-Confirm: yes` (§4.6) [^http-shutdown-1] |
 
 [^http-announce-1]: Body `{message: string required (max 1024 chars, control-byte sanitised), scope: "all"|"hub"|"level" required, level?: integer (REQUIRED when scope="level", must exist in cfg.levels)}`. `scope="all"` broadcasts the banner to all online users with the operator's token-label as the visible sender (= ADC `+mass`); `scope="hub"` broadcasts without sender in the banner (= ADC `+masshub`); `scope="level"` PMs only users at the given level (= ADC `+masslvl N`). Returns 200 with `data: {action:"announce", scope, message, sender, level?, recipients?}` per §7.1.1; `recipients` is the matched-user count for scope="level" (broadcast variants omit it - derive from `/v1/stats`). A single `admin`-scoped token can issue any of the three ADC variants via the structured body.
+
+[^http-chat-1]: #669 (hub side of [webui#177](https://github.com/luadch-ng/webui/issues/177)). Body `{message: string required (max 1024 chars, control-byte sanitised)}`. Posts the message into MAIN CHAT as the hubbot (= ADC `+talk`) - a BMSG from the hub-bot SID, so connected clients see the hubbot nick as the sender, not the token label. Per webui#177 the audit actor is the real operator asserted in `X-Actor` (`req.actor`), falling back to the token label / `"http-api"`. Returns 200 with `data: {action:"chat", message, sender}` per §7.1.1; `sender` is the hubbot nick (NOT the token label - no token-fingerprint leak, unlike the `/v1/announce` banner). The post is also mirrored into `etc_chatlog` (when that plugin is loaded) so it appears in `+history` and `GET /v1/chatlog`; hub-originated broadcasts bypass the onBroadcast chat-filter chain by design (the hubbot is not subject to chat rules / flood limits).
 
 [^http-topic-1]: Body `{topic?: string}` (max 256 chars, control-byte sanitised). Missing OR empty `topic` resets the hub topic to `cfg.hub_description`; non-empty sets it. The ADC `+topic default` magic-keyword does NOT apply on the HTTP path - the structured body expresses "reset" via absence, so HTTP callers CAN literally set the topic to the word "default" via `{"topic": "default"}`. Returns 200 with `data: {action:"topic-set"|"topic-reset", topic, previous}` per §7.1.1. The new topic is broadcast to all connected users via `IINF DE...` and persisted to `scripts/data/cmd_topic.tbl`.
 
@@ -1486,6 +1489,7 @@ the same code path the `+cmd` listener uses.
 > bug that takes months to surface.
 
 - `cmd_mass` → `POST /v1/announce`
+- `cmd_talk` → `POST /v1/chat`
 - `cmd_topic` → `POST /v1/topic`
 - `cmd_ban` → `GET/POST /v1/bans`, `DELETE /v1/bans/{id}`
 - `cmd_disconnect` → `DELETE /v1/users/{sid}`

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -663,7 +663,7 @@ empty so the on-disk shape stays compact.
 `reg.desc.set`, `reg.level.set`, `reg.nickchange`,
 `reg.password.change`, `hub.topic.set`, `hub.topic.reset`,
 `hub.reload`, `hub.restart`, `hub.shutdown`,
-`hub.announce.{all,hub,level}`,
+`hub.announce.{all,hub,level}`, `hub.chat.post`,
 `alias.{add,remove}`, `msgmanager.{block,unblock}`,
 `blacklist.remove`, `log.clear`, `records.reset`,
 `user.cleanup`, `user.cleanup.exception.{add,remove,clear}`,

--- a/scripts/cmd_talk.lua
+++ b/scripts/cmd_talk.lua
@@ -6,6 +6,12 @@
 
         usage: [+!#]talk <MSG>
 
+        v1.3:
+            - HTTP API: POST /v1/chat - post to main chat as the hubbot (admin scope)  webui#177 A
+            - extract post_to_mainchat() shared by +talk and the HTTP handler; mirror
+              hubbot posts into etc_chatlog (via its new log_line) so they appear in
+              +history / GET /v1/chatlog
+
         v1.2 by blastbeat:
             - get rid of useless 'bot_opchat_activate' variable
 
@@ -54,7 +60,7 @@
 --------------
 
 local scriptname = "cmd_talk"
-local scriptversion = "1.1"
+local scriptversion = "1.3"
 
 local cmd = "talk"
 
@@ -100,6 +106,21 @@ local msg_usage = lang.msg_usage or "Usage: [+!#]talk <MSG>"
 --[CODE]--
 ----------
 
+-- Post a line into main chat as the hubbot (BMSG via hub.broadcast,
+-- bot passed as `from` only). Also mirror it into etc_chatlog so it
+-- appears in `+history` and the GET /v1/chatlog feed - hub.broadcast
+-- does not fire onBroadcast, so etc_chatlog would otherwise miss
+-- hubbot posts. Chat filters / flood rules are bypassed by design
+-- (the hubbot is not a normal chat user). Shared by the ADC `+talk`
+-- command and the HTTP POST /v1/chat handler (webui#177 A).
+local post_to_mainchat = function( msg )
+    hub_broadcast( msg, hub_getbot )
+    local chatlog = hub_import( "etc_chatlog" )
+    if chatlog and chatlog.log_line then
+        chatlog.log_line( hub_getbot:nick(), msg )
+    end
+end
+
 local onbmsg = function( user, command, parameters )
     local user_level = user:level()
     if user_level < minlevel then
@@ -108,11 +129,36 @@ local onbmsg = function( user, command, parameters )
     end
     local param = utf_match( parameters, "^(.*)" )
     if param then
-        hub_broadcast( param, hub_getbot )
+        post_to_mainchat( param )
         return PROCESSED
     end
     user:reply( msg_usage, hub_getbot )
     return PROCESSED
+end
+
+-- HTTP handler: POST /v1/chat. Admin scope. Posts a line into main
+-- chat as the hubbot (= ADC `+talk`). Body { message } (max 1024,
+-- control-byte sanitised). Per webui#177: end users see the hubbot;
+-- the audit actor is the real operator (req.actor / X-Actor) with a
+-- token-label / "http-api" fallback. The response `sender` is the
+-- hubbot nick, NOT the token label - no token-fingerprint leak.
+local http_handler_chat = function( req )
+    local body = req.body or { }
+    local message = body.message
+    if not message or message == "" then
+        return { status = 400, error = { code = "E_BAD_INPUT",
+            message = "missing or empty 'message' field" } }
+    end
+    local clean_msg = util.strip_control_bytes( message )
+    post_to_mainchat( clean_msg )
+    local actor = req.actor
+    if not actor or actor == "" then actor = req.token_label or "http-api" end
+    audit.fire( audit.build( "hub.chat.post", { nick = actor, sid = "<http>" }, nil, clean_msg, nil ) )
+    return { status = 200, data = {
+        action  = "chat",
+        message = clean_msg,
+        sender  = hub_getbot:nick(),
+    } }
 end
 
 hub.setlistener( "onPrivateMessage", {},
@@ -160,8 +206,32 @@ hub.setlistener( "onStart", {},
         local hubcmd = hub_import( "etc_hubcommands" )
         assert( hubcmd )
         assert( hubcmd.add( cmd, onbmsg, minlevel ) )
+        -- HTTP API endpoint (webui#177 A). Coexists with the ADC
+        -- `+talk` chat-cmd above; both go through post_to_mainchat.
+        -- Raw hub.http_register (not util_http): hub-control endpoint
+        -- with no SID target. admin scope is the authorisation gate.
+        if hub.http_register then
+            hub.http_register( "POST", "/v1/chat", "admin", http_handler_chat, {
+                plugin = scriptname,
+                description = "post a message into main chat as the hubbot (= ADC `+talk`); body { message }",
+                request_schema = {
+                    message = { type = "string", required = true, max_length = 1024 },
+                },
+                response_schema = {
+                    action  = { type = "string", required = true },
+                    message = { type = "string", required = true },
+                    sender  = { type = "string", required = true },
+                },
+            } )
+        end
         return nil
     end
 )
 
 hub_debug( "** Loaded " .. scriptname .. " " .. scriptversion .. " **" )
+
+-- exposed for the unit tests (webui#177 A: POST /v1/chat hubbot post)
+return {
+    _http_handler_chat = http_handler_chat,
+    _post_to_mainchat  = post_to_mainchat,
+}

--- a/scripts/etc_chatlog.lua
+++ b/scripts/etc_chatlog.lua
@@ -2,6 +2,13 @@
 
     etc_chatlog.lua by Motnahp
 
+        v1.7:
+            - extract record_line() helper (build + trim + persist) shared by the
+              onBroadcast listener and a new exported log_line()
+            - export log_line(nick, message) so hub-originated main-chat posts (which
+              do not fire onBroadcast) can be recorded - used by cmd_talk for the
+              hubbot's +talk / POST /v1/chat posts  (webui#177 A)
+
         v1.6:
             - HTTP API: GET /v1/chatlog?lines=N (read scope)  #82 Phase 4 PR-1
             - extract get_log_tail() helper shared by ADC + HTTP paths
@@ -78,7 +85,7 @@
 --[[ Settings ]]--
 
 local scriptname = "etc_chatlog"
-local scriptversion = "1.6"
+local scriptversion = "1.7"
 
 -- HTTP API §6.4 tail-style ceiling. The §6.4 list-endpoint cap
 -- is 1000, but for chatlog the effective bound is also the
@@ -386,26 +393,47 @@ hub.setlistener( "onLogin", { },
     end
 )
 
+-- Append one line to the chat-log buffer: build the entry, trim to
+-- max_lines, persist every `saveit` arrivals. Shared by the
+-- onBroadcast listener below AND the exported `log_line`, so
+-- hub-originated main-chat posts (which do NOT fire onBroadcast) can
+-- still be recorded. Callers do their own gating.
+local record_line = function( nick, message )
+    savehistory = savehistory + 1  -- increment savehistory to save if it reaches saveit
+    local t = {  -- build table
+        [1] = os.date( "%Y-%m-%d / %H:%M:%S" ),
+        [2] = nick,
+        [3] = message
+    }
+    table.insert( t_log, t )  -- add table to t_log
+    for x = 1, #t_log -  max_lines do  -- remove an item of t_log it there are to many items in
+        table.remove( t_log, 1 )
+    end
+    if savehistory >= saveit then  -- save t_log and set savehistory 0
+        savehistory = 0
+        util.savearray( t_log, log_path )
+    end
+end
+
+-- Exported: record a main-chat line originating from another plugin.
+-- cmd_talk uses it for the hubbot's `+talk` / `POST /v1/chat` posts,
+-- which go out via hub.broadcast and therefore never fire
+-- onBroadcast - without this they would be absent from the log and
+-- the GET /v1/chatlog feed. Bypasses the onBroadcast gating on
+-- purpose (the hubbot is not subject to chat filters). No-op on bad
+-- input.
+local log_line = function( nick, message )
+    if type( nick ) ~= "string" or type( message ) ~= "string" then return end
+    record_line( util.strip_control_bytes( nick ), util.strip_control_bytes( message ) )
+end
+
 hub.setlistener( "onBroadcast", { },
     function( user, adccmd, msg)
         local data = hub.escapefrom(adccmd[6]) -- get current mainchat message, don't use 'msg'; reason: mainchat message might be changed by another script in the meantime
         local msg = string.match( msg, "^%s*(.*)" ) -- this pattern will generate an error ^%s*(.*%S) so i have changed it 2022-12-11
         local result = string.byte( msg, 1 )
         if msgmanager_permission[ user:level() ] and result ~= 33 and result ~= 35 and result ~= 43 then  -- in ASCII (decimal): 33 = "!"; 35 = "#"; 43 = "+"
-            savehistory = savehistory + 1  -- increment savehistory to save if it reaches saveit
-            local t = {  -- build table
-                [1] = os.date( "%Y-%m-%d / %H:%M:%S" ),
-                [2] = user:nick( ),
-                [3] = data
-            }
-            table.insert( t_log, t )  -- add table to t_log
-            for x = 1, #t_log -  max_lines do  -- remove an item of t_log it there are to many items in
-                table.remove( t_log, 1 )
-            end
-            if savehistory >= saveit then  -- save t_log and set savehistory 0
-                savehistory = 0
-                util.savearray( t_log, log_path )
-            end
+            record_line( user:nick( ), data )
         end
     end
 )
@@ -456,5 +484,15 @@ show_t_exceptions = function ( )  -- returns t_exceptions
 end
 
 hub.debug( "** Loaded " .. scriptname .. ".lua **" )
+
+-- Exported module (webui#177 A): `log_line` lets cmd_talk mirror the
+-- hubbot's main-chat posts into the log. The `_`-prefixed entries are
+-- unit-test hooks only.
+return {
+    log_line      = log_line,
+    _record_line  = record_line,
+    _get_log_tail = get_log_tail,
+    _t_log        = t_log,
+}
 
 --[[   End    ]]--

--- a/tests/unit/cmd_talk_endpoint_test.lua
+++ b/tests/unit/cmd_talk_endpoint_test.lua
@@ -1,0 +1,162 @@
+--[[
+
+    tests/unit/cmd_talk_endpoint_test.lua
+
+    Regression test for webui#177 A (hub side, #669): posting to main
+    chat as the hubbot from the HTTP API.
+
+    Two coupled units, tested together (the cmd_talk handler mirrors
+    through the REAL etc_chatlog.log_line):
+
+      1. etc_chatlog v1.7 exports `log_line(nick, message)` so
+         hub-originated main-chat posts - which go out via
+         hub.broadcast and therefore never fire onBroadcast - are
+         still recorded into the log buffer (and thus GET /v1/chatlog).
+         It builds one entry, trims, control-byte sanitises, and no-ops
+         on bad input.
+
+      2. cmd_talk v1.3's POST /v1/chat handler broadcasts the message
+         as the hubbot (BMSG: bot as `from`, no `pm`), returns
+         {action:"chat", message, sender=<hubbot nick>} (NOT the token
+         label - no fingerprint leak), records the real operator
+         (req.actor, with token-label / "http-api" fallback) as the
+         audit actor, and mirrors the post into etc_chatlog.
+
+    FAIL-PRE-FIX: on the unpatched tree cmd_talk has no
+    _http_handler_chat and etc_chatlog has no log_line, so both calls
+    are `attempt to call a nil value` - the test is red. The
+    assertions pin the behaviour.
+
+    Run: lua5.4 tests/unit/cmd_talk_endpoint_test.lua
+
+]]--
+
+local failures, checks = 0, 0
+local function ok( label, cond )
+    checks = checks + 1
+    if cond then io.write( "ok   " .. label .. "\n" )
+    else failures = failures + 1; io.write( "FAIL " .. label .. "\n" ) end
+end
+
+-- shared sandbox-global stubs
+_G.PROCESSED = "PROCESSED"
+_G.os = os; _G.string = string; _G.table = table
+_G.tonumber = tonumber; _G.tostring = tostring; _G.type = type
+_G.ipairs = ipairs; _G.pairs = pairs
+
+-- strip control bytes (< 0x20) so sanitisation is observable
+local function strip( s ) return ( s:gsub( "[%z\1-\31]", "" ) ) end
+_G.util = {
+    loadtable            = function( ) return { } end,
+    savearray            = function( ) end,
+    strip_control_bytes  = function( s ) return strip( s ) end,
+    getlowestlevel       = function( t ) local lo; for k in pairs( t ) do if not lo or k < lo then lo = k end end return lo or 0 end,
+}
+
+local _cfg = {
+    language                        = "en",
+    -- etc_chatlog
+    etc_chatlog_min_level_adv       = 80,
+    etc_chatlog_permission          = { },
+    etc_chatlog_max_lines           = 200,
+    etc_chatlog_default_lines       = 20,
+    etc_msgmanager_permission_main  = { },
+    -- cmd_talk
+    cmd_talk_minlevel               = 10,
+    bot_regchat_nick                = "RegChat",
+    bot_regchat_activate            = false,
+    bot_regchat_permission          = { },
+    bot_opchat_nick                 = "OpChat",
+    bot_opchat_permission           = { },
+}
+_G.cfg = {
+    get          = function( k ) return _cfg[ k ] end,
+    loadlanguage = function( ) return { } end,
+}
+_G.utf = {
+    match  = function( s, pat ) return string.match( s, pat ) end,
+    format = function( fmt, ... ) return string.format( fmt, ... ) end,
+}
+
+-- ===== Part 1: etc_chatlog.log_line =====
+_G.hub = {
+    setlistener   = function( ) end,
+    debug         = function( ) end,
+    getbot        = function( ) return { nick = function( ) return "HubBot" end } end,
+    escapefrom    = function( s ) return s end,
+    import        = function( ) return nil end,
+    http_register = function( ) end,
+}
+
+local cl = assert( loadfile( "scripts/etc_chatlog.lua" ) )( )
+ok( "etc_chatlog exports log_line", type( cl.log_line ) == "function" )
+
+cl.log_line( "HubBot", "hello from bot" )
+local tail1 = cl._get_log_tail( 1 )
+ok( "log_line records one line",         #tail1 == 1 )
+ok( "recorded nick is the hubbot",       tail1[ 1 ] and tail1[ 1 ].nick == "HubBot" )
+ok( "recorded message body preserved",   tail1[ 1 ] and tail1[ 1 ].message == "hello from bot" )
+
+cl.log_line( "Hub\1Bot", "a\2b" )
+local tail2 = cl._get_log_tail( 1 )
+ok( "log_line control-byte sanitises",   tail2[ 1 ] and tail2[ 1 ].nick == "HubBot" and tail2[ 1 ].message == "ab" )
+
+local before = #cl._t_log
+cl.log_line( nil, "x" ); cl.log_line( "n", 123 ); cl.log_line( nil, nil )
+ok( "log_line no-ops on bad input",      #cl._t_log == before )
+
+-- ===== Part 2: cmd_talk POST /v1/chat =====
+local bcast    -- last broadcast call
+local audited  -- last audit event
+local bot = { nick = function( ) return "HubBot" end, sid = function( ) return "AAAA" end }
+_G.hub = {
+    setlistener   = function( ) end,
+    debug         = function( ) end,
+    getbot        = function( ) return bot end,
+    broadcast     = function( msg, from, pm, me ) bcast = { msg = msg, from = from, pm = pm, me = me } end,
+    http_register = function( ) end,
+    import        = function( name )
+        if name == "etc_chatlog" then return cl end
+        if name == "bot_regchat" or name == "bot_opchat" then return { feed = function( ) end } end
+        return nil  -- cmd_help / etc_usercommands / etc_hubcommands: only used in onStart, which is not fired here
+    end,
+}
+_G.audit = {
+    build = function( action, actor, target, msg, extra ) return { action = action, actor = actor, msg = msg } end,
+    fire  = function( ev ) audited = ev end,
+}
+
+local p = assert( loadfile( "scripts/cmd_talk.lua" ) )( )
+ok( "cmd_talk exports _http_handler_chat", type( p._http_handler_chat ) == "function" )
+
+local logbefore = #cl._t_log
+local res = p._http_handler_chat( { body = { message = "hi chat" }, actor = "opNick", token_label = "webui (aB..Yz)" } )
+ok( "valid post -> status 200",                     res and res.status == 200 )
+ok( "action is chat",                               res and res.data and res.data.action == "chat" )
+ok( "message echoed back",                          res and res.data and res.data.message == "hi chat" )
+ok( "sender is the hubbot nick (no token leak)",    res and res.data and res.data.sender == "HubBot" )
+ok( "broadcast as hubbot (from=bot, no pm -> BMSG)", bcast and bcast.msg == "hi chat" and bcast.from == bot and bcast.pm == nil )
+ok( "post mirrored into the chat log",              #cl._t_log == logbefore + 1 )
+local lastlog = cl._get_log_tail( 1 )[ 1 ]
+ok( "mirrored line attributed to the hubbot",       lastlog and lastlog.nick == "HubBot" and lastlog.message == "hi chat" )
+ok( "audit action is hub.chat.post",                audited and audited.action == "hub.chat.post" )
+ok( "audit actor is the real operator (req.actor)", audited and audited.actor and audited.actor.nick == "opNick" )
+
+p._http_handler_chat( { body = { message = "x" }, token_label = "tok" } )
+ok( "audit falls back to token_label when no actor", audited and audited.actor.nick == "tok" )
+
+p._http_handler_chat( { body = { message = "y" } } )
+ok( "audit falls back to http-api when neither present", audited and audited.actor.nick == "http-api" )
+
+p._http_handler_chat( { body = { message = "he\1llo" }, actor = "op" } )
+ok( "message control bytes stripped before broadcast", bcast and bcast.msg == "hello" )
+
+local e1 = p._http_handler_chat( { body = { message = "" } } )
+ok( "empty message -> 400 E_BAD_INPUT", e1 and e1.status == 400 and e1.error and e1.error.code == "E_BAD_INPUT" )
+local e2 = p._http_handler_chat( { body = { } } )
+ok( "missing message -> 400", e2 and e2.status == 400 )
+local e3 = p._http_handler_chat( { } )
+ok( "missing body -> 400", e3 and e3.status == 400 )
+
+io.write( string.format( "\n%d checks, %d failures\n", checks, failures ) )
+os.exit( failures == 0 and 0 or 1 )

--- a/tests/unit/cmd_talk_endpoint_test.lua
+++ b/tests/unit/cmd_talk_endpoint_test.lua
@@ -44,8 +44,9 @@ _G.os = os; _G.string = string; _G.table = table
 _G.tonumber = tonumber; _G.tostring = tostring; _G.type = type
 _G.ipairs = ipairs; _G.pairs = pairs
 
--- strip control bytes (< 0x20) so sanitisation is observable
-local function strip( s ) return ( s:gsub( "[%z\1-\31]", "" ) ) end
+-- Mirror production util.strip_control_bytes EXACTLY (core/util.lua):
+-- control chars (incl. 0x7f) are REPLACED with '?', non-strings -> "".
+local function strip( s ) return ( type( s ) == "string" ) and ( s:gsub( "%c", "?" ) ) or "" end
 _G.util = {
     loadtable            = function( ) return { } end,
     savearray            = function( ) end,
@@ -99,7 +100,7 @@ ok( "recorded message body preserved",   tail1[ 1 ] and tail1[ 1 ].message == "h
 
 cl.log_line( "Hub\1Bot", "a\2b" )
 local tail2 = cl._get_log_tail( 1 )
-ok( "log_line control-byte sanitises",   tail2[ 1 ] and tail2[ 1 ].nick == "HubBot" and tail2[ 1 ].message == "ab" )
+ok( "log_line control-byte sanitises (-> '?')", tail2[ 1 ] and tail2[ 1 ].nick == "Hub?Bot" and tail2[ 1 ].message == "a?b" )
 
 local before = #cl._t_log
 cl.log_line( nil, "x" ); cl.log_line( "n", 123 ); cl.log_line( nil, nil )
@@ -149,7 +150,7 @@ p._http_handler_chat( { body = { message = "y" } } )
 ok( "audit falls back to http-api when neither present", audited and audited.actor.nick == "http-api" )
 
 p._http_handler_chat( { body = { message = "he\1llo" }, actor = "op" } )
-ok( "message control bytes stripped before broadcast", bcast and bcast.msg == "hello" )
+ok( "message control bytes sanitised before broadcast (-> '?')", bcast and bcast.msg == "he?llo" )
 
 local e1 = p._http_handler_chat( { body = { message = "" } } )
 ok( "empty message -> 400 E_BAD_INPUT", e1 and e1.status == 400 and e1.error and e1.error.code == "E_BAD_INPUT" )
@@ -157,6 +158,15 @@ local e2 = p._http_handler_chat( { body = { } } )
 ok( "missing message -> 400", e2 and e2.status == 400 )
 local e3 = p._http_handler_chat( { } )
 ok( "missing body -> 400", e3 and e3.status == 400 )
+
+-- the shared path used by the ADC `+talk` command directly: broadcasts
+-- as the hubbot AND mirrors into the chat log (same as /v1/chat)
+local dlog = #cl._t_log
+p._post_to_mainchat( "via talk" )
+ok( "_post_to_mainchat broadcasts as the hubbot (BMSG)", bcast and bcast.msg == "via talk" and bcast.from == bot and bcast.pm == nil )
+ok( "_post_to_mainchat mirrors into the chat log",       #cl._t_log == dlog + 1 )
+local tlog = cl._get_log_tail( 1 )[ 1 ]
+ok( "+talk mirror attributed to the hubbot",             tlog and tlog.nick == "HubBot" and tlog.message == "via talk" )
 
 io.write( string.format( "\n%d checks, %d failures\n", checks, failures ) )
 os.exit( failures == 0 and 0 or 1 )


### PR DESCRIPTION
@
Part of luadch-ng/webui#177 (A). Closes #669.

The hub-side endpoint for the WebUI Chat surface: post a line into **main chat as the hubbot**.

## What
- **`cmd_talk` `POST /v1/chat`** (admin scope). Body `{ message }` (max 1024, control-byte sanitised). Broadcasts as the hubbot (BMSG - bot as `from`, no `pm`), the same mechanism the existing ADC `+talk` command already uses. Extracts `post_to_mainchat()` shared by `+talk` and the HTTP handler.
- **Attribution (per webui#177):** end users see the **hubbot**; the **audit** actor is the real operator (`req.actor` / `X-Actor`) with a token-label / `"http-api"` fallback; the response `sender` is the hubbot nick, **not** the token label - no token-fingerprint leak (contrast the `/v1/announce` banner, tracked separately in the webui#177 C sub-issue).
- **`etc_chatlog` `log_line()` export** (+ `record_line()` factored out of the onBroadcast listener). `hub.broadcast` does not fire `onBroadcast`, so hubbot posts were absent from the log + `GET /v1/chatlog` feed; now `cmd_talk` mirrors every `+talk` / `/v1/chat` post through it. The onBroadcast chat-filter chain is bypassed by design (the hubbot is not subject to chat rules / flood limits). Side effect: `+talk` messages now also appear in `+history` / the chatlog - an intended improvement.

## Deep-dive notes (arc start)
`cmd_talk` already did hubbot->main-chat, so this adds an HTTP entry rather than a new plugin. `etc_chatlog` had no `return {}` table, so its exports had to move to the chunk-return table (that is what `hub.import` reads).

## Tests
`tests/unit/cmd_talk_endpoint_test.lua` - 22 checks over both units (endpoint + the real `log_line` mirror): envelope, hubbot broadcast shape (BMSG), sender = hubbot nick, audit actor precedence (req.actor -> token_label -> http-api), control-byte stripping, 400s. Proven RED on the unpatched tree (`log_line` / `_http_handler_chat` absent). Registered on both smoke.yml legs.

## Out of scope
WebUI Chat page (webui#177 B); moderation-attribution rework + the announce token-fingerprint leak fix (webui#177 C, separate hub sub-issue).
@