### PR TITLE
feat(etc_webhook): HTTP management API + per-endpoint enabled toggle (v0.04)

### DIFF
--- a/docs/WEBHOOKS.md
+++ b/docs/WEBHOOKS.md
@@ -85,6 +85,7 @@ return {
     endpoints = {
         {
             name             = "discourse",       -- [A-Za-z0-9_]; used in the path + env-var name
+            enabled          = true,               -- optional; default true. false = pause this endpoint without deleting it (or its secret)
             path             = "/v1/webhook/discourse",   -- default: /v1/webhook/<name>
             signature_header = "x-discourse-event-signature",  -- required
             signature_prefix = "sha256=",          -- stripped before compare ("" if the header is raw hex)
@@ -110,6 +111,11 @@ return {
 Header names are matched case-insensitively (the hub lowercases them).
 Any number of endpoints is supported; edit the file and `+reload` to add
 more.
+
+**`enabled`** (optional, default `true`) pauses one endpoint without
+deleting it or its secret: `enabled = false` makes the hub skip it (no
+route, no bot) on load, while the entry (and its config) stays in the
+file. Omitting the field means enabled.
 
 **Templates** use `{dotted.path}` placeholders resolved against the
 decoded JSON body, plus `{event}` (the value of the header named by
@@ -138,6 +144,39 @@ event the endpoint accepts). Two common uses:
   `post_created` (its auto opening post). `{ path = "post.post_number",
   not_equals = 1 }` drops that duplicate opening post while still announcing
   the topic (which carries no `post.post_number`) and real replies (>= 2).
+
+### 3.1 Managing endpoints via the WebUI / HTTP API
+
+`cfg/webhooks.tbl` can be edited by hand (above) OR managed over the HTTP
+API - the WebUI's **Webhooks** tab is the front end for it. The routes
+(admin scope for writes, `read` for the list) are:
+
+| Route | Does |
+|---|---|
+| `GET /v1/webhooks` | list endpoints + tuning; **secrets are redacted** (`has_secret` + `secret_source`, never the value) |
+| `POST /v1/webhooks` | create an endpoint |
+| `PUT /v1/webhooks/{name}` | replace an endpoint (a blank/omitted `secret` keeps the current one) |
+| `DELETE /v1/webhooks/{name}` | delete an endpoint |
+| `PUT /v1/webhooks` | update the global tuning (`max_per_minute` / `dedup_max` / `field_maxlen`) |
+
+Notes:
+
+- **The plugin owns the file.** A save through the API regenerates
+  `cfg/webhooks.tbl` (an atomic write, then `chmod 600`): a header banner
+  is kept, but hand-written comments and layout are **not** preserved, and
+  inline secrets are rewritten. Hand-editing still works; the two just do
+  not co-exist losslessly.
+- **A write needs a `+reload` to take effect.** Endpoint config is read
+  once at load, so every write returns `apply_status = "reload_required"`;
+  the WebUI shows a pending-reload banner.
+- **Secrets are write-only.** The API never returns a secret. A secret set
+  via env var / cfg key (`secret_source = "external"`) cannot be rotated by
+  writing the file (the override wins on load) - the WebUI marks it as
+  externally managed. WebUI-created endpoints store their secret inline.
+- **The management routes register whenever the plugin is whitelisted**
+  (`enabled = true` in `cfg.scripts`), independent of
+  `etc_webhook_activate`. So the Webhooks tab appears - and can flip the
+  master switch - even before the receiver is turned on.
 
 ---
 

--- a/examples/cfg/webhooks.tbl
+++ b/examples/cfg/webhooks.tbl
@@ -4,7 +4,13 @@
 
     Copy this file to  cfg/webhooks.tbl  and edit it. It is plain Lua
     (same as cfg.tbl). If you put secrets inline (see below), chmod it
-    600 - it is NOT exposed via the HTTP API, but treat it like cfg.tbl.
+    600 - treat it like cfg.tbl.
+
+    You can manage endpoints by hand here OR through the WebUI's Webhooks
+    tab / the HTTP API (GET/POST/PUT/DELETE /v1/webhooks*). A save through
+    the API regenerates this file (atomic write + chmod 600): a header
+    banner is kept, but comments and layout are NOT preserved and inline
+    secrets are rewritten. The API never returns a secret on read.
 
     The master switch etc_webhook_activate lives in cfg.tbl; everything
     else is here. After editing, run  +reload .
@@ -45,6 +51,7 @@ return {
         -- ============================ Discourse forum ============================
         {
             name             = "discourse",
+            enabled          = true,                       -- optional (default true); set false to pause this endpoint without deleting it
             path             = "/v1/webhook/discourse",   -- the Payload URL you configure in Discourse (via your reverse proxy)
             signature_header = "x-discourse-event-signature",
             signature_prefix = "sha256=",

--- a/scripts/etc_webhook.lua
+++ b/scripts/etc_webhook.lua
@@ -26,12 +26,33 @@
         endpoint config lives in cfg/webhooks.tbl (keeps cfg.tbl lean).
         Runtime dedup state lives in scripts/data/etc_webhook.tbl.
 
+        cfg/webhooks.tbl can be hand-edited (plain Lua) OR managed through
+        the HTTP API (GET/POST/PUT/DELETE /v1/webhooks*, admin scope for
+        writes) - the WebUI's Webhooks tab uses the latter. The plugin
+        owns the file either way; a WebUI save regenerates it (comments
+        dropped) via an atomic write + chmod 600. Endpoint changes reach
+        the live receiver only after a +reload, so the API returns
+        apply_status = "reload_required".
+
         Security: the endpoint registers with scope="none" (the router's
         bearer-token gate is skipped) and does its OWN HMAC auth over
         req.raw_body, constant-time compared (adclib.constant_time_eq).
         The HTTP listener itself is only reachable per the operator's
         http_port + reverse-proxy setup - see docs/WEBHOOKS.md.
 
+        v0.04: by Aybo - HTTP management API + per-endpoint `enabled`
+               toggle. GET/POST/PUT/DELETE /v1/webhooks/{name} (+ PUT
+               /v1/webhooks for the global tuning) let the WebUI create,
+               edit and delete endpoints without shell access; the plugin
+               writes cfg/webhooks.tbl itself (atomic tmp+rename, chmod
+               600 like user.tbl) and NEVER returns a secret on read (only
+               has_secret + secret_source). The management routes register
+               whenever the plugin is loaded - independent of
+               etc_webhook_activate - so the WebUI tab (gated on the route
+               being present) and the receiver gate are decoupled: you can
+               prepare endpoints and flip the master switch from the tab.
+               New optional `enabled` field (default true; absent = on)
+               pauses one endpoint without losing its config or secret.
         v0.03: by Aybo - per-endpoint `conditions` body-field filter
                (equals / not_equals) so a delivery can be filtered on a
                decoded JSON field, not just the event header. Solves two
@@ -54,7 +75,7 @@
 --------------
 
 local scriptname = "etc_webhook"
-local scriptversion = "0.03"
+local scriptversion = "0.04"
 
 local config_file = "cfg/webhooks.tbl"
 local dedup_file  = "scripts/data/etc_webhook.tbl"
@@ -69,10 +90,14 @@ local hub_regbot      = hub.regbot
 local util_loadtable  = util.loadtable
 local util_savetable  = util.savetable
 local util_strip      = util.strip_control_bytes
+local util_tabletostring = util.tabletostring    -- serialise config for the mgmt writer
+local util_atomic_write  = util.atomic_write      -- crash-safe tmp+rename write
+local util_chmod_secret  = util.chmod_secret      -- POSIX 0600 (webhooks.tbl may hold inline secrets)
 local hmac_sha256     = hmac.sha256
 local ct_eq           = adclib.constant_time_eq
 local adclib_sanitize = adclib.sanitize_utf8
 local os_time         = os.time
+local math_floor      = math.floor
 
 
 -- No lang files / no help entry: this plugin has NO chat command and no
@@ -92,10 +117,10 @@ local function resp_unauthorized( )
 end
 
 -- Module state (all reset on +reload, which re-runs this file).
-local endpoints   = { }    -- validated, active endpoints
-local bots        = { }    -- bot_nick -> bot object (deduped)
-local enabled     = false
-local tuning      = { max_per_minute = 10, dedup_max = 500, field_maxlen = 300 }
+local endpoints      = { }    -- validated, active endpoints
+local bots           = { }    -- bot_nick -> bot object (deduped)
+local receiver_active = false  -- the RECEIVER gate (activate && >=1 valid endpoint); distinct from per-endpoint `enabled`
+local tuning         = { max_per_minute = 10, dedup_max = 500, field_maxlen = 300 }
 
 -- dedup: seen[id] = last-seen epoch. Bounded to tuning.dedup_max.
 local seen        = { }
@@ -191,6 +216,7 @@ local function normalise_endpoint( raw )
         conditions       = conditions,
         has_conditions   = next( conditions ) ~= nil,
         default_template = ( type( raw.default_template ) == "string" and raw.default_template ) or "",
+        enabled          = ( raw.enabled ~= false ),   -- default true; only an explicit `enabled = false` pauses it
         inline_secret    = ( type( raw.secret ) == "string" and raw.secret ~= "" and raw.secret ) or nil,
         secret           = nil,             -- filled by caller
     }
@@ -410,6 +436,369 @@ local function make_handler( entry )
 end
 
 
+--------------------------------
+--[HTTP MANAGEMENT API (v0.04)]--
+--------------------------------
+-- GET/POST/PUT/DELETE /v1/webhooks* let the WebUI (or any admin token)
+-- manage cfg/webhooks.tbl without shell access. The plugin OWNS the file:
+-- writes go through an atomic tmp+rename + chmod 600 (like user.tbl), and
+-- a secret is NEVER returned on read (only has_secret + secret_source).
+-- Endpoint config is read once at load, so a change reaches the live
+-- receiver only after a +reload; every write therefore returns
+-- apply_status = "reload_required" and the caller shows the hub's
+-- pending-reload banner. These routes register whenever the plugin is
+-- loaded (see onStart), independent of the etc_webhook_activate gate.
+
+-- Static banner kept at the top of a machine-written webhooks.tbl. A
+-- `--[==[ ]==]` long-bracket level so a future ]] in the text can never
+-- close it early; loadtable ignores the comment and reads the `return`.
+local CONFIG_HEADER = "--[==[\n" ..
+    "    webhooks.tbl - managed by etc_webhook via the HTTP API / WebUI.\n\n" ..
+    "    You CAN still edit this by hand (plain Lua, same as cfg.tbl), but a\n" ..
+    "    save through the WebUI regenerates the file: comments and layout are\n" ..
+    "    NOT preserved and inline secrets are rewritten. Keep it chmod 600 (it\n" ..
+    "    may hold inline secrets). Schema + hand-edit guide:\n" ..
+    "    examples/cfg/webhooks.tbl and docs/WEBHOOKS.md.\n" ..
+    "]==]\n\n"
+
+local function is_scalar( v )
+    local t = type( v )
+    return t == "string" or t == "number" or t == "boolean"
+end
+
+local function err_resp( status, code, msg )
+    return { status = status, error = { code = code, message = msg } }
+end
+local function bad_input( msg ) return err_resp( 400, "E_BAD_INPUT", msg ) end
+local function not_found( msg ) return err_resp( 404, "E_NOT_FOUND", msg ) end
+local function internal( msg )  return err_resp( 500, "E_INTERNAL", "failed to write webhooks.tbl: " .. tostring( msg ) ) end
+
+-- Read the on-disk config as a raw operator table (tunings + endpoints[]),
+-- or a fresh scaffold if the file is absent/unreadable. Used for writes
+-- (mutate + re-serialise) - it carries inline secrets, so it never leaves
+-- the process.
+local function read_config_raw( )
+    local tbl = load_config()
+    if type( tbl ) ~= "table" then
+        return { max_per_minute = tuning.max_per_minute, dedup_max = tuning.dedup_max,
+                 field_maxlen = tuning.field_maxlen, endpoints = { } }
+    end
+    if type( tbl.endpoints ) ~= "table" then tbl.endpoints = { } end
+    return tbl
+end
+
+-- Index of the endpoint named `name` in a raw config table (nil if absent).
+local function find_endpoint( raw, name )
+    for i, e in ipairs( raw.endpoints ) do
+        if type( e ) == "table" and e.name == name then return i, e end
+    end
+    return nil
+end
+
+-- Serialise + persist the raw config: header banner + `return webhooks`,
+-- atomic write, then chmod 600 (mirrors core/cfg_users.lua's user.tbl path).
+local function write_config_raw( raw )
+    local content = CONFIG_HEADER .. util_tabletostring( raw, "webhooks" )
+    local ok, werr = util_atomic_write( config_file, content )
+    if not ok then return false, werr end
+    util_chmod_secret( config_file )   -- POSIX 0600; no-op on Windows
+    return true
+end
+
+-- True if endpoint `e` has a resolvable secret (inline in the body, or an
+-- env/cfg override for its derived key). A secret-less endpoint would load
+-- inert, so writes reject it rather than silently creating a dead route.
+local function endpoint_has_secret( e )
+    if type( e.secret ) == "string" and e.secret ~= "" then return true end
+    local key = "etc_webhook_" .. e.name .. "_secret"
+    local override = secrets and secrets.lookup and secrets.lookup( key )
+    return type( override ) == "string" and override ~= ""
+end
+
+-- Build a clean raw endpoint from an untrusted request body, keeping ONLY
+-- known keys with sane types (the security-critical input boundary). On
+-- edit, `keep_secret` is the existing inline secret used when the body
+-- omits `secret` (blank = keep). Returns (raw_endpoint) or (nil, reason).
+local function sanitise_endpoint_body( b, keep_secret )
+    if type( b ) ~= "table" then return nil, "body must be a JSON object" end
+    local e = { }
+    if type( b.name ) ~= "string" or not b.name:match( "^[%a%d_]+$" ) then
+        return nil, "invalid or missing 'name' (need [A-Za-z0-9_])"
+    end
+    e.name = b.name
+    if type( b.signature_header ) ~= "string" or b.signature_header == "" then
+        return nil, "missing 'signature_header'"
+    end
+    e.signature_header = b.signature_header
+    if b.path ~= nil then
+        if type( b.path ) ~= "string" or b.path:sub( 1, 1 ) ~= "/" then
+            return nil, "'path' must be a string starting with '/'"
+        end
+        e.path = b.path
+    end
+    if b.signature_prefix ~= nil then
+        if type( b.signature_prefix ) ~= "string" then return nil, "'signature_prefix' must be a string" end
+        if b.signature_prefix ~= "" then e.signature_prefix = b.signature_prefix end
+    end
+    if b.event_header ~= nil then
+        if type( b.event_header ) ~= "string" then return nil, "'event_header' must be a string" end
+        if b.event_header ~= "" then e.event_header = b.event_header end
+    end
+    if b.id_header ~= nil then
+        if type( b.id_header ) ~= "string" then return nil, "'id_header' must be a string" end
+        if b.id_header ~= "" then e.id_header = b.id_header end
+    end
+    if b.bot_nick ~= nil then
+        if type( b.bot_nick ) ~= "string" then return nil, "'bot_nick' must be a string" end
+        if b.bot_nick ~= "" then e.bot_nick = b.bot_nick end
+    end
+    if b.default_template ~= nil then
+        if type( b.default_template ) ~= "string" then return nil, "'default_template' must be a string" end
+        if b.default_template ~= "" then e.default_template = b.default_template end
+    end
+    if b.min_level ~= nil then
+        local ml = tonumber( b.min_level )
+        if not ml or ml < 0 then return nil, "'min_level' must be a number >= 0" end
+        e.min_level = math_floor( ml )
+    end
+    if b.enabled ~= nil then
+        if type( b.enabled ) ~= "boolean" then return nil, "'enabled' must be true or false" end
+        e.enabled = b.enabled
+    end
+    if b.events ~= nil then
+        if type( b.events ) ~= "table" then return nil, "'events' must be an array of strings" end
+        local ev = { }
+        for _, v in ipairs( b.events ) do
+            if type( v ) ~= "string" then return nil, "'events' must contain only strings" end
+            ev[ #ev + 1 ] = v
+        end
+        if #ev > 0 then e.events = ev end
+    end
+    if b.templates ~= nil then
+        if type( b.templates ) ~= "table" then return nil, "'templates' must be an object of event -> string" end
+        local tp, any = { }, false
+        for k, v in pairs( b.templates ) do
+            if type( k ) ~= "string" or type( v ) ~= "string" then
+                return nil, "'templates' keys and values must be strings"
+            end
+            tp[ k ] = v; any = true
+        end
+        if any then e.templates = tp end
+    end
+    if b.conditions ~= nil then
+        if type( b.conditions ) ~= "table" then return nil, "'conditions' must be an array" end
+        local cs = { }
+        for _, c in ipairs( b.conditions ) do
+            if type( c ) ~= "table" or type( c.path ) ~= "string" or c.path == "" then
+                return nil, "each condition needs a non-empty string 'path'"
+            end
+            local cc = { path = c.path }
+            if c.equals ~= nil then
+                if not is_scalar( c.equals ) then return nil, "condition 'equals' must be a string, number or boolean" end
+                cc.equals = c.equals
+            elseif c.not_equals ~= nil then
+                if not is_scalar( c.not_equals ) then return nil, "condition 'not_equals' must be a string, number or boolean" end
+                cc.not_equals = c.not_equals
+            else
+                return nil, "each condition needs 'equals' or 'not_equals'"
+            end
+            cs[ #cs + 1 ] = cc
+        end
+        if #cs > 0 then e.conditions = cs end
+    end
+    if b.secret ~= nil and type( b.secret ) ~= "string" then
+        return nil, "'secret' must be a string"
+    end
+    if type( b.secret ) == "string" and b.secret ~= "" then
+        e.secret = b.secret
+    elseif keep_secret ~= nil then
+        e.secret = keep_secret
+    end
+    return e
+end
+
+-- Redacted, editor-facing view of ONE raw endpoint for GET. Never returns
+-- the secret value; only has_secret + secret_source ("inline" = rotatable
+-- by writing the file, "external" = env/cfg override wins so a file write
+-- would NOT take effect, "none" = unset -> currently inert). Empty
+-- arrays/maps are omitted so the wire never carries the {}-vs-[] ambiguity.
+local function endpoint_public_view( raw_e )
+    local norm, reason = normalise_endpoint( raw_e )
+    local name = ( type( raw_e.name ) == "string" ) and raw_e.name or ""
+    local inline = ( type( raw_e.secret ) == "string" and raw_e.secret ~= "" ) or false
+    local has_secret, secret_source = false, "none"
+    if name ~= "" then
+        local override = secrets and secrets.lookup and secrets.lookup( "etc_webhook_" .. name .. "_secret" )
+        if type( override ) == "string" and override ~= "" then
+            has_secret, secret_source = true, "external"
+        elseif inline then
+            has_secret, secret_source = true, "inline"
+        end
+    elseif inline then
+        has_secret, secret_source = true, "inline"
+    end
+    local view = {
+        name             = name,
+        enabled          = ( raw_e.enabled ~= false ),
+        path             = ( norm and norm.path ) or raw_e.path or ( "/v1/webhook/" .. name ),
+        signature_header = ( type( raw_e.signature_header ) == "string" and raw_e.signature_header ) or "",
+        signature_prefix = ( type( raw_e.signature_prefix ) == "string" and raw_e.signature_prefix ) or "",
+        event_header     = ( type( raw_e.event_header ) == "string" and raw_e.event_header ) or "",
+        id_header        = ( type( raw_e.id_header ) == "string" and raw_e.id_header ) or "",
+        bot_nick         = ( type( raw_e.bot_nick ) == "string" and raw_e.bot_nick ) or "",
+        min_level        = tonumber( raw_e.min_level ) or 0,
+        default_template = ( type( raw_e.default_template ) == "string" and raw_e.default_template ) or "",
+        has_secret       = has_secret,
+        secret_source    = secret_source,
+        valid            = norm ~= nil,
+    }
+    if not norm then view.invalid_reason = reason end
+    -- Scalar-safe copies (NOT the raw on-disk tables): a hand-edited
+    -- webhooks.tbl could hold a function / reference cycle inside these,
+    -- and http_get_webhooks' data is dkjson-encoded OUTSIDE the handler's
+    -- error guard (envelope_success), so a raise there would crash the hub
+    -- loop, not just the request. Filtering to scalars here makes the whole
+    -- GET payload encode-safe regardless of file content, and keeps the
+    -- operator (equals/not_equals) shape the editor round-trips.
+    if type( raw_e.events ) == "table" then
+        local ev = { }
+        for _, v in ipairs( raw_e.events ) do
+            if type( v ) == "string" then ev[ #ev + 1 ] = v end
+        end
+        if #ev > 0 then view.events = ev end
+    end
+    if type( raw_e.templates ) == "table" then
+        local tp, any = { }, false
+        for k, v in pairs( raw_e.templates ) do
+            if type( k ) == "string" and type( v ) == "string" then tp[ k ] = v; any = true end
+        end
+        if any then view.templates = tp end
+    end
+    if type( raw_e.conditions ) == "table" then
+        local cs = { }
+        for _, c in ipairs( raw_e.conditions ) do
+            if type( c ) == "table" and type( c.path ) == "string" then
+                local cc
+                if is_scalar( c.equals ) then cc = { path = c.path, equals = c.equals }
+                elseif is_scalar( c.not_equals ) then cc = { path = c.path, not_equals = c.not_equals } end
+                if cc then cs[ #cs + 1 ] = cc end
+            end
+        end
+        if #cs > 0 then view.conditions = cs end
+    end
+    return view
+end
+
+-- onAudit trail for every mutation (who / which endpoint). Same shape as
+-- etc_records' HTTP reset audit: the bearer token's admin scope is the
+-- gate, token_label the actor. The endpoint name is the audit `target`
+-- and MUST be a flat table ({nick=name}) - audit.build's _snapshot_target
+-- drops a bare-string target to nil, which would lose the "which endpoint"
+-- the trail exists to record. Tuning changes have no endpoint (nil target).
+local function audit_mutation( req, action, name )
+    if not ( audit and audit.fire and audit.build ) then return end
+    local actor = util_strip( ( req and req.token_label ) or "http-api" )
+    local target = ( name and name ~= "-" ) and { nick = name } or nil
+    audit.fire( audit.build( action, { nick = actor, sid = "<http>" }, target, nil, nil ) )
+end
+
+-- GET /v1/webhooks (read): tunings + endpoints, secrets redacted.
+local function http_get_webhooks( req )
+    local raw = read_config_raw()
+    local eps = setmetatable( { }, { __jsontype = "array" } )   -- force [] when empty
+    for _, e in ipairs( raw.endpoints ) do
+        if type( e ) == "table" then eps[ #eps + 1 ] = endpoint_public_view( e ) end
+    end
+    return { status = 200, data = {
+        activate  = cfg.get( "etc_webhook_activate" ) and true or false,
+        tuning    = {
+            max_per_minute = tonumber( raw.max_per_minute ) or tuning.max_per_minute,
+            dedup_max      = tonumber( raw.dedup_max ) or tuning.dedup_max,
+            field_maxlen   = tonumber( raw.field_maxlen ) or tuning.field_maxlen,
+        },
+        endpoints = eps,
+    } }
+end
+
+-- POST /v1/webhooks (admin): create a new endpoint.
+local function http_create_webhook( req )
+    local e, reason = sanitise_endpoint_body( req.body, nil )
+    if not e then return bad_input( reason ) end
+    local raw = read_config_raw()
+    if find_endpoint( raw, e.name ) then
+        return bad_input( "endpoint '" .. e.name .. "' already exists" )
+    end
+    local norm, nreason = normalise_endpoint( e )   -- parity: must load cleanly
+    if not norm then return bad_input( nreason ) end
+    if not endpoint_has_secret( e ) then
+        return bad_input( "endpoint '" .. e.name .. "' has no secret (set 'secret', or configure an env/cfg key)" )
+    end
+    raw.endpoints[ #raw.endpoints + 1 ] = e
+    local ok, werr = write_config_raw( raw )
+    if not ok then return internal( werr ) end
+    audit_mutation( req, "webhook.create", e.name )
+    return { status = 200, data = { name = e.name, apply_status = "reload_required" } }
+end
+
+-- PUT /v1/webhooks/{name} (admin): replace an existing endpoint. A blank
+-- or omitted `secret` keeps the current inline secret (rotate-only model).
+local function http_update_webhook( req )
+    local name = req.path_vars and req.path_vars[ "name" ]
+    if type( name ) ~= "string" or name == "" then return bad_input( "missing name" ) end
+    local raw = read_config_raw()
+    local idx, existing = find_endpoint( raw, name )
+    if not idx then return not_found( "no such webhook '" .. name .. "'" ) end
+    local body = req.body
+    if type( body ) == "table" then body.name = name end   -- path name is authoritative
+    local keep = ( type( existing.secret ) == "string" and existing.secret ~= "" ) and existing.secret or nil
+    local e, reason = sanitise_endpoint_body( body, keep )
+    if not e then return bad_input( reason ) end
+    local norm, nreason = normalise_endpoint( e )
+    if not norm then return bad_input( nreason ) end
+    if not endpoint_has_secret( e ) then
+        return bad_input( "endpoint '" .. e.name .. "' would have no secret" )
+    end
+    raw.endpoints[ idx ] = e
+    local ok, werr = write_config_raw( raw )
+    if not ok then return internal( werr ) end
+    audit_mutation( req, "webhook.update", name )
+    return { status = 200, data = { name = name, apply_status = "reload_required" } }
+end
+
+-- DELETE /v1/webhooks/{name} (admin): remove an endpoint.
+local function http_delete_webhook( req )
+    local name = req.path_vars and req.path_vars[ "name" ]
+    if type( name ) ~= "string" or name == "" then return bad_input( "missing name" ) end
+    local raw = read_config_raw()
+    local idx = find_endpoint( raw, name )
+    if not idx then return not_found( "no such webhook '" .. name .. "'" ) end
+    table.remove( raw.endpoints, idx )
+    local ok, werr = write_config_raw( raw )
+    if not ok then return internal( werr ) end
+    audit_mutation( req, "webhook.delete", name )
+    return { status = 200, data = { name = name, apply_status = "reload_required" } }
+end
+
+-- PUT /v1/webhooks (admin): update the global tuning (flood cap, dedup
+-- size, field truncation). Endpoints are managed via the {name} routes.
+local function http_update_settings( req )
+    local b = req.body
+    if type( b ) ~= "table" then return bad_input( "body must be a JSON object" ) end
+    local raw = read_config_raw()
+    for _, key in ipairs( { "max_per_minute", "dedup_max", "field_maxlen" } ) do
+        if b[ key ] ~= nil then
+            local n = tonumber( b[ key ] )
+            if not n or n <= 0 then return bad_input( "'" .. key .. "' must be a number > 0" ) end
+            raw[ key ] = math_floor( n )
+        end
+    end
+    local ok, werr = write_config_raw( raw )
+    if not ok then return internal( werr ) end
+    audit_mutation( req, "webhook.settings", "-" )
+    return { status = 200, data = { apply_status = "reload_required" } }
+end
+
+
 --// module-load init (re-runs on +reload)
 local config = load_config()
 if type( config ) == "table" then
@@ -421,6 +810,8 @@ if type( config ) == "table" then
             local entry, reason = normalise_endpoint( raw )
             if not entry then
                 hub_debug( scriptname .. ": skipped endpoint (" .. tostring( reason ) .. ")" )
+            elseif not entry.enabled then
+                hub_debug( scriptname .. ": endpoint '" .. entry.name .. "' is disabled (enabled = false) - skipped" )
             else
                 -- Secret resolution: register the derived cfg key (so a
                 -- cfg.tbl-stored secret would be redacted from
@@ -443,7 +834,7 @@ end
 
 local activate = cfg.get( "etc_webhook_activate" )
 if activate and #endpoints > 0 then
-    enabled = true
+    receiver_active = true
     dedup_load()
     flood_start = os_time()
     last_save = os_time()
@@ -466,23 +857,36 @@ end
 
 hub.setlistener( "onStart", { },
     function( )
-        if not enabled then return nil end
         if not hub.http_register then
-            hub_debug( scriptname .. ": hub.http_register unavailable - endpoints not registered" )
+            hub_debug( scriptname .. ": hub.http_register unavailable - routes not registered" )
             return nil
         end
-        -- Register one scope="none" POST route per endpoint. The router
-        -- unregister_all's on every +reload before this fires, so a
-        -- straight re-register is safe (no duplicate-path throw).
-        for _, entry in ipairs( endpoints ) do
-            -- pcall so one bad custom path (duplicate / invalid) does not
-            -- abort registration of the remaining endpoints.
-            local ok, reg_err = pcall( hub.http_register, "POST", entry.path, "none", make_handler( entry ), {
-                plugin = scriptname,
-                description = "inbound webhook receiver for '" .. entry.name .. "' (HMAC-SHA256 signed; announces to chat)",
+        -- The router unregister_all's on every +reload before this fires,
+        -- so a straight re-register is safe (no duplicate-path throw). Each
+        -- register is pcall'd so one bad route never aborts the rest.
+        local function reg( method, path, scope, handler, desc )
+            local ok, reg_err = pcall( hub.http_register, method, path, scope, handler, {
+                plugin = scriptname, description = desc,
             } )
             if not ok then
-                hub_debug( scriptname .. ": could not register route " .. entry.path .. " for '" .. entry.name .. "': " .. tostring( reg_err ) )
+                hub_debug( scriptname .. ": could not register route " .. method .. " " .. path .. ": " .. tostring( reg_err ) )
+            end
+        end
+        -- Management API: registered whenever the plugin is loaded, even
+        -- when inert (activate=false / no endpoints yet), so the WebUI tab
+        -- (gated on GET /v1/webhooks being present) shows up and can create
+        -- the first endpoint + flip the master switch. Writes are admin.
+        reg( "GET",    "/v1/webhooks",        "read",  http_get_webhooks,   "list webhook endpoints + tuning (secrets redacted)" )
+        reg( "POST",   "/v1/webhooks",        "admin", http_create_webhook, "create a webhook endpoint (needs +reload)" )
+        reg( "PUT",    "/v1/webhooks",        "admin", http_update_settings,"update global webhook tuning (needs +reload)" )
+        reg( "PUT",    "/v1/webhooks/{name}", "admin", http_update_webhook, "update a webhook endpoint (needs +reload)" )
+        reg( "DELETE", "/v1/webhooks/{name}", "admin", http_delete_webhook, "delete a webhook endpoint (needs +reload)" )
+        -- Receiver routes: one scope="none" POST per LIVE endpoint, only
+        -- when active with >=1 valid endpoint (the HMAC-authed inbound path).
+        if receiver_active then
+            for _, entry in ipairs( endpoints ) do
+                reg( "POST", entry.path, "none", make_handler( entry ),
+                    "inbound webhook receiver for '" .. entry.name .. "' (HMAC-SHA256 signed; announces to chat)" )
             end
         end
         return nil
@@ -495,7 +899,7 @@ hub.setlistener( "onStart", { },
 -- announce for those after a restart - harmless).
 hub.setlistener( "onTimer", { },
     function( )
-        if enabled and seen_dirty and ( os_time() - last_save ) >= 30 then
+        if receiver_active and seen_dirty and ( os_time() - last_save ) >= 30 then
             dedup_save()
             seen_dirty = false
             last_save = os_time()

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -166,6 +166,15 @@ def override_test_ports(staging_dir: Path):
         # daily_at schedule stays at 04:00, so no scheduled backup fires
         # during the run; only the explicit +backup now does.
         (r'etc_backup_passphrase\s*=\s*""', 'etc_backup_passphrase = "smoke-backup-pass"'),
+        # etc_webhook v0.04: whitelist the plugin (ships enabled=false) so its
+        # management API (GET/POST/PUT/DELETE /v1/webhooks) registers and
+        # test_http_webhooks_management can drive the real config writer.
+        # etc_webhook_activate stays false: the mgmt routes register
+        # independent of it, so no receiver/bot is created and no webhooks.tbl
+        # is needed at boot (the test creates one). Also exercises the
+        # plugin's real-sandbox load path on every smoke boot.
+        (r'\{\s*"etc_webhook\.lua",\s*enabled\s*=\s*false\s*\}',
+         '{ "etc_webhook.lua", enabled = true }'),
     ]
     for pattern, replacement in rewrites:
         new_text, count = re.subn(pattern, replacement, text, count=1)
@@ -5903,6 +5912,179 @@ def test_http_phase4_etc_records(staging_dir: Path, proc=None):
     b = body_of(r)
     if '"/v1/records"' not in b:
         raise TestFailure(f"catalog missing /v1/records; body={b!r}")
+
+
+def test_http_webhooks_management(staging_dir: Path, proc=None):
+    """etc_webhook v0.04: HTTP management API for cfg/webhooks.tbl.
+
+    The plugin is whitelisted in the smoke config (enabled=true) but the
+    receiver stays OFF (etc_webhook_activate=false, no webhooks.tbl on
+    boot). The management routes register regardless, so this exercises
+    the REAL writer end to end: a POST serialises cfg/webhooks.tbl via
+    util.tabletostring + atomic_write + chmod 600, and the NEXT GET reads
+    it back through the real loadfile - so if the written file were not
+    valid, reloadable Lua the endpoint would not reappear.
+
+    Coverage:
+    - Anonymous GET -> 401; authed GET -> 200 + {activate, tuning, endpoints}.
+    - POST create -> 200 + apply_status=reload_required; then GET lists it
+      with the secret REDACTED (has_secret + secret_source, never a value).
+    - The on-disk cfg/webhooks.tbl exists, carries the header + the name,
+      and (POSIX) is mode 0600.
+    - PUT rotate -> 200; PUT unknown -> 404; DELETE -> 200 (then gone).
+    - POST invalid name -> 400; PUT /v1/webhooks tuning -> 200 + reflected.
+    - /v1/endpoints lists the collection + {name} routes.
+    """
+    import json as _json
+    import os as _os
+    import stat as _stat
+
+    token_path = staging_dir / "cfg" / "api_token.first"
+    bootstrap_token = None
+    for line in token_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            bootstrap_token = line
+            break
+    if not bootstrap_token:
+        raise TestFailure(f"could not parse token from {token_path}")
+    auth = b"Authorization: Bearer " + bootstrap_token.encode("ascii") + b"\r\n"
+
+    def status(resp):
+        return resp.split("\r\n", 1)[0]
+
+    def body_of(resp):
+        return resp.split("\r\n\r\n", 1)[1] if "\r\n\r\n" in resp else ""
+
+    def send(method, path, body_json=None):
+        req = method.encode("ascii") + b" " + path.encode("ascii") + b" HTTP/1.1\r\n" + auth
+        if body_json is not None:
+            body = body_json.encode("utf-8")
+            req += (b"Content-Type: application/json\r\n"
+                    + b"Content-Length: " + str(len(body)).encode("ascii") + b"\r\n\r\n"
+                    + body)
+        else:
+            req += b"\r\n"
+        return _http_roundtrip(req)
+
+    def data_of(resp, label):
+        if "200 OK" not in status(resp):
+            raise TestFailure(f"{label}: expected 200, got {status(resp)!r}; body={body_of(resp)!r}")
+        parsed = _json.loads(body_of(resp))
+        if not parsed.get("ok"):
+            raise TestFailure(f"{label}: ok=false; body={body_of(resp)!r}")
+        return parsed.get("data") or {}
+
+    # 1. Anonymous GET -> 401.
+    r = _http_roundtrip(b"GET /v1/webhooks HTTP/1.1\r\n\r\n")
+    if "401" not in status(r):
+        raise TestFailure(f"anonymous GET /v1/webhooks: expected 401, got {status(r)!r}")
+
+    # 2. Authed GET -> envelope shape; receiver off, zero endpoints on boot.
+    d = data_of(send("GET", "/v1/webhooks"), "GET /v1/webhooks")
+    if d.get("activate") is not False:
+        raise TestFailure(f"GET /v1/webhooks: expected activate=false on boot; data={d!r}")
+    if not isinstance(d.get("tuning"), dict) or not isinstance(d["tuning"].get("max_per_minute"), int):
+        raise TestFailure(f"GET /v1/webhooks: missing tuning.max_per_minute; data={d!r}")
+    if not isinstance(d.get("endpoints"), list):
+        raise TestFailure(f"GET /v1/webhooks: endpoints not a list; data={d!r}")
+
+    # 3. POST create -> 200 + reload_required. The template carries a quote,
+    # a backslash, a `]]` and a newline so the real util.tabletostring %q
+    # escaping is exercised end to end (serialise -> file -> loadfile -> GET);
+    # a broken escape would corrupt the file and drop the endpoint at step 4.
+    tricky_template = 'built "{status}" \\o/ ]] end\nline2'
+    create = _json.dumps({
+        "name": "smoketest",
+        "signature_header": "x-smoke-sig",
+        "signature_prefix": "sha256=",
+        "event_header": "x-smoke-event",
+        "events": ["build"],
+        "templates": {"build": tricky_template},
+        "secret": "smoke-secret-value-01",
+    })
+    d = data_of(send("POST", "/v1/webhooks", create), "POST /v1/webhooks")
+    if d.get("apply_status") != "reload_required":
+        raise TestFailure(f"POST /v1/webhooks: expected reload_required; data={d!r}")
+
+    # 4. GET reflects it (proves the written file is valid, reloadable Lua),
+    #    with the secret redacted.
+    d = data_of(send("GET", "/v1/webhooks"), "GET /v1/webhooks (post-create)")
+    ep = next((e for e in d["endpoints"] if e.get("name") == "smoketest"), None)
+    if ep is None:
+        raise TestFailure(f"POST then GET: 'smoketest' not listed (bad file write?); data={d!r}")
+    if "secret" in ep:
+        raise TestFailure(f"GET /v1/webhooks: secret value leaked in endpoint; ep={ep!r}")
+    if ep.get("has_secret") is not True or ep.get("secret_source") != "inline":
+        raise TestFailure(f"GET /v1/webhooks: expected has_secret+inline; ep={ep!r}")
+    if ep.get("enabled") is not True or ep.get("valid") is not True:
+        raise TestFailure(f"GET /v1/webhooks: expected enabled+valid; ep={ep!r}")
+    if ep.get("templates", {}).get("build") != tricky_template:
+        raise TestFailure(
+            f"template with quote/backslash/]]/newline did not round-trip through "
+            f"the real writer (%q escaping); got {ep.get('templates')!r}")
+
+    # 5. The real on-disk file: header + name present, and 0600 on POSIX.
+    whooks = staging_dir / "cfg" / "webhooks.tbl"
+    if not whooks.exists():
+        raise TestFailure("POST /v1/webhooks: cfg/webhooks.tbl was not written")
+    ftext = whooks.read_text(encoding="utf-8")
+    if "managed by etc_webhook" not in ftext or 'name = "smoketest"' not in ftext:
+        raise TestFailure(f"cfg/webhooks.tbl missing header/name; content={ftext[:200]!r}")
+    if sys.platform != "win32":
+        mode = _stat.S_IMODE(_os.stat(whooks).st_mode)
+        if mode != 0o600:
+            raise TestFailure(f"cfg/webhooks.tbl mode should be 0600, got {oct(mode)}")
+
+    # 5b. enabled=false round-trips through the real writer (boolean serialise
+    #     + reload), then clean it up.
+    data_of(send("POST", "/v1/webhooks", _json.dumps(
+        {"name": "pausedhook", "signature_header": "x-p", "secret": "p-secret-03", "enabled": False})),
+        "POST /v1/webhooks (paused)")
+    d = data_of(send("GET", "/v1/webhooks"), "GET /v1/webhooks (paused)")
+    pep = next((e for e in d["endpoints"] if e.get("name") == "pausedhook"), None)
+    if pep is None or pep.get("enabled") is not False:
+        raise TestFailure(f"enabled=false did not round-trip through the writer; ep={pep!r}")
+    data_of(send("DELETE", "/v1/webhooks/pausedhook"), "DELETE /v1/webhooks/pausedhook")
+
+    # 6. PUT rotate secret -> 200; PUT unknown -> 404.
+    d = data_of(send("PUT", "/v1/webhooks/smoketest",
+                     '{"name":"smoketest","signature_header":"x-smoke-sig","secret":"rotated-secret-02"}'),
+                "PUT /v1/webhooks/smoketest")
+    if d.get("apply_status") != "reload_required":
+        raise TestFailure(f"PUT /v1/webhooks/smoketest: expected reload_required; data={d!r}")
+    r = send("PUT", "/v1/webhooks/ghost",
+             '{"name":"ghost","signature_header":"x","secret":"k"}')
+    if "404" not in status(r):
+        raise TestFailure(f"PUT /v1/webhooks/ghost: expected 404, got {status(r)!r}")
+
+    # 7. POST invalid name -> 400.
+    r = send("POST", "/v1/webhooks", '{"name":"bad name","signature_header":"x","secret":"k"}')
+    if "400" not in status(r):
+        raise TestFailure(f"POST bad name: expected 400, got {status(r)!r}")
+
+    # 8. PUT /v1/webhooks (global tuning) -> 200 + reflected in GET.
+    d = data_of(send("PUT", "/v1/webhooks", '{"max_per_minute":25}'), "PUT /v1/webhooks (tuning)")
+    if d.get("apply_status") != "reload_required":
+        raise TestFailure(f"PUT /v1/webhooks tuning: expected reload_required; data={d!r}")
+    d = data_of(send("GET", "/v1/webhooks"), "GET /v1/webhooks (post-tuning)")
+    if d["tuning"].get("max_per_minute") != 25:
+        raise TestFailure(f"PUT tuning not reflected; tuning={d.get('tuning')!r}")
+
+    # 9. DELETE -> 200, then gone.
+    d = data_of(send("DELETE", "/v1/webhooks/smoketest"), "DELETE /v1/webhooks/smoketest")
+    if d.get("apply_status") != "reload_required":
+        raise TestFailure(f"DELETE /v1/webhooks/smoketest: expected reload_required; data={d!r}")
+    d = data_of(send("GET", "/v1/webhooks"), "GET /v1/webhooks (post-delete)")
+    if any(e.get("name") == "smoketest" for e in d["endpoints"]):
+        raise TestFailure(f"DELETE then GET: 'smoketest' still present; data={d!r}")
+
+    # 10. /v1/endpoints catalog lists the management routes.
+    r = _http_roundtrip(b"GET /v1/endpoints HTTP/1.1\r\n" + auth + b"\r\n")
+    b = body_of(r)
+    for route in ('"/v1/webhooks"', '"/v1/webhooks/{name}"'):
+        if route not in b:
+            raise TestFailure(f"catalog missing {route}; body={b!r}")
 
 
 def test_http_phase4_etc_blacklist(staging_dir: Path, proc=None):
@@ -13821,6 +14003,18 @@ def main():
             failed.append("HTTP API Phase 4 etc_records (#82 / #249)")
         else:
             log("PASS  HTTP API Phase 4 etc_records (#82 / #249)")
+
+        # etc_webhook v0.04: HTTP management API for cfg/webhooks.tbl
+        # (create/edit/delete endpoints). Exercises the real config
+        # writer (util.tabletostring + atomic_write + chmod 600) end to
+        # end - the post-POST GET re-reads the written file via loadfile.
+        try:
+            test_http_webhooks_management(staging_dir, proc=proc)
+        except Exception as e:
+            log(f"FAIL  HTTP API etc_webhook management: {e}")
+            failed.append("HTTP API etc_webhook management")
+        else:
+            log("PASS  HTTP API etc_webhook management")
 
         # Phase 4 PR-3 of #82 / #249: etc_blacklist plugin migrated to
         # GET /v1/blacklist + DELETE /v1/blacklist/{nick}. Self-seeds

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -6029,8 +6029,12 @@ def test_http_webhooks_management(staging_dir: Path, proc=None):
     if not whooks.exists():
         raise TestFailure("POST /v1/webhooks: cfg/webhooks.tbl was not written")
     ftext = whooks.read_text(encoding="utf-8")
-    if "managed by etc_webhook" not in ftext or 'name = "smoketest"' not in ftext:
-        raise TestFailure(f"cfg/webhooks.tbl missing header/name; content={ftext[:200]!r}")
+    if "managed by etc_webhook" not in ftext:
+        raise TestFailure(f"cfg/webhooks.tbl missing header; content={ftext[:200]!r}")
+    # util.tabletostring serialises keys as `[ "name" ] = "smoketest"`, so
+    # match the quoted name value rather than an assumed `name = ` form.
+    if '"smoketest"' not in ftext:
+        raise TestFailure(f"cfg/webhooks.tbl missing endpoint name; content={ftext!r}")
     if sys.platform != "win32":
         mode = _stat.S_IMODE(_os.stat(whooks).st_mode)
         if mode != 0o600:

--- a/tests/unit/etc_webhook_test.lua
+++ b/tests/unit/etc_webhook_test.lua
@@ -55,6 +55,7 @@ local CONFIG_FILE = "cfg/webhooks.tbl"
 local DEDUP_FILE  = "scripts/data/etc_webhook.tbl"
 local _now, _activate, _config, _dedup, _users
 local _listeners, _routes, _announced
+local _written, _chmod_called          -- mgmt writer round-trip capture (v0.04)
 
 local SECRET = "s3cr3t-webhook-key"
 
@@ -100,13 +101,38 @@ _G.util = {
     end,
     savetable = function( t, _name, p ) if p == DEDUP_FILE then _dedup = t end end,
     strip_control_bytes = function( s ) if type( s ) ~= "string" then return "" end return ( s:gsub( "%c", "?" ) ) end,
+    -- mgmt writer (v0.04): tabletostring captures the raw table it is asked
+    -- to serialise; atomic_write "commits" it back to _config so a write
+    -- then a read round-trips (mirrors the on-disk file). The real
+    -- util.tabletostring output is exercised by the smoke test.
+    tabletostring = function( tbl, _name ) _written = tbl; return "SERIALISED\n" end,
+    atomic_write  = function( p, _content ) if p == CONFIG_FILE then _config = _written end return true end,
+    chmod_secret  = function( _p ) _chmod_called = true end,
 }
-_G.secrets = { register = function( ) end, lookup = function( ) return nil end }   -- force inline-secret path
+-- secrets.lookup returns an env/cfg override for a key iff seeded in
+-- _overrides (default: none -> inline-secret path). Lets a test exercise
+-- secret_source = "external".
+local _overrides = { }
+_G.secrets = { register = function( ) end, lookup = function( k ) return _overrides[ k ] end }
+
+-- audit stub: capture fired events so a test can assert the endpoint name
+-- reaches audit as a flat-table target (a bare-string target is dropped to
+-- nil by the real audit.build - the v0.04 bug this guards).
+local _audit_events = { }
+_G.audit = {
+    build = function( action, actor, target, reason, meta )
+        return { action = action, actor = actor, target = target, reason = reason, meta = meta }
+    end,
+    fire  = function( ev ) _audit_events[ #_audit_events + 1 ] = ev end,
+}
+local function last_audit( ) return _audit_events[ #_audit_events ] end
 
 _G.hub = {
     setlistener   = function( ev, _opts, fn ) _listeners[ ev ] = fn end,
+    -- key by "METHOD path": v0.04 registers GET/POST/PUT on the same
+    -- /v1/webhooks path, so a path-only key would clobber siblings.
     http_register = function( method, path, scope, handler, meta )
-        _routes[ path ] = { method = method, scope = scope, handler = handler, meta = meta }
+        _routes[ method .. " " .. path ] = { method = method, scope = scope, handler = handler, meta = meta }
     end,
     regbot   = function( p ) return { nick = function( ) return p.nick end } end,
     getbot   = function( ) return { hubbot = true } end,
@@ -135,10 +161,13 @@ end
 -- sign the body the way the plugin verifies it
 local function sig_for( body ) return "sha256=" .. hmac.sha256( SECRET, body ) end
 
-local function post( path, body, headers )
-    local route = _routes[ path ]
-    if not route then return nil end
-    return route.handler( { headers = headers, raw_body = body, body = nil } )
+local function route( method, path ) return _routes[ method .. " " .. path ] end
+
+-- invoke a management handler with a synthetic admin request
+local function call( method, path, body, path_vars )
+    local r = route( method, path )
+    if not r then return nil end
+    return r.handler( { body = body, path_vars = path_vars, token_label = "op1" } )
 end
 
 -- convenience: a Discourse-style post_created request with a decoded body
@@ -174,7 +203,7 @@ local function base_config( )
 end
 
 local function fire_handler( req )
-    return _routes[ "/v1/webhook/discourse" ].handler( req )
+    return route( "POST", "/v1/webhook/discourse" ).handler( req )
 end
 
 ----------------------------------------------------------------------
@@ -184,9 +213,15 @@ _now = 1000; _activate = true; _dedup = nil; _users = { }
 _config = base_config( )
 load_plugin( )
 
-truthy( "route registered for the discourse endpoint", _routes[ "/v1/webhook/discourse" ] ~= nil )
-eq( "route is POST",  _routes[ "/v1/webhook/discourse" ].method, "POST" )
-eq( "route scope is none", _routes[ "/v1/webhook/discourse" ].scope, "none" )
+truthy( "route registered for the discourse endpoint", route( "POST", "/v1/webhook/discourse" ) ~= nil )
+eq( "route is POST",  route( "POST", "/v1/webhook/discourse" ).method, "POST" )
+eq( "route scope is none", route( "POST", "/v1/webhook/discourse" ).scope, "none" )
+-- v0.04: management routes register alongside the receiver
+truthy( "mgmt GET /v1/webhooks registered",    route( "GET", "/v1/webhooks" ) ~= nil )
+eq( "mgmt GET scope is read",                  route( "GET", "/v1/webhooks" ).scope, "read" )
+eq( "mgmt POST scope is admin",                route( "POST", "/v1/webhooks" ).scope, "admin" )
+eq( "mgmt PUT {name} scope is admin",          route( "PUT", "/v1/webhooks/{name}" ).scope, "admin" )
+eq( "mgmt DELETE {name} scope is admin",       route( "DELETE", "/v1/webhooks/{name}" ).scope, "admin" )
 
 local BODY = '{"post":{"username":"alice","topic_title":"Hello"}}'
 local BTBL = { post = { username = "alice", topic_title = "Hello" } }
@@ -317,15 +352,20 @@ _users = { }
 _config = base_config( )
 _config.endpoints[ 1 ].secret = nil    -- no inline; secrets.lookup returns nil
 load_plugin( )
-truthy( "no-secret endpoint: route NOT registered", _routes[ "/v1/webhook/discourse" ] == nil )
+truthy( "no-secret endpoint: receiver route NOT registered", route( "POST", "/v1/webhook/discourse" ) == nil )
+truthy( "no-secret endpoint: mgmt API still registered", route( "GET", "/v1/webhooks" ) ~= nil )
 
 ----------------------------------------------------------------------
--- 12. activate = false -> inert (no routes)
+-- 12. activate = false -> receiver inert, but mgmt API still present
+--     (v0.04: the WebUI tab must be reachable to flip the switch on)
 ----------------------------------------------------------------------
 _activate = false
 _config = base_config( )
 load_plugin( )
-truthy( "activate=false: no routes registered", next( _routes ) == nil )
+truthy( "activate=false: receiver route NOT registered", route( "POST", "/v1/webhook/discourse" ) == nil )
+truthy( "activate=false: mgmt GET still registered",     route( "GET", "/v1/webhooks" ) ~= nil )
+r = call( "GET", "/v1/webhooks" )
+eq( "activate=false: GET reports activate=false", r.data.activate, false )
 _activate = true
 
 ----------------------------------------------------------------------
@@ -404,6 +444,159 @@ _announced = { }
 local B_RELEASED = '{"action":"released"}'
 fire_handler( discourse_req( "e2", "post_created", sig_for( B_RELEASED ), B_RELEASED, { action = "released" } ) )
 eq( "conditions equals: action=released announced", #_announced, 1 )
+
+----------------------------------------------------------------------
+-- 15. HTTP management API (v0.04). The routes are net-new (absent on
+--     v0.03), and the enabled-skip case (20) is a provable RED on v0.03:
+--     normalise ignored `enabled`, so a disabled endpoint still got a
+--     receiver route.
+----------------------------------------------------------------------
+local NEWEP = {
+    name = "ci", signature_header = "x-ci-signature", signature_prefix = "sha256=",
+    event_header = "x-ci-event", events = { "build" }, id_header = "x-ci-id",
+    bot_nick = "CI", min_level = 0,
+    templates = { build = "build {status}" },
+    conditions = { { path = "branch", equals = "main" } },
+    secret = "ci-secret",
+}
+
+-- 15. GET: shape + secret redaction (inline source)
+_overrides = { }
+_config = base_config( ); _activate = true; _dedup = nil; _users = { }
+load_plugin( )
+r = call( "GET", "/v1/webhooks" )
+eq( "GET: status 200", r.status, 200 )
+eq( "GET: one endpoint listed", #r.data.endpoints, 1 )
+local d = r.data.endpoints[ 1 ]
+eq( "GET: endpoint name", d.name, "discourse" )
+eq( "GET: secret value NOT present", d.secret, nil )
+eq( "GET: has_secret true (inline)", d.has_secret, true )
+eq( "GET: secret_source = inline", d.secret_source, "inline" )
+eq( "GET: enabled defaults true", d.enabled, true )
+eq( "GET: valid true", d.valid, true )
+eq( "GET: tuning max_per_minute from file", r.data.tuning.max_per_minute, 3 )
+eq( "GET: activate reported true", r.data.activate, true )
+
+-- 15b. GET: secret_source=external when an env/cfg override exists
+_overrides = { [ "etc_webhook_discourse_secret" ] = "env-value" }
+r = call( "GET", "/v1/webhooks" )
+eq( "GET: secret_source = external with env/cfg override", r.data.endpoints[ 1 ].secret_source, "external" )
+_overrides = { }
+
+-- 16. POST create -> 200 reload_required, chmod 600 on write, then listed
+_config = base_config( ); load_plugin( )
+_chmod_called = false
+r = call( "POST", "/v1/webhooks", NEWEP )
+eq( "POST: status 200", r.status, 200 )
+eq( "POST: apply_status reload_required", r.data.apply_status, "reload_required" )
+eq( "POST: writer chmod 600 called", _chmod_called, true )
+eq( "POST: audit action webhook.create", last_audit() and last_audit().action, "webhook.create" )
+eq( "POST: audit target is endpoint name (flat table, not dropped)",
+    last_audit() and last_audit().target and last_audit().target.nick, "ci" )
+r = call( "GET", "/v1/webhooks" )
+eq( "POST: endpoint count now 2", #r.data.endpoints, 2 )
+local ci
+for _, e in ipairs( r.data.endpoints ) do if e.name == "ci" then ci = e end end
+truthy( "POST: created endpoint present in GET", ci ~= nil )
+eq( "POST: created has_secret", ci and ci.has_secret, true )
+eq( "POST: created events preserved", ci and ci.events and ci.events[ 1 ], "build" )
+eq( "POST: created path defaulted", ci and ci.path, "/v1/webhook/ci" )
+
+-- 16b. POST duplicate name -> 400
+_config = base_config( ); load_plugin( )
+r = call( "POST", "/v1/webhooks", { name = "discourse", signature_header = "x", secret = "k" } )
+eq( "POST dup name: 400", r.status, 400 )
+eq( "POST dup name: E_BAD_INPUT", r.error.code, "E_BAD_INPUT" )
+
+-- 16c. POST invalid name -> 400
+r = call( "POST", "/v1/webhooks", { name = "bad name!", signature_header = "x", secret = "k" } )
+eq( "POST bad name: 400", r.status, 400 )
+
+-- 16d. POST no resolvable secret -> 400 (never a silently-inert endpoint)
+_overrides = { }
+r = call( "POST", "/v1/webhooks", { name = "nosec", signature_header = "x-sig" } )
+eq( "POST no secret: 400", r.status, 400 )
+
+-- 17. PUT full-replace, blank secret keeps the current inline secret
+_config = base_config( ); load_plugin( )
+r = call( "PUT", "/v1/webhooks/{name}",
+    { name = "discourse", signature_header = "x-new-sig", min_level = 50 }, { name = "discourse" } )
+eq( "PUT: status 200", r.status, 200 )
+eq( "PUT keep-secret: inline secret unchanged", _config.endpoints[ 1 ].secret, SECRET )
+r = call( "GET", "/v1/webhooks" )
+local pu = r.data.endpoints[ 1 ]
+eq( "PUT: signature_header updated", pu.signature_header, "x-new-sig" )
+eq( "PUT: min_level updated", pu.min_level, 50 )
+eq( "PUT: still has_secret", pu.has_secret, true )
+eq( "PUT full-replace: events dropped (not in body)", pu.events, nil )
+
+-- 17b. PUT with a secret rotates the inline secret
+_config = base_config( ); load_plugin( )
+r = call( "PUT", "/v1/webhooks/{name}",
+    { name = "discourse", signature_header = "x", secret = "rotated-key" }, { name = "discourse" } )
+eq( "PUT rotate: 200", r.status, 200 )
+eq( "PUT rotate: new inline secret stored", _config.endpoints[ 1 ].secret, "rotated-key" )
+
+-- 17c. PUT unknown name -> 404
+r = call( "PUT", "/v1/webhooks/{name}",
+    { name = "ghost", signature_header = "x", secret = "k" }, { name = "ghost" } )
+eq( "PUT unknown: 404", r.status, 404 )
+eq( "PUT unknown: E_NOT_FOUND", r.error.code, "E_NOT_FOUND" )
+
+-- 18. DELETE -> gone from GET
+_config = base_config( ); load_plugin( )
+r = call( "DELETE", "/v1/webhooks/{name}", nil, { name = "discourse" } )
+eq( "DELETE: 200", r.status, 200 )
+eq( "DELETE: audit target name", last_audit() and last_audit().target and last_audit().target.nick, "discourse" )
+r = call( "GET", "/v1/webhooks" )
+eq( "DELETE: endpoint removed", #r.data.endpoints, 0 )
+
+-- 18b. DELETE unknown -> 404
+r = call( "DELETE", "/v1/webhooks/{name}", nil, { name = "ghost" } )
+eq( "DELETE unknown: 404", r.status, 404 )
+
+-- 19. PUT /v1/webhooks (global tuning)
+_config = base_config( ); load_plugin( )
+r = call( "PUT", "/v1/webhooks", { max_per_minute = 42, dedup_max = 999 } )
+eq( "settings: 200", r.status, 200 )
+eq( "settings: reload_required", r.data.apply_status, "reload_required" )
+eq( "settings: audit action", last_audit() and last_audit().action, "webhook.settings" )
+truthy( "settings: audit target nil (no endpoint)", last_audit() and last_audit().target == nil )
+r = call( "GET", "/v1/webhooks" )
+eq( "settings: max_per_minute updated", r.data.tuning.max_per_minute, 42 )
+eq( "settings: dedup_max updated", r.data.tuning.dedup_max, 999 )
+eq( "settings: field_maxlen untouched", r.data.tuning.field_maxlen, 20 )
+r = call( "PUT", "/v1/webhooks", { max_per_minute = 0 } )
+eq( "settings: reject <= 0", r.status, 400 )
+
+-- 20. enabled=false: receiver route skipped, but still listed in GET.
+--     RED on v0.03 (enabled ignored -> receiver route WAS registered).
+_config = base_config( )
+_config.endpoints[ 1 ].enabled = false
+load_plugin( )
+truthy( "enabled=false: receiver route NOT registered", route( "POST", "/v1/webhook/discourse" ) == nil )
+r = call( "GET", "/v1/webhooks" )
+eq( "enabled=false: still listed in GET", #r.data.endpoints, 1 )
+eq( "enabled=false: GET reports enabled=false", r.data.endpoints[ 1 ].enabled, false )
+
+-- 21. GET view is scalar-safe: a hand-edited file with non-scalar junk in
+--     events/templates/conditions is FILTERED (the GET data is dkjson-
+--     encoded outside the handler guard, so raw passthrough of a function/
+--     cycle would crash the hub loop). RED pre-fix (raw passthrough).
+_overrides = { }
+_config = base_config( )
+_config.endpoints[ 1 ].events     = { "ok", function() end, { nested = 1 } }
+_config.endpoints[ 1 ].templates  = { good = "hi", bad = function() end }
+_config.endpoints[ 1 ].conditions = { { path = "p", equals = "v" }, { path = "q", equals = function() end } }
+load_plugin( )
+r = call( "GET", "/v1/webhooks" )
+local sv = r.data.endpoints[ 1 ]
+eq( "scalar-safe: only string events kept", sv.events and #sv.events, 1 )
+eq( "scalar-safe: string event value", sv.events and sv.events[ 1 ], "ok" )
+eq( "scalar-safe: string template kept", sv.templates and sv.templates.good, "hi" )
+truthy( "scalar-safe: function template dropped", sv.templates and sv.templates.bad == nil )
+eq( "scalar-safe: only scalar-valued conditions kept", sv.conditions and #sv.conditions, 1 )
+eq( "scalar-safe: kept condition path", sv.conditions and sv.conditions[ 1 ].path, "p" )
 
 ----------------------------------------------------------------------
 if failures > 0 then


### PR DESCRIPTION
## What

Adds an HTTP management API to `etc_webhook` (v0.04) so inbound-webhook endpoints can be created/edited/deleted from the WebUI instead of hand-editing `cfg/webhooks.tbl` + `+reload`. This is PR-1 of the arc; the WebUI **Webhooks** tab that consumes it lands in `luadch-ng/webui`.

## Routes

| Route | Scope | Does |
|---|---|---|
| `GET /v1/webhooks` | read | list endpoints + tuning, **secrets redacted** |
| `POST /v1/webhooks` | admin | create an endpoint |
| `PUT /v1/webhooks` | admin | update global tuning |
| `PUT /v1/webhooks/{name}` | admin | replace an endpoint |
| `DELETE /v1/webhooks/{name}` | admin | delete an endpoint |

Registered whenever the plugin is whitelisted (independent of `etc_webhook_activate`), so the WebUI tab - gated on `GET /v1/webhooks` being present in `/v1/endpoints` - appears and can flip the master switch before the receiver is on. Receiver routes stay gated on activate + a valid endpoint.

## Key points

- **Plugin owns the file.** Writes go through `util.tabletostring` + `util.atomic_write` + `util.chmod_secret` (atomic tmp+rename then 0600, same path as `core/cfg_users.lua`'s user.tbl), keeping a header banner. A write returns `apply_status: "reload_required"`.
- **Secrets are write-only.** GET never returns a value - only `has_secret` + `secret_source` (`inline` = rotatable via file, `external` = env/cfg override wins on load, `none` = unset). A blank/omitted `secret` on PUT keeps the current one.
- **New `enabled` field** (default true; absent = on) pauses one endpoint without deleting its config/secret.
- **Validation boundary:** `sanitise_endpoint_body` rebuilds a fresh whitelist-typed table (dkjson metatables / junk can't reach the serializer), `name` regex keeps the derived cfg-key/env-var/path un-traversable, `%q` serialization prevents string break-out. GET copies events/templates/conditions through a scalar-only filter (the encode runs outside the handler guard, so a hand-edited function/cycle there could otherwise crash the hub loop).

## Tests

- **Unit** (97 assertions, green on Lua 5.4): mgmt CRUD, redaction, `secret_source`, keep/rotate, audit target, scalar-safe filtering. The `enabled`-skip case is **provably RED on v0.03** (which ignored `enabled` and still registered a receiver route).
- **Smoke** (`test_http_webhooks_management`): drives the **real** writer end to end - the post-POST GET re-reads the written file via `loadfile`, so a bad serialization drops the endpoint. Asserts 0600 (POSIX), a quote/backslash/`]]`/newline template round-trip, and an `enabled=false` round-trip. `etc_webhook` is whitelisted in the smoke config.
- Real `util.tabletostring` round-trip validated locally (header + booleans + `%q`-escaped secrets/templates reload correctly).

## Review

Independent adversarial review + maintainer spot-check done: no blockers. Two `concern`s fixed (audit dropped the endpoint name via a bare-string target; GET passed raw operator tables to dkjson) + nits (module flag renamed `receiver_active`, explicit secret-type check, added smoke coverage for special chars + `enabled=false`).

Part of #682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
