### PR TITLE
fix(etc_webhook): address 4-axis review of the v0.04 management API

### DIFF
--- a/docs/HTTP_API.md
+++ b/docs/HTTP_API.md
@@ -1381,6 +1381,28 @@ an unknown path).
 
 [^http-webhook-1]: One route per operator-configured endpoint (`<name>` is the endpoint's configured path segment). Scope is `none` - the router does NOT gate it; the plugin authenticates each delivery itself via an HMAC-SHA256 signature over the raw body (see [`WEBHOOKS.md`](WEBHOOKS.md)). Signature mismatch returns **401** with the plugin's own `{code:"unauthorized"}` body; a body over the 64 KiB cap returns **413**; a non-JSON content type returns **415**. Registered only when `etc_webhook` is loaded and the endpoint has a resolvable secret - otherwise the path is absent and an unregistered path falls through to the router's generic 401/404.
 
+#### Webhooks (management)
+
+| Method | Path | Scope | Plugin |
+|---|---|---|---|
+| GET | `/v1/webhooks` | read | `etc_webhook` (v0.04) [^http-webhookmgmt-1] |
+| POST | `/v1/webhooks` | admin | `etc_webhook` [^http-webhookmgmt-2] |
+| PUT | `/v1/webhooks` | admin | `etc_webhook` [^http-webhookmgmt-3] |
+| PUT | `/v1/webhooks/{name}` | admin | `etc_webhook` [^http-webhookmgmt-4] |
+| DELETE | `/v1/webhooks/{name}` | admin | `etc_webhook` [^http-webhookmgmt-5] |
+
+Create/edit/delete the endpoints that back the inbound receiver routes above, without shell access (the WebUI Webhooks tab). The plugin owns `cfg/webhooks.tbl`: writes are atomic + `chmod 600`, and since endpoint config is read once at load, every write returns `apply_status: "reload_required"`. Registered whenever `etc_webhook` is whitelisted, independent of `etc_webhook_activate` (so the tab appears before the receiver is on). Secrets are write-only. See [`WEBHOOKS.md`](WEBHOOKS.md) §3.1.
+
+[^http-webhookmgmt-1]: Returns 200 with `data: {activate: bool, tuning: {max_per_minute, dedup_max, field_maxlen}, endpoints: [...]}`. Each endpoint carries its config plus `has_secret` (bool) and `secret_source` (`"inline"` = rotatable by writing the file, `"external"` = an env/cfg override wins on load, `"none"` = unset) and `valid` (+ `invalid_reason` when false) - **the secret value is never returned**. `read` scope matches `GET /v1/config`.
+
+[^http-webhookmgmt-2]: Body is one endpoint (`request_schema`: `name` [A-Za-z0-9_], max 64; `signature_header` required; optional `signature_prefix`, `path`, `event_header`, `id_header`, `bot_nick`, `default_template`, `min_level`, `enabled`, `events[]`, `templates{}`, `conditions[]`, `secret`). Returns 200 `{action: "webhook-created", name, apply_status}`. **400 E_BAD_INPUT** on a bad/duplicate name, missing `signature_header`, or an unresolvable secret (no inline + no env/cfg override). `audit_redact_body` keeps the ingested secret out of `api_audit.log`.
+
+[^http-webhookmgmt-3]: Body `{max_per_minute?, dedup_max?, field_maxlen?}` (positive integers). Returns 200 `{action: "webhook-tuned", apply_status}`. Updates only the global tuning; endpoints are managed via the `{name}` routes.
+
+[^http-webhookmgmt-4]: Full replace of the named endpoint (same schema as POST; `name` is taken from the path). A blank or omitted `secret` **keeps** the current one (rotate-only); a non-empty `secret` rotates it. Returns 200 `{action: "webhook-updated", name, apply_status}`; **404 E_NOT_FOUND** if the name is unknown. `audit_redact_body` set.
+
+[^http-webhookmgmt-5]: No request body. Returns 200 `{action: "webhook-deleted", name, apply_status}`; **404 E_NOT_FOUND** if the name is unknown.
+
 #### Shipped post-Phase-4 (#82 arc closed 2026-05-27)
 
 The four "future-scope" items below were shipped in a single day on

--- a/scripts/etc_webhook.lua
+++ b/scripts/etc_webhook.lua
@@ -466,6 +466,14 @@ local function is_scalar( v )
     return t == "string" or t == "number" or t == "boolean"
 end
 
+-- Derived per-endpoint secret key (single source of truth): the cfg.tbl
+-- key AND, upper-cased, the env var LUADCH_ETC_WEBHOOK_<NAME>_SECRET.
+-- Kept in one place so the module-load resolver and the two mgmt readers
+-- cannot drift on the key format.
+local function secret_key( name )
+    return "etc_webhook_" .. name .. "_secret"
+end
+
 local function err_resp( status, code, msg )
     return { status = status, error = { code = code, message = msg } }
 end
@@ -510,8 +518,7 @@ end
 -- inert, so writes reject it rather than silently creating a dead route.
 local function endpoint_has_secret( e )
     if type( e.secret ) == "string" and e.secret ~= "" then return true end
-    local key = "etc_webhook_" .. e.name .. "_secret"
-    local override = secrets and secrets.lookup and secrets.lookup( key )
+    local override = secrets and secrets.lookup and secrets.lookup( secret_key( e.name ) )
     return type( override ) == "string" and override ~= ""
 end
 
@@ -525,6 +532,7 @@ local function sanitise_endpoint_body( b, keep_secret )
     if type( b.name ) ~= "string" or not b.name:match( "^[%a%d_]+$" ) then
         return nil, "invalid or missing 'name' (need [A-Za-z0-9_])"
     end
+    if #b.name > 64 then return nil, "'name' too long (max 64)" end
     e.name = b.name
     if type( b.signature_header ) ~= "string" or b.signature_header == "" then
         return nil, "missing 'signature_header'"
@@ -628,7 +636,7 @@ local function endpoint_public_view( raw_e )
     local inline = ( type( raw_e.secret ) == "string" and raw_e.secret ~= "" ) or false
     local has_secret, secret_source = false, "none"
     if name ~= "" then
-        local override = secrets and secrets.lookup and secrets.lookup( "etc_webhook_" .. name .. "_secret" )
+        local override = secrets and secrets.lookup and secrets.lookup( secret_key( name ) )
         if type( override ) == "string" and override ~= "" then
             has_secret, secret_source = true, "external"
         elseif inline then
@@ -640,7 +648,10 @@ local function endpoint_public_view( raw_e )
     local view = {
         name             = name,
         enabled          = ( raw_e.enabled ~= false ),
-        path             = ( norm and norm.path ) or raw_e.path or ( "/v1/webhook/" .. name ),
+        -- path must be scalar-guarded like every other field below: when the
+        -- endpoint is invalid (norm=nil), the raw fallback would otherwise
+        -- pass a hand-edited function/cycle straight to dkjson.encode.
+        path             = ( norm and norm.path ) or ( type( raw_e.path ) == "string" and raw_e.path ) or ( "/v1/webhook/" .. name ),
         signature_header = ( type( raw_e.signature_header ) == "string" and raw_e.signature_header ) or "",
         signature_prefix = ( type( raw_e.signature_prefix ) == "string" and raw_e.signature_prefix ) or "",
         event_header     = ( type( raw_e.event_header ) == "string" and raw_e.event_header ) or "",
@@ -737,7 +748,7 @@ local function http_create_webhook( req )
     local ok, werr = write_config_raw( raw )
     if not ok then return internal( werr ) end
     audit_mutation( req, "webhook.create", e.name )
-    return { status = 200, data = { name = e.name, apply_status = "reload_required" } }
+    return { status = 200, data = { action = "webhook-created", name = e.name, apply_status = "reload_required" } }
 end
 
 -- PUT /v1/webhooks/{name} (admin): replace an existing endpoint. A blank
@@ -762,7 +773,7 @@ local function http_update_webhook( req )
     local ok, werr = write_config_raw( raw )
     if not ok then return internal( werr ) end
     audit_mutation( req, "webhook.update", name )
-    return { status = 200, data = { name = name, apply_status = "reload_required" } }
+    return { status = 200, data = { action = "webhook-updated", name = name, apply_status = "reload_required" } }
 end
 
 -- DELETE /v1/webhooks/{name} (admin): remove an endpoint.
@@ -776,7 +787,7 @@ local function http_delete_webhook( req )
     local ok, werr = write_config_raw( raw )
     if not ok then return internal( werr ) end
     audit_mutation( req, "webhook.delete", name )
-    return { status = 200, data = { name = name, apply_status = "reload_required" } }
+    return { status = 200, data = { action = "webhook-deleted", name = name, apply_status = "reload_required" } }
 end
 
 -- PUT /v1/webhooks (admin): update the global tuning (flood cap, dedup
@@ -794,8 +805,8 @@ local function http_update_settings( req )
     end
     local ok, werr = write_config_raw( raw )
     if not ok then return internal( werr ) end
-    audit_mutation( req, "webhook.settings", "-" )
-    return { status = 200, data = { apply_status = "reload_required" } }
+    audit_mutation( req, "webhook.tune", "-" )
+    return { status = 200, data = { action = "webhook-tuned", apply_status = "reload_required" } }
 end
 
 
@@ -818,11 +829,11 @@ if type( config ) == "table" then
                 -- GET /v1/config), then env-var-first, then the inline
                 -- secret in cfg/webhooks.tbl. Registration happens for
                 -- every configured endpoint, before the activate gate.
-                local secret_key = "etc_webhook_" .. entry.name .. "_secret"
-                if secrets and secrets.register then secrets.register( secret_key ) end
-                local resolved = ( secrets and secrets.lookup and secrets.lookup( secret_key ) ) or entry.inline_secret
+                local skey = secret_key( entry.name )
+                if secrets and secrets.register then secrets.register( skey ) end
+                local resolved = ( secrets and secrets.lookup and secrets.lookup( skey ) ) or entry.inline_secret
                 if type( resolved ) ~= "string" or resolved == "" then
-                    hub_debug( scriptname .. ": endpoint '" .. entry.name .. "' has no secret (env LUADCH_" .. string.upper( secret_key ) .. " / cfg / inline) - skipped" )
+                    hub_debug( scriptname .. ": endpoint '" .. entry.name .. "' has no secret (env LUADCH_" .. string.upper( skey ) .. " / cfg / inline) - skipped" )
                 else
                     entry.secret = resolved
                     endpoints[ #endpoints + 1 ] = entry
@@ -863,24 +874,72 @@ hub.setlistener( "onStart", { },
         end
         -- The router unregister_all's on every +reload before this fires,
         -- so a straight re-register is safe (no duplicate-path throw). Each
-        -- register is pcall'd so one bad route never aborts the rest.
-        local function reg( method, path, scope, handler, desc )
-            local ok, reg_err = pcall( hub.http_register, method, path, scope, handler, {
-                plugin = scriptname, description = desc,
-            } )
+        -- register is pcall'd so one bad route never aborts the rest. `extras`
+        -- merges request/response_schema + audit_redact_body into the meta.
+        local function reg( method, path, scope, handler, desc, extras )
+            local meta = { plugin = scriptname, description = desc }
+            if extras then for k, v in pairs( extras ) do meta[ k ] = v end end
+            local ok, reg_err = pcall( hub.http_register, method, path, scope, handler, meta )
             if not ok then
                 hub_debug( scriptname .. ": could not register route " .. method .. " " .. path .. ": " .. tostring( reg_err ) )
             end
         end
+        -- One endpoint request schema for POST + PUT/{name} (surfaced in
+        -- /v1/endpoints for WebUI form rendering; the router pre-validates
+        -- top-level types before the handler's fuller sanitise). `name` is
+        -- required on create but path-sourced on update, so it is not
+        -- required here - the create handler enforces it.
+        local endpoint_req = {
+            name             = { type = "string",  required = false, max_length = 64 },
+            signature_header = { type = "string",  required = true },
+            signature_prefix = { type = "string",  required = false },
+            path             = { type = "string",  required = false },
+            event_header     = { type = "string",  required = false },
+            id_header        = { type = "string",  required = false },
+            bot_nick         = { type = "string",  required = false },
+            default_template = { type = "string",  required = false },
+            min_level        = { type = "integer", required = false, min = 0 },
+            enabled          = { type = "boolean", required = false },
+            events           = { type = "array",   required = false },
+            templates        = { type = "object",  required = false },
+            conditions       = { type = "array",   required = false },
+            secret           = { type = "string",  required = false },
+        }
+        local write_resp = {
+            action       = { type = "string", required = true },
+            apply_status = { type = "string", required = true },
+            name         = { type = "string", required = false },
+        }
         -- Management API: registered whenever the plugin is loaded, even
         -- when inert (activate=false / no endpoints yet), so the WebUI tab
         -- (gated on GET /v1/webhooks being present) shows up and can create
-        -- the first endpoint + flip the master switch. Writes are admin.
-        reg( "GET",    "/v1/webhooks",        "read",  http_get_webhooks,   "list webhook endpoints + tuning (secrets redacted)" )
-        reg( "POST",   "/v1/webhooks",        "admin", http_create_webhook, "create a webhook endpoint (needs +reload)" )
-        reg( "PUT",    "/v1/webhooks",        "admin", http_update_settings,"update global webhook tuning (needs +reload)" )
-        reg( "PUT",    "/v1/webhooks/{name}", "admin", http_update_webhook, "update a webhook endpoint (needs +reload)" )
-        reg( "DELETE", "/v1/webhooks/{name}", "admin", http_delete_webhook, "delete a webhook endpoint (needs +reload)" )
+        -- the first endpoint + flip the master switch. Writes are admin, and
+        -- the two routes that ingest a plaintext `secret` (POST + PUT/{name})
+        -- set audit_redact_body so the secret never lands in api_audit.log.
+        reg( "GET",    "/v1/webhooks",        "read",  http_get_webhooks,   "list webhook endpoints + tuning (secrets redacted)", {
+            response_schema = {
+                activate  = { type = "boolean", required = true },
+                tuning    = { type = "object",  required = true },
+                endpoints = { type = "array",   required = true },
+            },
+        } )
+        reg( "POST",   "/v1/webhooks",        "admin", http_create_webhook, "create a webhook endpoint (needs +reload)", {
+            request_schema = endpoint_req, response_schema = write_resp, audit_redact_body = true,
+        } )
+        reg( "PUT",    "/v1/webhooks",        "admin", http_update_settings,"update global webhook tuning (needs +reload)", {
+            request_schema = {
+                max_per_minute = { type = "integer", required = false, min = 1 },
+                dedup_max      = { type = "integer", required = false, min = 1 },
+                field_maxlen   = { type = "integer", required = false, min = 1 },
+            },
+            response_schema = write_resp,
+        } )
+        reg( "PUT",    "/v1/webhooks/{name}", "admin", http_update_webhook, "update a webhook endpoint (needs +reload)", {
+            request_schema = endpoint_req, response_schema = write_resp, audit_redact_body = true,
+        } )
+        reg( "DELETE", "/v1/webhooks/{name}", "admin", http_delete_webhook, "delete a webhook endpoint (needs +reload)", {
+            response_schema = write_resp,
+        } )
         -- Receiver routes: one scope="none" POST per LIVE endpoint, only
         -- when active with >=1 valid endpoint (the HMAC-authed inbound path).
         if receiver_active then

--- a/tests/smoke/run.py
+++ b/tests/smoke/run.py
@@ -6006,6 +6006,19 @@ def test_http_webhooks_management(staging_dir: Path, proc=None):
     d = data_of(send("POST", "/v1/webhooks", create), "POST /v1/webhooks")
     if d.get("apply_status") != "reload_required":
         raise TestFailure(f"POST /v1/webhooks: expected reload_required; data={d!r}")
+    if d.get("action") != "webhook-created":
+        raise TestFailure(f"POST /v1/webhooks: expected action=webhook-created; data={d!r}")
+
+    # The ingested secret must be REDACTED in api_audit.log (the route sets
+    # audit_redact_body), never written verbatim - it is the sole credential
+    # guarding the scope=none receiver and api_audit.log is not 0600.
+    alines = data_of(send("GET", "/v1/log/api?lines=50"), "GET /v1/log/api").get("lines") or []
+    joined = "\n".join(alines)
+    if "smoke-secret-value-01" in joined:
+        raise TestFailure("POST /v1/webhooks: secret leaked verbatim into api_audit.log")
+    post_line = next((l for l in alines if "POST /v1/webhooks " in l and "/v1/webhooks/" not in l), None)
+    if not post_line or "body=[redacted]" not in post_line:
+        raise TestFailure(f"POST /v1/webhooks: audit body not redacted; line={post_line!r}")
 
     # 4. GET reflects it (proves the written file is valid, reloadable Lua),
     #    with the secret redacted.

--- a/tests/unit/etc_webhook_test.lua
+++ b/tests/unit/etc_webhook_test.lua
@@ -489,6 +489,7 @@ _chmod_called = false
 r = call( "POST", "/v1/webhooks", NEWEP )
 eq( "POST: status 200", r.status, 200 )
 eq( "POST: apply_status reload_required", r.data.apply_status, "reload_required" )
+eq( "POST: action label", r.data.action, "webhook-created" )
 eq( "POST: writer chmod 600 called", _chmod_called, true )
 eq( "POST: audit action webhook.create", last_audit() and last_audit().action, "webhook.create" )
 eq( "POST: audit target is endpoint name (flat table, not dropped)",
@@ -508,9 +509,13 @@ r = call( "POST", "/v1/webhooks", { name = "discourse", signature_header = "x", 
 eq( "POST dup name: 400", r.status, 400 )
 eq( "POST dup name: E_BAD_INPUT", r.error.code, "E_BAD_INPUT" )
 
--- 16c. POST invalid name -> 400
+-- 16c. POST invalid name -> 400 (bad chars, and overlong)
 r = call( "POST", "/v1/webhooks", { name = "bad name!", signature_header = "x", secret = "k" } )
 eq( "POST bad name: 400", r.status, 400 )
+r = call( "POST", "/v1/webhooks", { name = string.rep( "a", 65 ), signature_header = "x", secret = "k" } )
+eq( "POST overlong name (>64): 400", r.status, 400 )
+r = call( "POST", "/v1/webhooks", { name = "numsec", signature_header = "x", secret = 12345 } )
+eq( "POST non-string secret: 400", r.status, 400 )
 
 -- 16d. POST no resolvable secret -> 400 (never a silently-inert endpoint)
 _overrides = { }
@@ -560,7 +565,7 @@ _config = base_config( ); load_plugin( )
 r = call( "PUT", "/v1/webhooks", { max_per_minute = 42, dedup_max = 999 } )
 eq( "settings: 200", r.status, 200 )
 eq( "settings: reload_required", r.data.apply_status, "reload_required" )
-eq( "settings: audit action", last_audit() and last_audit().action, "webhook.settings" )
+eq( "settings: audit action", last_audit() and last_audit().action, "webhook.tune" )
 truthy( "settings: audit target nil (no endpoint)", last_audit() and last_audit().target == nil )
 r = call( "GET", "/v1/webhooks" )
 eq( "settings: max_per_minute updated", r.data.tuning.max_per_minute, 42 )
@@ -597,6 +602,16 @@ eq( "scalar-safe: string template kept", sv.templates and sv.templates.good, "hi
 truthy( "scalar-safe: function template dropped", sv.templates and sv.templates.bad == nil )
 eq( "scalar-safe: only scalar-valued conditions kept", sv.conditions and #sv.conditions, 1 )
 eq( "scalar-safe: kept condition path", sv.conditions and sv.conditions[ 1 ].path, "p" )
+
+-- 22. path guard: an INVALID endpoint (norm=nil because it has no name) with
+--     a function `path` must NOT leak the function into the wire view - the
+--     raw-path fallback is scalar-guarded (else dkjson.encode crashes the loop).
+_config = { endpoints = { { signature_header = "h", path = function() end } } }
+load_plugin( )
+r = call( "GET", "/v1/webhooks" )
+local iv = r.data.endpoints[ 1 ]
+truthy( "path guard: view.path is a string, not the raw function", type( iv.path ) == "string" )
+eq( "path guard: invalid endpoint flagged valid=false", iv.valid, false )
 
 ----------------------------------------------------------------------
 if failures > 0 then


### PR DESCRIPTION
## What

Follow-up to #683 (already on `dev`). After the merge I ran a fresh 4-axis review (security / regression / consistency / code-quality) - notably because the fixes applied to the *first* review's findings had not themselves been re-reviewed. This addresses everything it surfaced. Regression, file-write safety, and authz came back **clean**.

## Security (both fixed)

- **BLOCKER - secret leaked to the audit log.** `POST /v1/webhooks` and `PUT /v1/webhooks/{name}` ingest a plaintext `secret` but did not set `audit_redact_body`, so with `log_api_audit` on the HMAC secret landed verbatim in `api_audit.log` (which lacks `webhooks.tbl`'s 0600). Every other secret-ingesting route already sets the flag. Both routes now set `audit_redact_body = true`; a smoke assertion proves the secret is redacted and never verbatim.
- **CONCERN - incomplete crash-safety fix.** `endpoint_public_view` scalar-guarded every field except `path` (the raw fallback fired for an invalid hand-edited endpoint). A function/cycle `path` reaches `dkjson.encode`, which runs *outside* the handler's error guard → hub-loop crash on a read GET. `path` is now type-guarded; unit case 22 covers it.

## Consistency

- `HTTP_API.md`: the 5 management routes added to the endpoint catalog (§1b.11) with per-route footnotes.
- `request_schema` + `response_schema` on all routes (every HTTP-plugin sibling has them; the WebUI reads `request_schema` from `/v1/endpoints` to build forms). The router now pre-validates top-level types.
- `action` label on every write response (`webhook-created/-updated/-deleted/-tuned`), matching records-reset / config-set.
- Audit action `webhook.settings` -> `webhook.tune` (verb form).

## Code quality

- `secret_key(name)` extracted as the single source for the derived cfg-key / env-var string (was hand-built at three sites in security-relevant code).
- Defensive 400s for a name > 64 chars and a non-string `secret`.

## Validation

- 102 unit assertions green (Lua 5.4); RED-proven cases retained (enabled-skip, scalar-safe, and now path-guard).
- Smoke extended (audit-redaction guard + action check); the review fixes will be live-re-validated against `:dev` in the devlab after merge.

Part of #682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
