### PR TITLE
Promote to master: etc_lockdown fresh-boot checkfile-noise fix (#686)

### DIFF
--- a/scripts/etc_lockdown.lua
+++ b/scripts/etc_lockdown.lua
@@ -1,6 +1,10 @@
 --[[
 
-    etc_lockdown.lua v0.01 by Aybo ( #501 )
+    etc_lockdown.lua v0.02 by Aybo ( #501 )
+
+        v0.02 - probe io.open before util.loadtable at load, so a fresh /
+                never-activated hub ( no state file yet ) no longer logs a
+                `checkfile: No such file` line into error.log every boot.
 
         Transient "maintenance mode": temporarily admit only users at or
         above a chosen level, kick everyone below, and refuse new logins
@@ -57,7 +61,7 @@
 --------------
 
 local scriptname    = "etc_lockdown"
-local scriptversion = "0.01"
+local scriptversion = "0.02"
 
 local cmd_main = "lockdown"
 
@@ -155,8 +159,20 @@ end
 -- Persisted lockdown state. Shape ( when active ):
 --   { active=true, level=N, message=<str|nil>, expires_at=<abs os.time|nil>,
 --     by_nick=<str>, by_level=<int>, started_at=<abs os.time> }
--- Loaded once at module load; util.loadtable returns nil on a fresh hub.
-local state = sane_state( util.loadtable( store_path ) )
+-- Loaded once at module load. Probe with io.open FIRST so a missing store
+-- ( the normal case until the first activation writes it - lockdown ships
+-- off ) does not log a `checkfile: No such file` line on every boot / +reload,
+-- which the dashboard's Recent-errors tile would then surface. Same io.open
+-- peek etc_stats_history / etc_geoip / etc_blocklist_feeds use ( hub_runtime
+-- #445 first-run-noise lesson ). sane_state coerces a corrupt / nil load to a
+-- safe inactive record.
+local function load_state( )
+    local f = io.open( store_path, "r" )
+    if not f then return sane_state( nil ) end    -- one source of truth for the inactive default
+    f:close( )
+    return sane_state( util.loadtable( store_path ) )
+end
+local state = load_state( )
 
 local function persist( )
     util.savetable( state, "etc_lockdown_state", store_path )

--- a/tests/unit/etc_lockdown_test.lua
+++ b/tests/unit/etc_lockdown_test.lua
@@ -44,7 +44,7 @@ end
 -- Controllable clock + capture state
 ----------------------------------------------------------------------
 local _now = 1000000
-local _cfg, _persisted, _saved, _save_count, _reports, _audit, _online, _wl
+local _cfg, _persisted, _saved, _save_count, _reports, _audit, _online, _wl, _loadtable_called
 
 local function reset_cfg( )
     _cfg = {
@@ -61,6 +61,7 @@ end
 local function fresh( )
     _saved = nil; _save_count = 0; _reports = { }; _audit = { }
     _online = { }; _wl = { }
+    _loadtable_called = false
 end
 
 ----------------------------------------------------------------------
@@ -75,8 +76,20 @@ _G.tonumber, _G.tostring, _G.pcall = tonumber, tostring, pcall
 local _real_os = os
 _G.os = setmetatable( { time = function( ) return _now end }, { __index = _real_os } )
 
+-- io stub: override open() to simulate the store file's existence - it exists
+-- iff there is persisted state to load (mirrors reality; the .tbl is written
+-- only on the first state change), so the fresh-hub path exercises the plugin's
+-- io.open peek. Everything else (stderr, write) falls through to the real io.
+local _real_io = io
+_G.io = setmetatable( {
+    open = function( path )
+        if _persisted ~= nil then return { close = function( ) end } end
+        return nil, tostring( path ) .. ": No such file or directory"
+    end,
+}, { __index = _real_io } )
+
 _G.util = {
-    loadtable = function( ) return _persisted end,
+    loadtable = function( ) _loadtable_called = true; return _persisted end,
     savetable = function( t, name, path ) _saved = t; _save_count = _save_count + 1 end,
 }
 _G.cfg = {
@@ -360,6 +373,27 @@ do
     -- non-numeric expires_at is likewise coerced
     local p2, L2 = load_plugin( nil, { active = true, level = 60, expires_at = "soon" } )
     falsy( "corrupt: bad expires_at coerced to inactive", p2._state( ).active )
+end
+
+----------------------------------------------------------------------
+-- fresh hub ( no store file ): the io.open peek short-circuits so
+-- util.loadtable ( and thus util.checkfile ) is NOT called, and no
+-- "No such file" checkfile line is logged on every boot / +reload.
+-- Proven RED on the pre-fix load that called util.loadtable directly.
+----------------------------------------------------------------------
+do
+    local p = load_plugin( )                        -- persisted nil -> store "missing"
+    falsy( "fresh-hub: util.loadtable NOT called ( no checkfile noise )", _loadtable_called )
+    falsy( "fresh-hub: state inactive", p._state( ).active )
+end
+
+do
+    -- when the store DOES exist, loadtable is still consulted and the
+    -- persisted lockdown loads ( the peek only skips the missing-file case )
+    local p = load_plugin( nil, { active = true, level = 60, expires_at = _now + 600,
+        by_nick = "op", by_level = 60, started_at = _now } )
+    truthy( "existing-store: util.loadtable consulted", _loadtable_called )
+    truthy( "existing-store: persisted lockdown active", p._state( ).active )
 end
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
Promote the single `dev` commit to `master`: #686 - `etc_lockdown` no longer logs a `checkfile: No such file` line into error.log every boot/+reload on a fresh or never-activated hub.

`etc_lockdown` ships disabled, so its state file is not written until the first activation; the module-load read called `util.loadtable` unconditionally, and `loadtable` -> `checkfile` -> `io.open` on a missing file logged the line (surfaced by the WebUI dashboard's Recent-errors tile). Fixed with the `io.open` peek every other state-file plugin already uses.

Unit test proven RED on the unpatched load (74/1) -> GREEN (75/0), on both smoke legs. Live-verified on the `:dev` devlab: both load branches (missing -> silent, present -> loads+applies). Independent review (security/regression/spaghetti) = SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)