### PR TITLE
docs: currency audit - fix drift across 12 docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,8 @@ dependency updates are manual.
 | LuaSec      | **1.3.2**       | `luasec/`      | TLS support, links against OpenSSL; upstream-blocked for OpenSSL-3 API (Phase 4, #3) |
 | LuaSocket   | **3.1.0**       | `luasocket/`   | TCP/UDP, IPv6 capable                |
 | basexx      | (no version)    | `basexx/`      | Pure Lua, base32/64 encoding         |
+| dkjson      | (no version)    | `dkjson/`      | Pure Lua, JSON encode/decode; load-bearing for the HTTP API + the lang JSON loader (`util.loadjsontable`) |
+| slaxml      | (no version)    | `slaxml/`      | Pure Lua, XML parser                  |
 | unicode     | shim            | `slnunicode/unicode.lua` | ~40-line Lua shim that replaces the unmaintained slnunicode C module; uses `string.X` and Lua 5.4 builtin `utf8` |
 | adclib      | (no version)    | `adclib/`      | C module: ADC hashing & escaping     |
 | zlib_stream | (own binding)   | `zlib_stream/` | C binding for ZLIF stream compression (Phase 8 S4b); links the **system** zlib (`find_package(ZLIB REQUIRED)`) - the one dependency NOT bundled |
@@ -131,7 +133,7 @@ order (its inline comments explain each ordering constraint).
 
 | Subsystem | Modules | Responsibility |
 |---|---|---|
-| Boot + config | `init`, `const`, `cfg`, `cfg_defaults`, `cfg_users`, `cfg_lang`, `cfg_secret`, `secrets`, `cfg_write` | Restricted env + module loader; program constants; settings/user.tbl/language handling; AES-256-GCM at-rest crypto; env-var-first secret lookup; comment/layout-preserving single-key cfg.tbl writer (#644) |
+| Boot + config | `init`, `const`, `cfg`, `cfg_defaults`, `cfg_users`, `cfg_lang`, `cfg_secret`, `secrets`, `cfg_write` | Restricted env + module loader; program constants; settings/user.tbl handling; `cfg_lang` language handling - on-disk lang layout is now JSON in per-language subdirs (`lang/<lng>/hub.json`, `scripts/lang/<lng>/<name>.json`; en/de/nl/sv), loaded JSON-first via `cfg_lang.loadlanguage`, Weblate-managed (see [`docs/TRANSLATING.md`](docs/TRANSLATING.md)); AES-256-GCM at-rest crypto; env-var-first secret lookup; comment/layout-preserving single-key cfg.tbl writer (#644) |
 | Network + ADC | `server`, `iostream`, `adc`, `hub`, `hub_dispatch`, `hub_user_object`, `hub_bot_object`, `hbri`, `ratelimit`, `blocklist`, `whitelist`, `ipmatch` | event loop + SSL (poll on POSIX / select on Windows, #310); framing pipeline; ADC parse/escape/format; main loop + login; command dispatch; user/bot objects; dual-stack secondary-IP verification; DoS limits; pre-handshake IP/CIDR blocklist; global allowlist (whitelist beats automated blocks, not manual pins); IP/CIDR primitives |
 | HTTP API | `http`, `http_router`, `http_client`, `http_filter`, `http_events`, `util_http` | Inbound HTTP/JSON API + router + auth; non-blocking OUTBOUND client; filter/sort/paginate helper; deferred-event endpoints; plugin endpoint helper |
 | Crypto + boot trust | `sha256`, `hmac`, `cert_bootstrap`, `cacert_bootstrap`, `backup_archive` | Pure-Lua SHA-256; HMAC-SHA256 (RFC 2104, sandbox-exposed for signed-webhook auth, #398); first-boot TLS-cert auto-gen (#77); CA-bundle reconciliation; LDBK1 encrypted backup archive format (tar + AES-256-GCM, PBKDF2, #480) |
@@ -387,7 +389,7 @@ contract, preflight): see [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) §3 and
   **this file**, not in memory, because they belong with the code. Durable
   engineering patterns belong in [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) so
   they reach every assistant and contributor, not just one memory owner.
-- **Releases** - this fork's latest release is `v3.1.14` (see §2 and §8); UPSTREAM
+- **Releases** - this fork's latest release is `v3.1.15` (see §2 and §8); UPSTREAM
   `luadch/luadch` last released v2.23 back in 2022-04-02 (see Upstream policy below).
 
 ### Upstream policy
@@ -437,7 +439,7 @@ open a fresh issue here that references the upstream one in its body.
   source of truth (`wc -l`, `gh issue list`, CI) instead. Two exemptions, because
   they do NOT drift: (a) frozen historical facts about a CLOSED phase (e.g. "24
   findings / 22 closed" in the §5 table); (b) release/version/"verified-on"
-  markers (e.g. "latest release v3.1.14", the deps-table verified date). A live
+  markers (e.g. "latest release v3.1.15", the deps-table verified date). A live
   status line (like §5 "In flight") must name the tracker as its source of truth.
 
 ### Tooling gotchas (these have already burned us)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ authorship intact. No need to close and reopen it.
 ## Translating
 
 You do not need to touch code to help. luadch is translated on Weblate at
-[translate.dcvault.net](https://translate.dcvault.net/) - pick the `luadch`
+[translate.dcvault.net](https://translate.dcvault.net/) - pick the `luadch-ng`
 project and your language. Translations flow back into the repo automatically;
 see [`docs/TRANSLATING.md`](docs/TRANSLATING.md) for the how-to and the rules
 (keep `%s` placeholders, keep DC jargon in English).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Help us translate Luadch-ng into your language. Visit our [Translation Hub](http
 
 
 ## ToDo
-- 🌐 Web interface for hub management
+- 🌐 Web interface for hub management (in progress in the companion repo `luadch-ng-webui`; backed by this hub's HTTP + webhook management API, but not part of this repo's release)
 
 ## Quick Start
 

--- a/docs/BLOCKLIST.md
+++ b/docs/BLOCKLIST.md
@@ -396,7 +396,7 @@ before enabling on a public hub - the free tiers differ sharply:
 
 | Provider | `provider` | Free tier | Commercial use on free tier | Auth |
 |---|---|---|---|---|
-| [proxycheck.io](https://proxycheck.io) | `proxycheck` | 1,000/day (100/day without a key) | Not explicitly granted - the terms neither permit nor forbid it. Treat as unconfirmed. | API key as query param (optional) |
+| [proxycheck.io](https://proxycheck.io) | `proxycheck` | 1,000/day (100/day without a key) | Not explicitly granted - the terms neither permit nor forbid it. Treat as unconfirmed. | API key in POST body (optional) |
 | [VPNAPI.io](https://vpnapi.io) | `vpnapi` | 1,000/day | **No** - the free tier is "personal, non-commercial use" only. A public/community hub needs a paid plan. | API key (required) |
 | [IPQualityScore](https://www.ipqualityscore.com) | `ipqs` | 1,000/**month** (35/day cap) | **Evaluation only** - free/trial use is for testing; production/commercial use needs a paid plan. | API key in the URL path (required) |
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -499,13 +499,15 @@ or migrate `user.tbl` to a new install, repeat the `icacls` command.
 
 ## Known cosmetic build warnings
 
-The Linux build emits 5 deprecation warnings from the bundled `luasec/` C
-sources against system OpenSSL 3.x (`EC_KEY_*`, `PEM_read_bio_DHparams`,
-`SSL_CTX_set_tmp_dh_callback`, `EC_KEY_free`, `DH_free`). These are
+The Linux build emits a handful of deprecation warnings from the bundled
+`luasec/` C sources against system OpenSSL 3.x (`EC_KEY_*`,
+`PEM_read_bio_DHparams`, `SSL_CTX_set_tmp_dh_callback`, `EC_KEY_free`,
+`DH_free`). These are
 cosmetic — the functions still work in current OpenSSL. The negotiated
 TLS session is modern (TLS 1.3 + AES-256-GCM verified). Tracked in
 [issue #3](https://github.com/luadch-ng/luadch-ng/issues/3) as
 `upstream-blocked` / `wontfix`.
 
-The Windows build (gcc 16+) emits 2 stylistic `-Wparentheses` warnings
-from the third-party Tiger hash code in `adclib/tiger.cpp`. Same category.
+The Windows build (gcc 16+) emits a couple of stylistic `-Wparentheses`
+warnings from the third-party Tiger hash code in `adclib/tiger.cpp`. Same
+category (also tracked under [issue #3](https://github.com/luadch-ng/luadch-ng/issues/3)).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -61,7 +61,7 @@ After a fresh install, before opening the hub to real users:
 | Path                     | What it is                                                   |
 |--------------------------|--------------------------------------------------------------|
 | `cfg/cfg.tbl`            | Main hub configuration (Lua-serialised table)                |
-| `cfg/user.tbl`           | Registered users (nick, password hash, level, …)             |
+| `cfg/user.tbl`           | Registered users + password-equivalents (cleartext-equivalent as ADC requires; encrypted at rest by default - see SECURITY.md) |
 | `cfg/user.tbl.bak`       | Rolling backup the hub maintains automatically               |
 | `lang/de/hub.json`, `en/hub.json` | Hub-side strings (greeting, error messages, …)      |
 | `scripts/lang/de/*.json` / `en/*.json` | Per-script translations                          |
@@ -103,7 +103,8 @@ ssl_params = {
     cafile      = "certs/cacert.pem",
     protocol    = "tlsv1_3",   -- TLS 1.3 only; cannot negotiate down
     options     = { "no_sslv2", "no_sslv3", "no_tlsv1", "no_tlsv1_1", "no_renegotiation" },
-    ciphers     = "HIGH+kEDH:HIGH+kEECDH:HIGH:!PSK:!SRP:!3DES:!aNULL",
+    ciphers     = "HIGH",
+    ciphersuites = "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256",
     curve       = "prime256v1",
 },
 ```
@@ -127,9 +128,11 @@ To enable plain ADC alongside TLS, set `tcp_ports = { 5000 }` (and / or `tcp_por
 
 ### Default account warning
 
-The bundled `[BOT]HubSecurity` script warns in main chat as long as the
-`dummy` account is still registered. **Take that warning seriously** —
-do not run a public hub with `dummy / test` active.
+The bundled `etc_dummy_warning` plugin warns level-100 users at login
+(both in main chat and via PM) as long as the `dummy` account is still
+registered - the message is delivered by the hub bot (default nick
+`[BOT]HubSecurity`). **Take that warning seriously** - do not run a
+public hub with `dummy / test` active.
 
 ---
 
@@ -166,7 +169,8 @@ specific commands.
 ```
 +reg <nick> <level>           # register a new user at <level>
 +delreg <nick>                # remove a registered user
-+regme <nick> <password>      # self-register (if cfg allows it)
++regme <nick> <password>      # self-register (optional add-on; install
+                              #   examples/etc/other_available_scripts/cmd_regme.lua first)
 +setpass <newpass>            # change your own password
 +accinfo <nick>               # show registration info for someone
 ```
@@ -272,4 +276,11 @@ plugin appends its own entries.
 - The shipped `cfg/cfg.tbl` itself — every key has an inline comment
 - [PLUGIN_API.md](PLUGIN_API.md) - the plugin API reference
 - [SCRIPTS.md](SCRIPTS.md) — bundled plugin reference + rate-limit configuration
+- [SECURITY.md](SECURITY.md) - threat model, at-rest crypto, file permissions
+- [BLOCKLIST.md](BLOCKLIST.md) - blocklist engine, GeoIP, feeds, proxy detection
+- [BACKUP.md](BACKUP.md) - encrypted automatic backups + offline restore
+- [HTTP_API.md](HTTP_API.md) - inbound HTTP/JSON management API
+- [WEBHOOKS.md](WEBHOOKS.md) - inbound signed-webhook receiver
+- [CACERT.md](CACERT.md) - CA-bundle reconciliation
+- [TRANSLATING.md](TRANSLATING.md) - language files + Weblate workflow
 - [docs/phases/](phases/) — modernization journals (what changed and why)

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -325,10 +325,11 @@ rules don't get involved).
 
 ## Updating
 
-> **⚠️ Always back up first.** Operator-owned state lives in `cfg/`,
-> `scripts/lang/`, `scripts/data/`, `scripts/cfg/`, `certs/`, and
-> `secrets/`. None of these are touched by an image upgrade, but a
-> clean snapshot is the safety net for any production hub.
+> **⚠️ Always back up first.** Operator-owned state lives in `cfg/`
+> (including per-plugin config `cfg/<name>.tbl`, e.g. `cfg/webhooks.tbl`),
+> `scripts/lang/`, `scripts/data/`, `certs/`, and `secrets/`. None of
+> these are touched by an image upgrade, but a clean snapshot is the
+> safety net for any production hub.
 >
 > ```sh
 > tar -czf "luadch-backup-$(date +%F).tar.gz" cfg scripts certs secrets
@@ -371,7 +372,7 @@ What is **not** touched:
 | `cfg/user.tbl`, `cfg/user.tbl.bak` | User database |
 | `scripts/lang/<lng>/*.json` (existing) | Your translations / MOTD customizations stay; only NEW bundled language files are added |
 | `scripts/data/*.tbl` | Plugin runtime state (bans, regs, caches) |
-| `scripts/cfg/*.tbl` | Per-plugin operator settings |
+| `cfg/<name>.tbl` (e.g. `cfg/webhooks.tbl`) | Per-plugin operator settings |
 | `scripts/<your-custom>.lua` | Custom plugins keep their distinct filenames - the auto-sync only touches files that exist in the image's `/defaults/scripts/` |
 | `certs/*` | TLS keys |
 | `secrets/master.key` | AES master key |

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -16,10 +16,10 @@ build/install/luadch/
 ├── luadch          (Linux) or Luadch.exe (Windows) — the hub binary
 ├── liblua.so       (Linux) or lua.dll (Windows)
 ├── libssl-3-x64.dll, libcrypto-3-x64.dll        (Windows only)
-├── lib/                                          shared plugins (.so/.dll + .lua)
+├── lib/                                          bundled Lua/C dependency modules
 ├── core/           Lua core modules
 ├── scripts/        bundled command / bot / utility scripts
-├── cfg/            cfg.tbl + user.tbl (default templates)
+├── cfg/            cfg.tbl, user.tbl, and other default templates
 ├── certs/          TLS cert generation helpers
 ├── lang/           hub-side language files
 ├── docs/           embedded docs
@@ -198,7 +198,7 @@ What is worth backing up:
 | Path                       | Why                                    |
 |----------------------------|----------------------------------------|
 | `cfg/cfg.tbl`              | hub configuration, edited by you       |
-| `cfg/user.tbl`             | registered users + hashed credentials  |
+| `cfg/user.tbl`             | registered users + password-equivalents (cleartext-equivalent as ADC requires; encrypted at rest - see SECURITY.md) |
 | `cfg/user.tbl.bak`         | rolling backup the hub maintains itself|
 | `scripts/data/*.tbl`       | per-script state (bans, chatlog, etc.) |
 | `certs/cacert.pem`, `serverkey.pem`, `servercert.pem` | TLS keys; users will see a different keyprint after a regen |
@@ -239,10 +239,11 @@ cmake --install build              # writes to build/install/luadch/
 # 2. Stop the running hub
 sudo systemctl stop luadch
 
-# 3. Replace the read-only parts only — keep cfg/, certs/, scripts/data/, log/
+# 3. Replace the read-only parts only - keep cfg/, certs/, scripts/data/,
+#    scripts/lang/, log/
 sudo rsync -a --delete \
     --exclude='/cfg/' --exclude='/certs/' --exclude='/log/' \
-    --exclude='/scripts/data/' \
+    --exclude='/scripts/data/' --exclude='/scripts/lang/' \
     build/install/luadch/ /opt/luadch/
 
 # 4. Restart
@@ -251,7 +252,14 @@ sudo systemctl start luadch
 
 The exclude list is the contract: those are the directories the
 running hub considers state, and the new build's defaults must not
-clobber them.
+clobber them. `scripts/lang/` holds operator-editable translations and
+MOTD text (owned by you / Weblate post-migration), so it is excluded too.
+
+> **⚠️ `--delete` removes any custom plugin under `scripts/` that is not
+> present in the new build.** If you drop your own `.lua` files into
+> `scripts/`, either add an `--exclude` for each, or exclude `scripts/`
+> wholesale and hand-merge bundled-plugin updates - the same auto-sync
+> contract the Docker image follows (see [DOCKER.md](DOCKER.md)).
 
 If a release notes mentions a `cfg/cfg.tbl` migration, copy any new
 keys from `build/install/luadch/cfg/cfg.tbl` into `/opt/luadch/cfg/cfg.tbl`

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -84,8 +84,9 @@ that environment:
     `pcall`, `xpcall`, `select`, `setmetatable`, `getmetatable`,
     `tonumber`, `tostring`, `type`, `print`, `collectgarbage`
   - Full stdlib: `table`, `math`, `coroutine`
-  - **Curated stdlib**: `os` (only `time` / `date` / `difftime`), `io`
-    (only `open`, with absolute paths and `..` traversal rejected)
+  - **Curated stdlib**: `os` (only `time` / `date` / `difftime` /
+    `clock`), `io` (only `open`, with absolute paths and `..` traversal
+    rejected)
   - UTF-8 string lib: `string` is replaced with `utf` (a UTF-8-aware
     wrapper); plain Lua `string.*` byte methods are not directly
     reachable
@@ -938,10 +939,21 @@ needed for the first table, only harmless.)
 ### 10.6 Forbidden post-login INF fields
 
 A normal-state user cannot mutate `I4`, `I6`, `PD`, `ID`, `HI`, `CT`,
-`OP`, `RG`, `HU`, `BO` via `onInf`. The post-login INF guard in
-[`scripts/hub_inf_manager.lua`](../scripts/hub_inf_manager.lua) kicks
-with `ISTA 240` on attempt. If your plugin needs to change one of
-these, the user must reconnect.
+`OP`, `RG`, `HU`, `BO` via `onInf` - but the mechanism differs by field.
+The post-login INF guard in
+[`scripts/hub_inf_manager.lua`](../scripts/hub_inf_manager.lua):
+
+- **kills with `ISTA 240`** on `HI`, `CT`, `OP`, `RG`, `HU`, `BO`
+  (forbidden flags) and `PD`, `ID` (identity spoof) - the connection is
+  dropped.
+- **silently strips** `I4` / `I6` (`cmd:deletenp`, non-fatal since
+  [#222](https://github.com/luadch-ng/luadch-ng/issues/222)): the stripped
+  fields never reach the broadcast, but the session survives - real DC++
+  clients emit routine post-login INF updates carrying `I4` (NAT rebind,
+  ISP-IP change), so killing them was user-hostile.
+
+Either way the claimed mutation does not take effect; if your plugin needs
+to change one of these, the user must reconnect.
 
 ### 10.7 UTF-8 input is the plugin's responsibility
 

--- a/docs/PLUGIN_SANDBOX_MIGRATION.md
+++ b/docs/PLUGIN_SANDBOX_MIGRATION.md
@@ -35,7 +35,7 @@ the code wins.
 |---|---|
 | Lua language basics | `assert`, `error`, `pairs`, `ipairs`, `next`, `pcall`, `xpcall`, `select`, `setmetatable`, `getmetatable`, `tonumber`, `tostring`, `type`, `print`, `collectgarbage`, `PROCESSED` |
 | Lua stdlib (full) | `table`, `math`, `coroutine` |
-| Lua stdlib (curated) | `os` (only `time`, `date`, `difftime`), `io` (only `open`, path-restricted) |
+| Lua stdlib (curated) | `os` (only `time`, `date`, `difftime`, `clock`), `io` (only `open`, path-restricted) |
 | String lib | `string` (= `utf`, UTF-8-aware), `utf` (alias for the same) |
 | luadch core | `hub`, `cfg`, `util`, `util_http`, `http_filter`, `http_events`, `http_client`, `adc`, `adclib`, `signal`, `out`, `unicode`, `sysinfo`, `const`, `audit`, `secrets`, `whitelist`, `blocklist`, `mmdb`, `geoip_update`, `hmac`, `backup` |
 | Optional libs | `ssl` (with `.x509` pre-attached as a field), `socket`, `basexx`, `zlib_stream`, `dkjson` |
@@ -157,12 +157,13 @@ local loaded = package.loaded["foo"]
 | `package.loaded` lookup | not supported |
 | `package.loadlib` | not supported (was a sandbox escape) |
 
-### `os.execute` / `os.remove` / `os.rename` / `os.exit` / `os.setlocale` / `os.tmpname` / `os.tmpfile` / `os.getenv` / `os.clock`
+### `os.execute` / `os.remove` / `os.rename` / `os.exit` / `os.setlocale` / `os.tmpname` / `os.tmpfile` / `os.getenv`
 
-These were all blocked in Tier-2 Sub-PR-2 (#212).
+These were all blocked in Tier-2 Sub-PR-2 (#212). (`os.clock` was blocked
+there too but later re-exposed as a read-only time accessor in #325/#326.)
 
 **Replacement:** None for most. The plugin sandbox exposes only
-`os.time`, `os.date`, `os.difftime`. If your plugin shells out to
+`os.time`, `os.date`, `os.difftime`, `os.clock`. If your plugin shells out to
 system commands, that work must move into a luadch core helper (the
 canonical example: cmd_hubinfo's OS / CPU / RAM detection moved into
 `core/sysinfo.lua` in #213, accessed by the plugin via

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -86,6 +86,7 @@ one-line summary from each entry; see the entry for commands and cfg keys.
 | [etc_proxydetect](#etc_proxydetect) | Live proxy / VPN / Tor detection via an external provider API on connect |
 | [etc_status_push](#etc_status_push) | Periodically pushes the hub's public status to an external HTTP(S) endpoint |
 | [etc_prometheus](#etc_prometheus) | Prometheus text-exposition `/metrics` endpoint for the HTTP API |
+| [etc_stats_history](#etc_stats_history) | Sampled online-users time-series backing the WebUI dashboard history graph |
 | [etc_regserver_announce](#etc_regserver_announce) | Announces this hub to an external ADC hublist regserver |
 | [etc_clientblocker](#etc_clientblocker) | Block clients by Lua-pattern match against the BINF `AP+VE` field |
 | [etc_keyprint](#etc_keyprint) | Automatically extract and cache hub certificate keyprint (SHA256) for client validation |
@@ -386,9 +387,8 @@ other users' passwords.
 **Commands:** `+setpass myself <password>` /
 `+setpass nick <nick> <password>`
 
-**Config:** `cmd_setpass_permission`, `cmd_setpass_advanced_rc`,
-`cmd_setpass_report`, `cmd_setpass_report_hubbot`,
-`cmd_setpass_report_opchat`
+**Config:** `cmd_setpass_permission`, `cmd_setpass_permission_own_pw`,
+`cmd_setpass_advanced_rc`
 
 ### cmd_shutdown
 
@@ -424,7 +424,7 @@ Broadcast messages anonymously without nickname prefix.
 
 **Commands:** `+talk <message>`
 
-**Config:** `cmd_talk_permission`
+**Config:** `cmd_talk_minlevel`
 
 ### cmd_topic
 
@@ -500,7 +500,7 @@ Useful for administration.
 
 **Commands:** `+userlist [bydate]`
 
-**Config:** `cmd_userlist_permission`
+**Config:** `cmd_userlist_minlevel`
 
 ### cmd_usersearch
 
@@ -534,7 +534,8 @@ re-registration.
 Log main chat messages with timestamps, user nicks, and message
 content. Display on user login.
 
-**Config:** `etc_chatlog_activate`
+**Config:** `etc_chatlog_permission`, `etc_chatlog_max_lines`,
+`etc_chatlog_default_lines`, `etc_chatlog_min_level_adv`
 
 ### etc_cmdlog
 
@@ -542,7 +543,8 @@ Audit log of all operator `+cmd` invocations (who, what, when).
 
 **Commands:** `+cmdlog show`
 
-**Config:** `etc_cmdlog_activate`
+**Config:** `etc_cmdlog_command_tbl`, `etc_cmdlog_minlevel`,
+`etc_cmdlog_redact_args`
 
 ### etc_dhtblocker
 
@@ -550,7 +552,7 @@ Disconnect users with DHT (Distributed Hash Table) search enabled.
 Prevents unwanted network search participation.
 
 **Config:** `etc_dhtblocker_activate`, `etc_dhtblocker_report`,
-`etc_dhtblocker_report_hubbot`, `etc_dhtblocker_report_opchat`
+`etc_dhtblocker_report_tohubbot`, `etc_dhtblocker_report_toopchat`
 
 ### etc_dummy_warning
 
@@ -1092,6 +1094,26 @@ searches, script errors. The full metric catalog is in
 
 **Config:** `etc_prometheus_activate`
 
+### etc_stats_history
+
+Samples the online-human count on a timer into a 3-tier, RRD-style ring
+buffer and exposes it via `GET /v1/stats/history`, feeding the WebUI
+dashboard online-users history graph
+([#665](https://github.com/luadch-ng/luadch-ng/issues/665)). Endpoint-only:
+no ADC command, no report, no lang file. Ships ENABLED by default in
+`examples/cfg/cfg.tbl` (API-toggleable).
+
+The three tiers consolidate the same 60-second samples into progressively
+wider buckets - 10-min slots x 144 = 24 h, 1-h x 168 = 7 d, 6-h x 120 =
+30 d - each keeping the peak-concurrent count per slot, so the endpoint
+just returns the tier matching the requested range with no server-side
+downsampling. The buffers persist to `scripts/data/etc_stats_history.tbl`
+(operator-owned, survives `+reload` / restart); there is no backfill - the
+graph accumulates from first enable.
+
+**HTTP API:** `GET /v1/stats/history?range=24h|7d|30d` (read scope,
+default `24h`) -> `{range, interval_sec, points:[{t,count}]}`.
+
 ### etc_regserver_announce
 
 Announces this hub to an external ADC hublist regserver by POSTing an
@@ -1379,7 +1401,10 @@ endpoint config lives in `cfg/webhooks.tbl` (copy
 `examples/cfg/webhooks.tbl`). The HTTP API listener must be reachable
 from the sender - put a reverse proxy with TLS in front. Full setup
 (Discourse / GitHub webhook config, reverse proxy, security) in
-[`docs/WEBHOOKS.md`](WEBHOOKS.md).
+[`docs/WEBHOOKS.md`](WEBHOOKS.md). The per-endpoint `conditions`
+body-field filter, the per-endpoint `enabled` toggle, and the
+`/v1/webhooks` management API (WebUI-backed) are covered in
+[`docs/WEBHOOKS.md` §3.1](WEBHOOKS.md#31-managing-endpoints-via-the-webui--http-api).
 
 **Config:** `etc_webhook_activate` + `cfg/webhooks.tbl`
 
@@ -1443,9 +1468,8 @@ hublists during a lockdown. State survives `+reload` / restart
 ### hub_bot_cleaner
 
 Remove unused bot accounts from user database on timer. Prevents
-clutter from disabled scripts.
-
-**Config:** `hub_bot_cleaner_days`
+clutter from disabled scripts. Timing and report settings are
+hardcoded in the plugin (no cfg keys).
 
 ### hub_cmd_manager
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -56,7 +56,7 @@ The trust boundary is between "operator-installed plugin" and
 `_ENV` from an explicit `SANDBOX_GLOBALS` whitelist (added in
 [#206](https://github.com/luadch-ng/luadch-ng/issues/206)). `os` and
 `io` are curated shims: `os` exposes only `time` / `date` /
-`difftime`; `io` exposes only a path-restricted `open` (relative
+`difftime` / `clock`; `io` exposes only a path-restricted `open` (relative
 paths, no `..` traversal) - `io.popen`, `io.lines`, `package`,
 `require`, and `debug` are NOT reachable. Subprocess access lives
 in a separate [`core/sysinfo.lua`](../core/sysinfo.lua) module
@@ -109,9 +109,10 @@ do, including:
 - Read its own and every other admin token's audit-log bodies via
   `GET /v1/log/api`. Bodies for routes that opt into the
   [`HTTP_API.md`](HTTP_API.md) §8 redact mechanism
-  (`audit_redact_body = true` - currently the two
-  password endpoints) log as `[redacted]` even to admin readers,
-  but everything else is plaintext.
+  (`audit_redact_body = true` - the config-write `PUT /v1/config/{key}`,
+  the `POST /v1/auth/verify` login, the password-rotation / reg plugin
+  routes, and etc_webhook's signed routes) log as `[redacted]` even to
+  admin readers, but everything else is plaintext.
 - Issue `POST /v1/restart` / `POST /v1/shutdown` / `POST /v1/reload`.
 - Toggle plugins (`PUT /v1/plugins/{name}/enabled`).
 - Mutate any non-denylisted cfg key (`PUT /v1/config/{key}`).
@@ -393,8 +394,10 @@ POSIX (Phase 7b,
 - `log/audit-YYYY-MM-DD.jsonl` (#84 staff-action audit trail;
   `etc_auditlog` `chmod_secret`s the file on first write per
   daily path).
-- `certs/serverkey.pem` and `certs/cakey.pem` are 0600'd by
-  `examples/certs/make_cert.sh` at generation time.
+- `certs/serverkey.pem` is 0600'd by `core/cert_bootstrap.lua` when the
+  hub auto-generates the TLS pair on first boot (the default TLS-only
+  path, #77); `examples/certs/make_cert.sh` 0600's `serverkey.pem` /
+  `cakey.pem` only when you regenerate them manually.
 
 ### Linux / BSD - one-time migration
 


### PR DESCRIPTION
A multi-agent documentation-currency audit against the current source. **Good news first:** the highest-traffic docs (HTTP_API, PLUGIN_API, WEBHOOKS, DEVELOPMENT, BUILDING, DOCKER, BACKUP, CACERT, TRANSLATING) are current - HTTP_API's route list fully reconciles with the code including the webhook v0.04 mgmt API. The drift was concentrated; this PR fixes it. Docs-only, no behaviour change. Every "current reality" value was verified against source before editing.

## Highlights

- **[HIGH]** `user.tbl` was described as a "password hash" (CONFIGURATION.md + INSTALLING.md) - ADC requires the hub hold the cleartext-equivalent; the protection is at-rest AES-256-GCM, not a hash. Corrected.
- **CONFIGURATION.md**: `+regme` marked as an optional example plugin (not bundled); `ssl_params` now shows `ciphers = "HIGH"` + the `ciphersuites` line matching the shipped cfg; `[BOT]HubSecurity` (a bot nick) vs the actual `etc_dummy_warning` plugin untangled.
- **CLAUDE.md**: latest-release marker v3.1.14 -> v3.1.15 (2 spots); lang Lua->JSON/Weblate layout noted in the `cfg_lang` row; `dkjson` + `slaxml` added to the bundled-deps table.
- **SCRIPTS.md**: 8 plugins' fictional/wrong cfg keys corrected (operators were setting no-ops); `etc_stats_history` documented (it ships enabled and backs the dashboard graph); `etc_webhook` pointed at WEBHOOKS.md.
- **DOCKER.md / INSTALLING.md**: phantom `scripts/cfg/` path -> `cfg/<name>.tbl`; the update rsync now excludes `scripts/lang/` and warns that `--delete` removes custom plugins.
- **PLUGIN_API.md / SECURITY.md / PLUGIN_SANDBOX_MIGRATION.md**: post-login `I4`/`I6` are silently stripped, not `ISTA 240`-killed; `os.clock` is exposed (was listed as blocked in 3 docs); serverkey 0600 credited to `cert_bootstrap.lua`; the `audit_redact_body` routes named correctly.
- **BLOCKLIST.md**: proxycheck API key is sent in the POST body, not a query param.
- **README / CONTRIBUTING / BUILDING**: WebUI todo -> in-progress companion repo; Weblate slug `luadch-ng`; point-in-time build-warning counts softened.

Two source (non-doc) inconsistencies were also surfaced and are being tracked separately: `CMakeLists.txt` project version `2.24.0` lags `core/const.lua`'s `v3.2.0-dev`, and `cmd_botflag_permission` has no `cfg_defaults` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)