### PR TITLE
chore: fix two audit-surfaced consistency gaps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT IS_MULTI_CONFIG AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 project(luadch
-    VERSION 2.24.0
+    VERSION 3.2.0
     DESCRIPTION "luadch — DC++ ADC hub server"
     LANGUAGES C CXX
 )

--- a/core/cfg_defaults.lua
+++ b/core/cfg_defaults.lua
@@ -1061,6 +1061,38 @@ local defaults = {
         end
     },
 
+    ---------------------------------------------------------------------------------------------------------------------------------
+    --// cmd_botflag.lua settings
+
+    cmd_botflag_permission = { {
+
+        [ 0 ] = false,
+        [ 10 ] = false,
+        [ 20 ] = false,
+        [ 30 ] = false,
+        [ 40 ] = false,
+        [ 50 ] = false,
+        [ 55 ] = false,
+        [ 60 ] = false,
+        [ 70 ] = false,
+        [ 80 ] = false,
+        [ 100 ] = true,  -- default = only the hubowner may flag accounts
+
+    },
+        function( value )
+            if not types_table( value ) then
+                return false
+            else
+                for i, k in pairs( value ) do
+                    if not ( types_boolean( k, nil, true ) and types_number( i, nil, true ) ) then
+                        return false
+                    end
+                end
+            end
+            return true
+        end
+    },
+
     -- Shared by cmd_accinfo (+accinfo / +accinfoop) and cmd_usersearch:
     -- when true, those commands echo a registered user's stored password
     -- in their chat/PM reply instead of "<REDACTED>". Default false keeps


### PR DESCRIPTION
Two tiny consistency fixes surfaced by the docs-currency audit. No behaviour change.

- **`CMakeLists.txt`**: the `project()` `VERSION` was still `2.24.0` (a pre-fork leftover); bumped to `3.2.0` to match `core/const.lua`'s `v3.2.0-dev`. Nothing reads the CMake version, so this is cosmetic metadata.
- **`core/cfg_defaults.lua`**: added the `cmd_botflag_permission` default (hubowner-only, mirroring the shipped `examples/cfg/cfg.tbl`). `scripts/cmd_botflag.lua` reads the key but it had no default, so `cfg.get` would crash on it if a hand-edited `cfg.tbl` lacked it (the example cfg ships it, so stock installs were never affected - this just closes the gap).

`cfg_defaults_test` (17/17) and `cmd_botflag_test` (23/23) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)