### PR TITLE
fix(usr_uptime): guard nil uptime_tbl so onTimer save cannot crash the hub (v0.13.1)

### DIFF
--- a/scripts/usr_uptime.lua
+++ b/scripts/usr_uptime.lua
@@ -4,6 +4,17 @@
 
         usage: [+!#]useruptime [CT1 <FIRSTNICK> | CT2 <NICK>]
 
+        v0.13.1: by Aybo
+            - fix hub-crash on start when scripts/data/usr_uptime.tbl is
+              missing or unreadable AND no user logs in during the first
+              onTimer cycle: util.loadtable returned nil, onTimer then
+              called util.savetable( nil, ... ), which crashes in the
+              serializer ("bad argument #1 to 'for iterator' (table
+              expected, got nil)" in core/util.lua). Seed uptime_tbl to {}
+              at load so it is invariantly a table; onTimer / onExit can no
+              longer hand savetable a nil. The scattered type(nil) guards
+              in new_entry / get_useruptime / tbl are now belt-and-braces.
+
         v0.13: by Aybo
             - carry a user's accumulated uptime over to the new nick on
               +nickchange / HTTP rename. uptime_tbl is keyed by firstnick;
@@ -122,7 +133,7 @@
 --------------
 
 local scriptname = "usr_uptime"
-local scriptversion = "0.13"
+local scriptversion = "0.13.1"
 
 local cmd = { "useruptime", "uu" }
 
@@ -132,7 +143,12 @@ local uptime_file = "scripts/data/usr_uptime.tbl"
 --// imports
 local scriptlang = cfg.get( "language" )
 local lang, err = cfg.loadlanguage( scriptlang, scriptname ); lang = lang or { }; err = err and hub.debug( err )
-local uptime_tbl = util.loadtable( uptime_file )
+-- Seed to {} so uptime_tbl is invariantly a table: a missing or unreadable
+-- store (util.loadtable -> nil) must never reach util.savetable, which
+-- crashes on a nil argument in the onTimer / onExit saves before any login
+-- lazily creates the table (the onTimer 60s tick on an empty, freshly
+-- updated hub was the reported crash).
+local uptime_tbl = util.loadtable( uptime_file ) or { }
 local minlevel = cfg.get( "usr_uptime_minlevel" )
 local permission = cfg.get( "usr_uptime_permission" )
 local opchat = hub.import( "bot_opchat" )

--- a/tests/unit/usr_uptime_test.lua
+++ b/tests/unit/usr_uptime_test.lua
@@ -84,7 +84,14 @@ _G.cfg = {
 
 _G.util = {
     loadtable      = function( ) return _saved end,
-    savetable      = function( t ) _saved = t end,   -- reference-persist (simulates on-disk)
+    savetable      = function( t )
+        -- Faithful to core/util.lua: the serialiser does `for k in pairs(t)`,
+        -- which errors "bad argument #1 to 'for iterator' (table expected,
+        -- got nil)" on a nil argument exactly as the hub does. A table
+        -- reference-persists (simulates on-disk), so tests 1-3 are unchanged.
+        for _ in pairs( t ) do break end
+        _saved = t
+    end,
     getlowestlevel = function( ) return 50 end,
     formatseconds  = function( ) return 0, 0, 0, 0 end,
 }
@@ -207,6 +214,27 @@ for _ = 1, 120 do _now = _now + 1; fire( "onTimer" ) end
 fire( "onLogout", userC )
 _online[ 1 ] = nil
 eq( "single session: 120s online credited exactly on logout", credited( "Carol" ), 120 )
+
+----------------------------------------------------------------------
+-- Test 4: hub-crash regression (v0.13.1). A freshly updated / empty hub
+-- whose scripts/data/usr_uptime.tbl is MISSING (util.loadtable -> nil)
+-- must not crash when the 60s onTimer tick fires before any login has
+-- lazily created the table. Pre-fix uptime_tbl stayed nil and onTimer
+-- called util.savetable( nil, ... ), which errors in the serialiser
+-- ("bad argument #1 to 'for iterator' (table expected, got nil)"); the
+-- savetable stub above reproduces that error faithfully.
+----------------------------------------------------------------------
+_saved  = nil                       -- missing / unreadable store -> loadtable returns nil
+_online = { }                       -- empty hub: no login lazily creates the table
+_now    = _base
+load_plugin( )
+
+_now = _base + 61                   -- open the 60s onTimer credit gate
+local ok, err = pcall( function( ) fire( "onTimer" ) end )
+truthy( "missing store + empty hub: onTimer does not crash on save (err="
+    .. tostring( err ) .. ")", ok )
+truthy( "missing store: onTimer persists a table, not nil (got "
+    .. type( _saved ) .. ")", type( _saved ) == "table" )
 
 ----------------------------------------------------------------------
 if failures > 0 then


### PR DESCRIPTION
Production hub-crash fix. Hit on the DCVault hub right after a master-image update.

## Crash

`usr_uptime.lua` loads state with `util.loadtable( uptime_file )`, which returns nil when `scripts/data/usr_uptime.tbl` is missing or unreadable. `onTimer` (and `onExit`) then call `util.savetable( uptime_tbl, ... )` with no nil guard -> `sortserialize` does `for k in pairs(nil)` -> `bad argument #1 to 'for iterator' (table expected, got nil)`. Trigger: a freshly updated / empty hub with a missing `usr_uptime.tbl` and no login during the first 60s onTimer cycle (a login would lazily create the table via `new_entry`).

## Fix

`local uptime_tbl = util.loadtable( uptime_file ) or { }` - `uptime_tbl` is invariantly a table, so the onTimer / onExit saves can never receive nil. Matches every sibling plugin (etc_msgmanager, hub_runtime, etc_stats_history, ...) which already seed/guard their loaded state; an independent consistency sweep found usr_uptime was the sole outlier.

## Test

`tests/unit/usr_uptime_test.lua` Test 4: missing store + empty hub + an onTimer tick past the 60s gate. The savetable stub is upgraded to reproduce the real serializer's nil error faithfully. Proven RED on the unpatched plugin (fails with the exact incident error) and GREEN patched. Both CI legs already run this test.

## Behaviour note

The opchat "database corrupt or missing" announcement no longer fires - it only fired on the eliminated nil path, and a missing file on a fresh hub is normal (not a fault), aligning with the #445 first-boot-noise suppression. No new data-loss path (a corrupt file was already overwritten with `{}` before).

Independent review: SHIP, no must-fix findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
